### PR TITLE
test(shared): pin the verifier clock in the bearer exp-boundary cases

### DIFF
--- a/packages/shared/src/__tests__/core-link-bearer.test.ts
+++ b/packages/shared/src/__tests__/core-link-bearer.test.ts
@@ -97,12 +97,23 @@ describe("core-link bearer", () => {
     });
   });
 
-  describe("exp clock-skew tolerance", () => {
+  describe("exp boundary", () => {
+    // Pin the verifier's clock via `opts.now` — reading Date.now() twice lets
+    // the millisecond tick between sign and verify, which fails the inclusive
+    // boundary on a loaded CI runner.
     it("accepts a bearer exp exactly now (boundary inclusive)", () => {
       const exp = Date.now();
       const token = signBearer({ coreId: "core_abc", exp }, SECRET);
-      const result = verifyBearer(token, SECRET);
+      const result = verifyBearer(token, SECRET, { now: exp });
       expect(result.ok).toBe(true);
+    });
+
+    it("rejects a bearer 1ms past exp", () => {
+      const exp = Date.now();
+      const token = signBearer({ coreId: "core_abc", exp }, SECRET);
+      const result = verifyBearer(token, SECRET, { now: exp + 1 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("expired");
     });
   });
 });


### PR DESCRIPTION
## The flake

`core-link bearer > exp clock-skew tolerance > accepts a bearer exp exactly now (boundary inclusive)` reads `Date.now()` twice — once to mint `exp`, and again inside `verifyBearer` when `opts.now` is omitted. When the millisecond ticks between the two reads (easy on a loaded CI runner — there's JSON, base64 and an HMAC in the gap), `exp` lands 1ms in the past and the inclusive-boundary assertion fails. It has bitten at least twice: once on PR #86's Unit Tests run, once during that PR's local pre-flight.

## The fix

`verifyBearer` already takes an injectable `now` documented as being for tests — the boundary case now pins it to `exp`, making the test deterministic. A companion case pins the exclusive side (`now: exp + 1` → `expired`), which the suite previously didn't cover.

The describe block also drops its "clock-skew tolerance" name: the implementation has no tolerance window, only an inclusive boundary, and the name shouldn't claim otherwise.

## Checks

- `vitest run` in `packages/shared` — 162/162 passing, 12/12 in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)