### PR TITLE
ci: retire GHCR — Docker Hub is the only container registry (ADR 0018)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -97,7 +97,7 @@ body:
         both sides if the two are on different machines.
       render: shell
       placeholder: |
-        Panel:   ghcr.io/actana/panel:0.1.0, docker compose behind my own nginx
+        Panel:   actana/panel:0.1.0, docker compose behind my own nginx
         Core:    Ubuntu 24.04 x64, installed via install.sh, systemd user unit
         Browser: Firefox 141
         Harness: claude 2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: read
     with:
       image: panel
       ref: ${{ github.sha }}
@@ -461,7 +460,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: read
     with:
       image: core
       ref: ${{ github.sha }}
@@ -484,10 +482,10 @@ jobs:
   # property of a version tag.
   #
   # They are separate jobs from the two above, rather than the same jobs with
-  # conditional inputs, because `permissions:` takes no expression and a caller
-  # that asks for `packages: write` fails at startup where the token cannot be
-  # granted it — a fork's PR. The two sets are mutually exclusive on
-  # `github.event_name`, so no single run ever builds an image twice.
+  # conditional inputs, because the ruleset pins the PR jobs' check names, and
+  # a job that sometimes pushes is a job whose green means two different
+  # things. The two sets are mutually exclusive on `github.event_name`, so no
+  # single run ever builds an image twice.
   #
   # `!= 'pull_request'` rather than `== 'push'`, so `workflow_dispatch`
   # republishes `:edge` the way images-edge.yml's own dispatch did.
@@ -510,7 +508,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: write
     secrets: inherit
     with:
       image: panel
@@ -526,7 +523,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: write
     secrets: inherit
     with:
       image: core

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -18,16 +18,16 @@ name: Container image
 # per-architecture Core tarball — emulating either under QEMU is slow and
 # proves the wrong machine.
 #
-# Registries. GHCR always, authenticated with the workflow's own `github.token`,
-# which GHCR accepts for packages owned by this repository. Docker Hub *as well*
-# whenever the DOCKERHUB_TOKEN secret is set — absent it, every Docker Hub step
-# is skipped and the run still succeeds on GHCR alone. That gating is what lets
-# a fork build and release without any Docker Hub account. See docs/ci-cd.md.
+# Registry. Docker Hub only (ADR 0018 — GHCR was retired): the image name is
+# docker.io/<DOCKERHUB_NAMESPACE or repo owner>/<image>. A non-pushing build —
+# `push: false`, the PR path — needs no credentials at all; a pushing build
+# requires DOCKERHUB_USERNAME / DOCKERHUB_TOKEN and fails in `resolve`, before
+# anything is built, when they are missing. See docs/ci-cd.md.
 #
 # No `permissions:` block here on purpose. A reusable workflow may not request
-# more than its caller granted — declaring `packages: write` made the PR build
-# in ci.yml, which needs only `read`, fail at startup. The callers set what they
-# need: `write` for the edge and release paths, `read` for the PR build.
+# more than its caller granted, and nothing here needs more than `contents:
+# read` — Docker Hub authenticates with repository secrets, not the workflow's
+# own token.
 
 on:
   workflow_call:
@@ -70,17 +70,17 @@ jobs:
     name: Resolve registries
     runs-on: ubuntu-24.04
     outputs:
-      ghcr: ${{ steps.registries.outputs.ghcr }}
-      dockerhub: ${{ steps.registries.outputs.dockerhub }}
-      images: ${{ steps.registries.outputs.images }}
+      image: ${{ steps.registry.outputs.image }}
     steps:
-      - id: registries
+      - id: registry
         env:
           OWNER: ${{ github.repository_owner }}
           IMAGE: ${{ inputs.image }}
+          PUSH: ${{ inputs.push }}
           # A repository variable, so a fork publishing under a different
           # Docker Hub org doesn't have to edit this file.
           DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -89,22 +89,24 @@ jobs:
             *) echo "unknown image '$IMAGE' — expected 'panel' or 'core'" >&2; exit 1 ;;
           esac
 
-          # GHCR requires a lowercase namespace.
-          ghcr="ghcr.io/${OWNER,,}/${IMAGE}"
-          echo "ghcr=$ghcr" >> "$GITHUB_OUTPUT"
+          # Docker Hub requires a lowercase namespace.
+          namespace="${DOCKERHUB_NAMESPACE:-${OWNER,,}}"
+          image="docker.io/${namespace,,}/${IMAGE}"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
 
-          images="$ghcr"
-          if [[ -n "$DOCKERHUB_TOKEN" ]]; then
-            namespace="${DOCKERHUB_NAMESPACE:-${OWNER,,}}"
-            dockerhub="docker.io/${namespace,,}/${IMAGE}"
-            echo "dockerhub=$dockerhub" >> "$GITHUB_OUTPUT"
-            images="$images $dockerhub"
-            echo "Publishing to GHCR and Docker Hub ($dockerhub)."
-          else
-            echo "dockerhub=" >> "$GITHUB_OUTPUT"
-            echo "DOCKERHUB_TOKEN is not set — publishing to GHCR only."
+          # A missing credential is decided here, before anything is built —
+          # unlike a *broken* one, it costs nothing to catch early. Docker Hub
+          # is the only registry, so a pushing build without credentials has
+          # nowhere to publish at all.
+          if [[ "$PUSH" == "true" && ( -z "$DOCKERHUB_TOKEN" || -z "$DOCKERHUB_USERNAME" ) ]]; then
+            echo "::error title=Missing Docker Hub credential::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must both be set to publish $image — Docker Hub is the only registry images are published to (ADR 0018). One personal access token (Read & Write) serves both the image push and the description sync. See docs/REPO_SETUP.md section 2."
+            exit 1
           fi
-          echo "images=$images" >> "$GITHUB_OUTPUT"
+          if [[ "$PUSH" == "true" ]]; then
+            echo "Publishing to $image."
+          else
+            echo "Build and smoke only ($image, no push)."
+          fi
 
   build:
     name: Build + smoke (${{ matrix.arch }})
@@ -131,7 +133,7 @@ jobs:
       - name: Build the Panel image
         if: inputs.image == 'panel'
         env:
-          IMAGE: ${{ needs.resolve.outputs.ghcr }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
           REPO: ${{ github.repository }}
@@ -149,7 +151,7 @@ jobs:
       - name: Smoke — boots, sets up, survives container recreation
         if: inputs.image == 'panel'
         env:
-          IMAGE: ${{ needs.resolve.outputs.ghcr }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
         run: node scripts/smoke-panel-image.mjs --image "$IMAGE:$STAGE-$ARCH" --skip-build
@@ -183,7 +185,7 @@ jobs:
       - name: Build the Core image
         if: inputs.image == 'core'
         env:
-          IMAGE: ${{ needs.resolve.outputs.ghcr }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
           REPO: ${{ github.repository }}
@@ -222,7 +224,7 @@ jobs:
       - name: Smoke — the image boots unprivileged and a Panel pairs with it
         if: inputs.image == 'core'
         env:
-          IMAGE: ${{ needs.resolve.outputs.ghcr }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
         run: |
@@ -259,7 +261,7 @@ jobs:
       - name: Trivy — fixable CRITICAL/HIGH gate
         if: always() && inputs.image == 'core'
         env:
-          IMAGE: ${{ needs.resolve.outputs.ghcr }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
           TRIVY_VERSION: 0.73.0
@@ -296,47 +298,21 @@ jobs:
       - name: Push the per-arch tags
         if: inputs.push
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_ACTOR: ${{ github.actor }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          GHCR_IMAGE: ${{ needs.resolve.outputs.ghcr }}
-          IMAGES: ${{ needs.resolve.outputs.images }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
-          echo "$GH_TOKEN" | docker login ghcr.io --username "$GH_ACTOR" --password-stdin
-
-          # GHCR is the primary registry and it has already authenticated, so a
-          # Docker Hub credential problem must not take the release down with
-          # it: push what we can, then fail at the end with the reason. Failing
-          # here instead would leave GHCR unpublished because a *mirror* was
-          # misconfigured.
-          dockerhub_ok=1
-          if [[ -n "$DOCKERHUB_TOKEN" ]]; then
-            if ! echo "$DOCKERHUB_TOKEN" | docker login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin; then
-              dockerhub_ok=0
-              echo "::error title=Docker Hub login failed::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN were rejected. The username depends on which kind of token you made. ORGANISATION access token (created under the org, app.docker.com/accounts/<org>): DOCKERHUB_USERNAME must be the ORGANISATION NAME — an OAT authenticates as the org, not as the person who created it, and OATs need a Team or Business subscription. PERSONAL access token (Account settings > Personal access tokens): DOCKERHUB_USERNAME is your own username, and that account needs push rights on the target repos. Either way the token needs Read & Write, and an account password will never work. GHCR was published; Docker Hub was not."
-            fi
+          # A broken credential fails here, before any tag is pushed — with
+          # one registry there is no mirror posture to soften it, and nothing
+          # has been half-published yet.
+          if ! echo "$DOCKERHUB_TOKEN" | docker login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin; then
+            echo "::error title=Docker Hub login failed::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN were rejected. The username depends on which kind of token you made. ORGANISATION access token (created under the org, app.docker.com/accounts/<org>): DOCKERHUB_USERNAME must be the ORGANISATION NAME — an OAT authenticates as the org, not as the person who created it, and OATs need a Team or Business subscription. PERSONAL access token (Account settings > Personal access tokens): DOCKERHUB_USERNAME is your own username, and that account needs push rights on the target repos. Either way the token needs Read & Write, and an account password will never work."
+            exit 1
           fi
-
-          for image in $IMAGES; do
-            if [[ "$image" == docker.io/* && "$dockerhub_ok" -eq 0 ]]; then
-              echo "Skipping $image — Docker Hub login failed."
-              continue
-            fi
-            # The image was built under the GHCR name; retag for any other registry.
-            if [[ "$image" != "$GHCR_IMAGE" ]]; then
-              docker tag "$GHCR_IMAGE:$STAGE-$ARCH" "$image:$STAGE-$ARCH"
-            fi
-            docker push "$image:$STAGE-$ARCH"
-          done
-
-          # Deliberately not `exit 1` here: the publish job needs this one to
-          # succeed, and failing now would leave GHCR with per-arch tags and no
-          # manifest. The run is failed at the end of publish instead, once
-          # GHCR is completely published.
+          docker push "$IMAGE:$STAGE-$ARCH"
 
   publish:
     name: Publish the multi-arch manifest
@@ -346,11 +322,9 @@ jobs:
     steps:
       - name: Stitch per-arch tags into the release tags
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_ACTOR: ${{ github.actor }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          IMAGES: ${{ needs.resolve.outputs.images }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
           IMAGE_KIND: ${{ inputs.image }}
           MATRIX: ${{ inputs.matrix }}
           STAGE: ${{ inputs.stage }}
@@ -361,17 +335,9 @@ jobs:
             echo "no tags requested for a pushing build" >&2
             exit 1
           fi
-          echo "$GH_TOKEN" | docker login ghcr.io --username "$GH_ACTOR" --password-stdin
-
-          # Same posture as the build job: GHCR is finished no matter what
-          # Docker Hub does, and the run is failed at the very end if Docker
-          # Hub was configured but unusable.
-          dockerhub_ok=1
-          if [[ -n "$DOCKERHUB_TOKEN" ]]; then
-            if ! echo "$DOCKERHUB_TOKEN" | docker login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin; then
-              dockerhub_ok=0
-              echo "::error title=Docker Hub login failed::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN were rejected. DOCKERHUB_USERNAME must be the Docker Hub *account* that owns the access token — not the organisation name. If you publish under an org, set DOCKERHUB_USERNAME to your user account and DOCKERHUB_NAMESPACE to the org. The token needs Read & Write. GHCR was published; Docker Hub was not."
-            fi
+          if ! echo "$DOCKERHUB_TOKEN" | docker login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin; then
+            echo "::error title=Docker Hub login failed::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN were rejected between the per-arch push and the manifest stitch. The per-arch tags are on Docker Hub; the release tags are not. Re-run this job once the credentials are fixed."
+            exit 1
           fi
 
           # The arch list comes from the same matrix the build job used, so a
@@ -379,63 +345,54 @@ jobs:
           # than referencing a tag that was never pushed.
           arches="$(echo "$MATRIX" | jq -r '.include[].arch' | tr '\n' ' ')"
 
-          for image in $IMAGES; do
-            if [[ "$image" == docker.io/* && "$dockerhub_ok" -eq 0 ]]; then
-              echo "Skipping $image — Docker Hub login failed."
-              continue
-            fi
-            sources=()
-            for arch in $arches; do sources+=("$image:$STAGE-$arch"); done
-            tag_args=()
-            for tag in $TAGS; do tag_args+=(--tag "$image:$tag"); done
-            docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-            primary="$image:${TAGS%% *}"
-            docker buildx imagetools inspect "$primary"
+          sources=()
+          for arch in $arches; do sources+=("$IMAGE:$STAGE-$arch"); done
+          tag_args=()
+          for tag in $TAGS; do tag_args+=(--tag "$IMAGE:$tag"); done
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          primary="$IMAGE:${TAGS%% *}"
+          docker buildx imagetools inspect "$primary"
 
-            # The Panel's HEALTHCHECK is a Docker extension to the OCI image
-            # config, and a builder is free to drop it: podman does exactly
-            # that, silently, without --format docker (ADR 0016 D23). The
-            # build job already proved it on the per-arch image *before* that
-            # image was pushed, which is the gate that can actually stop a
-            # publish. This second check covers what that one cannot see —
-            # the stitched manifest is a different artifact, assembled after
-            # the per-arch tags exist — so it fails the run loudly rather
-            # than leaving a healthcheck-less image tagged :latest unnoticed.
-            #
-            # Read back by pulling each platform and asking the *daemon* for
-            # the config, which is the same reader `smoke-panel-image.mjs` uses
-            # before the push and the only one proven to answer this question.
-            #
-            # Not `imagetools inspect --format '{{json .Image}}'`, which is what
-            # this gate used and what made it red on run 30912583589: it
-            # reported MISSING for linux/amd64 and linux/arm64 on an image that
-            # had the healthcheck. It had it before the push — the per-arch
-            # smoke asserts exactly this and was green on both arches — and
-            # `imagetools create` stitches an index over the existing per-arch
-            # manifests without rewriting a config blob, so nothing between the
-            # two could have removed it. What that format renders is a Go
-            # struct, and the field is a Docker extension the struct need not
-            # carry. A reader that cannot represent the answer is not evidence
-            # of a missing healthcheck; it is a broken question.
-            #
-            # Second reason to leave that path, observed locally against the
-            # published image but not in CI: `{{json}}` there emitted the
-            # backtick in the HEALTHCHECK's template literal as `\``, which is
-            # not a valid JSON escape, and jq rejected the document outright.
-            # The daemon's own encoder emits the backtick literally.
-            if [[ "$IMAGE_KIND" == panel ]]; then
-              for arch in $arches; do
-                docker pull --quiet --platform "linux/$arch" "$primary" >/dev/null
-                healthcheck="$(docker image inspect --format '{{json .Config.Healthcheck}}' "$primary")"
-                if ! jq -e '(.Test // []) | join(" ") | contains("/nodejs/bin/node")' \
-                     >/dev/null <<<"$healthcheck"; then
-                  echo "::error title=Published image has no healthcheck::$primary at linux/$arch is missing the /nodejs/bin/node HEALTHCHECK. The builder dropped it between the per-arch build and the manifest. Config.Healthcheck was $healthcheck" >&2
-                  exit 1
-                fi
-                echo "  $primary at linux/$arch carries its healthcheck"
-              done
-            fi
-          done
-
-          # Configured but broken is a failure — just not one that costs GHCR.
-          [[ "$dockerhub_ok" -eq 1 ]] || exit 1
+          # The Panel's HEALTHCHECK is a Docker extension to the OCI image
+          # config, and a builder is free to drop it: podman does exactly
+          # that, silently, without --format docker (ADR 0016 D23). The
+          # build job already proved it on the per-arch image *before* that
+          # image was pushed, which is the gate that can actually stop a
+          # publish. This second check covers what that one cannot see —
+          # the stitched manifest is a different artifact, assembled after
+          # the per-arch tags exist — so it fails the run loudly rather
+          # than leaving a healthcheck-less image tagged :latest unnoticed.
+          #
+          # Read back by pulling each platform and asking the *daemon* for
+          # the config, which is the same reader `smoke-panel-image.mjs` uses
+          # before the push and the only one proven to answer this question.
+          #
+          # Not `imagetools inspect --format '{{json .Image}}'`, which is what
+          # this gate used and what made it red on run 30912583589: it
+          # reported MISSING for linux/amd64 and linux/arm64 on an image that
+          # had the healthcheck. It had it before the push — the per-arch
+          # smoke asserts exactly this and was green on both arches — and
+          # `imagetools create` stitches an index over the existing per-arch
+          # manifests without rewriting a config blob, so nothing between the
+          # two could have removed it. What that format renders is a Go
+          # struct, and the field is a Docker extension the struct need not
+          # carry. A reader that cannot represent the answer is not evidence
+          # of a missing healthcheck; it is a broken question.
+          #
+          # Second reason to leave that path, observed locally against the
+          # published image but not in CI: `{{json}}` there emitted the
+          # backtick in the HEALTHCHECK's template literal as `\``, which is
+          # not a valid JSON escape, and jq rejected the document outright.
+          # The daemon's own encoder emits the backtick literally.
+          if [[ "$IMAGE_KIND" == panel ]]; then
+            for arch in $arches; do
+              docker pull --quiet --platform "linux/$arch" "$primary" >/dev/null
+              healthcheck="$(docker image inspect --format '{{json .Config.Healthcheck}}' "$primary")"
+              if ! jq -e '(.Test // []) | join(" ") | contains("/nodejs/bin/node")' \
+                   >/dev/null <<<"$healthcheck"; then
+                echo "::error title=Published image has no healthcheck::$primary at linux/$arch is missing the /nodejs/bin/node HEALTHCHECK. The builder dropped it between the per-arch build and the manifest. Config.Healthcheck was $healthcheck" >&2
+                exit 1
+              fi
+              echo "  $primary at linux/$arch carries its healthcheck"
+            done
+          fi

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -321,7 +321,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: write
     secrets: inherit
     with:
       image: core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,22 +32,13 @@ name: Release
 # raw.githubusercontent.com/actana/control/main/install.sh, so a broken
 # installer is fixable without cutting a release.
 #
-# ── Two things that must not be "fixed" later ────────────────────────────────
+# ── The registry posture ─────────────────────────────────────────────────────
 #
-# 1. GHCR is pushed first and must complete, even though Docker Hub is the
-#    "primary" registry (D32). Primary means the canonical place a user is told
-#    to pull from, not the publish order. GHCR authenticates with the
-#    workflow's own `github.token` and therefore *cannot* fail on credentials,
-#    which is exactly why it goes first. Do not reorder the pushes to match the
-#    word.
-#
-# 2. Present-but-broken Docker Hub credentials publish GHCR completely — per-arch
-#    tags *and* manifest — and then fail the run at the very end (D31, and see
-#    container-image.yml, which is where that happens). Failing early would
-#    strand GHCR with per-arch tags and no manifest.
-#
-# A *missing* credential is the other case, and it is decided here in `resolve`
-# before anything is built: fatal on actana/control, skipped on a fork.
+# Docker Hub is the only registry (ADR 0018 — GHCR was retired). A *missing*
+# credential is decided here in `resolve` before anything is built: fatal, on
+# any repo, because there is no longer a registry that authenticates for free.
+# A present-but-*broken* credential fails at the `docker login` in
+# container-image.yml, before any tag is pushed.
 
 on:
   push:
@@ -114,20 +105,18 @@ jobs:
             echo "tags=$version latest" >> "$GITHUB_OUTPUT"
           fi
 
-      # D31. A fork has no Docker Hub account and must still be able to cut a
-      # release to GHCR alone — but on the repo whose docs tell people to
-      # `docker pull docker.io/actana/…`, a release that never reached the
-      # primary registry must not report success. Same one PAT serves both the
-      # `docker login` in container-image.yml and the description API below:
-      # an organization access token can push images but answers "Cannot log
-      # into an organization account" on POST /v2/users/login, so it would mean
-      # paying for Team or Business *and still* provisioning a PAT.
+      # D31, amended by ADR 0018: Docker Hub is the only registry, so missing
+      # credentials mean the images have nowhere to go — on any repo, fork or
+      # not. The same one PAT serves both the `docker login` in
+      # container-image.yml and the description API below: an organization
+      # access token can push images but answers "Cannot log into an
+      # organization account" on POST /v2/users/login, so it would mean paying
+      # for Team or Business *and still* provisioning a PAT.
       #
       # Checked before anything is built, deliberately — unlike a *broken*
       # credential, a missing one costs nothing to catch early.
-      - name: Require Docker Hub credentials on the canonical repo
+      - name: Require Docker Hub credentials
         env:
-          REPO: ${{ github.repository }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
@@ -135,11 +124,7 @@ jobs:
           if [[ -n "$DOCKERHUB_TOKEN" && -n "$DOCKERHUB_USERNAME" ]]; then
             exit 0
           fi
-          if [[ "$REPO" != "actana/control" ]]; then
-            echo "::notice title=Docker Hub skipped::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN are not set on $REPO. Publishing to GHCR only."
-            exit 0
-          fi
-          echo "::error title=Missing Docker Hub credential::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must both be set on actana/control — Docker Hub is the registry the docs tell operators to pull from, so a release that reaches GHCR alone is not a release. One personal access token (Read & Write, from an account with Admin on the org) serves both the image push and the description sync. See docs/REPO_SETUP.md section 2."
+          echo "::error title=Missing Docker Hub credential::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must both be set — Docker Hub is the only registry the images are published to, so a release without them is not a release. One personal access token (Read & Write, from an account with Admin on the org) serves both the image push and the description sync. See docs/REPO_SETUP.md section 2."
           exit 1
 
   tarball:
@@ -284,7 +269,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: write
     secrets: inherit
     with:
       image: panel
@@ -299,7 +283,6 @@ jobs:
     uses: ./.github/workflows/container-image.yml
     permissions:
       contents: read
-      packages: write
     secrets: inherit
     with:
       image: core
@@ -379,8 +362,8 @@ jobs:
   # Docker Hub does not pull a README from GitHub on its own — the repository
   # description is a field you PATCH through its API. This syncs one file per
   # image, so `actana/panel` and `actana/core` each get their own page rather
-  # than sharing the source repo's README (which is what GHCR shows, and which
-  # describes the project rather than either image).
+  # than sharing the source repo's README (which describes the project rather
+  # than either image).
   #
   #   docs/images/panel.md → docker.io/<ns>/panel
   #   docs/images/core.md  → docker.io/<ns>/core

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -13,8 +13,8 @@ directory. Back that directory up and you have backed up the Panel.
 
 It ships two equivalent ways:
 
-- a **Docker image**, `ghcr.io/actana/panel` — built by CI on
-  every release
+- a **Docker image**, [`actana/panel`](https://hub.docker.com/r/actana/panel)
+  on Docker Hub — built by CI on every release
 - the same build as a **plain Node process**, for machines where containers
   are unavailable or unwanted
 
@@ -70,7 +70,7 @@ setup is one command:
 docker run -d --name actana-panel \
   -p 127.0.0.1:7420:7420 \
   -v actana-panel-data:/data \
-  ghcr.io/actana/panel:latest
+  actana/panel:latest
 ```
 
 Open `http://localhost:7420`. Binding `127.0.0.1` keeps the plain-HTTP port

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Open `http://localhost:7420`, create the Operator, and paste that blob into
 
 ```bash
 docker run -d -p 127.0.0.1:7420:7420 -v actana-panel-data:/data \
-  ghcr.io/actana/panel:latest
+  actana/panel:latest
 ```
 
 [DEPLOY.md](DEPLOY.md) covers the compose path, the bare `node` path,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ The things this project actually controls:
   the registration blob that establishes it.
 - The **Core** — the daemon, `actana setup`, the installer (`install.sh`),
   and the release tarballs and their checksums.
-- The **published container image**, `ghcr.io/actana/panel`.
+- The **published container image**, [`actana/panel`](https://hub.docker.com/r/actana/panel) on Docker Hub.
 
 ## What is out of scope
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -22,7 +22,7 @@
 # blob, and is never something you supply or renew.
 services:
   panel:
-    image: ghcr.io/actana/panel:latest
+    image: actana/panel:latest
     restart: unless-stopped
     ports:
       # Loopback on purpose: this is plain HTTP. `localhost` is a secure
@@ -45,7 +45,7 @@ services:
   # host`, `tmpfs:` or `init:` — all four belonged to the systemd fixture this
   # replaced, and tini is PID 1 inside the image itself (ADR 0016 D14).
   core:
-    image: ghcr.io/actana/core:latest
+    image: actana/core:latest
     restart: unless-stopped
     environment:
       # The address the Panel dials, and therefore the SAN in this Core's
@@ -82,7 +82,7 @@ services:
 #
 # >>> second Core
 #   core2:
-#     image: ghcr.io/actana/core:latest
+#     image: actana/core:latest
 #     restart: unless-stopped
 #     environment:
 #       - ACTANA_PUBLIC_HOST=core2

--- a/deploy/panel.Dockerfile
+++ b/deploy/panel.Dockerfile
@@ -70,9 +70,9 @@ RUN mkdir -p /staged/data
 # it from a tag name.
 FROM gcr.io/distroless/nodejs24@sha256:2e3b3a96d1d7286c3e4727f9c84b4dc32b6b33e7d7d4425c5a5c8186ad85fa93
 
-# `image.source` is what links the package to its repository on GHCR — without
-# it the package page has no README and no provenance. An ARG rather than a
-# literal so a fork's build links to the fork; CI passes its own values.
+# `image.source` is what links the image back to its repository for
+# `docker image inspect` and any label-reading registry UI. An ARG rather than
+# a literal so a fork's build links to the fork; CI passes its own values.
 # Docker Hub ignores all of this and reads its description from the API
 # instead (the `descriptions` job in .github/workflows/release.yml).
 ARG IMAGE_SOURCE=https://github.com/actana/control

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -33,15 +33,15 @@ Set under **Settings → Secrets and variables → Actions**.
 | `DOCKERHUB_NAMESPACE` | Variable | Docker Hub org to publish under. Optional; defaults to the GitHub owner (`actana`) |
 
 With these set, both images publish to `docker.io/actana/panel` and
-`docker.io/actana/core` alongside their GHCR copies, and each image's Docker Hub
-page is rewritten from `docs/images/`.
+`docker.io/actana/core`, and each image's Docker Hub page is rewritten from
+`docs/images/`.
 
-Nothing else is required: GHCR authenticates with the workflow's own
-`github.token`. On a **fork**, leave the pair unset: every Docker Hub step is
-skipped and releases still publish to GHCR. On **`actana/control`** the same
-gap fails the release before it builds anything — Docker Hub is the registry the
-docs tell operators to pull from, so a release that reached GHCR alone is not a
-release ([ADR 0016](adr/0016-the-0-1-0-shape.md) D31). See [`ci-cd.md`](ci-cd.md).
+Docker Hub is the **only** registry
+([ADR 0018](adr/0018-docker-hub-is-the-only-registry.md) — GHCR was retired),
+so the pair is required wherever images are published: a release or edge build
+without it fails before anything is built. PR builds never push and need no
+credentials, so a fork gets green PRs with nothing set. See
+[`ci-cd.md`](ci-cd.md).
 
 ### It must be a *personal* access token, and one token does both jobs
 
@@ -139,8 +139,6 @@ changelog is assembled from.
       reporting channel
 - [ ] Enable Dependabot alerts + security updates
 - [ ] Enable secret scanning + push protection
-- [ ] Set the GHCR packages `panel` and `core` to **public** once the repo is public,
-      or `docker pull` fails for everyone but org members
 - [ ] After the first release, check that **both Docker Hub pages render** —
       `actana/panel` and `actana/core`. Nothing here is manual: `release.yml`'s
       `descriptions` job PATCHes each page from [`docs/images/`](images/) as

--- a/docs/adr/0018-docker-hub-is-the-only-registry.md
+++ b/docs/adr/0018-docker-hub-is-the-only-registry.md
@@ -1,0 +1,25 @@
+# Docker Hub is the only registry — GHCR is retired
+
+ADR 0016 shipped a two-registry posture: GHCR always (it authenticates with the workflow's own `github.token`, so it cannot fail on credentials), Docker Hub additionally when `DOCKERHUB_TOKEN` is set, with D31/D32 pinning the ordering and failure semantics that posture forces. In practice Docker Hub was always the canonical registry — the one D32 calls "primary", the one the descriptions job curates a page for, the one operators were meant to pull from — while the docs and the compose file still pointed at `ghcr.io`, and the GHCR packages (including a stale `actana-panel` left over from before the images were renamed) sat beside it as an unadvertised copy. Two registries meant two sets of published bytes to reason about, a soft-fail mirror dance in `container-image.yml` whose comments outweighed its code, and a package list on GitHub that had already drifted.
+
+**This ADR retires GHCR entirely.** `container-image.yml` builds under the Docker Hub name and publishes only there; the callers drop `packages:` permissions; the compose file, docs, and issue template say `actana/panel` / `actana/core`; the GHCR packages are deleted from the org. D26's registry inventory shrinks by one, and D31/D32's "must not be fixed later" clauses are superseded — the ordering problem they pinned no longer exists when there is one registry.
+
+The credential posture inverts cleanly:
+
+- A **non-pushing build** (the PR path, `push: false`) needs no credentials, exactly as before.
+- A **missing** credential on a pushing build fails in `resolve`, before anything is built, on any repo — there is no longer a registry that authenticates for free, so "publish to GHCR alone and succeed" is not a state that can exist.
+- A **broken** credential fails at `docker login`, before any tag is pushed. The old soft-fail ("publish GHCR completely, fail at the very end") existed to keep a broken *mirror* from costing the primary; with one registry there is nothing to protect and a hard fail is honest.
+
+## Considered Options
+
+- **Keep GHCR as a mirror (status quo, rejected).** The mirror was doing no work: no deployment pulled from it, the docs that mentioned it contradicted the ADR that called Docker Hub primary, and its existence forced the most convoluted code in the pipeline — the dual-login, soft-fail, stitch-per-registry dance.
+- **Keep GHCR and drop Docker Hub (rejected).** GHCR's free authentication is genuinely convenient, but the Docker Hub org, its curated per-image pages, and operator muscle memory (`actana/panel` with no registry prefix) all point the other way — and Docker Hub is where the pull traffic already is.
+- **Flip the mirror direction — Docker Hub primary, GHCR best-effort (rejected).** Keeps every line of the soft-fail complexity and both package lists, for a copy nobody is told about.
+
+## Consequences
+
+- **Forks can no longer publish images with zero configuration.** The PR path still works untouched, but a fork that wants edge tags or releases must set `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (and usually `DOCKERHUB_NAMESPACE`). This was the one real property GHCR bought; it is traded away knowingly.
+- **The GHCR packages (`panel`, `core`, `actana-panel`) are deleted manually** — the org packages UI, or a token with `read:packages` + `delete:packages`. Anything still pulling `ghcr.io/actana/…` breaks on its next pull; as of this writing nothing is known to.
+- **`packages: write` disappears from every workflow**, shrinking the workflow token's blast radius.
+- The OCI `image.source` / `image.description` labels stay: Docker Hub ignores them, but `docker image inspect` and any label-reading UI still finds the source repository.
+- D26's note that `gcr.io` is a "third registry" now reads as second; the dependency itself is unchanged.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -40,8 +40,8 @@ lookalike pipeline that drifts.
 | `actana/panel` | The Panel web service. **This is the one you deploy.** |
 | `actana/core` | The Core daemon. **A second, supported way to run a Core.** |
 
-Both are published to GHCR (`ghcr.io/actana/…`) and Docker Hub
-(`docker.io/actana/…`) under the same tags.
+Both are published to Docker Hub (`docker.io/actana/…`) — the only registry
+([ADR 0018](adr/0018-docker-hub-is-the-only-registry.md)).
 
 `actana/core` is built from [`../deploy/core.Dockerfile`](../deploy/core.Dockerfile)
 and is a Core you run rather than a machine you install one on: `tini` is PID 1
@@ -54,23 +54,17 @@ Installing on a machine you own — `install.sh` plus `actana setup` plus a user
 service, see [`../INSTALL.md`](../INSTALL.md) — is untouched and equally
 supported. The container is a second distribution, not a replacement.
 
-### Where each registry's description comes from
+### Where each image's description comes from
 
-The two registries work differently, and neither reads a README from GitHub on
-its own:
-
-- **GHCR** links a package to its repository through the
-  `org.opencontainers.image.source` label, and then shows **this repository's
-  README** on the package page. There is no per-package README, so both images
-  show the same project README; the only per-image text is the
-  `org.opencontainers.image.description` label. Both images set these labels at
-  build time.
-- **Docker Hub** ignores those labels and stores its own per-repository
-  description, set through its API. The `descriptions` job in
-  [`release.yml`](../.github/workflows/release.yml) pushes one file per image —
-  [`docs/images/panel.md`](images/panel.md) and
-  [`docs/images/core.md`](images/core.md) — gated on the two publish jobs, so
-  the page never describes a version nobody can pull yet.
+Docker Hub does not read a README from GitHub on its own — it stores its own
+per-repository description, set through its API. The `descriptions` job in
+[`release.yml`](../.github/workflows/release.yml) pushes one file per image —
+[`docs/images/panel.md`](images/panel.md) and
+[`docs/images/core.md`](images/core.md) — gated on the two publish jobs, so
+the page never describes a version nobody can pull yet. (The images also set
+the `org.opencontainers.image.source` / `description` labels at build time;
+Docker Hub ignores them, but `docker image inspect` and any label-reading UI
+finds its way back to the source.)
 
 Edit those two files to change what Docker Hub shows. A typo is fixable without
 cutting a release: merge the fix to `main`, then
@@ -85,10 +79,10 @@ the API endpoint rejects organization ones; see [`REPO_SETUP.md`](REPO_SETUP.md)
 
 The product ships as three things, on one pipeline, from the same tag:
 
-- **The Panel** is a container. `release.yml` → `ghcr.io/actana/panel`
-  (and Docker Hub, when configured). No installer, no signing — the image is
+- **The Panel** is a container. `release.yml` → `docker.io/actana/panel`.
+  No installer, no signing — the image is
   the release artifact ([ADR 0010](adr/0010-panel-becomes-a-self-hosted-web-service.md)).
-- **The Core, as a container** comes from the same workflow → `ghcr.io/actana/core`.
+- **The Core, as a container** comes from the same workflow → `docker.io/actana/core`.
 - **The Core** — the thing a real Core actually runs — is a per-platform
   tarball. `release.yml` → `linux-x64` and `linux-arm64` with published
   checksums, which `install.sh` and `actana update` verify against.
@@ -384,19 +378,17 @@ bumps it and not CI's Node is *meant* to go red there.
 
 ## Registries
 
-**GHCR always.** It authenticates with the workflow's own `github.token`, which
-GHCR accepts for packages owned by this repository. No secret to configure, and
-it works in forks.
+**Docker Hub, and nothing else**
+([ADR 0018](adr/0018-docker-hub-is-the-only-registry.md) — GHCR was retired).
+It authenticates with the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets, so:
 
-**Docker Hub additionally**, whenever the `DOCKERHUB_TOKEN` secret is set. Every
-Docker Hub step is individually gated on that secret being non-empty, so:
-
-- With the keys set → the same manifest is published to both registries.
-- Without them → the run publishes to GHCR alone and still succeeds.
-- With the keys set but **wrong** → GHCR is published *completely* (per-arch
-  tags and manifests), Docker Hub is skipped, and the run then fails with an
-  annotation naming the cause. A misconfigured mirror must not cost you the
-  primary registry, but nor should it pass silently.
+- A **non-pushing build** — the PR path, `push: false` — needs no credentials
+  at all. Forks get green PR builds with zero configuration.
+- A **pushing build with the keys missing** fails in `resolve`, before
+  anything is built: there is nowhere to publish, and a missing credential
+  costs nothing to catch early.
+- A **pushing build with the keys wrong** fails at the `docker login`, before
+  any tag is pushed — nothing is half-published.
 
 If you see `unauthorized: incorrect username or password`, the cause is almost
 always that `DOCKERHUB_USERNAME` does not match the *kind* of token in
@@ -414,17 +406,14 @@ a PAT belonging to a member with push rights is the way in.
 
 An account password never works in place of a token.
 
-That gating is what lets a fork — or this repo before the keys were added —
-build and release without a Docker Hub account. Adding the keys is a settings
-change, not a code change; see [`REPO_SETUP.md`](REPO_SETUP.md) §2.
+The image name is derived, never hardcoded:
+`docker.io/<DOCKERHUB_NAMESPACE or repo owner>/panel`. A fork that sets its
+own keys publishes under its own namespace with no edit to any workflow; see
+[`REPO_SETUP.md`](REPO_SETUP.md) §2.
 
-The image name is derived, never hardcoded: `ghcr.io/<repo owner>/panel`,
-and `docker.io/<DOCKERHUB_NAMESPACE or repo owner>/panel`. A fork
-publishes under its own namespace with no edit to any workflow.
+### `gcr.io` is a second registry, and it is in the build path
 
-### `gcr.io` is a third registry, and it is in the build path
-
-Docker Hub primary and GHCR mirror is a decision about **publishing**. Pulling
+Docker Hub as the sole registry is a decision about **publishing**. Pulling
 the Panel's runtime base from `gcr.io/distroless/nodejs24` is a different thing
 in a different direction: an availability and rate-limit dependency on Google's
 registry, on **every single build** — every PR that touches the Panel image,
@@ -437,25 +426,24 @@ What that means in practice:
 - **When `gcr.io` is down or throttling, the Panel image cannot be built.** Not
   degraded — the `FROM` fails and the job is red. Nothing already published is
   affected: pulling `actana/panel` never touches `gcr.io`, because the base's
-  layers are inside the image operators pull from Docker Hub or GHCR.
+  layers are inside the image operators pull from Docker Hub.
 - **The Core image does not have this dependency.** It builds `FROM ubuntu`,
   which is Docker Hub, so an outage at one registry does not stop both images.
 - **Anonymous pulls are rate-limited per source IP**, and GitHub-hosted runners
   share theirs. The build pulls one base per job, so this has room; a fan-out
   that built the Panel image many times in parallel would not.
-- **There is no mirror configured, deliberately.** Copying the base into GHCR
-  and building `FROM` that would trade Google's availability for a copy that
-  can go stale and for a second thing Dependabot would have to be taught to
-  update. The pin is a digest, so a `gcr.io` outage delays a build; it cannot
-  change what a build produces.
+- **There is no mirror configured, deliberately.** Copying the base into
+  another registry and building `FROM` that would trade Google's availability
+  for a copy that can go stale and for a second thing Dependabot would have to
+  be taught to update. The pin is a digest, so a `gcr.io` outage delays a
+  build; it cannot change what a build produces.
 
-Three registries are therefore in play, doing three different jobs:
+Two registries are therefore in play, doing two different jobs:
 
 | Registry | Role | Fails how |
 | --- | --- | --- |
 | `gcr.io` | pulls the Panel's runtime base | no Panel image can be built |
-| Docker Hub | pulls `ubuntu` and `node`; publishes both images (primary) | no Core image can be built; publishing is skipped if credentials are absent |
-| GHCR | publishes both images (always) | release fails — there is no fallback for the primary publish target |
+| Docker Hub | pulls `ubuntu` and `node`; publishes both images | no Core image can be built; a pushing build without working credentials is red |
 
 ## Housekeeping
 
@@ -564,8 +552,11 @@ with the config copied alongside, so `extends` still resolves — is what the
 
 ## Notes for forks
 
-Everything works in a fork with no configuration: GHCR uses the fork's own
-token and namespace, Docker Hub steps skip, and the PR build never pushes.
+The PR path works in a fork with no configuration: a PR build never pushes,
+so it needs no registry credentials at all. Publishing — the edge tags on a
+push to `main`, and releases — requires setting `DOCKERHUB_USERNAME` /
+`DOCKERHUB_TOKEN` (and optionally `DOCKERHUB_NAMESPACE`) on the fork; without
+them a pushing build fails in `resolve` with an annotation naming the fix.
 
-PRs *from* a fork run without repository secrets — so `DOCKERHUB_TOKEN` is
-empty there and the publishing steps skip. That is expected, not a failure.
+PRs *from* a fork run without repository secrets — that is fine, because the
+PR build is the non-pushing one.

--- a/docs/images/core.md
+++ b/docs/images/core.md
@@ -122,7 +122,6 @@ architecture, so the two cannot be cross-built.
 ## Links
 
 - [Source](https://github.com/actana/control) · [Installing on a machine you own](https://github.com/actana/control/blob/main/INSTALL.md) · [Security policy](https://github.com/actana/control/blob/main/SECURITY.md)
-- Also published as `ghcr.io/actana/core`
 
 MIT licensed. A derivative work of Mission Control by AgentSystem Labs — see
 [NOTICE](https://github.com/actana/control/blob/main/NOTICE).

--- a/docs/images/panel.md
+++ b/docs/images/panel.md
@@ -83,7 +83,6 @@ compose above brings both up together.
 ## Links
 
 - [Source](https://github.com/actana/control) · [Deployment guide](https://github.com/actana/control/blob/main/DEPLOY.md) · [Security policy](https://github.com/actana/control/blob/main/SECURITY.md)
-- Also published as `ghcr.io/actana/panel`
 
 MIT licensed. A derivative work of Mission Control by AgentSystem Labs — see
 [NOTICE](https://github.com/actana/control/blob/main/NOTICE).

--- a/scripts/__tests__/panel-image.test.mjs
+++ b/scripts/__tests__/panel-image.test.mjs
@@ -417,18 +417,18 @@ describe("release workflow", () => {
     expect(words(workflow)).toContain(words(quote));
   });
 
-  // D31. Skipping everywhere is right for a fork and wrong for the repo that
-  // tells people to pull from Docker Hub: a release that never reached the
-  // primary registry must not report success.
-  it("fails a missing Docker Hub credential on the canonical repo only", () => {
-    expect(workflow).toContain("actana/control");
+  // D31, amended by ADR 0018: Docker Hub is the only registry, so a missing
+  // credential fails the release before anything is built — on any repo,
+  // fork or not. There is no longer a registry that authenticates for free.
+  it("fails a missing Docker Hub credential before building anything", () => {
     expect(workflow).toMatch(/DOCKERHUB_TOKEN/);
     expect(workflow).toContain("::error title=Missing Docker Hub credential");
+    expect(workflow).not.toContain("Publishing to GHCR only");
   });
 
   it("pushes the image name the compose file pulls", () => {
     expect(imageWorkflow).toContain(PANEL_IMAGE.split("/").pop());
-    expect(imageWorkflow).toContain("ghcr.io");
+    expect(imageWorkflow).toContain("docker.io/");
   });
 
   it("builds each architecture on a runner of that architecture", () => {
@@ -445,11 +445,13 @@ describe("release workflow", () => {
     );
   });
 
-  it("publishes to Docker Hub only when the token is configured", () => {
-    // Every Docker Hub step is gated on a non-empty DOCKERHUB_TOKEN, so a repo
-    // (or fork) without the secret still releases to GHCR.
-    expect(imageWorkflow).toContain('if [[ -n "$DOCKERHUB_TOKEN" ]]');
+  it("publishes to Docker Hub and nowhere else", () => {
+    // ADR 0018: GHCR was retired. A pushing build without credentials fails
+    // in `resolve`, before anything is built — there is nowhere else to
+    // publish — and a PR build (push: false) needs no credentials at all.
     expect(imageWorkflow).toContain("docker.io/");
+    expect(imageWorkflow).not.toContain("ghcr.io");
+    expect(imageWorkflow).toContain("::error title=Missing Docker Hub credential");
   });
 
   it("derives the registry namespace instead of hardcoding an owner", () => {
@@ -803,8 +805,9 @@ describe("docker hub descriptions", () => {
     expect(core).not.toContain("--public-host core");
   });
 
-  it("links the GHCR packages back to this repository", () => {
-    // Without image.source the package page has no README at all.
+  it("links the images back to this repository via OCI labels", () => {
+    // Docker Hub ignores these, but any registry UI that reads OCI labels —
+    // and every `docker image inspect` — finds its way back to the source.
     expect(readRepoFile(PANEL_DOCKERFILE)).toContain("org.opencontainers.image.source");
     expect(imageWorkflow).toContain("org.opencontainers.image.source");
   });

--- a/scripts/lib/panel-image.mjs
+++ b/scripts/lib/panel-image.mjs
@@ -30,7 +30,7 @@ export const PANEL_DOCKERFILE = "deploy/panel.Dockerfile";
  * workflow pushes the version tag and `latest`, and the smoke script builds a
  * local tag — all against this one name.
  */
-export const PANEL_IMAGE = "ghcr.io/actana/panel";
+export const PANEL_IMAGE = "actana/panel";
 
 /** The single directory inside the container that must be a mounted volume. */
 export const PANEL_DATA_DIR = "/data";
@@ -76,7 +76,7 @@ export const CORE_PORT = 8443;
  * reference compose pulls `:latest` so a clean checkout brings the pair up
  * without building either one.
  */
-export const CORE_IMAGE = "ghcr.io/actana/core";
+export const CORE_IMAGE = "actana/core";
 
 /** Where the Core image extracts the release tarball (ADR 0016 D13). */
 export const CORE_APP_ROOT = "/opt/actana";


### PR DESCRIPTION
## Why

Docker Hub was already the canonical registry (ADR 0016 D32) — the one operators are told to pull from, with curated per-image pages. GHCR was an unadvertised copy: no deployment pulls from it, the user-facing docs had already half-migrated away from it, and keeping it forced the most convoluted code in the pipeline (dual login, soft-fail mirror posture, per-registry manifest stitching) plus a stale `actana-panel` package sitting beside `panel` and `core` on GitHub.

## What changes

- **`container-image.yml`** builds under the `docker.io/<DOCKERHUB_NAMESPACE or owner>/<image>` name and publishes only there.
  - PR builds (`push: false`) still need no credentials at all.
  - A pushing build with **missing** credentials fails in `resolve`, before anything is built — there is nowhere else to publish.
  - A pushing build with **broken** credentials fails at `docker login`, before any tag is pushed. The old "publish GHCR completely, fail at the very end" dance existed only to protect the primary from a broken mirror; with one registry it goes away.
- **`ci.yml` / `release.yml` / `housekeeping.yml`** drop `packages: read|write` — the workflow token no longer needs any packages scope. No job names change, so the ruleset's required checks are untouched.
- **`release.yml`**'s missing-credential gate is now fatal on any repo, not just `actana/control`. Forks keep zero-config green PRs; publishing from a fork now requires its own Docker Hub keys (the one real property GHCR bought, traded away knowingly).
- **Docs & fixtures**: `deploy/docker-compose.yml`, README, DEPLOY, SECURITY, `docs/images/*`, `ci-cd.md`, `REPO_SETUP.md`, and the bug-report template all say `actana/panel` / `actana/core`. The OCI `image.source` labels stay — Docker Hub ignores them, but `docker image inspect` still finds the source.
- **ADR 0018** records the decision and supersedes D31/D32's "must not be fixed later" ordering clauses.
- **Tests** updated: `panel-image.test.mjs` now asserts the single-registry posture (77/77 green); `workflows.test.mjs` and `image-cve-gate.test.mjs` pass unaffected.

## After merge (manual)

Delete the three GHCR packages from the org (Settings → Packages, or a token with `read:packages` + `delete:packages`): `panel`, `core`, and the stale `actana-panel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)