### PR TITLE
fix(core-image): pay down 4 of 7 fixable CRITICAL/HIGH — npm 11.19.0, Node 24.19.0

### DIFF
--- a/deploy/core.Dockerfile
+++ b/deploy/core.Dockerfile
@@ -92,6 +92,13 @@ RUN apt-get update \
 # out for the same reason the tarball is in — this is a download we verify,
 # not a publisher we trust.
 ARG NODE_VERSION=24.19.0
+# npm newer than the one Node bundles, because that is where the image's only
+# fixable CRITICAL/HIGH live: npm's vendored tar/undici/brace-expansion under
+# /usr/local/lib/node_modules/npm. 12.0.2 clears four of the seven measured on
+# 2026-08-04, including the lone CRITICAL (tar). Pinned exactly, and bumped on
+# the same weekly cadence as NODE_VERSION (#51) — no released npm clears all
+# seven, so this pays findings down; it does not green a raw scan.
+ARG NPM_VERSION=12.0.2
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
       amd64) node_arch=x64 ;; \
@@ -107,8 +114,11 @@ RUN set -eux; \
     tar -xJf "${archive}" -C /usr/local --strip-components=1 \
         --exclude CHANGELOG.md --exclude LICENSE --exclude README.md; \
     rm -f "${archive}" SHASUMS256.txt; \
+    npm install -g "npm@${NPM_VERSION}"; \
+    npm cache clean --force; \
+    rm -rf /root/.npm; \
     node --version; \
-    npm --version
+    [ "$(npm --version)" = "${NPM_VERSION}" ]
 
 # uid 1000 and gid 1000, by number, always (D12).
 #

--- a/deploy/core.Dockerfile
+++ b/deploy/core.Dockerfile
@@ -94,11 +94,25 @@ RUN apt-get update \
 ARG NODE_VERSION=24.19.0
 # npm newer than the one Node bundles, because that is where the image's only
 # fixable CRITICAL/HIGH live: npm's vendored tar/undici/brace-expansion under
-# /usr/local/lib/node_modules/npm. 12.0.2 clears four of the seven measured on
-# 2026-08-04, including the lone CRITICAL (tar). Pinned exactly, and bumped on
-# the same weekly cadence as NODE_VERSION (#51) — no released npm clears all
-# seven, so this pays findings down; it does not green a raw scan.
-ARG NPM_VERSION=12.0.2
+# /usr/local/lib/node_modules/npm. 11.19.0 clears four of the seven measured
+# on 2026-08-04, including the lone CRITICAL (tar); no released npm clears all
+# seven, so this pays findings down — it does not green a raw scan.
+#
+# 11.19.0 and NOT 12.x, though 12.0.2's vendored tree is identical for all
+# four (measured from both published tarballs, #82): npm 12 ships allowScripts
+# off by default, which blocks dependency preinstall/install/postinstall AND
+# the implicit `node-gyp rebuild` for any binding.gyp package — the exact
+# capability build-essential/python3 above exist to serve, and how Harness
+# postinstalls run. Crossing that major is a product decision for an ADR, not
+# a rider on a CVE bump.
+#
+# The tarball is fetched from the registry and SHA-512-checked against the
+# digest pinned below — the same "download we verify" footing as the Node
+# fetch above (D8); a bare `npm install -g npm@x` would be publisher trust.
+# The hex is that release's registry dist.integrity, base64-decoded; the two
+# ARGs move together, on the same #51 cadence as NODE_VERSION.
+ARG NPM_VERSION=11.19.0
+ARG NPM_SHA512=48377f8478372aa1c4e47b763475b135836da82436a5700f2e5e8eb5084fc840f93c7b117eb3ad3b5f7d3194c81b6710a10d59448f6ddbcb21ac3fb672bdc003
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
       amd64) node_arch=x64 ;; \
@@ -114,7 +128,11 @@ RUN set -eux; \
     tar -xJf "${archive}" -C /usr/local --strip-components=1 \
         --exclude CHANGELOG.md --exclude LICENSE --exclude README.md; \
     rm -f "${archive}" SHASUMS256.txt; \
-    npm install -g "npm@${NPM_VERSION}"; \
+    npm_tgz="npm-${NPM_VERSION}.tgz"; \
+    curl -fsSL -o "${npm_tgz}" "https://registry.npmjs.org/npm/-/${npm_tgz}"; \
+    echo "${NPM_SHA512}  ${npm_tgz}" | sha512sum -c -; \
+    npm install -g "${npm_tgz}"; \
+    rm -f "${npm_tgz}"; \
     npm cache clean --force; \
     rm -rf /root/.npm; \
     node --version; \

--- a/deploy/core.Dockerfile
+++ b/deploy/core.Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update \
 # carries `nodejs` at all. NodeSource and every other third-party apt repo are
 # out for the same reason the tarball is in — this is a download we verify,
 # not a publisher we trust.
-ARG NODE_VERSION=24.18.1
+ARG NODE_VERSION=24.19.0
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
       amd64) node_arch=x64 ;; \

--- a/docs/research/core-base-measure/core-image-cve-claim-2026-08-05.md
+++ b/docs/research/core-base-measure/core-image-cve-claim-2026-08-05.md
@@ -134,11 +134,21 @@ Checked for anything newly actionable as of 2026-08-05:
   no CVEs fixed, and its npm 11.17.0 was already measured
   ([`core-image-2026-08-04.md`](core-image-2026-08-04.md)) to clear **none** of the seven npm-tree
   findings. The weekly `base-pins` housekeeping job will pick it up on cadence; there is no
-  security reason to bump out of band.
+  security reason to bump out of band. (#82 took the bump anyway — a deliberate
+  stay-current-while-touching-the-layer choice, not a security necessity, and not a prerequisite
+  for the npm pin beside it.)
 - **Paying down the npm seven**: a pinned npm bump to 11.19.0+/12.0.2 would clear four of seven,
   including the only CRITICAL (`tar` CVE-2026-59873) — already recorded in
   [`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md) as belonging to #51's weekly-rebuild scope,
-  not to a PR gate. Nothing found on 2026-08-05 changes that.
+  not to a PR gate. Nothing found on 2026-08-05 changes that. Applied by #82 as `npm@11.19.0`,
+  integrity-pinned against its registry `dist.integrity`. **Not** 12.0.2, although its vendored
+  tree is identical for all four packages (verified from both published tarballs): npm 12's
+  `allowScripts`-off default blocks dependency install scripts *and* implicit `node-gyp rebuild`,
+  which is the capability the toolchain — and with it the 1200 suppressed `linux-libc-dev` rows —
+  exists to provide. The three that remain (`brace-expansion` → 5.0.8/5.0.9, `ip-address` →
+  10.3.1) are fixed upstream but shipped by no released npm; they stay visible in the scan
+  summary's reported-only block, outside the gate's scoped-out npm path — so the check that the
+  pin worked is that block showing 3 rows instead of 7, not the gate passing.
 
 ## What was NOT re-verified
 

--- a/docs/research/core-base-measure/core-image-cve-claim-2026-08-05.md
+++ b/docs/research/core-base-measure/core-image-cve-claim-2026-08-05.md
@@ -1,0 +1,162 @@
+# "These 3 lines are introducing 1000+ vulnerabilities within the core" — checked, 2026-08-05
+
+A user read `docker history`-style output of the Core image and attributed 1000+ vulnerabilities to
+the three RUN instructions in [`deploy/core.Dockerfile`](../../../deploy/core.Dockerfile): the apt
+layer, the Node 24.18.1 tarball layer, and the Core tarball layer. This file checks that claim
+against the repository's checked-in measurements and against primary external sources, and
+attributes the count per layer.
+
+## TL;DR
+
+**The number is real; the attribution is wrong in every way that matters.**
+
+- The raw count is even slightly higher than claimed: **1246 distinct CVEs** (1323 finding rows) on
+  the shipped image, per the checked-in 2026-08-04 scan (Trivy 0.73.0).
+- But it is not "3 lines". **One transitive package in one line — `linux-libc-dev`, pulled in as
+  `build-essential` → `libc6-dev` → `linux-libc-dev` in the apt layer — accounts for 1200 of the
+  1246 (96%).** The Node layer adds ~19 distinct, the Core tarball layer adds ~0.
+- Those 1200 are **Linux kernel CVEs mapped onto a header-only package**. `linux-libc-dev` ships
+  C headers under `/usr/include`, no executable code, and the kernel a container runs is the
+  *host's* — the image never loads a kernel. This mapping is a documented scanner limitation
+  (Ubuntu issues advisories per *source* package; Trivy flags every binary package built from a
+  vulnerable source), confirmed against both the Trivy maintainers and Ubuntu's own CVE data.
+- **None of the 1200 is a fixable CRITICAL or HIGH.** After the checked-in, justified suppression
+  ([`.trivyignore.rego`](../../../.trivyignore.rego)), 46 distinct findings remain. The only
+  fixable CRITICAL/HIGH in the image (7) are npm's own vendored dependencies inside the Node
+  tarball, and no released Node or npm clears all of them.
+- Nothing newly actionable: the pinned Node 24.18.1 **is** the current v24 security release
+  (2026-07-29, 12 CVEs fixed); 24.19.0 (2026-08-03) is a feature release, not a security release.
+
+So the honest restatement of the claim is: *one apt token in one line drags in one header package
+that a scanner charges with ~1200 host-kernel CVEs it cannot express in a container; everything
+else in all three lines together is 46 distinct findings, of which zero OS-package findings are
+fixable CRITICAL/HIGH.*
+
+## Per-layer attribution
+
+From the measured build-up in
+[`core-image-2026-08-04.md`](core-image-2026-08-04.md) (rows A–E; Trivy 0.73.0, DB of 2026-08-04,
+linux/arm64, base digest `noble-20260730.1` — the digest the Dockerfile pins):
+
+| layer | distinct CVEs added | of which `linux-libc-dev` | fixable CRIT/HIGH added |
+|---|---:|---:|---:|
+| `FROM ubuntu:24.04@sha256:561618e2…` (not one of the 3 lines) | 6 | 0 | 0 |
+| RUN 1 — apt layer, *without* `build-essential python3` | +9 (→ 15) | 0 | 0 |
+| RUN 1 — the same layer's `build-essential python3` | +1212 (→ 1227) | 1200 | 0 |
+| RUN 2 — Node 24.18.1 tarball | +19 (→ 1246) | 0 | **7** (all in npm's vendored deps) |
+| RUN 3 — Core tarball into `/opt/actana` | ~0 | 0 | 0 |
+
+Reading of each of the three accused lines:
+
+1. **The apt layer** is where the number lives — but not spread across its ~20 packages. The base
+   contributes 6; `bash sudo ca-certificates curl git openssh-client ripgrep jq less vim-tiny
+   unzip lsof xz-utils tini` together take it to 15. Adding `build-essential python3` takes it to
+   1227, and 1200 of those are attributed to a single package neither named in the Dockerfile nor
+   installed for its own sake: `linux-libc-dev`, a hard transitive dependency of the C toolchain.
+2. **The Node tarball layer** adds ~19 distinct findings, all Node/npm-attributed. This layer —
+   not the apt layer — is where every *fixable CRITICAL/HIGH* in the image lives: 7 CVEs, all in
+   `usr/local/lib/node_modules/npm/node_modules/` (npm's own vendored `tar`, `undici`,
+   `brace-expansion`, `ip-address`), per [`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md). The
+   tarball itself is fetched from nodejs.org and SHA-256-verified against the release's own
+   `SHASUMS256.txt` — provenance is not the issue; npm's bundled tree is.
+3. **The Core tarball layer** adds essentially nothing. Trivy scans the 15 first-party packages
+   under `/opt/actana` and finds zero — `pnpm-workspace.yaml`'s overrides (`tar >=7.5.19`,
+   `brace-expansion >=5.0.7`) already hold the repo's own tree above the fixed versions.
+
+## What the 1200 `linux-libc-dev` findings actually are
+
+`linux-libc-dev` is the Linux kernel's userspace API headers: per
+[`.trivyignore.rego`](../../../.trivyignore.rego) and ADR 0016 D7
+([`docs/adr/0016-the-0-1-0-shape.md`](../../adr/0016-the-0-1-0-shape.md)), 1008 of its 1015 files
+are under `/usr/include` and the package contains no executable code. The findings charged to it
+are *kernel* CVEs, and the kernel a container runs is the host's — nothing in this image can be
+exploited through a header it compiled against.
+
+Why a scanner charges them to a header package — verified against primary sources:
+
+- **Trivy maintainers confirm the mechanism.** Ubuntu (like Debian) issues security advisories per
+  *source* package (`linux`), without stating which *binary* packages are affected, so Trivy flags
+  every binary package built from the vulnerable source — maintainer knqyf263: "if BIND is
+  vulnerable, it will be detected even if only `bind-licence` is installed." Known, documented,
+  no ideal fix:
+  [aquasecurity/trivy discussion #6562](https://github.com/aquasecurity/trivy/discussions/6562)
+  ("trivy detecting vulnerabilities in linux header packages?"),
+  [aquasecurity/trivy issue #3010](https://github.com/aquasecurity/trivy/issues/3010),
+  [aquasecurity/trivy issue #1596](https://github.com/aquasecurity/trivy/issues/1596) (kernel CVEs
+  inside containers should be judged against the *host* kernel, not the image).
+- **Ubuntu's own CVE data confirms the scale and the mapping.** ubuntu.com's tracker was returning
+  503/504 on 2026-08-05 (see "not re-verified"), so this was checked against OSV.dev's bulk export
+  of Ubuntu's security data
+  ([`Ubuntu:24.04:LTS/all.zip`](https://osv-vulnerabilities.storage.googleapis.com/Ubuntu%3A24.04%3ALTS/all.zip),
+  fetched 2026-08-05): the noble ecosystem carries **4,920 CVE records against the `linux` source
+  package**, and **4,633 of them explicitly list `linux-libc-dev` as an affected binary**. For
+  comparison, the same data set carries: `git` 7, `curl` 13, `openssh` 12, `openssl` 22, `sudo` 1,
+  `vim` 12, `jq` 3, `less` 3, `unzip` 2. That is the "base + tools minus linux-libc-dev ≈ small
+  double digits" story confirmed from an independent primary source: every other package in the
+  image lives in single or low double digits; the kernel source package lives in the thousands,
+  and the header package inherits all of it.
+
+Why they are suppressed rather than fixed: there is nothing to fix *in the image*. The findings
+are unfixed kernel CVEs (0 fixable among the 1200 — the D11 gate, which fails only on fixable
+CRITICAL/HIGH, would pass with the suppression file deleted), and dropping the package would mean
+dropping `build-essential`, which the product needs: `npm install` on any project with a native
+addon invokes node-gyp, which needs make, g++ and python3 — this repo's own `better-sqlite3` and
+`node-pty` are the proof. So D7 suppresses exactly that one package, in one checked-in file with
+the justification written beside it ([`.trivyignore.rego`](../../../.trivyignore.rego)), applied
+via `--ignore-policy` and *asserted* to have taken effect by
+[`scripts/scan-core-image.mjs`](../../../scripts/scan-core-image.mjs) (a plain `.trivyignore`
+cannot express a package-scoped rule and fails silently — measured in
+[`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md)). What the suppression buys is a readable
+report: 46 rows a reader can act on instead of 1200 rows of kernel headers burying them.
+
+## What remains after suppression, and what is actionable
+
+**46 distinct findings** survive ([`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md): raw 1323
+rows / 1246 distinct → 123 rows / 46 distinct). Of those, the fixable CRITICAL/HIGH are exactly
+seven, all inside the system Node's bundled npm (`tar` 7.5.15, `undici` 6.26.0, `brace-expansion`
+5.0.6, `ip-address` 10.2.0). Those seven are scoped out of the CI gate by path
+([`scripts/lib/image-cve-gate.mjs`](../../../scripts/lib/image-cve-gate.mjs), ADR 0016 D11
+amendment) because they are not payable by any PR: the repo measured that no released Node 24 and
+no released npm (up to 12.0.2) ships a clean vendored tree. The gate itself runs in CI on the
+built image ([`.github/workflows/container-image.yml`](../../../.github/workflows/container-image.yml),
+Trivy 0.73.0 pinned and checksum-verified).
+
+Checked for anything newly actionable as of 2026-08-05:
+
+- **Node 24.18.1 is real and is the current v24 security release.** Release directory:
+  [nodejs.org/dist/v24.18.1](https://nodejs.org/dist/v24.18.1/) (published 2026-07-29, with
+  `SHASUMS256.txt` and the linux-x64/arm64 tarballs the Dockerfile fetches). The
+  [v24.18.1 release post](https://nodejs.org/en/blog/release/v24.18.1) is a **security release
+  fixing 12 CVEs** (3 high, 5 medium, 4 low), so the pin already carries every shipped Node
+  runtime security fix.
+- **24.19.0 (2026-08-03) is newer but is not a security release** — the
+  [v24.19.0 release post](https://nodejs.org/en/blog/release/v24.19.0) is a feature release with
+  no CVEs fixed, and its npm 11.17.0 was already measured
+  ([`core-image-2026-08-04.md`](core-image-2026-08-04.md)) to clear **none** of the seven npm-tree
+  findings. The weekly `base-pins` housekeeping job will pick it up on cadence; there is no
+  security reason to bump out of band.
+- **Paying down the npm seven**: a pinned npm bump to 11.19.0+/12.0.2 would clear four of seven,
+  including the only CRITICAL (`tar` CVE-2026-59873) — already recorded in
+  [`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md) as belonging to #51's weekly-rebuild scope,
+  not to a PR gate. Nothing found on 2026-08-05 changes that.
+
+## What was NOT re-verified
+
+- **The scan counts themselves** (1323/1246 raw, 1200 `linux-libc-dev`, 46 after suppression, the
+  seven fixable CRITICAL/HIGH, and the per-row build-up A–E). Trivy is not installed on this
+  machine and no built Core image exists locally, so no re-scan was run and no image was built.
+  These numbers are taken from the checked-in 2026-08-04 measurements
+  ([`core-image-2026-08-04.md`](core-image-2026-08-04.md),
+  [`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md); Trivy 0.73.0, vuln DB of 2026-08-04) and are
+  DB-date-sensitive: a scan today would differ by a handful of rows, not in shape.
+- **ubuntu.com's security tracker pages** (`ubuntu.com/security/cves?package=linux-libc-dev`)
+  were returning 503/504 throughout 2026-08-05 and could not be read directly. The scale and the
+  source→binary mapping were instead verified against OSV.dev's bulk export of the same Ubuntu
+  security data (figures above); the two are fed from the same Ubuntu CVE tracker, but the
+  tracker's own rendered per-package count was not seen first-hand.
+- **The exact overlap between "1200 at scan time" and "open on the tracker today."** The OSV
+  export shows 4,920 noble kernel-CVE records total; which ~1200 of those Trivy counted against
+  the specific installed `linux-libc-dev` version on 2026-08-04 depends on that day's DB and the
+  installed package version, and was not reconstructed.
+- **The `.trivyignore` silent-no-op behaviour** (plain format filtering 0 of 1200 without
+  warning) — taken from [`cve-gate-2026-08-04.md`](cve-gate-2026-08-04.md), not re-run.

--- a/scripts/__tests__/panel-image.test.mjs
+++ b/scripts/__tests__/panel-image.test.mjs
@@ -628,8 +628,9 @@ describe("core image", () => {
     }
     // One global install is not a Harness: npm replacing its own bundled copy
     // (the NPM_VERSION pin, where the image's only fixable CRITICAL/HIGH
-    // live). Strip that exact form; anything else that matches still fails.
-    const withoutNpmItself = built.replace('npm install -g "npm@${NPM_VERSION}"', "");
+    // live), installed from the SHA-512-checked local tarball. Strip that
+    // exact form; anything else that matches still fails.
+    const withoutNpmItself = built.replace('npm install -g "${npm_tgz}"', "");
     expect(withoutNpmItself).not.toMatch(/npm (install|i) -g/);
   });
 

--- a/scripts/__tests__/panel-image.test.mjs
+++ b/scripts/__tests__/panel-image.test.mjs
@@ -626,7 +626,11 @@ describe("core image", () => {
     for (const harness of ["@anthropic-ai/claude-code", "@openai/codex", "opencode", "cursor"]) {
       expect(built).not.toContain(harness);
     }
-    expect(built).not.toMatch(/npm (install|i) -g/);
+    // One global install is not a Harness: npm replacing its own bundled copy
+    // (the NPM_VERSION pin, where the image's only fixable CRITICAL/HIGH
+    // live). Strip that exact form; anything else that matches still fails.
+    const withoutNpmItself = built.replace('npm install -g "npm@${NPM_VERSION}"', "");
+    expect(withoutNpmItself).not.toMatch(/npm (install|i) -g/);
   });
 
   it("keeps systemd, and the machine-shaped install, out entirely", () => {


### PR DESCRIPTION
## What

Four commits on the Core image's security surface, driven by a layer-by-layer investigation of the raw 1246-CVE scan count:

- **npm pinned to 11.19.0** (new `ARG NPM_VERSION` + `ARG NPM_SHA512`) over the bundled 11.17.0. All seven fixable CRITICAL/HIGH in the shipped image live in npm's vendored tree (`tar`, `undici`, `brace-expansion`, `ip-address`), per the 2026-08-04 measurement; 11.19.0 clears four, including the only CRITICAL (both `tar` rows). **Not 12.0.2**: its vendored tree is identical for all four (verified from both published tarballs), and npm 12's `allowScripts`-off default blocks dependency install scripts and implicit `node-gyp rebuild` — the capability this image's toolchain exists for. The tarball is fetched from the registry and SHA-512-checked against the pinned digest (its registry `dist.integrity`, base64-decoded), on the same D8 footing as the Node fetch.
- **Node pin 24.18.1 → 24.19.0** via `check-base-pins.mjs --fix-node`. Not a security bump (24.18.1 was itself the current v24 security release) and not a prerequisite for the npm pin — a deliberate stay-current-while-touching-the-layer choice, reconciled in the evidence doc. Both base image digests measured current in the same run.
- **Evidence** in `docs/research/core-base-measure/core-image-cve-claim-2026-08-05.md`: 1200 of the 1246 raw findings are kernel CVEs mapped onto `linux-libc-dev` (header-only, host-owned kernel), independently confirmed against OSV.dev's Ubuntu noble export; no toolchain on Ubuntu avoids it (`libc6-dev` hard-depends on it).

The `bakes no Harnesses` guard (D9) strips the one exact npm-tarball install form before asserting — any other global install still fails it.

## Result

Pays down 4 of 7 fixable CRITICAL/HIGH, including the lone CRITICAL. **3 fixable HIGH remain** (`brace-expansion` → 5.0.8/5.0.9, `ip-address` → 10.3.1): fixed upstream, shipped by no released npm, reported-not-gated pending an upstream release on the #51 cadence. Gated scan otherwise unchanged (46 findings, allowlist still one file, one entry per D7/D37).

## Verification

`scripts/__tests__` — 107 pass across `panel-image` and `base-pins` suites. Pre-existing `core-launcher` failure on `main` (local actana install leaking into the test) is untouched and unrelated.

No rebuilt-image scan was run here (no docker in the sandbox), and the D11 gate is blind to the npm path by construction — the check that the pin worked is the scan summary's reported-only block showing **3 rows instead of 7**, not the gate passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)