### PR TITLE
fix(core-link): carry a delete op so a Core-owned Session can be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project, newest first.
 
 ## 0.1.0 — unreleased
 
-The core-link protocol moves to 0.10.0 so a project's remembered session
-settings can cross the wire. The Panel and its Cores are version-locked, so
-every Core needs updating alongside the Panel — an older one renders as "needs
-update" rather than degrading.
+The core-link protocol moves to 0.11.0 so a project's remembered session
+settings can cross the wire, and so a Session that lives on a Core can be
+deleted at all. The Panel and its Cores are version-locked, so every Core needs
+updating alongside the Panel — an older one renders as "needs update" rather
+than degrading.
+
+Deleting a Session on a Core used to fail. The task-mutation frame carried no
+delete operation, so every delete fell through to the Panel's own endpoint,
+which cannot see a row that lives in the Core's database. Deleting from the
+Session card menu and from the open session's terminal panel both work now, on
+every Core.
 
 Two New session dialog changes come with it. "Remember settings for this
 project" now persists on the Core that owns the project, so it survives a

--- a/docs/adr/0018-the-task-mutation-frame-carries-delete.md
+++ b/docs/adr/0018-the-task-mutation-frame-carries-delete.md
@@ -1,0 +1,22 @@
+# The task-mutation frame carries delete
+
+Deleting a Session that lives on a Core failed. Every other task mutation — title, pin, icon, status, archive — dispatches through the Core-routing task-mutation dispatcher, but delete had nothing to route: `CoreLinkTaskMutation` offered `create` and `update` only. So all three delete call sites fell through to the Panel's own HTTP endpoint, which cannot find a row that lives in the owning Core's SQLite (ADR 0004/0005) and answers not-found. This ADR records the contract addition that fixes it, because it changes the wire.
+
+**The frame gains a `delete` op.** `{op: "delete", taskId}`. On the Core it removes the row — SQLite's `ON DELETE CASCADE` takes the terminal logs, prompts, and token usage hanging off it, the same hard delete the Panel server performs for a Panel-owned row — and hands back the snapshot of what it removed, mirroring `archiveProject`. A row that is not there comes back as `task: null`, the way a missing row on `update` already does, rather than an `error` frame: the Panel treats "already gone" as success, and an error frame would make a double-click look like a failure. `CORE_LINK_PROTOCOL_VERSION` → 0.11.0.
+
+**The Core appends `task:deleted`.** The same kind the Panel server emits for a Panel-owned row, so a reconnecting Panel replays a Core-owned delete through the handler it already has — the one that prunes that session's stored finish notifications. No new event kind, and no Panel-side translation layer.
+
+**No pending-question clear rides along**, unlike the Panel server's delete. A pending question is an in-memory map on the *Panel* server, filled by the hooks route, which resolves the task against the Panel's own database — a Core-owned task never gets an entry to clear, and nothing on the Core tracks one. Recorded here because the symmetry with the Panel's delete otherwise looks broken.
+
+## Considered Options
+
+- **Reuse `update` with a sentinel — say `archived: "delete"` or a `deleted` flag (rejected).** It would have avoided the minor bump. Rejected because the row does not survive: the Core cannot return a patched snapshot, `updateTask`'s partial-patch contract stops describing what happens, and the event kind would have to be inferred from a field value rather than the op. `create`/`update` are discriminated ops precisely so the Core dispatches without sniffing fields.
+- **Soft-delete the row instead (rejected).** Archive is already the reversible hide, and it is a distinct operation with its own event kind. A second, permanent hide would leave two rows-that-are-not-there with different rules and no way to reclaim the disk.
+- **Route delete over the Panel's HTTP API by asking the Core for the row first (rejected).** No transport exists for it: the row is never in the Panel's database, so there is nothing for that endpoint to delete regardless of what the Panel knows about it.
+
+## Consequences
+
+- **Every Core must be updated alongside the Panel.** The minor moved, so a Core still speaking 0.10.0 is incompatible under the major.minor rule and renders as "needs update" (ADR 0005). That is the honest answer here: an unbumped Core would accept the frame's outer type and reject the op at the mutation store's runtime guard — a delete that reports an error per row instead of one Core that says it needs updating.
+- **The Panel-local arm of the dispatcher answers `null` for a delete.** The Panel's DELETE route replies 204 with no body, so a deleted row and a missing one are indistinguishable from the caller's side. Every delete caller awaits and ignores the value; the alternative was an extra GET for a row about to vanish.
+- **Teardown must precede the delete at every call site.** It always did in the project route; the terminal panel ran the two concurrently, which was harmless only while the delete could not reach the Core. Both halves now land on the same machine, and the cascade takes the `terminal_logs` a still-running PTY is writing to.
+- **`deleteAllArchived` is routed but still unreachable for a Core-owned row.** A Core's archived rows do not cross the link (`queryTasks` selects `WHERE archived = 0`), so the Archived list it reads is Panel-only until #62 lands. Routing it now means that button goes live working, rather than going live already failing.

--- a/packages/core/src/__tests__/core-mutation-store.test.ts
+++ b/packages/core/src/__tests__/core-mutation-store.test.ts
@@ -158,6 +158,38 @@ describe("coreMutationStore (integration against real schema)", () => {
     expect(idle?.ptyId).toBeNull();
   });
 
+  it("delete removes the task from tasksList and hands back what it removed", () => {
+    coreMutationStore.mutateProject({
+      op: "create",
+      projectId: "p-int-5",
+      name: "delete-src",
+      path: userDataDir,
+    });
+    coreMutationStore.mutateTask({
+      op: "create",
+      taskId: "t-doomed",
+      projectId: "p-int-5",
+      title: "doomed",
+      agent: "claude-code",
+    });
+    coreMutationStore.mutateTask({
+      op: "create",
+      taskId: "t-spared",
+      projectId: "p-int-5",
+      title: "spared",
+      agent: "claude-code",
+    });
+
+    const removed = coreMutationStore.mutateTask({ op: "delete", taskId: "t-doomed" });
+    expect(removed?.taskId).toBe("t-doomed");
+    expect(removed?.title).toBe("doomed");
+    expect(coreQueryStore.listTasks("p-int-5").map((t) => t.taskId)).toEqual(["t-spared"]);
+  });
+
+  it("reports a delete of a row that isn't there as null, not an exception", () => {
+    expect(coreMutationStore.mutateTask({ op: "delete", taskId: "t-ghost" })).toBeNull();
+  });
+
   it("throws on an unknown project mutation op (stale-shape guard)", () => {
     expect(() =>
       coreMutationStore.mutateProject({

--- a/packages/core/src/core-mutation-store.ts
+++ b/packages/core/src/core-mutation-store.ts
@@ -24,6 +24,7 @@ import {
   archiveProject as archiveProjectSql,
   createProject as createProjectSql,
   createTask as createTaskSql,
+  deleteTask as deleteTaskSql,
   pinProject as pinProjectSql,
   querySessions as querySessionsSql,
   renameProject as renameProjectSql,
@@ -142,6 +143,8 @@ export const coreMutationStore: CoreMutationPort = {
         return createTaskSql(conn, mutation, now);
       case "update":
         return updateTaskSql(conn, mutation, now);
+      case "delete":
+        return deleteTaskSql(conn, mutation.taskId);
     }
     throw new Error(`unknown task mutation op: ${(mutation as { op?: string }).op}`);
   },

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -466,6 +466,11 @@ export class PtyCoreLinkServer {
    *
    * On `create`, the kind is always `task:created` — a new row's icon is part
    * of the initial snapshot the tasks list carries, not a discrete change.
+   *
+   * On `delete`, the kind is `task:deleted` — the same name the Panel server
+   * emits when it deletes a Panel-owned row, so a reconnecting Panel replays a
+   * Core-owned delete through the handler it already has (it prunes that
+   * session's stored finish notifications keyed on the event's `taskId`).
    */
   private recordTaskMutation(
     mutation: CoreLinkTaskMutation,
@@ -475,11 +480,13 @@ export class PtyCoreLinkServer {
     const kind =
       mutation.op === "create"
         ? "task:created"
-        : isIconOnlyUpdate(mutation)
-          ? "task:iconChanged"
-          : isPinnedOnlyUpdate(mutation)
-            ? "task:pinnedChanged"
-            : "task:updated";
+        : mutation.op === "delete"
+          ? "task:deleted"
+          : isIconOnlyUpdate(mutation)
+            ? "task:iconChanged"
+            : isPinnedOnlyUpdate(mutation)
+              ? "task:pinnedChanged"
+              : "task:updated";
     const payload = JSON.stringify({ taskId: task.taskId, projectId: task.projectId });
     this.eventLog.appendEvent(kind, payload, { taskId: task.taskId });
   }

--- a/packages/panel/src/components/views/TerminalPanel.tsx
+++ b/packages/panel/src/components/views/TerminalPanel.tsx
@@ -7,7 +7,7 @@ import { useResizablePanel } from "~/lib/use-resizable-panel";
 import { useHotkey } from "~/lib/use-hotkey";
 import { useFocusWithin } from "~/lib/use-focus-within";
 import { isUserTerminalXtermFocused } from "~/lib/terminal-pane-helpers";
-import { api } from "~/lib/api";
+import { mutateTaskForCore } from "~/lib/mutate-task-for-core";
 import { useTerminals } from "~/lib/terminal-store";
 import { useUserTerminals } from "~/lib/user-terminal-store";
 import { queryKeys } from "~/queries";
@@ -81,7 +81,14 @@ export function TerminalPanel({
     }
     setDeleting(true);
     try {
-      await Promise.all([onClose(active.taskId), api.deleteTask(active.taskId)]);
+      // The row lives in the owning Core's database (ADR 0004/0005), so the
+      // delete rides the panel link to that Core — the Panel's own endpoint
+      // has no such row and would 404. `active.coreId` is null for a
+      // Panel-owned row, which routes back to that endpoint.
+      await Promise.all([
+        onClose(active.taskId),
+        mutateTaskForCore(active.coreId, { op: "delete", taskId: active.taskId }),
+      ]);
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: queryKeys.tasks(active.project.id),

--- a/packages/panel/src/components/views/TerminalPanel.tsx
+++ b/packages/panel/src/components/views/TerminalPanel.tsx
@@ -81,14 +81,16 @@ export function TerminalPanel({
     }
     setDeleting(true);
     try {
+      // Tear the terminal down first, then delete — not both at once, the way
+      // this ran while the delete could only 404 for a Core-owned row. Both
+      // halves now land on the same Core, and the row's delete cascades the
+      // terminal_logs a still-running PTY is writing to.
+      await onClose(active.taskId);
       // The row lives in the owning Core's database (ADR 0004/0005), so the
       // delete rides the panel link to that Core — the Panel's own endpoint
       // has no such row and would 404. `active.coreId` is null for a
       // Panel-owned row, which routes back to that endpoint.
-      await Promise.all([
-        onClose(active.taskId),
-        mutateTaskForCore(active.coreId, { op: "delete", taskId: active.taskId }),
-      ]);
+      await mutateTaskForCore(active.coreId, { op: "delete", taskId: active.taskId });
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: queryKeys.tasks(active.project.id),

--- a/packages/panel/src/lib/__tests__/mutate-task-for-core.test.ts
+++ b/packages/panel/src/lib/__tests__/mutate-task-for-core.test.ts
@@ -4,9 +4,14 @@ const apiCalls: string[] = [];
 const archiveTask = vi.fn();
 const restoreTask = vi.fn();
 const updateTask = vi.fn();
+const deleteTask = vi.fn();
 
 vi.mock("~/lib/api", () => ({
   api: {
+    deleteTask: (id: string) => {
+      apiCalls.push(`delete:${id}`);
+      return deleteTask(id);
+    },
     archiveTask: (id: string) => {
       apiCalls.push(`archive:${id}`);
       return archiveTask(id);
@@ -48,6 +53,7 @@ describe("mutateTaskForCore", () => {
     archiveTask.mockReset().mockResolvedValue(panelTask({ archived: true }));
     restoreTask.mockReset().mockResolvedValue(panelTask({ archived: false }));
     updateTask.mockReset().mockResolvedValue(panelTask());
+    deleteTask.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -126,6 +132,35 @@ describe("mutateTaskForCore", () => {
 
     expect(apiCalls).toEqual(["update:t1"]);
     expect(updateTask).toHaveBeenCalledWith("t1", { pinned: true });
+  });
+
+  it("routes a Core-owned delete over the panel link, not the Panel's HTTP API", async () => {
+    vi.stubGlobal("window", {});
+    const mutateTask = vi.fn().mockResolvedValue({
+      taskId: "t1",
+      projectId: "p1",
+      title: "Session",
+      icon: null,
+      agent: "claude",
+      status: "ready",
+      archived: true,
+      pinned: false,
+      updatedAt: 43,
+    });
+    __setPanelBridgeForTests({ mutateTask } as never);
+
+    const snapshot = await mutateTaskForCore("core-a", { op: "delete", taskId: "t1" });
+
+    expect(mutateTask).toHaveBeenCalledWith("core-a", { op: "delete", taskId: "t1" });
+    expect(apiCalls).toEqual([]);
+    // The Core hands back the row it removed, so the caller can echo it.
+    expect(snapshot?.taskId).toBe("t1");
+  });
+
+  it("deletes a Panel-owned row over the delete endpoint", async () => {
+    expect(await mutateTaskForCore(null, { op: "delete", taskId: "t1" })).toBeNull();
+
+    expect(apiCalls).toEqual(["delete:t1"]);
   });
 
   it("reports a missing Panel-owned row as null", async () => {

--- a/packages/panel/src/lib/mutate-task-for-core.ts
+++ b/packages/panel/src/lib/mutate-task-for-core.ts
@@ -15,7 +15,8 @@ import { api } from "~/lib/api";
  *
  * Throws on transport failure or a Core-side error frame so the caller can
  * surface it in the picker/dialog. Returns `null` when the mutation targeted a
- * missing row.
+ * missing row — and, on a Panel-owned `delete`, always: that endpoint answers
+ * with no body, so a deleted row and a missing one look the same from here.
  *
  * A null `coreId` names a row in the Panel's own database — the last rows not
  * owned by a Core — and is written over the Panel's HTTP API instead. That

--- a/packages/panel/src/lib/mutate-task-for-core.ts
+++ b/packages/panel/src/lib/mutate-task-for-core.ts
@@ -19,8 +19,9 @@ import { api } from "~/lib/api";
  *
  * A null `coreId` names a row in the Panel's own database — the last rows not
  * owned by a Core — and is written over the Panel's HTTP API instead. That
- * arm disappears with those rows. It understands `title`, `pinned`, and
- * `archived`; anything else on the patch is dropped.
+ * arm disappears with those rows. It understands `delete`, plus `title`,
+ * `pinned`, and `archived` on an `update`; anything else on the patch is
+ * dropped.
  */
 export async function mutateTaskForCore(
   coreId: string | null | undefined,
@@ -35,6 +36,14 @@ export async function mutateTaskForCore(
 async function mutatePanelLocalTask(
   mutation: CoreLinkTaskMutation,
 ): Promise<CoreLinkTaskSnapshot | null> {
+  if (mutation.op === "delete") {
+    // The DELETE route answers 204 with no body, so there is no row to echo
+    // back the way the Core's delete does. Every delete caller awaits the
+    // promise and ignores the value, so null is the honest answer rather than
+    // a fabricated snapshot or an extra GET to fetch a row about to vanish.
+    await api.deleteTask(mutation.taskId);
+    return null;
+  }
   if (mutation.op !== "update") {
     throw new Error(`cannot ${mutation.op} a task that no Core owns`);
   }

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -1414,7 +1414,9 @@ function ProjectPage() {
           taskId,
           isActive ? { activateTaskId: next?.id ?? null } : undefined,
         );
-        await api.deleteTask(taskId);
+        // Route to the Core that owns the row (ADR 0005) — the Panel's own
+        // delete endpoint only knows Panel-owned rows.
+        await mutateTaskForCore(coreId, { op: "delete", taskId });
         void refresh();
       } catch (e: unknown) {
         if (previousTasks) {
@@ -1614,11 +1616,12 @@ function ProjectPage() {
     onTogglePinned: toggleSessionPinned,
   };
 
-  // Delete every archived row shown for this project. Still on the Panel's own
-  // delete endpoint, which is sound only because the rows it can see are
-  // Panel-owned — a Core's archived rows never reach `tasks` (see
-  // archiveTasks). Whoever teaches the core-link to list them owes this
-  // function a `mutateTaskForCore` route too, or it will 404 the way archive did.
+  // Delete every archived row shown for this project. Routed by owner like
+  // every other task mutation, though only Panel-owned rows reach it today: a
+  // Core's archived rows never cross the link (see archiveTasks), so the
+  // Archived list this reads is Panel-only until #62 lands. The routing is here
+  // so the button works the moment those rows appear, rather than going live
+  // already 404'ing.
   const deleteAllArchived = () => {
     setConfirmDeleteArchived(false);
     if (!project) return;
@@ -1636,7 +1639,7 @@ function ProjectPage() {
         await Promise.all(
           archived.map(async (t) => {
             await terminals.close(t.id).catch(() => undefined);
-            await api.deleteTask(t.id);
+            await mutateTaskForCore(coreId, { op: "delete", taskId: t.id });
           }),
         );
         void refresh();

--- a/packages/panel/src/server/panel-link/__tests__/write-path.test.ts
+++ b/packages/panel/src/server/panel-link/__tests__/write-path.test.ts
@@ -299,6 +299,10 @@ function mutationPort(): CoreMutationPort {
       }
       const existing = tasks.get(mutation.taskId);
       if (!existing) return null;
+      if (mutation.op === "delete") {
+        tasks.delete(mutation.taskId);
+        return existing;
+      }
       const next: CoreLinkTaskSnapshot = {
         ...existing,
         ...(mutation.title === undefined ? {} : { title: mutation.title }),
@@ -536,6 +540,48 @@ describe("writing to a Core from the browser", () => {
       mutation: { op: "update", taskId: task.taskId, title: "restock" },
     });
     expect(reIconed.task).toMatchObject({ icon: "rocket" });
+  });
+
+  it("deletes a session on the Core and tells a watching tab it is gone", async () => {
+    const { coreId } = await pair();
+    const tab = await openTab();
+    tab.subscribe(coreId, 0);
+
+    const task = (
+      await tab.ask(coreId, {
+        type: "tasksMutate",
+        mutation: { op: "create", projectId: "proj_1", title: "restock", agent: "claude-code" },
+      })
+    ).task as CoreLinkTaskSnapshot;
+
+    const removed = await tab.ask(coreId, {
+      type: "tasksMutate",
+      mutation: { op: "delete", taskId: task.taskId },
+    });
+
+    // The Core answers with the row it removed, and it is out of the sessions
+    // list the next read returns.
+    expect(removed).toMatchObject({
+      type: "tasksMutateResult",
+      task: expect.objectContaining({ taskId: task.taskId, title: "restock" }),
+    });
+    expect((await tab.ask(coreId, { type: "sessionsList" })).sessions).toEqual([]);
+
+    await vi.waitFor(() => {
+      expect(tab.events(coreId).map((e) => e.kind)).toContain("task:deleted");
+    }, 5_000);
+  });
+
+  it("reports a delete of a session the Core does not have as a null row", async () => {
+    const { coreId } = await pair();
+    const tab = await openTab();
+
+    const answer = await tab.ask(coreId, {
+      type: "tasksMutate",
+      mutation: { op: "delete", taskId: "task_gone" },
+    });
+
+    expect(answer).toMatchObject({ type: "tasksMutateResult", task: null });
   });
 
   it("tells a watching tab which kind of change happened", async () => {

--- a/packages/shared/src/__tests__/core-mutations.test.ts
+++ b/packages/shared/src/__tests__/core-mutations.test.ts
@@ -7,6 +7,7 @@ import {
   pinProject,
   querySessions,
   renameProject,
+  deleteTask,
   updateProjectSettings,
   updateTask,
   validateProjectPath,
@@ -542,6 +543,49 @@ describe("updateTask", () => {
     updateTask(asWriter(db), { op: "update", taskId: "t1", icon: "wrench" }, 5);
     updateTask(asWriter(db), { op: "update", taskId: "t1", title: "renamed" }, 6);
     expect(queryTasks(asReader(db))[0]!.icon).toBe("wrench");
+  });
+});
+
+describe("deleteTask", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = openDb();
+    createProject(
+      asWriter(db),
+      { op: "create", projectId: "p1", name: "x", path: "/p" },
+      "/p",
+      1,
+    );
+    createTask(
+      asWriter(db),
+      { op: "create", taskId: "t1", projectId: "p1", title: "orig", agent: "claude-code" },
+      1,
+    );
+    createTask(
+      asWriter(db),
+      { op: "create", taskId: "t2", projectId: "p1", title: "keep", agent: "claude-code" },
+      1,
+    );
+  });
+
+  it("removes the row and returns the pre-delete snapshot", () => {
+    const snap = deleteTask(asWriter(db), "t1");
+    expect(snap?.taskId).toBe("t1");
+    expect(snap?.title).toBe("orig");
+    expect(queryTasks(asReader(db)).map((t) => t.taskId)).toEqual(["t2"]);
+  });
+
+  it("deletes an archived row too — that is the only way one leaves the DB", () => {
+    updateTask(asWriter(db), { op: "update", taskId: "t1", archived: true }, 5);
+    expect(deleteTask(asWriter(db), "t1")?.archived).toBe(true);
+    expect(
+      db.prepare(`SELECT COUNT(*) AS n FROM tasks WHERE id = 't1'`).get(),
+    ).toEqual({ n: 0 });
+  });
+
+  it("returns null when the taskId is unknown, leaving every row in place", () => {
+    expect(deleteTask(asWriter(db), "missing")).toBeNull();
+    expect(queryTasks(asReader(db))).toHaveLength(2);
   });
 });
 

--- a/packages/shared/src/__tests__/core-mutations.test.ts
+++ b/packages/shared/src/__tests__/core-mutations.test.ts
@@ -393,7 +393,7 @@ describe("archiveProject", () => {
   });
 });
 
-// ─── createTask / updateTask ──────────────────────────────────────────────
+// ─── createTask / updateTask / deleteTask ─────────────────────────────────
 
 describe("createTask", () => {
   let db: Database.Database;

--- a/packages/shared/src/core-link-frames.ts
+++ b/packages/shared/src/core-link-frames.ts
@@ -148,9 +148,10 @@ export type CoreLinkEvent = {
 export type CoreLinkTaskStatus = string;
 
 /**
- * A task mutation — either `create` (a new task under an existing project) or
- * `update` (patch an existing task row). The discriminant lets the Core
- * dispatch to `createTask` / `updateTask` without a nullable-id sniff.
+ * A task mutation — `create` (a new task under an existing project), `update`
+ * (patch an existing task row), or `delete` (remove one). The discriminant lets
+ * the Core dispatch to `createTask` / `updateTask` / `deleteTask` without a
+ * nullable-id sniff.
  *
  * On `create`, `projectId`, `title`, and `agent` are required — everything
  * else defaults on the Core (status → `ready`, pinned/archived → false).
@@ -159,6 +160,11 @@ export type CoreLinkTaskStatus = string;
  * On `update`, `taskId` is required and identifies the row; any of
  * `status`/`title`/`pinned`/`archived` may be set. Fields omitted are left
  * untouched (partial patch, mirroring the Panel server's PATCH shape).
+ *
+ * On `delete`, `taskId` is required and the row is removed outright — the
+ * Core's SQLite cascades the rows hanging off it, mirroring the Panel
+ * server's own DELETE. A missing row comes back as `task: null`, the same way
+ * a missing row on `update` does; it is not an error frame.
  */
 export type CoreLinkTaskMutation =
   | {
@@ -185,6 +191,10 @@ export type CoreLinkTaskMutation =
        * routes through this frame.
        */
       icon?: string | null;
+    }
+  | {
+      op: "delete";
+      taskId: string;
     };
 
 /**
@@ -595,8 +605,14 @@ export type CoreLinkServerFrame =
  * wanted: the minor moved, so a Core still speaking 0.9.0 is incompatible by
  * the major.minor rule below and renders as "needs update" (ADR 0005). It
  * never reaches the mutation store's runtime `op` check.
+ * Issue 63 adds a `delete` op to {@link CoreLinkTaskMutation} and the
+ * `task:deleted` event kind the Core appends for it → 0.11.0. Deleting a
+ * Core-owned Session had no operation to carry, so every delete call site fell
+ * through to the Panel's own endpoint and 404'd. Same rule as above: the minor
+ * moved, so a Core on 0.10.0 is "needs update" rather than a Core that accepts
+ * the frame and silently drops the op.
  */
-export const CORE_LINK_PROTOCOL_VERSION = "0.10.0";
+export const CORE_LINK_PROTOCOL_VERSION = "0.11.0";
 
 /**
  * Does a Core advertising `reported` speak this build's core-link?

--- a/packages/shared/src/core-mutations.ts
+++ b/packages/shared/src/core-mutations.ts
@@ -464,6 +464,28 @@ export function updateTask(
   return readTaskSnapshot(sqlite, input.taskId);
 }
 
+/**
+ * Delete a task row and return the snapshot of what was removed. SQLite's
+ * ON DELETE CASCADE takes the rows hanging off it (terminal_logs, prompts,
+ * token_usage, …) — the same hard delete the Panel server's `deleteTask`
+ * performs for a Panel-owned row. Returns `null` when nothing matched, the way
+ * {@link updateTask} reports a missing row, so the server answers
+ * `tasksMutateResult` with a null task rather than an `error` frame.
+ *
+ * The pre-delete snapshot is what comes back (mirroring {@link archiveProject})
+ * so `tasksMutateResult.task` carries the same shape for every op and the
+ * caller doesn't branch on `op` to read the answer.
+ */
+export function deleteTask(
+  sqlite: CoreMutationSqlite,
+  taskId: string,
+): CoreLinkTaskSnapshot | null {
+  const before = readTaskSnapshot(sqlite, taskId);
+  if (!before) return null;
+  sqlite.prepare(`DELETE FROM tasks WHERE id = ?`).run(taskId);
+  return before;
+}
+
 function readTaskSnapshot(
   sqlite: CoreMutationSqlite,
   taskId: string,

--- a/packages/shared/src/core-mutations.ts
+++ b/packages/shared/src/core-mutations.ts
@@ -475,6 +475,14 @@ export function updateTask(
  * The pre-delete snapshot is what comes back (mirroring {@link archiveProject})
  * so `tasksMutateResult.task` carries the same shape for every op and the
  * caller doesn't branch on `op` to read the answer.
+ *
+ * No pending-question clear rides along, unlike the Panel server's delete.
+ * A pending question is an in-memory map on the *Panel* server, filled by the
+ * hooks route, which resolves the task against the Panel's own database — so a
+ * Core-owned task never gets an entry to clear. Nothing on the Core tracks one.
+ * The Panel-side state that does follow a Core-owned session (its stored
+ * session-finish notifications) is pruned off the `task:deleted` event this
+ * delete appends.
  */
 export function deleteTask(
   sqlite: CoreMutationSqlite,


### PR DESCRIPTION
Deleting a Session that lives on a Core failed. Every other task mutation routes through the Core-routing dispatcher, but delete had nothing to carry: `CoreLinkTaskMutation` was `create | update` only, so all three delete call sites fell through to the Panel's own endpoint, which cannot find a row that lives in the owning Core's SQLite (ADR 0004/0005) and answers not-found.

## What changed

- **Contract** — the task-mutation frame gains `{op: "delete", taskId}`. `CORE_LINK_PROTOCOL_VERSION` → 0.11.0, so a Core on 0.10.0 says "needs update" rather than accepting the frame and rejecting the op per row.
- **Core** — `deleteTask` removes the row (SQLite cascades what hangs off it, the same hard delete the Panel server does for a Panel-owned row) and returns the pre-delete snapshot, mirroring `archiveProject`. A missing row comes back as `task: null`, the way `update` already reports one — not an error frame. The server appends `task:deleted`, the same kind the Panel emits, so a reconnecting Panel replays it through the handler it already has.
- **Call sites** — the terminal panel's delete, the Session card menu's delete, and delete-all-archived all dispatch through `mutateTaskForCore`. Each still tears the terminal down first; the terminal panel used to do both at once, which was safe only while the delete could not reach the Core.
- **Panel-local arm** — grew a delete arm over the DELETE endpoint. It answers `null` because that route has no body to echo.

No pending-question clear rides along, despite the issue asking for one: that map is in-memory Panel-server state filled by the hooks route, which resolves the task against the Panel's own database, so a Core-owned task never has an entry — and nothing on the Core tracks one. ADR 0018 records this so it isn't rediscovered.

`deleteAllArchived` stays unreachable for a Core-owned row until #62 makes a Core's archived rows visible; it is routed now so that button goes live working rather than going live already failing.

## ADR

CONTRIBUTING asks for an ADR in the same PR as a wire-contract change — `docs/adr/0018-the-task-mutation-frame-carries-delete.md`.

## Test plan

- `packages/shared` — `deleteTask` removes the row, deletes an archived row, returns the pre-delete snapshot, reports a missing row as null.
- `packages/core` — the mutation store round-trips a delete against the real schema and answers null for a row it doesn't have.
- `packages/panel` — the dispatcher routes a Core-owned delete over the panel link and a Panel-owned one over the HTTP endpoint; the end-to-end write-path suite deletes a session on a real Core over mTLS, sees it leave `sessionsList`, and sees `task:deleted` reach a watching tab.
- `pnpm -r typecheck` clean. Full suite green except pre-existing 5s-timeout flakes under parallel load (the same class fails on `main` unchanged, in files this PR doesn't touch).

Closes #63