### PR TITLE
fix(panel): route archive and restore to the Core that owns the task

### DIFF
--- a/packages/panel/src/lib/__tests__/archive-session.test.ts
+++ b/packages/panel/src/lib/__tests__/archive-session.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutateTaskForCore = vi.fn();
+
+vi.mock("~/lib/mutate-task-for-core", () => ({
+  mutateTaskForCore: (...args: unknown[]) => mutateTaskForCore(...args),
+}));
+
+import { archiveOpenSession } from "../archive-session";
+import type { OpenTerminal } from "~/lib/terminal-store";
+
+function session(over: Partial<OpenTerminal> = {}): OpenTerminal {
+  return {
+    taskId: "t1",
+    ptyId: null,
+    startCommand: "claude",
+    dangerouslySkipPermissions: false,
+    cwd: "/work",
+    project: { id: "p1" },
+    task: { id: "t1" },
+    ...over,
+  } as OpenTerminal;
+}
+
+function queryClientStub() {
+  const invalidated: unknown[] = [];
+  return {
+    client: { invalidateQueries: (arg: unknown) => (invalidated.push(arg), Promise.resolve()) },
+    invalidated,
+  };
+}
+
+describe("archiveOpenSession", () => {
+  beforeEach(() => {
+    mutateTaskForCore.mockReset().mockResolvedValue({ taskId: "t1", archived: true });
+  });
+
+  it("routes the archive to the Core that owns the task row", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const { client } = queryClientStub();
+
+    await archiveOpenSession(session({ coreId: "core-a" }), close, client as never, {
+      skipInvalidate: true,
+    });
+
+    expect(close).toHaveBeenCalledWith("t1", { activateTaskId: null });
+    expect(mutateTaskForCore).toHaveBeenCalledWith("core-a", {
+      op: "update",
+      taskId: "t1",
+      archived: true,
+    });
+  });
+
+  it("passes a Panel-owned session's null coreId straight through", async () => {
+    const { client } = queryClientStub();
+
+    await archiveOpenSession(session({ coreId: null }), vi.fn().mockResolvedValue(undefined), client as never, {
+      skipInvalidate: true,
+    });
+
+    expect(mutateTaskForCore.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  it("still archives when closing the PTY fails", async () => {
+    const close = vi.fn().mockRejectedValue(new Error("pty gone"));
+    const { client } = queryClientStub();
+
+    await archiveOpenSession(session({ coreId: "core-a" }), close, client as never, {
+      skipInvalidate: true,
+    });
+
+    expect(mutateTaskForCore).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the Core rejects the mutation so the caller can toast", async () => {
+    mutateTaskForCore.mockRejectedValue(new Error("link down"));
+    const { client } = queryClientStub();
+
+    await expect(
+      archiveOpenSession(session({ coreId: "core-a" }), vi.fn().mockResolvedValue(undefined), client as never, {
+        skipInvalidate: true,
+      }),
+    ).rejects.toThrow("link down");
+  });
+});

--- a/packages/panel/src/lib/__tests__/mutate-task-for-core.test.ts
+++ b/packages/panel/src/lib/__tests__/mutate-task-for-core.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiCalls: string[] = [];
+const archiveTask = vi.fn();
+const restoreTask = vi.fn();
+const updateTask = vi.fn();
+
+vi.mock("~/lib/api", () => ({
+  api: {
+    archiveTask: (id: string) => {
+      apiCalls.push(`archive:${id}`);
+      return archiveTask(id);
+    },
+    restoreTask: (id: string) => {
+      apiCalls.push(`restore:${id}`);
+      return restoreTask(id);
+    },
+    updateTask: (id: string, body: unknown) => {
+      apiCalls.push(`update:${id}`);
+      return updateTask(id, body);
+    },
+  },
+}));
+
+import { __setPanelBridgeForTests } from "~/lib/panel-bridge";
+import { mutateTaskForCore } from "../mutate-task-for-core";
+
+function panelTask(over: Record<string, unknown> = {}) {
+  return {
+    task: {
+      id: "t1",
+      projectId: "p1",
+      title: "Session",
+      icon: null,
+      agent: "claude",
+      status: "ready",
+      archived: false,
+      pinned: false,
+      updatedAt: 42,
+      ...over,
+    },
+  };
+}
+
+describe("mutateTaskForCore", () => {
+  beforeEach(() => {
+    apiCalls.length = 0;
+    archiveTask.mockReset().mockResolvedValue(panelTask({ archived: true }));
+    restoreTask.mockReset().mockResolvedValue(panelTask({ archived: false }));
+    updateTask.mockReset().mockResolvedValue(panelTask());
+  });
+
+  afterEach(() => {
+    __setPanelBridgeForTests(null);
+    vi.unstubAllGlobals();
+  });
+
+  it("routes a Core-owned archive over the panel link, not the Panel's HTTP API", async () => {
+    // The bridge is null while server-rendering; this suite runs in node, so
+    // stand up the `window` the bridge lookup gates on.
+    vi.stubGlobal("window", {});
+    const mutateTask = vi.fn().mockResolvedValue({
+      taskId: "t1",
+      projectId: "p1",
+      title: "Session",
+      icon: null,
+      agent: "claude",
+      status: "ready",
+      archived: true,
+      pinned: false,
+      updatedAt: 43,
+    });
+    __setPanelBridgeForTests({ mutateTask } as never);
+
+    const snapshot = await mutateTaskForCore("core-a", {
+      op: "update",
+      taskId: "t1",
+      archived: true,
+    });
+
+    expect(mutateTask).toHaveBeenCalledWith("core-a", {
+      op: "update",
+      taskId: "t1",
+      archived: true,
+    });
+    expect(apiCalls).toEqual([]);
+    expect(snapshot?.archived).toBe(true);
+  });
+
+  it("archives a Panel-owned row over the archive endpoint", async () => {
+    const snapshot = await mutateTaskForCore(null, {
+      op: "update",
+      taskId: "t1",
+      archived: true,
+    });
+
+    expect(apiCalls).toEqual(["archive:t1"]);
+    expect(snapshot?.archived).toBe(true);
+  });
+
+  it("restores a Panel-owned row over the restore endpoint", async () => {
+    const snapshot = await mutateTaskForCore(null, {
+      op: "update",
+      taskId: "t1",
+      archived: false,
+    });
+
+    expect(apiCalls).toEqual(["restore:t1"]);
+    expect(snapshot?.archived).toBe(false);
+  });
+
+  it("applies title/pinned before flipping archived on a Panel-owned row", async () => {
+    await mutateTaskForCore(null, {
+      op: "update",
+      taskId: "t1",
+      title: "Renamed",
+      archived: true,
+    });
+
+    expect(apiCalls).toEqual(["update:t1", "archive:t1"]);
+    expect(updateTask).toHaveBeenCalledWith("t1", { title: "Renamed" });
+  });
+
+  it("leaves a patch without archived on the update endpoint alone", async () => {
+    await mutateTaskForCore(null, { op: "update", taskId: "t1", pinned: true });
+
+    expect(apiCalls).toEqual(["update:t1"]);
+    expect(updateTask).toHaveBeenCalledWith("t1", { pinned: true });
+  });
+
+  it("reports a missing Panel-owned row as null", async () => {
+    archiveTask.mockResolvedValue({ task: null });
+
+    expect(
+      await mutateTaskForCore(null, { op: "update", taskId: "gone", archived: true }),
+    ).toBeNull();
+  });
+});

--- a/packages/panel/src/lib/archive-session.ts
+++ b/packages/panel/src/lib/archive-session.ts
@@ -22,6 +22,11 @@ type CloseSessionFn = (
  * `activateTaskId` is handed to `close` so the caller can promote a replacement
  * session to active (e.g. the grid activating the closed cell's neighbour);
  * it defaults to null, which leaves the project with no active session.
+ *
+ * For a Core-owned session this is one-way from the UI: the flag flips in the
+ * Core's SQLite, but `queryTasks` selects `WHERE archived = 0`, so the row
+ * leaves the grid and never reappears under Archived to restore from. See the
+ * note on `archiveTasks` in projects.$id.tsx.
  */
 export async function archiveOpenSession(
   session: OpenTerminal,

--- a/packages/panel/src/lib/archive-session.ts
+++ b/packages/panel/src/lib/archive-session.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { api } from "~/lib/api";
+import { mutateTaskForCore } from "~/lib/mutate-task-for-core";
 import type { OpenTerminal } from "~/lib/terminal-store";
 import { queryKeys } from "~/queries";
 
@@ -32,7 +32,14 @@ export async function archiveOpenSession(
   await close(session.taskId, {
     activateTaskId: opts?.activateTaskId ?? null,
   }).catch(() => undefined);
-  await api.archiveTask(session.taskId);
+  // The row lives in the owning Core's database (ADR 0004/0005), so the flip
+  // rides the panel link to that Core — the Panel's own HTTP API has no such
+  // row and would 404. `session.coreId` is null for a Panel-owned row.
+  await mutateTaskForCore(session.coreId, {
+    op: "update",
+    taskId: session.taskId,
+    archived: true,
+  });
   if (!opts?.skipInvalidate) await invalidateSessionQueries(queryClient, [session]);
 }
 

--- a/packages/panel/src/lib/mutate-task-for-core.ts
+++ b/packages/panel/src/lib/mutate-task-for-core.ts
@@ -46,8 +46,12 @@ async function mutatePanelLocalTask(
   // their own endpoints because flipping the flag also clears the pending
   // question and emits `task:archived`/`task:restored`. Apply the plain
   // columns first, then flip archived, so the returned snapshot carries both.
-  const archiveOnly = mutation.archived !== undefined && Object.keys(patch).length === 0;
-  let task = archiveOnly ? null : (await api.updateTask(mutation.taskId, patch)).task;
+  // An archive-only patch skips the PATCH round trip; an empty patch with no
+  // archived flag still goes through it, so a no-op mutation returns the row.
+  let task =
+    Object.keys(patch).length > 0 || mutation.archived === undefined
+      ? (await api.updateTask(mutation.taskId, patch)).task
+      : null;
   if (mutation.archived !== undefined) {
     const flipped = mutation.archived
       ? await api.archiveTask(mutation.taskId)

--- a/packages/panel/src/lib/mutate-task-for-core.ts
+++ b/packages/panel/src/lib/mutate-task-for-core.ts
@@ -19,7 +19,8 @@ import { api } from "~/lib/api";
  *
  * A null `coreId` names a row in the Panel's own database — the last rows not
  * owned by a Core — and is written over the Panel's HTTP API instead. That
- * arm disappears with those rows.
+ * arm disappears with those rows. It understands `title`, `pinned`, and
+ * `archived`; anything else on the patch is dropped.
  */
 export async function mutateTaskForCore(
   coreId: string | null | undefined,
@@ -37,10 +38,22 @@ async function mutatePanelLocalTask(
   if (mutation.op !== "update") {
     throw new Error(`cannot ${mutation.op} a task that no Core owns`);
   }
-  const { task } = await api.updateTask(mutation.taskId, {
+  const patch = {
     ...(mutation.title !== undefined ? { title: mutation.title } : {}),
     ...(mutation.pinned !== undefined ? { pinned: mutation.pinned } : {}),
-  });
+  };
+  // `archived` is not a column the PATCH route accepts: archive/restore are
+  // their own endpoints because flipping the flag also clears the pending
+  // question and emits `task:archived`/`task:restored`. Apply the plain
+  // columns first, then flip archived, so the returned snapshot carries both.
+  const archiveOnly = mutation.archived !== undefined && Object.keys(patch).length === 0;
+  let task = archiveOnly ? null : (await api.updateTask(mutation.taskId, patch)).task;
+  if (mutation.archived !== undefined) {
+    const flipped = mutation.archived
+      ? await api.archiveTask(mutation.taskId)
+      : await api.restoreTask(mutation.taskId);
+    task = flipped.task;
+  }
   if (!task) return null;
   return {
     taskId: task.id,

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -1460,6 +1460,15 @@ function ProjectPage() {
   // Archive one or more active sessions: kill each tty, flip the archived flag,
   // and repoint the terminal panel if the active session is being archived.
   // No confirmation — archiving is reversible via Restore.
+  //
+  // That last sentence holds for a Panel-owned row only. On a Core-owned
+  // project the flag flips in the Core's SQLite (the data is safe), but
+  // `queryTasks` selects `WHERE archived = 0` — "archived rows never cross the
+  // core-link" (packages/shared/src/core-query.ts) — so the row simply stops
+  // being listed: it never appears under Archived and there is nothing to
+  // Restore or Delete-all-archived from. Archive is a one-way hide there until
+  // the core-link can list archived rows (e.g. an `includeArchived` on
+  // `tasksList`); issue #18.
   const archiveTasks = (targets: Task[]) => {
     if (!project || targets.length === 0) return;
     const ids = new Set(targets.map((t) => t.id));
@@ -1546,6 +1555,11 @@ function ProjectPage() {
     }
   };
 
+  // Un-archive one session. Routed by owner like every other task mutation,
+  // but reachable today only for a Panel-owned row: the Archived list is built
+  // from `tasks`, and a Core never sends an archived row over the link (see
+  // archiveTasks above). The routing is here so restore works the moment the
+  // core-link starts listing them — not because a Core row can reach it now.
   const restoreSession = (taskId: string) => {
     if (!project) return;
     const task = tasks.find((t) => t.id === taskId);
@@ -1579,6 +1593,11 @@ function ProjectPage() {
     onTogglePinned: toggleSessionPinned,
   };
 
+  // Delete every archived row shown for this project. Still on the Panel's own
+  // delete endpoint, which is sound only because the rows it can see are
+  // Panel-owned — a Core's archived rows never reach `tasks` (see
+  // archiveTasks). Whoever teaches the core-link to list them owes this
+  // function a `mutateTaskForCore` route too, or it will 404 the way archive did.
   const deleteAllArchived = () => {
     setConfirmDeleteArchived(false);
     if (!project) return;

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -1493,7 +1493,13 @@ function ProjectPage() {
                 t.id === activeTaskId ? { activateTaskId: next?.id ?? null } : undefined,
               )
               .catch(() => undefined);
-            await api.archiveTask(t.id);
+            // Route to the Core that owns the row (ADR 0005) — the Panel's
+            // own archive endpoint only knows Panel-owned rows.
+            await mutateTaskForCore(coreId, {
+              op: "update",
+              taskId: t.id,
+              archived: true,
+            });
           }),
         );
         void refresh();
@@ -1552,7 +1558,7 @@ function ProjectPage() {
 
     void (async () => {
       try {
-        await api.restoreTask(taskId);
+        await mutateTaskForCore(coreId, { op: "update", taskId, archived: false });
         void refresh();
       } catch (e: unknown) {
         if (previousTasks) {


### PR DESCRIPTION
Closes #18.

## What was wrong

`POST /api/tasks/:id/archive` 404'd for every Core-owned session. Under ADR
0004/0005 a Core-owned task row lives in that Harness's SQLite and is never
written to the Panel's database, so the Panel's own archive handler could only
miss the row. Every other task mutation (title, pin, icon, status) already
dispatches through `mutateTaskForCore`; archive and restore did not.

## The change

Both client call sites now route through the dispatcher, on the `update` op's
existing `archived` flag:

- `archiveOpenSession` uses the session's own `coreId` — `OpenTerminal` already
  carries it, so no signature change was needed.
- `archiveTasks` and `restoreSession` in `projects.$id.tsx` use the project's
  `coreId`, already in scope.

The Panel-local arm of `mutateTaskForCore` forwarded only `title` and `pinned`
and silently dropped `archived`, so it would have no-op'd for the remaining
Panel-owned rows. It now flips the flag over the archive/restore endpoints
rather than the PATCH route — PATCH has no such column, and its service skips
the pending-question clear and the `task:archived`/`task:restored` events.

Covers all the entry points the issue names: the per-session archive/close (X)
button, the grid cell close, "Archive finished / disconnected", and "Archive
all" in the grid.

## Tests

New: `mutate-task-for-core.test.ts` (Core-owned archive rides the panel link and
never touches the HTTP API; Panel-owned archive/restore hit their endpoints;
combined patches ordered; missing row reports null) and `archive-session.test.ts`
(routes on the session's `coreId`, archives even when the PTY close fails,
rethrows so the caller can toast).

Full suite green: 2190 tests. Typecheck clean; lint unchanged (0 errors).

## Noted, not fixed

Three things surfaced in review that are outside this issue:

- The optimistic cache writes in `projects.$id.tsx` (archive, restore, pin,
  delete) use the untagged `queryKeys.tasks(projectId)`, while the query reads
  from `tasksCacheKey(projectId, coreId)`. For a Core-owned project the
  optimistic flip and its rollback land in a bucket nothing reads, so the card
  moves only once `refresh()` lands. Affects several mutations, not just
  archive.
- The Core arm sends `op: "update"`, so the Core emits `task:updated` rather
  than a dedicated archived event. Nothing is lost today — the Core has no
  pending-question concept and no `task:archived` kind on the core-link — but
  it is a divergence from the Panel-local path worth knowing about.

- **Archive is one-way for a Core-owned row.** `queryTasks` selects
  `WHERE archived = 0` (`packages/shared/src/core-query.ts`), so a Core's
  archived rows never cross the link. The flag flips safely in the Core's
  SQLite, but the card leaves the list instead of moving to Archived — and
  restore and "Delete all archived" cannot reach it, so the restore routing
  this PR adds is currently only exercised by Panel-owned rows. Exposing them
  (e.g. an `includeArchived` on `tasksList`) is the follow-up; until then the
  behavior is documented at the four call sites that assumed reversibility
  (7efaad7), rather than left as an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
