### PR TITLE
ci(release): two modes, an explicit latest guard, and no tag trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,8 +495,10 @@ jobs:
   # The release-tarball seam (core-installer issue 01): the artifact
   # operators actually download must extract and boot on its own — bundled Node,
   # bundled natives, no system Node, no network. Built here on every PR for the
-  # runner's own platform so a broken tarball is caught before tag time;
-  # release.yml builds and smokes both released targets on a tag push.
+  # runner's own platform so a broken tarball is caught before release time;
+  # release.yml builds and smokes both released targets when a release runs —
+  # called from the promotion or dispatched by hand, never on a tag push
+  # (ADR 0023 D40).
   #
   # This is now the only boot-and-dial smoke on a PR. There was a second —
   # `smoke-standalone-core.mjs`, against the unpacked bundle — but it made the
@@ -643,8 +645,10 @@ jobs:
   # release target again (ADR 0016 D28, as amended) does not change that. D35
   # took the macOS legs off the PR gate because they were 72% of the bill at
   # 10× billing, and that is the decision this file keeps: zero macOS minutes
-  # on a pull request. The one mac leg lives in release.yml, runs on a tag, and
-  # waits on a human approval; `e2e-actana-setup-macos.mjs` stays deleted, and
+  # on a pull request. The one mac leg lives in release.yml and now builds
+  # alongside the Linux legs — the human approval moved out of it to the head of
+  # `promote.yml` (ADR 0023 D15, landing in #111), which is upstream of the
+  # whole release; `e2e-actana-setup-macos.mjs` stays deleted, and
   # docs/core-macos-prerelease-checklist.md is what a person runs instead.
   # `scripts/__tests__/workflows.test.mjs` fails if a macOS runner appears in
   # this file.

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -12,14 +12,23 @@ name: Container image
 #   ci.yml      → pr-<prid><YYYYMM> to `-dev`, amd64     (every PR push)
 #   ci.yml      → beta-x.y.z to the release repositories
 #                 and sha-<short> to `-dev`, multi-arch  (every train merge)
-#   release.yml → :<version> and :latest                 (every v* tag)
+#   release.yml → :<version> and :latest                 (every release)
 #
-# `mode` (ADR 0023 D38) covers the two PR paths that build nothing: `verify`
-# asserts a published digest carries a given commit's revision label (D19), and
-# `pass` reports success immediately (draft or documentation-only, D33). Both
-# run the same jobs under the same names as a build — a required check whose
-# job is skipped stays Pending forever, which is the failure D33 exists to
-# avoid.
+# `mode` (ADR 0023 D38) covers the paths that build nothing. `verify` asserts a
+# published digest carries a given commit's revision label (D19) and `pass`
+# reports success immediately (draft or documentation-only, D33); both run the
+# same jobs under the same names as a build, because a required check whose job
+# is skipped stays Pending forever, which is the failure D33 exists to avoid.
+#
+# `promote` (D16, D17) is the third, and the only one of them that publishes.
+# It makes the same assertion `verify` does — that `source_tag`'s digest was
+# built from `ref` — and then re-points `tags` at that exact digest with
+# `docker buildx imagetools create`, the command the manifest stitch below
+# already uses. Nothing is built, so nothing can differ between the bytes a
+# human approved as `beta-x.y.z` and the bytes published as `x.y.z`. The
+# assertion is not decoration: `beta-x.y.z` moves on every train merge, so
+# "retag whatever it points at" would promote untested bytes whenever somebody
+# merged after the approver tested.
 #
 # Two repositories, one build. `tags` publishes to `<image>` and `dev_tags` to
 # `<image>-dev` from the same per-architecture bytes, so `sha-<short>` is a
@@ -76,11 +85,22 @@ on:
         description: >-
           What this call does, under one check name (ADR 0023 D38):
           `build` builds, smokes and — when push is true — publishes;
+          `promote` builds nothing, asserts `source_tag`'s published digest
+          carries `ref` as its org.opencontainers.image.revision label, and
+          re-points `tags` at that digest (D16, D17);
           `verify` builds nothing and asserts `tags`'s published digest carries
           `ref` as its org.opencontainers.image.revision label (D19);
           `pass` reports success immediately (D33).
         type: string
         default: build
+      source_tag:
+        description: >-
+          The published tag whose digest `promote` re-points `tags` at (e.g.
+          beta-0.1.0), in the same repository. Required by `promote` and
+          rejected by every other mode — a build path carrying one is a caller
+          that thinks it is promoting.
+        type: string
+        default: ""
       push:
         description: "Publish the image. False builds and smokes only."
         type: boolean
@@ -122,6 +142,7 @@ jobs:
           PUSH: ${{ inputs.push }}
           TAGS: ${{ inputs.tags }}
           DEV_TAGS: ${{ inputs.dev_tags }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
           # A repository variable, so a fork publishing under a different
           # Docker Hub org doesn't have to edit this file.
           DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
@@ -134,14 +155,37 @@ jobs:
             *) echo "unknown image '$IMAGE' — expected 'panel' or 'core'" >&2; exit 1 ;;
           esac
           case "$MODE" in
-            build|verify|pass) ;;
-            *) echo "unknown mode '$MODE' — expected 'build', 'verify' or 'pass'" >&2; exit 1 ;;
+            build|promote|verify|pass) ;;
+            *) echo "unknown mode '$MODE' — expected 'build', 'promote', 'verify' or 'pass'" >&2; exit 1 ;;
           esac
-          # A mode that builds nothing has nothing to publish. Catching the
-          # combination here rather than letting it push means a caller cannot
-          # turn a verification into a publish by passing one input twice.
-          if [[ "$MODE" != "build" && "$PUSH" == "true" ]]; then
+          # A mode that builds nothing and promotes nothing has nothing to
+          # publish. Catching the combination here rather than letting it push
+          # means a caller cannot turn a verification into a publish by passing
+          # one input twice.
+          if [[ "$MODE" != "build" && "$MODE" != "promote" && "$PUSH" == "true" ]]; then
             echo "mode '$MODE' builds nothing and cannot push" >&2; exit 1
+          fi
+          # `promote` is the one mode that publishes without building, so its
+          # inputs are checked rather than assumed: without a source there is
+          # no digest to re-point, and a promote that did not push would report
+          # a green check having done nothing at all — which is the shape of
+          # failure a release must never take.
+          if [[ "$MODE" == "promote" ]]; then
+            if [[ -z "${SOURCE_TAG// }" ]]; then
+              echo "::error title=Nothing to promote::mode 'promote' needs source_tag — the published tag whose digest is re-pointed at '$TAGS' (ADR 0023 D17)."
+              exit 1
+            fi
+            if [[ "$PUSH" != "true" ]]; then
+              echo "::error title=A promotion that publishes nothing::mode 'promote' exists to re-point tags; push must be true." >&2
+              exit 1
+            fi
+            if [[ -n "${DEV_TAGS// }" ]]; then
+              echo "::error title=A promotion publishes to the release repository only::dev_tags '$DEV_TAGS' were requested. The -dev handles belong to the build paths (ADR 0023 D36)." >&2
+              exit 1
+            fi
+          elif [[ -n "${SOURCE_TAG// }" ]]; then
+            echo "::error title=source_tag outside promote mode::mode '$MODE' was given source_tag '$SOURCE_TAG'. Only 'promote' re-points an existing digest; a build path carrying one is a caller that thinks it is promoting." >&2
+            exit 1
           fi
 
           # Docker Hub requires a lowercase namespace.
@@ -201,7 +245,9 @@ jobs:
             echo "::error title=Missing Docker Hub credential::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must both be set to publish $image — Docker Hub is the only registry images are published to (ADR 0018). One personal access token (Read & Write) serves both the image push and the description sync. See docs/REPO_SETUP.md section 2."
             exit 1
           fi
-          if [[ "$PUSH" == "true" ]]; then
+          if [[ "$MODE" == "promote" ]]; then
+            echo "Promoting $image:$SOURCE_TAG to $TAGS. Nothing is built, so there is no per-arch scaffolding."
+          elif [[ "$PUSH" == "true" ]]; then
             if [[ -n "${TAGS// }" ]]; then echo "Publishing $TAGS to $image."; fi
             if [[ -n "${DEV_TAGS// }" ]]; then echo "Publishing $DEV_TAGS to $dev_image."; fi
             echo "Per-arch scaffolding goes to $scaffold_image."
@@ -239,6 +285,7 @@ jobs:
           IMAGE: ${{ inputs.image }}
           TAGS: ${{ inputs.tags }}
           DEV_TAGS: ${{ inputs.dev_tags }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           set -euo pipefail
           case "$MODE" in
@@ -249,6 +296,9 @@ jobs:
                 echo "::notice title=${IMAGE} image — build, no push::Building and smoking the ${IMAGE} image. Nothing is published — a fork pull request has no registry credential, by design (ADR 0023 D34)."
               fi
               ;;
+            promote)
+              echo "::notice title=${IMAGE} image — promote::Building nothing. Asserting ${SOURCE_TAG} was built from this commit, then re-pointing ${TAGS} at that exact digest (ADR 0023 D16, D17)."
+              ;;
             verify)
               echo "::notice title=${IMAGE} image — verify::Building nothing. Asserting the published ${TAGS} carries this commit as its revision label (ADR 0023 D19)."
               ;;
@@ -257,31 +307,50 @@ jobs:
               ;;
           esac
 
-      # D19/D16, the design's central claim on the pull request side. The
-      # promotion pull request would otherwise rebuild both images for an hour
-      # to produce bytes that already exist; instead the redundant work becomes
-      # the verification the design needs. `beta-x.y.z` moves on every train
-      # merge, so what is asserted is not "the tag exists" but "the digest it
-      # names was built from *this* commit" — a train that moved after the
-      # approver tested fails here rather than at the dispatch.
+      # D16, the design's central claim, asserted on both the paths that reach
+      # it. On a promotion pull request (`verify`, D19) it replaces an hour of
+      # rebuilding bytes that already exist; on the release itself (`promote`)
+      # it is the precondition for the retag below, and the *only* thing
+      # standing between "re-point x.y.z at beta-x.y.z" and promoting bytes
+      # nobody ran. `beta-x.y.z` moves on every train merge, so what is
+      # asserted is not "the tag exists" but "the digest it names was built
+      # from *this* commit" — a train that moved after the approver tested
+      # fails here rather than in an operator's `docker pull`.
+      #
+      # One implementation for both, deliberately: two would be two chances to
+      # weaken the assertion that the whole design reduces to. Only the tag
+      # being read and the wording of the failure differ.
+      #
+      # Every architecture is checked, because the manifest is per-platform and
+      # a promotion re-points all of them at once.
       #
       # Read through the daemon, by pulling the platform and asking it for the
       # config. `imagetools inspect`'s Go struct is the reader this repository
       # already learned not to trust for an image-config question
       # (scripts/__tests__/panel-image.test.mjs), and a pull of an image that
       # is about to be promoted is seconds against an hour saved.
-      - name: Verify the published digest carries this commit
-        if: inputs.mode == 'verify'
+      - name: Assert the published digest carries this commit
+        if: inputs.mode == 'verify' || inputs.mode == 'promote'
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           IMAGE: ${{ needs.resolve.outputs.image }}
+          MODE: ${{ inputs.mode }}
           TAGS: ${{ inputs.tags }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
           ARCH: ${{ matrix.arch }}
           EXPECTED: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          ref="$IMAGE:${TAGS%% *}"
+          # `verify` reads the tag it was asked to verify; `promote` reads the
+          # tag it is about to re-point, which is a different tag from the ones
+          # in `tags` — those do not exist yet, and one of them may be
+          # `latest`, pointing at the *previous* release.
+          if [[ "$MODE" == "promote" ]]; then
+            ref="$IMAGE:$SOURCE_TAG"
+          else
+            ref="$IMAGE:${TAGS%% *}"
+          fi
           # Authenticated when a credential exists — an anonymous pull shares
           # its rate limit with every other runner on the same egress address,
           # and this check must not be flaky.
@@ -299,15 +368,29 @@ jobs:
           echo "  revision label: ${revision:-<none>}"
           echo "  expected:       $EXPECTED"
           if [[ "$revision" != "$EXPECTED" ]]; then
-            echo "::error title=The train moved; re-approve::$ref was built from ${revision:-an image with no revision label}, not from $EXPECTED. Something merged into the train after the image this pull request would promote was published. Wait for the train's publish to finish, then re-approve against the image it produces (ADR 0023 D16)."
+            if [[ "$MODE" == "promote" ]]; then
+              echo "::error title=Refusing to promote a digest built from another commit::$ref at linux/$ARCH was built from ${revision:-an image with no revision label}, not from $EXPECTED — the commit this release is promoting. Promotion re-points an existing digest at '$TAGS', so those bytes would be published, and possibly as :latest, without anyone having run them. Something merged into the train after the image was published, or its publish never finished: re-run the train's image jobs so $SOURCE_TAG names $EXPECTED, then re-run this release (ADR 0023 D16)."
+            else
+              echo "::error title=The train moved; re-approve::$ref was built from ${revision:-an image with no revision label}, not from $EXPECTED. Something merged into the train after the image this pull request would promote was published. Wait for the train's publish to finish, then re-approve against the image it produces (ADR 0023 D16)."
+            fi
             exit 1
           fi
-          echo "✅ $ref carries $EXPECTED — the promoted digest is the tested one."
+          echo "✅ $ref at linux/$ARCH carries $EXPECTED — the promoted digest is the tested one."
 
       # ---------------------------------------------------------------- panel
 
       # The OCI labels live in the Dockerfile so a local build carries them too;
       # only source/revision are passed in, so a fork links to the fork.
+      #
+      # The revision comes from the checkout — `git rev-parse HEAD`, the commit
+      # whose bytes are in this image — and not from `github.sha`, which is the
+      # commit the *event* named. The two agree on the pull request and train
+      # paths, where the caller passes `ref: github.sha`, and they do not agree
+      # on a backport: that runs as a `workflow_dispatch` on the default
+      # branch while building a commit from `release/x.y`, so `github.sha`
+      # would label the image with a commit it does not contain. D16's
+      # assertion is a comparison against this label, and a label that is not
+      # the truth is the one failure that assertion cannot detect.
       - name: Build the Panel image
         if: inputs.mode == 'build' && inputs.image == 'panel'
         env:
@@ -315,12 +398,14 @@ jobs:
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
+          revision="$(git rev-parse HEAD)"
+          echo "Labelling with org.opencontainers.image.revision=$revision"
           docker build \
             --file deploy/panel.Dockerfile \
             --build-arg "IMAGE_SOURCE=https://github.com/$REPO" \
-            --build-arg "IMAGE_REVISION=$SHA" \
+            --build-arg "IMAGE_REVISION=$revision" \
             --tag "$IMAGE:$STAGE-$ARCH" .
 
       # The acceptance criterion, against the exact bytes being released:
@@ -367,16 +452,18 @@ jobs:
           STAGE: ${{ inputs.stage }}
           ARCH: ${{ matrix.arch }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          # From the checkout, not from `github.sha` — see the Panel build.
+          revision="$(git rev-parse HEAD)"
+          echo "Labelling with org.opencontainers.image.revision=$revision"
           docker build \
             --file deploy/core.Dockerfile \
             --build-context tarball=artifacts/core \
             --label "org.opencontainers.image.title=Actana Core" \
             --label "org.opencontainers.image.description=The Actana Control Core: the daemon a Panel pairs with, and the machine your agentic coding sessions run on. Set ACTANA_PUBLIC_HOST to the host your Panel will dial and mount a volume at /home/core, which holds the pairing identity, the database and each Harness's credentials. Harnesses (claude-code, codex, cursor-cli, opencode) install at runtime into that volume, not into the image." \
             --label "org.opencontainers.image.source=https://github.com/$REPO" \
-            --label "org.opencontainers.image.revision=$SHA" \
+            --label "org.opencontainers.image.revision=$revision" \
             --label "org.opencontainers.image.licenses=MIT" \
             --tag "$IMAGE:$STAGE-$ARCH" \
             deploy
@@ -430,9 +517,14 @@ jobs:
       # also pins the *scanner*, so a finding count only moves when a
       # deliberate bump moves it.
       #
+      # It runs on the backport path too, and that is the point of saying so:
+      # a backport is the one release built rather than promoted (ADR 0023
+      # D26), and a CVE-flagged backport must not reach a repository people
+      # deploy from. D37's relaxation is for `-dev` only.
+      #
       # `always()` reports the gate even when the smoke above failed, which is
       # not the same as blessing an image that did not boot: `Push the per-arch
-      # tags` carries a bare `if: inputs.push`, so a failed step earlier in the
+      # tags` carries no `always()` of its own, so a failed step earlier in the
       # job keeps it skipped whatever the scanner says. Without it, D11's
       # measurement is hostage to an unrelated leg — a red smoke means nobody
       # sees the finding count at all.
@@ -473,8 +565,11 @@ jobs:
 
       # --------------------------------------------------------------- shared
 
+      # `inputs.mode == 'build'` because `promote` publishes too, and has no
+      # per-arch bytes to publish: it re-points an existing multi-arch digest
+      # in the `publish` job below and never touches a scaffolding tag.
       - name: Push the per-arch tags
-        if: inputs.push
+        if: inputs.push && inputs.mode == 'build'
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -518,6 +613,17 @@ jobs:
     # leaves push_required true and this job blocking.
     continue-on-error: ${{ !inputs.push_required }}
     steps:
+      # Two sources, one command. A build stitches its per-arch tags into the
+      # requested tags; a promotion (ADR 0023 D17) hands the *same* command a
+      # single source — the already-published `beta-x.y.z` index — and gets a
+      # second name for that digest. `imagetools create` copies an index
+      # without rewriting a config blob, which is what makes "the promoted
+      # bytes are the approved bytes" a property of the tool rather than a
+      # claim about it.
+      #
+      # It runs only after `build` succeeded, and on the promotion path `build`
+      # is where every architecture's revision label was asserted against the
+      # promoted commit (D16). Nothing is re-pointed before that assertion.
       - name: Stitch per-arch tags into the release tags
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -526,10 +632,12 @@ jobs:
           DEV_IMAGE: ${{ needs.resolve.outputs.dev_image }}
           SCAFFOLD_IMAGE: ${{ needs.resolve.outputs.scaffold_image }}
           IMAGE_KIND: ${{ inputs.image }}
+          MODE: ${{ inputs.mode }}
           MATRIX: ${{ inputs.matrix }}
           STAGE: ${{ inputs.stage }}
           TAGS: ${{ inputs.tags }}
           DEV_TAGS: ${{ inputs.dev_tags }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           set -euo pipefail
           if [[ -z "${TAGS// }${DEV_TAGS// }" ]]; then
@@ -543,11 +651,19 @@ jobs:
 
           # The arch list comes from the same matrix the build job used, so a
           # caller that builds one arch produces a one-arch manifest rather
-          # than referencing a tag that was never pushed.
+          # than referencing a tag that was never pushed. In promote mode it is
+          # the list of architectures whose revision label was asserted.
           arches="$(echo "$MATRIX" | jq -r '.include[].arch' | tr '\n' ' ')"
 
           sources=()
-          for arch in $arches; do sources+=("$SCAFFOLD_IMAGE:$STAGE-$arch"); done
+          if [[ "$MODE" == "promote" ]]; then
+            # One source: the published index. No per-arch tags exist for this
+            # run because this run built nothing.
+            sources+=("$IMAGE:$SOURCE_TAG")
+            echo "Promoting $IMAGE:$SOURCE_TAG to $TAGS — a retag, not a build (ADR 0023 D17)."
+          else
+            for arch in $arches; do sources+=("$SCAFFOLD_IMAGE:$STAGE-$arch"); done
+          fi
           # One stitch per destination repository, from one set of per-arch
           # bytes: `sha-<short>` in `-dev` and `beta-x.y.z` in the release
           # repository are then two names for one digest (ADR 0023 D11), which

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Release
 
-# Everything a `v*` tag publishes: the three Core tarballs and their
+# Everything a release publishes: the three Core tarballs and their
 # SHA256SUMS, the Panel and Core images, and the GitHub Release. One file
 # rather than four, because they are one event (ADR 0016 D34).
 #
-#   resolve ─┬─ tarball ───────── installer-e2e ─┐
-#            │                                   │
-#            └─ tarball-macos ⏸ ─┬─ panel ───────┤
-#                                └─ core ────────┴── github-release
+#   resolve ─┬─ tarball ──────── installer-e2e ─┐
+#            │                                  │
+#            └─ tarball-macos ─┬─ panel ────────┤
+#                              └─ core ─────────┴── github-release
 #
 # `panel` and `core` go through the reusable container-image.yml with
 # push: true, and both they and the tarball legs feed `github-release`.
@@ -20,14 +20,44 @@ name: Release
 # and four pages that drift until someone happens to cut a release is the
 # larger problem.
 #
-# ⏸ is the deliberate one: `tarball-macos` declares `environment: macos-release`
-# and therefore waits for a human. See its own comment.
+# ── Two modes (ADR 0023 D17, D26) ────────────────────────────────────────────
 #
-# Everything that leaves this repository sits downstream of that ⏸ — the images
-# and their `:latest`, the Docker Hub pages, the GitHub Release and its assets.
-# Only the Linux build-and-test work runs while a reviewer decides, and none of
-# it is published. That is what makes "reject" a real answer: an image push is
-# not undoable, and `:latest` has no history to roll back to.
+# `resolve` picks one from where the tag lives, and says which in the log:
+#
+#   promote   the tag is reachable from `main`. `panel` and `core` re-point the
+#             verified `beta-x.y.z` digest at `<version>` (and `latest`) with
+#             `docker buildx imagetools create`, and **build nothing**. A
+#             promotion cannot produce different bytes because it produces no
+#             bytes — which is this ADR's central claim, and it reduces to the
+#             assertion that the digest's `org.opencontainers.image.revision`
+#             label equals the promoted commit before anything is retagged.
+#
+#   backport  the tag is on a `release/*` branch. No beta train exists for an
+#             old line, so there is no digest to promote and the images are
+#             built and pushed from that branch. It is the one documented
+#             exception in the design (D26), and it keeps every gate the build
+#             path has — the smoke, and the Trivy CVE gate that stands between
+#             a flagged image and a repository people deploy from.
+#
+# Both modes go through the same reusable workflow under the same two job
+# names. `Panel image` / `Core image` are also the names of ci.yml's pinned
+# required checks; the events differ so there is no clash, but a rename here
+# would be a rename of a pinned check name and neither moves.
+#
+# ── The human pause is no longer here (ADR 0023 D15) ─────────────────────────
+#
+# `tarball-macos` used to declare `environment: macos-release`, so that every
+# publishing job sat downstream of a person. That ordering is preserved and
+# strengthened rather than dropped: the pause moved to the head of
+# `promote.yml`, which is upstream of this entire workflow — so the
+# fast-forward onto `main` is downstream of the human too, and `main` never
+# contains unapproved code. Exactly one pause exists; two would be a worse
+# experience for no extra safety.
+#
+# The image jobs still wait on `tarball-macos`, now for a different reason: not
+# a gate on a person, but a gate on the release being whole. An image and its
+# `:latest` published beside a GitHub Release that is missing a third of its
+# tarballs is the failure this ordering still prevents.
 #
 # Exactly four assets (D28, as amended): actana-core-<version>-linux-x64.tar.gz,
 # actana-core-<version>-linux-arm64.tar.gz,
@@ -57,15 +87,37 @@ name: Release
 # A present-but-*broken* credential fails at the `docker login` in
 # container-image.yml, before any tag is pushed.
 
+# ── The trigger (ADR 0023 D40) ───────────────────────────────────────────────
+#
+# There is no `push: tags: v*` trigger, and its absence is load-bearing.
+# `promote.yml` invokes this workflow by `workflow_call` and *also* pushes
+# `vx.y.z` as a record. Keeping the tag trigger would fire **two release runs**
+# for one promotion, and they would not even block each other: `github.ref_name`
+# is the tag under a tag push and the *caller's* ref under a `workflow_call`,
+# so the two runs would take different concurrency keys and race to build the
+# same tarballs and create the same GitHub Release.
+#
+# It also removes the need for a guard rather than adding one: a stray
+# hand-pushed `v*` tag now does nothing at all, which is a stronger property
+# than a check that catches it.
 on:
-  push:
-    tags:
-      - "v*"
-  # Re-runs a whole tag: rebuilds the tarballs and images, re-attaches the
-  # assets. A Docker Hub description typo is no longer fixed from here —
-  # merge the fix and the weekly `descriptions` chore publishes it, or
-  # `gh workflow run housekeeping.yml -f chore=descriptions` does it now
-  # (ADR 0023 D43).
+  # promote.yml, after the human pause and the fast-forward (D15, D40). The
+  # tag is pushed as a record before this is called, and `resolve` requires it
+  # to exist — every job downstream checks it out.
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0). Must already exist on origin."
+        type: string
+        required: true
+  # Re-runs a whole release: re-resolves the mode, rebuilds the tarballs,
+  # retags or rebuilds the images, re-attaches the assets. It is also the only
+  # way a backport releases at all (D26) and how its release candidate goes out
+  # (D30) — no promotion calls this for a `release/*` tag.
+  #
+  # A Docker Hub description typo is no longer fixed from here — merge the fix
+  # and the weekly `descriptions` chore publishes it, or `gh workflow run
+  # housekeeping.yml -f chore=descriptions` does it now (D43).
   workflow_dispatch:
     inputs:
       tag:
@@ -73,7 +125,14 @@ on:
         required: true
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  # Derived from the version, never from `github.ref_name` (D40). That
+  # expression resolves differently depending on how this workflow was
+  # entered, so two invocations for one version would take two different keys
+  # and run at the same time — which is exactly the race the dropped tag
+  # trigger would have caused. `inputs.tag` is the same string on both
+  # triggers, and `resolve` rejects anything that is not `vx.y.z`, so it *is*
+  # the version.
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 permissions:
@@ -89,40 +148,136 @@ jobs:
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
       version: ${{ steps.ref.outputs.version }}
-      tags: ${{ steps.ref.outputs.tags }}
+      sha: ${{ steps.ref.outputs.sha }}
+      mode: ${{ steps.ref.outputs.mode }}
+      image_mode: ${{ steps.ref.outputs.image_mode }}
+      source_tag: ${{ steps.ref.outputs.source_tag }}
+      tags: ${{ steps.tags.outputs.tags }}
+      latest: ${{ steps.tags.outputs.latest }}
+      prerelease: ${{ steps.tags.outputs.prerelease }}
     steps:
+      # Every branch and every tag. Both questions this job answers are
+      # questions about the whole ref graph rather than about one commit:
+      # which mode this is, is "where does this tag live" (D26), and whether
+      # `latest` moves is "is this the highest released version" (D28).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+
+      # The checkout brings the refs that existed when this job started, and
+      # `promote.yml` pushes the tag immediately before invoking this workflow.
+      # A second fetch costs a moment and removes a race that would otherwise
+      # read as "no such tag" on a perfectly good promotion.
+      - name: Fetch every branch and tag
+        run: git fetch --force --prune --tags origin "+refs/heads/*:refs/remotes/origin/*"
+
       - id: ref
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            ref="$INPUT_TAG"
-          else
-            ref="$REF_NAME"
-          fi
+          ref="$INPUT_TAG"
           # All three components, and no `+build` metadata. `v0` and `v0.1`
           # would publish exactly the moving `:0` / `:0.1` tags D30 forbids,
           # and `+` is not a legal character in a Docker tag — nor would
-          # `v0.1.0+abc` read as a prerelease below, so it would move :latest.
+          # `v0.1.0+abc` read as a prerelease, so it would move :latest.
           if [[ ! "$ref" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "release ref must be a version tag like v0.1.0 or v1.0.0-rc.1 — all three components, no +build metadata" >&2
+            echo "::error title=Not a version tag::'$ref' is not a version tag like v0.1.0 or v1.0.0-rc.1 — all three components, no +build metadata."
             exit 1
           fi
           version="${ref#v}"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          # `<version>` and `latest`, and no `0` / `0.1` ladder (D30): under
-          # semver a `0.x` minor bump *is* the breaking change, so a moving `:0`
-          # tag is a lie by construction. A prerelease (v1.0.0-rc.1) publishes
-          # its own version and must not move :latest.
-          if [[ "$version" == *-* ]]; then
-            echo "tags=$version" >> "$GITHUB_OUTPUT"
-          else
-            echo "tags=$version latest" >> "$GITHUB_OUTPUT"
+
+          # The tag is the record a release leaves behind (D40), and every job
+          # downstream checks it out. Deciding its absence here means one
+          # actionable error rather than four checkout failures at once.
+          if ! sha="$(git rev-parse -q --verify "refs/tags/$ref^{commit}")"; then
+            echo "::error title=No such tag::$ref is not on origin. A release publishes an existing tag — promotion pushes it as a record before calling this workflow (ADR 0023 D40), and a dispatch needs it pushed first."
+            exit 1
           fi
+
+          # The mode, read off the branch graph and nothing else (D26). Not an
+          # input and not a label: "this is a backport" is a fact about where
+          # the tag lives, and a human-set flag would be the thing forgotten
+          # during the incident that produced the backport.
+          if git merge-base --is-ancestor "$sha" origin/main; then
+            mode=promote
+            image_mode=promote
+            source_tag="beta-$version"
+            echo "::notice title=Promote mode::$ref ($sha) is reachable from main, so the train published $source_tag and a human approved that digest. The image jobs retag it and build nothing (ADR 0023 D17); the retag is refused unless the digest's revision label is $sha (D16)."
+          else
+            lines="$(git branch --remotes --contains "$sha" --list 'origin/release/*' | sed 's/^[* ]*//' | tr '\n' ' ')"
+            if [[ -z "${lines// }" ]]; then
+              echo "::error title=Tag is on neither main nor a release line::$ref ($sha) is not reachable from main and is on no origin/release/* branch, so there is neither a beta digest to promote nor a release line to build from. A release tag lives in exactly one of those two places (ADR 0023 D26)."
+              exit 1
+            fi
+            mode=backport
+            image_mode=build
+            source_tag=""
+            echo "::notice title=Backport mode::$ref ($sha) is on ${lines% } and is not reachable from main, so no beta train ever published a digest for it. The images are built and pushed from the release line — the one documented exception to digest promotion (ADR 0023 D26). Every gate the build path has applies unchanged, the Trivy CVE gate included."
+          fi
+
+          {
+            echo "ref=$ref"
+            echo "version=$version"
+            echo "sha=$sha"
+            echo "mode=$mode"
+            echo "image_mode=$image_mode"
+            echo "source_tag=$source_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      # The `latest` guard (D28) — the one that reaches end users. Both
+      # surfaces come from here: `tags` below feeds the docker tag list, and
+      # `latest` feeds `gh release create --latest=` in `github-release`. They
+      # are two renderings of one decision taken in
+      # scripts/lib/release-latest.mjs, which is where the rule is written down
+      # and unit-tested, because the failure is silent, reaches every existing
+      # user, and lies dormant until the first backport.
+      #
+      # The script's stdout is `key=value` and nothing else, so it pipes
+      # straight into $GITHUB_OUTPUT; `tee` keeps it in the log, and its
+      # reasoning goes to stderr.
+      - id: tags
+        env:
+          MODE: ${{ steps.ref.outputs.mode }}
+          RELEASE_VERSION: ${{ steps.ref.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/release-tags.mjs \
+            --mode "$MODE" --version "$RELEASE_VERSION" | tee -a "$GITHUB_OUTPUT"
+
+      # Belt and braces, in D28's own words. The rule is already structural in
+      # the module — a backport never reaches the comparison that could answer
+      # `latest` — and it is re-asserted here because *these* are the values
+      # that flow into the two publishing jobs, and because a guard that only
+      # exists inside the thing it guards is one edit away from being gone.
+      - name: A backport moves latest on neither surface
+        env:
+          MODE: ${{ steps.ref.outputs.mode }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+          LATEST: ${{ steps.tags.outputs.latest }}
+          RELEASE_REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$MODE" != "backport" ]]; then
+            echo "$MODE $RELEASE_REF: the highest-version test decided latest=$LATEST, publishing '$TAGS'."
+            exit 0
+          fi
+          for tag in $TAGS; do
+            if [[ "$tag" == "latest" ]]; then
+              echo "::error title=A backport must never move latest::Backport $RELEASE_REF resolved the docker tags '$TAGS'. Publishing an old line's patch as :latest moves every operator's \`docker pull\` backwards, with no history to roll back to (ADR 0023 D28)."
+              exit 1
+            fi
+          done
+          if [[ "$LATEST" != "false" ]]; then
+            echo "::error title=A backport must never be the GitHub latest release::Backport $RELEASE_REF resolved latest=$LATEST. /releases/latest is what install.sh installs by default and what the in-product update checker compares against, so this would tell every user on a newer line to downgrade (ADR 0023 D28)."
+            exit 1
+          fi
+          echo "✅ backport $RELEASE_REF publishes '$TAGS' and passes --latest=false. Neither surface moves."
 
       # D31, amended by ADR 0018: Docker Hub is the only registry, so missing
       # credentials mean the images have nowhere to go — on any repo, fork or
@@ -147,13 +302,12 @@ jobs:
           exit 1
 
   # The two Linux legs. The mac leg is `tarball-macos` below rather than a third
-  # row here, for two reasons. `needs:` waits on a matrix job whole, so an
-  # approval pause on any row of this one would hold `installer-e2e` — a
-  # Linux-only check that has nothing to wait for — behind a human. And
-  # `environment:` is a job-level key, so putting it here at all would mean
-  # `environment: ${{ matrix.environment }}` with an empty string on the Linux
-  # rows: a load-bearing gate expressed as a value that is usually blank.
-  # Split, the manual checks and the Linux installer e2e run side by side.
+  # row here. It was split when it carried the approval environment — a
+  # job-level key that a matrix cannot express per row, and `needs:` waits on a
+  # matrix job whole, so the pause would have held `installer-e2e` behind a
+  # human for no reason. The environment is gone (ADR 0023 D15) and the split
+  # stays: the mac leg bills at 10×, and keeping it out of this matrix is what
+  # lets the Linux legs and the installer e2e run without waiting on it.
   tarball:
     name: Core tarball (${{ matrix.target }})
     needs: resolve
@@ -225,24 +379,24 @@ jobs:
           retention-days: 14
 
   # The macOS Core tarball — the only macOS minutes this repository spends
-  # (D28, as amended). It is release-only and never runs on a pull request:
-  # macOS runners bill at 10×, and three macOS legs were once 72% of the whole
-  # CI bill (D35). One leg, on a release cadence, behind a person.
+  # (ADR 0016 D28, as amended). It is release-only and never runs on a pull
+  # request: macOS runners bill at 10×, and three macOS legs were once 72% of
+  # the whole CI bill (D35). One leg, on a release cadence.
   #
-  # `environment: macos-release` is the gate. That environment carries required
-  # reviewers, so this job enters "waiting" the moment the tag is pushed and
-  # burns no minutes until someone approves it in the UI. The reviewer's job is
-  # not to click: it is to run docs/core-macos-prerelease-checklist.md on real
-  # Apple hardware — Gatekeeper behaviour on an unsigned bundle, reboot and
-  # logout persistence of the LaunchAgent — none of which a runner that is
-  # destroyed rather than restarted can answer. Approving is the statement that
-  # the checklist passed.
+  # It used to declare `environment: macos-release`, which held it — and
+  # therefore every publishing job downstream of it — until a human had run
+  # docs/core-macos-prerelease-checklist.md on real Apple hardware. **That
+  # environment is gone from here (ADR 0023 D15), and the pause is not.** It
+  # moved to the head of `promote.yml`, upstream of this whole workflow, which
+  # puts the fast-forward onto `main` downstream of the human as well: `main`
+  # never contains unapproved code, where before it already did by the time
+  # anyone was asked. Exactly one pause exists, and this is no longer it.
   #
-  # The whole release waits on it, deliberately — `github-release` needs this
-  # job, and the reason is on that job. A release is rare, and the pause is the
-  # manual test window. Setting the environment up is an admin step: see
-  # docs/REPO_SETUP.md §2. On a fork with no such environment configured,
-  # GitHub creates an unprotected one on first use and this leg simply runs.
+  # The reviewer therefore builds their macOS tarball from the train tip rather
+  # than from a tag that does not exist yet. By D16's assertion that is the
+  # same commit, and it is available earlier, which is strictly better for
+  # them. The checklist itself is unchanged and still the gate — it is simply
+  # worked before the promotion is dispatched.
   #
   # macos-15 is Apple silicon (macos-15-intel is the Intel label), which is what
   # makes this a build rather than a cross-compile: node-pty's darwin-arm64
@@ -250,7 +404,6 @@ jobs:
   tarball-macos:
     name: Core tarball (mac-arm64)
     needs: resolve
-    environment: macos-release
     runs-on: macos-15
     timeout-minutes: 30
     env:
@@ -363,22 +516,32 @@ jobs:
             --tarball "artifacts/core/actana-core-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz" \
             --distro ${{ matrix.distro }}
 
-  # The images do not wait on the `tarball` job: container-image.yml builds the
-  # Core tarball it bakes in itself, on the runner that will ship it. They are
-  # the long pole (~3½ min for both images, both arches, both registries), so
-  # running them beside the Linux tarball legs is what keeps the machine part
-  # of a release under six minutes.
+  # The two image jobs, in whichever of the two modes `resolve` picked.
   #
-  # They *do* wait on `tarball-macos`, which is the leg behind the
-  # `macos-release` approval, and that is the whole point of the gate: pushing
-  # an image is not undoable. `:latest` is a moving pointer with no history, so
-  # a reviewer who works the checklist, hits a blocker and rejects — exactly as
-  # docs/core-macos-prerelease-checklist.md instructs — has to be able to
-  # believe that nothing shipped. If these two jobs ran on `resolve` alone,
-  # `docker pull actana/core:latest` would already be serving the build they
-  # just declared unfit, and the README quickstart points there. The cost is
-  # that a release is as slow as its reviewer; the alternative is a rejection
-  # that does not reject anything.
+  # In **promote** mode neither builds anything: `container-image.yml` pulls
+  # the `beta-x.y.z` digest, asserts its `org.opencontainers.image.revision`
+  # label equals the promoted commit, and only then re-points `<version>` (and
+  # `latest`, when the guard allows it) at that same digest with `docker
+  # buildx imagetools create` — the command it already uses to stitch
+  # multi-arch manifests. Seconds, and no bytes (ADR 0023 D16, D17).
+  #
+  # In **backport** mode they are the ordinary build-and-push path against the
+  # release line, because no beta digest exists to promote (D26).
+  #
+  # They do not wait on the `tarball` job: container-image.yml builds the Core
+  # tarball it bakes in itself, on the runner that will ship it.
+  #
+  # They *do* wait on `tarball-macos`. That used to be the approval gate; since
+  # D15 moved the pause into `promote.yml` it is a different guarantee, and
+  # still one worth having: a release is atomic or it is not a release. An
+  # image and its `:latest` are not undoable, so publishing them before the
+  # macOS leg has produced the tarball `github-release` needs would mean a
+  # `:latest` pointing at a version whose GitHub Release is missing a third of
+  # its assets — with `install.sh` reading exactly that Release.
+  #
+  # `name:` on both is pinned by the "Protect main" ruleset (the same two check
+  # names ci.yml uses on pull requests). Renaming either blocks every pull
+  # request in the repository until an admin updates the ruleset.
   panel:
     name: Panel image
     needs: [resolve, tarball-macos]
@@ -388,8 +551,14 @@ jobs:
     secrets: inherit
     with:
       image: panel
-      ref: ${{ needs.resolve.outputs.ref }}
+      # The commit, not the tag. In promote mode this is what the beta
+      # digest's revision label has to equal (D16); in backport mode it is what
+      # gets checked out and built. A tag would resolve to the same object and
+      # say less.
+      ref: ${{ needs.resolve.outputs.sha }}
       stage: ${{ needs.resolve.outputs.version }}
+      mode: ${{ needs.resolve.outputs.image_mode }}
+      source_tag: ${{ needs.resolve.outputs.source_tag }}
       tags: ${{ needs.resolve.outputs.tags }}
       push: true
 
@@ -402,8 +571,10 @@ jobs:
     secrets: inherit
     with:
       image: core
-      ref: ${{ needs.resolve.outputs.ref }}
+      ref: ${{ needs.resolve.outputs.sha }}
       stage: ${{ needs.resolve.outputs.version }}
+      mode: ${{ needs.resolve.outputs.image_mode }}
+      source_tag: ${{ needs.resolve.outputs.source_tag }}
       tags: ${{ needs.resolve.outputs.tags }}
       push: true
 
@@ -415,13 +586,13 @@ jobs:
     # here for a different reason (D36): an arm64 tarball the one-liner cannot
     # install is not an asset worth attaching.
     #
-    # `tarball-macos` is in here for a third: it is the leg behind the
-    # `macos-release` approval. It is now redundant — `panel` and `core` need
-    # it too, so it is already transitive — and it is kept named because a
-    # `needs:` list is the only place a reader learns what a job waits for, and
-    # this is the job whose assets the approval most directly governs. A
-    # SHA256SUMS covering a subset of the architectures the docs promise is
-    # worse than a release that is late.
+    # `tarball-macos` is in here for a third: this job composes SHA256SUMS
+    # across all three targets and refuses anything but four assets, so the mac
+    # leg is a hard input rather than a nice-to-have. It is redundant as a
+    # `needs:` — `panel` and `core` wait on it too, so it is already transitive
+    # — and kept named because a `needs:` list is the only place a reader
+    # learns what a job waits for. A SHA256SUMS covering a subset of the
+    # architectures the docs promise is worse than a release that is late.
     needs: [resolve, tarball, tarball-macos, installer-e2e, panel, core]
     runs-on: ubuntu-24.04
     permissions:
@@ -461,14 +632,44 @@ jobs:
       #
       # The upload path is create-or-upload idempotent, so it does not matter
       # whether the GitHub Release already exists when this runs.
+      #
+      # ── The second surface of the `latest` guard (ADR 0023 D28) ────────────
+      #
+      # `gh release create` was called here with no `--latest` flag at all, and
+      # the API defaults `make_latest` to **true**. That default is what makes
+      # a backport dangerous on this side: publishing `1.2.4` after `1.4.0`
+      # would make `/releases/latest` answer `v1.2.4`, which is the endpoint
+      # `install.sh` installs from by default and the one the in-product update
+      # checker compares against — so every 1.4.x user would be told an older
+      # version is available. `--latest` and `--prerelease` are therefore
+      # always passed explicitly, from the same decision that produced the
+      # docker tags, and never defaulted.
+      #
+      # `gh release edit` re-asserts both on the re-run path: `upload` cannot
+      # express them, and a Release created by hand carries whatever GitHub
+      # picked for it.
       - name: Attach to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_REF: ${{ needs.resolve.outputs.ref }}
+          RELEASE_MODE: ${{ needs.resolve.outputs.mode }}
+          RELEASE_LATEST: ${{ needs.resolve.outputs.latest }}
+          RELEASE_PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
         shell: bash
         run: |
           set -euo pipefail
+          # The same assertion `resolve` makes, at the surface it protects. A
+          # release job that trusted an upstream output to still be right is
+          # how the one guard that mattered gets bypassed by a later edit.
+          if [[ "$RELEASE_LATEST" != "true" && "$RELEASE_LATEST" != "false" ]]; then
+            echo "::error title=No explicit latest decision::resolve produced latest='$RELEASE_LATEST'. This flag is never defaulted — the API's default is true, which is the bug (ADR 0023 D28)."
+            exit 1
+          fi
+          if [[ "$RELEASE_MODE" == "backport" && "$RELEASE_LATEST" != "false" ]]; then
+            echo "::error title=A backport must never be the GitHub latest release::$RELEASE_REF is a backport and resolved --latest=$RELEASE_LATEST. /releases/latest is what the one-command installer resolves by default and what the in-product update checker compares against, so this would tell every user on a newer line to downgrade (ADR 0023 D28)."
+            exit 1
+          fi
           mapfile -t files < <(find core-tarballs -maxdepth 1 -type f \( -name '*.tar.gz' -o -name 'SHA256SUMS' \) | sort)
           if (( ${#files[@]} != 4 )); then
             echo "::error title=Wrong asset count::expected 4 assets (three tarballs + SHA256SUMS), found ${#files[@]}" >&2
@@ -477,11 +678,17 @@ jobs:
           fi
           echo "Attaching ${#files[@]} asset(s) to $RELEASE_REF:"
           printf '  %s\n' "${files[@]}"
+          echo "$RELEASE_MODE release: --latest=$RELEASE_LATEST --prerelease=$RELEASE_PRERELEASE"
 
           if gh release view "$RELEASE_REF" >/dev/null 2>&1; then
             gh release upload "$RELEASE_REF" "${files[@]}" --clobber
+            gh release edit "$RELEASE_REF" \
+              --latest="$RELEASE_LATEST" \
+              --prerelease="$RELEASE_PRERELEASE"
           else
             gh release create "$RELEASE_REF" "${files[@]}" \
               --title "$RELEASE_REF" \
+              --latest="$RELEASE_LATEST" \
+              --prerelease="$RELEASE_PRERELEASE" \
               --notes "Core tarballs for Linux and Apple-silicon macOS Cores. Verify with \`sha256sum -c SHA256SUMS\`."
           fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,10 +79,15 @@ routing around it.
 - [`core-linux-rehearsal.md`](core-linux-rehearsal.md) — rehearsing a Linux install
 - [`core-macos-prerelease-checklist.md`](core-macos-prerelease-checklist.md) — the macOS
   checks a runner cannot perform (Gatekeeper, and reboot/logout persistence).
-  **This one is the release gate**: a `v*` tag pauses on the `macos-release`
+  **This one is the release gate**: a release pauses on the `macos-release`
   environment until a reviewer works through it on real Apple hardware, and
   nothing — images, `:latest`, Release or tarballs — publishes until they
-  approve
+  approve. *Where* that pause sits is moving
+  ([ADR 0023](adr/0023-release-trains-and-digest-promotion.md) D15): it is no
+  longer `release.yml`'s `tarball-macos` job, and pushing a `v*` tag now fires
+  nothing at all (D40). It becomes the first step of `promote.yml` (#111),
+  which gates the fast-forward onto `main` as well. Exactly one pause exists
+  either way, and the checklist itself is unchanged
 - [`local-build-screen-recording.md`](local-build-screen-recording.md)
 
 ## Historical record

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -131,10 +131,10 @@ answer on a fork, and the wrong answer to ignore here.
 Set under **Settings → Environments**, not under Secrets and variables. It
 holds no secrets at all; the only thing it carries is a list of people.
 
-> **Do this before the first `v*` tag, not after.** A missing environment is
+> **Do this before the first promotion, not after.** A missing environment is
 > not a red build — GitHub auto-creates a referenced environment with **no
-> protection rules** on first use, so the mac leg would run immediately and the
-> whole release would publish unreviewed, silently. `GET
+> protection rules** on first use, so the gated job would run immediately and
+> the whole release would publish unreviewed, silently. `GET
 > /repos/actana/control/environments` returning `total_count: 0` means the gate
 > described below does not exist yet.
 
@@ -142,30 +142,43 @@ holds no secrets at all; the only thing it carries is a list of people.
 - [ ] **Required reviewers** → the people who own a Mac and can run the
       checklist. At least one, and give it more than one — until somebody
       approves, nothing a release would publish is published
-- [ ] Leave **deployment branches** unrestricted: the job that uses it runs on
-      a `v*` tag, and a branch restriction would refuse the tag
+- [ ] Leave **deployment branches** unrestricted: a branch restriction would
+      refuse the ref the gated job runs on
 - [ ] Confirm it took: `gh api repos/actana/control/environments --jq
       '.environments[].name'` lists `macos-release`
 
-`release.yml`'s `tarball-macos` job declares this environment, so on a tag push
-it enters **waiting** and burns no runner minutes until it is approved
-([ADR 0016](adr/0016-the-0-1-0-shape.md) D28, as amended). Approval is not a
-formality: the reviewer runs
+> **The job that declares this environment is moving.** `release.yml`'s
+> `tarball-macos` no longer declares it: under [ADR
+> 0023](adr/0023-release-trains-and-digest-promotion.md) D15 the pause is the
+> **first** thing `promote.yml` does, so the fast-forward onto `main` is
+> downstream of the human as well and `main` never contains unapproved code.
+> Exactly one pause exists either way. Until `promote.yml` lands (#111) the
+> environment is configured and referenced by nothing, which is inert — set it
+> up regardless, because the promotion workflow is what will reference it and a
+> missing environment is silently unprotected rather than red.
+>
+> The rest of this section is unchanged by that move: same environment name,
+> same reviewers, same checklist. What changes is *when* the reviewer is asked
+> — before the promotion is dispatched, against the train tip, rather than
+> after a tag is pushed. By D16's assertion that is the same commit, and it is
+> available earlier.
+
+Approval is not a formality: the reviewer runs
 [`core-macos-prerelease-checklist.md`](core-macos-prerelease-checklist.md) on
 real Apple hardware — Gatekeeper on an unsigned bundle, and whether the
 LaunchAgent survives a reboot and a logout — none of which a runner that is
 destroyed rather than restarted can answer. Clicking approve is the statement
 that it passed.
 
-**What a reviewer's approval actually controls: everything a release
-publishes.** `github-release` needs that job, and so do the `panel` and `core`
-image builds. So a rejection stops the GitHub Release, the tarballs, both
-images and `:latest`. (The Docker Hub pages are no longer downstream of it —
-they sync on a weekly clock now, and a page is not a published artifact.) That
-is the property worth protecting: an image push cannot be undone
-and `:latest` has no history, so a reviewer who rejects on a Gatekeeper blocker
-must be able to believe nothing shipped. The cost is that a release is as slow
-as its reviewer, which is the cheaper side of the trade.
+**What a reviewer's approval controls: everything a release publishes.** With
+the pause at the head of promotion, that is the whole of it — the fast-forward,
+the tag, both images and `:latest`, the GitHub Release and its tarballs.
+(The Docker Hub pages are not downstream of it — they sync on a weekly clock
+now, and a page is not a published artifact.) That is the property worth
+protecting: an image push cannot be undone and `:latest` has no history, so a
+reviewer who rejects on a Gatekeeper blocker must be able to believe nothing
+shipped. The cost is that a release is as slow as its reviewer, which is the
+cheaper side of the trade.
 
 ## 3. Branch ruleset for `main` (Settings → Rules → Rulesets)
 
@@ -241,10 +254,13 @@ single squashed commit, and every one of those tags drags the upstream Electron
 history behind it. They are **deleted on sight, not merely left unpushed**,
 because leaving them in a clone is a loaded gun:
 
-- [`release.yml`](../.github/workflows/release.yml) triggers on `v*`, so a
-  single `git push --tags` would both re-import the upstream history into a
-  repository that was squashed on purpose **and** fire 102 release runs —
-  each one publishing tarballs, two images and a GitHub Release.
+- A single `git push --tags` would re-import the upstream history into a
+  repository that was squashed on purpose. It no longer fires 102 release runs
+  as well: [`release.yml`](../.github/workflows/release.yml) has no `push:
+  tags` trigger, and a stray `v*` tag now does nothing at all ([ADR
+  0023](adr/0023-release-trains-and-digest-promotion.md) D40). That is the
+  reason the clause was written the way it was, and it is worth keeping in mind
+  when reading the rest of this warning.
 - They sort above `0.1.0`, so `git describe` and any future mirror would report
   a version this product has never released.
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -9,7 +9,7 @@ checks, labels) lives in [`REPO_SETUP.md`](REPO_SETUP.md).
 | --- | --- | --- |
 | [`ci.yml`](../.github/workflows/ci.yml) | every PR | nothing — it gates |
 | [`ci.yml`](../.github/workflows/ci.yml) | push to `main` | `:edge`, `:sha-<short>` |
-| [`release.yml`](../.github/workflows/release.yml) | `v*` tag | Core tarballs + checksums, `:<version>`, `:latest`, the GitHub Release, each image's Docker Hub page |
+| [`release.yml`](../.github/workflows/release.yml) | `workflow_call` from the promotion, or a dispatch — **not** a `v*` tag ([ADR 0023](adr/0023-release-trains-and-digest-promotion.md) D40) | Core tarballs + checksums, `:<version>`, `:latest` when it is the highest version, the GitHub Release |
 | [`housekeeping.yml`](../.github/workflows/housekeeping.yml) | daily cron | stale labels / closures |
 | [`housekeeping.yml`](../.github/workflows/housekeeping.yml) | weekly cron | a rebuilt-and-republished Core image, a `NODE_VERSION` bump PR, and an issue for anything the dev-tree audit or the Harness canary found |
 | [`landing.yml`](../.github/workflows/landing.yml) | push to `main` under `landing/**`, or dispatch | `landing/` uploaded to Bunny Edge Storage and the pull zone purged — the page at control.actana.ai |
@@ -553,15 +553,42 @@ deleting it.
 
 ## Cutting a release
 
+> **This section describes the pre-train flow and is being replaced.** Under
+> [ADR 0023](adr/0023-release-trains-and-digest-promotion.md) a release is a
+> **promotion**, not a tag push: `promote.yml` pauses for the human,
+> fast-forwards `main`, pushes `vx.y.z` as a record and calls `release.yml` by
+> `workflow_call`. Two clauses of that are already true in `release.yml` and
+> contradict what follows, so they are stated here rather than left to
+> surprise someone:
+>
+> - **Pushing a `v*` tag does nothing at all** (D40). The tag trigger is gone;
+>   keeping it beside the `workflow_call` would fire two racing release runs.
+>   `gh workflow run release.yml -f tag=v0.1.0` is how a release is driven by
+>   hand, and it is how a backport releases at all.
+> - **The macOS leg no longer waits for anybody** (D15). The pause moved to the
+>   head of `promote.yml`, which is upstream of the whole release — so it now
+>   also gates the fast-forward onto `main`. Exactly one pause exists.
+>
+> The full rewrite of this page — the train model, the tag ladder and the
+> rollback runbook — is #113.
+
 ```bash
-git tag v0.1.0 && git push origin v0.1.0
+gh workflow run release.yml --repo actana/control -f tag=v0.1.0
 ```
 
-That fires `release.yml`: the two Linux tarball legs and the installer e2e run
-straight away, the mac leg waits for a person (below), and once it is approved
-the two image builds, the GitHub Release and each image's Docker Hub page
-follow. If one needs rebuilding, the workflow accepts a `workflow_dispatch`
-with the tag name — the tag must already exist on origin.
+The two Linux tarball legs and the installer e2e run straight away, the mac
+tarball builds alongside them, and the two image jobs and the GitHub Release
+follow. Each image's Docker Hub page is no longer part of it — that syncs on a
+weekly clock now (D43). The tag must already exist on origin.
+
+`release.yml` resolves one of **two modes** from where that tag lives (D26). A
+tag reachable from `main` is a **promotion**: the image jobs re-point the
+`beta-x.y.z` digest a human already ran at `<version>` and build nothing, after
+asserting the digest was built from the promoted commit (D16, D17). A tag on a
+`release/*` branch is a **backport**: no beta train exists for an old line, so
+its images are built from that branch — the one documented exception in the
+design, and it keeps the CVE gate. A backport never moves `:latest`, on Docker
+Hub or on GitHub (D28).
 
 `release.yml` attaches nothing until its arm64 installer legs are green
 (see [The installer e2e](#the-installer-e2e-and-why-it-is-one-job-on-two-triggers)),
@@ -576,9 +603,11 @@ in `release.yml`, so both are yours:
   before you push the tag.
 - **The `macos-release` environment exists with required reviewers on it.**
   Without it there is no pause at all: GitHub auto-creates a referenced
-  environment with no protection rules, so the mac leg runs immediately and the
-  release publishes unreviewed — silently, not as a red build. See
-  [`REPO_SETUP.md`](REPO_SETUP.md) §2.
+  environment with no protection rules, so the gated job runs immediately and
+  the release publishes unreviewed — silently, not as a red build. The
+  environment is no longer referenced from `release.yml` (D15); it is
+  `promote.yml` that will hold it, and until that lands nothing references it.
+  See [`REPO_SETUP.md`](REPO_SETUP.md) §2.
 
 `resolve` does fail the run outright when `DOCKERHUB_USERNAME` or
 `DOCKERHUB_TOKEN` is missing on `actana/control`, before anything is built —
@@ -586,16 +615,19 @@ that one the workflow does check.
 
 ### The approval pause — a release waits for a person
 
-The `tarball-macos` job declares `environment: macos-release`, and that
-environment has required reviewers. So a tag push does **not** produce a
-release on its own: the job goes to **waiting** the moment the run starts, and
-only the unpublished machine work — the Linux tarballs and the installer e2e —
-proceeds while it waits.
+> **The pause has moved out of `release.yml` (ADR 0023 D15).** What follows
+> describes it correctly except for *where* it sits: it is the first step of
+> `promote.yml` rather than the `tarball-macos` job, which means it now gates
+> the fast-forward onto `main` as well, and the reviewer builds their tarball
+> from the train tip rather than from the tag. Exactly one pause exists.
+
+The gated job goes to **waiting** the moment the run starts, and only
+unpublished machine work proceeds while it waits.
 
 **Nothing leaves the repository until a reviewer approves.** Every publishing
-job sits downstream of that leg: `github-release` needs it, and so do `panel`
-and `core`. No image, no moved `:latest`, no GitHub Release
-([ADR 0016](adr/0016-the-0-1-0-shape.md) D28, as amended).
+job sits downstream of the pause: no image, no moved `:latest`, no GitHub
+Release ([ADR 0016](adr/0016-the-0-1-0-shape.md) D28, as amended; ADR 0023
+D15).
 
 That ordering costs a release the reviewer's own latency, and it buys the one
 thing that makes "reject" a real answer: an image push is not undoable, and
@@ -607,9 +639,9 @@ worse than a release that is late.
 The pause is the manual test window, not a rubber stamp. Before approving,
 the reviewer:
 
-1. Builds the tarball on their own Mac from the tagged commit —
+1. Builds the tarball on their own Mac from the commit under review —
    `pnpm core:tarball` on Apple silicon produces exactly the `mac-arm64` asset
-   the waiting leg will. The leg has not run yet, so there is nothing to
+   the release will. Nothing has been built yet, so there is nothing to
    download.
 2. Works through
    [`core-macos-prerelease-checklist.md`](core-macos-prerelease-checklist.md)

--- a/docs/core-macos-prerelease-checklist.md
+++ b/docs/core-macos-prerelease-checklist.md
@@ -1,12 +1,23 @@
 # macOS Core — the release approval checklist
 
-> **This page is the gate.** `release.yml`'s `tarball-macos` job declares
-> `environment: macos-release`, and that environment has required reviewers, so
-> a tag push pauses there until a person approves it (ADR 0016 D28, as
-> amended). Working through this list on real Apple hardware **is** what the
-> reviewer is approving. Every publishing job needs that leg — the Release, the
-> tarballs, both images and `:latest` — so nothing publishes until they do. An
-> unticked box below is a reason to reject the release, not a note to file.
+> **This page is the gate.** The `macos-release` environment has required
+> reviewers, and the job that declares it pauses until a person approves.
+> Working through this list on real Apple hardware **is** what the reviewer is
+> approving. An unticked box below is a reason to reject the release, not a
+> note to file.
+>
+> **Where the pause sits is moving** ([ADR
+> 0023](adr/0023-release-trains-and-digest-promotion.md) D15). It used to be
+> `release.yml`'s `tarball-macos` job, which paused after the tag was pushed;
+> it becomes the **first** step of `promote.yml`, so the fast-forward onto
+> `main` is downstream of the approval too and `main` never contains
+> unapproved code. Exactly one pause exists either way, and this checklist is
+> unchanged by the move. `release.yml` no longer carries the environment
+> (#110); `promote.yml` picks it up (#111).
+>
+> One practical difference for you: you build the tarball you are testing from
+> the **train tip** rather than from a tag that does not exist yet. By D16's
+> assertion that is the same commit, and it is available earlier.
 
 **Nothing automated can cover what follows**, which is why the gate is a person
 rather than a job. A GitHub runner is destroyed rather than restarted, and a
@@ -143,12 +154,12 @@ the two properties this checklist exists to protect, and an unticked box in
 either means the Mac Core in front of you is not fit to run — as does the
 Gatekeeper box in section 1. Any of those three is a **reject**.
 
-**Rejecting stops everything a tag would publish**, not just the macOS
+**Rejecting stops everything a release would publish**, not just the macOS
 tarball: no GitHub Release, no Linux tarballs, no `actana/panel` or
-`actana/core` image, no moved `:latest`, no Docker Hub description update.
-Every publishing job in `release.yml` sits downstream of the leg you are
-holding. Nothing needs rolling back, because nothing left the repository — the
-fix ships in the next tag.
+`actana/core` image, no moved `:latest`. With the pause at the head of
+promotion (ADR 0023 D15) it also stops the fast-forward itself, so `main` does
+not advance either. Nothing needs rolling back, because nothing left the
+repository — the fix rides the train and is promoted next time.
 
 Approving spends the runner minutes, then releases the images and the four
 assets in one go. Nothing else is waiting on you afterwards.

--- a/scripts/__tests__/panel-image.test.mjs
+++ b/scripts/__tests__/panel-image.test.mjs
@@ -315,17 +315,34 @@ describe("reference compose", () => {
 });
 
 describe("release workflow", () => {
-  it("builds the image on version tags, like the Core release", () => {
-    expect(workflow).toMatch(/tags:\s*\n\s*- "v\*"/);
+  // The Panel image ships on a version tag — but the tag no longer *triggers*
+  // anything (ADR 0023 D40). `promote.yml` calls this workflow and pushes the
+  // tag as a record; a `push: tags` trigger beside that would fire a second
+  // release run that the first could not even block. What is asserted here is
+  // what did not change: the release is still entered with a `v*` tag, and it
+  // is that tag the image jobs publish under. The trigger itself is pinned in
+  // scripts/__tests__/workflows.test.mjs.
+  it("publishes the image for a version tag it is handed, not one it watches", () => {
+    expect(workflow).toMatch(/^ {2}workflow_call:$/m);
+    expect(workflow).not.toMatch(/tags:\s*\n\s*- "v\*"/);
+    expect(workflow).toMatch(/description: "Tag to .*\(e\.g\. v0\.1\.0\)/);
   });
 
   it("delegates the build to the shared image workflow", () => {
     expect(workflow).toContain("./.github/workflows/container-image.yml");
   });
 
-  it("publishes :latest alongside the version, but never for a prerelease", () => {
-    expect(workflow).toContain("$version latest");
-    expect(workflow).toMatch(/version.*==.*\*-\*/);
+  // `tags="$version latest"` for anything without a `-` in it used to live
+  // here as two lines of shell, and it was the whole of the `latest` rule —
+  // no highest-version test, so a backport of an old line would have moved
+  // `:latest` backwards for every operator (D28). The decision moved to
+  // scripts/lib/release-latest.mjs, where the prerelease case is one of three
+  // and all of them are covered by scripts/__tests__/release-latest.test.mjs.
+  // What this file asserts is the wiring: one decision, reaching the images.
+  it("takes its tag list from the tested latest guard, not from inline shell", () => {
+    expect(workflow).toContain("node scripts/release-tags.mjs");
+    expect(workflow).not.toContain("$version latest");
+    expect(workflow).toContain("tags: ${{ needs.resolve.outputs.tags }}");
   });
 
   // D30 lives in the tag regex as much as in the tag list: `v0` and `v0.1`

--- a/scripts/__tests__/release-latest.test.mjs
+++ b/scripts/__tests__/release-latest.test.mjs
@@ -1,0 +1,250 @@
+// The `latest` guard (ADR 0023 D28), which is the one that reaches end users.
+//
+// `:latest` is a pointer with no history and `/releases/latest` is what
+// `install.sh` installs by default. Move either of them backwards — publish
+// `1.2.4` after `1.4.0` — and every 1.4.x user is told an older version is
+// available, silently, with no red build anywhere. The bug is dormant until
+// the first backport, which is precisely the release nobody wants to be
+// improvising during.
+//
+// So the rule is tested here rather than exercised in CI, because exercising
+// it in CI would mean cutting a real backport of a real old line. The claims
+// below are the ones D28 makes:
+//
+//   * a backport is *structurally* incapable of emitting `latest` — not
+//     "loses the comparison", but never reaches it, for any version and any
+//     ladder including one where it would win
+//   * the Docker tag list and the `gh release --latest` flag are one decision
+//     rendered twice and cannot drift apart
+//   * a prerelease publishes its own version and nothing else (D30)
+//   * `latest` follows an explicit highest-version test, which is the test the
+//     old `tags="$version latest"` did not have
+
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertNeverLatest,
+  compareReleaseVersions,
+  isHighestRelease,
+  parseReleaseVersion,
+  publishedVersionsFromTags,
+  resolveReleaseTags,
+} from "../lib/release-latest.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const LADDER = ["v1.0.0", "v1.2.3", "v1.3.0", "v1.4.0", "v1.5.0-rc.1"];
+
+describe("backport mode is structurally incapable of emitting latest (D28)", () => {
+  it("withholds latest from the backport that would otherwise move it backwards", () => {
+    const decision = resolveReleaseTags({ mode: "backport", version: "1.2.4", published: LADDER });
+    expect(decision.latest).toBe(false);
+    expect(decision.tags).toEqual(["1.2.4"]);
+    expect(decision.reason).toMatch(/backport/);
+  });
+
+  // The load-bearing one. A backport that *wins* the highest-version test —
+  // there is no higher tag in the ladder at all — still publishes no `latest`,
+  // which is what makes this structural rather than a comparison that happens
+  // to come out right. If the mode check were reordered below the comparison,
+  // every other test in this file would still pass and this one would fail.
+  it("withholds latest even when the backport is the highest version there is", () => {
+    const decision = resolveReleaseTags({
+      mode: "backport",
+      version: "9.9.9",
+      published: ["v1.0.0"],
+    });
+    expect(isHighestRelease("9.9.9", ["v1.0.0"])).toBe(true);
+    expect(decision.latest).toBe(false);
+    expect(decision.tags).toEqual(["9.9.9"]);
+  });
+
+  // Every version against every ladder: no arrangement of the inputs, and no
+  // bug in the comparison the mode check sits above, produces `latest`.
+  it("emits no latest for any version against any ladder", () => {
+    const versions = ["0.0.1", "1.2.4", "1.4.1", "1.5.0", "2.0.0", "9.9.9", "1.2.4-rc.1"];
+    const ladders = [[], ["v1.4.0"], LADDER, ["v0.0.1"], ["v9.9.9", "v1.2.3"]];
+    for (const version of versions) {
+      for (const published of ladders) {
+        const decision = resolveReleaseTags({ mode: "backport", version, published });
+        expect(decision.latest, `${version} against [${published}]`).toBe(false);
+        expect(decision.tags, `${version} against [${published}]`).toEqual([version]);
+      }
+    }
+  });
+
+  it("throws rather than publishes if a backport ever arrives carrying latest", () => {
+    expect(() => assertNeverLatest({ mode: "backport", tags: ["1.2.4", "latest"], latest: true }))
+      .toThrow(/never move `latest`/);
+    // Either surface alone is enough to fail it: the tag list and the flag are
+    // checked independently, because a half-applied guard is the failure this
+    // assertion exists to catch.
+    expect(() => assertNeverLatest({ mode: "backport", tags: ["1.2.4"], latest: true })).toThrow();
+    expect(() =>
+      assertNeverLatest({ mode: "backport", tags: ["1.2.4", "latest"], latest: false }),
+    ).toThrow();
+    expect(() => assertNeverLatest({ mode: "backport", tags: ["1.2.4"], latest: false })).not.toThrow();
+    // Not a backport, not this assertion's business.
+    expect(() =>
+      assertNeverLatest({ mode: "promote", tags: ["1.4.0", "latest"], latest: true }),
+    ).not.toThrow();
+  });
+});
+
+describe("the highest-version test gates latest on both surfaces (D28)", () => {
+  it("gives latest to a promotion that is the highest version", () => {
+    const decision = resolveReleaseTags({ mode: "promote", version: "1.5.0", published: LADDER });
+    expect(decision).toMatchObject({ latest: true, prerelease: false, tags: ["1.5.0", "latest"] });
+  });
+
+  it("gives latest to the very first release, whose ladder is empty", () => {
+    expect(resolveReleaseTags({ mode: "promote", version: "0.1.0", published: [] }).latest).toBe(
+      true,
+    );
+  });
+
+  it("counts the release's own tag, which is pushed before the run (D40)", () => {
+    // `v1.5.0` is already on origin by the time `resolve` reads the ladder.
+    const decision = resolveReleaseTags({
+      mode: "promote",
+      version: "1.5.0",
+      published: [...LADDER, "v1.5.0"],
+    });
+    expect(decision.latest).toBe(true);
+  });
+
+  it("withholds latest from a re-release of an older version", () => {
+    const decision = resolveReleaseTags({ mode: "promote", version: "1.3.0", published: LADDER });
+    expect(decision.latest).toBe(false);
+    expect(decision.reason).toMatch(/not the highest/);
+    expect(decision.reason).toContain("1.4.0");
+  });
+
+  it("ignores prereleases in the ladder — nobody runs an rc as their latest", () => {
+    expect(isHighestRelease("1.4.1", ["v1.5.0-rc.1", "v1.4.0"])).toBe(true);
+  });
+
+  // The two surfaces are one boolean rendered twice. A tag list carrying
+  // `latest` while the flag says false — or the reverse — is the drift D28
+  // asks for the guard on both sides to prevent.
+  it("keeps the docker tag and the gh release flag in agreement, always", () => {
+    for (const mode of ["promote", "backport"]) {
+      for (const version of ["1.2.4", "1.5.0", "2.0.0", "1.5.0-rc.1"]) {
+        for (const published of [[], LADDER, ["v9.0.0"]]) {
+          const decision = resolveReleaseTags({ mode, version, published });
+          expect(decision.tags.includes("latest"), `${mode} ${version}`).toBe(decision.latest);
+        }
+      }
+    }
+  });
+});
+
+describe("prerelease tags publish their version and never move latest (D30)", () => {
+  it("publishes 1.2.4-rc.1 under its own version only", () => {
+    const decision = resolveReleaseTags({
+      mode: "backport",
+      version: "1.2.4-rc.1",
+      published: LADDER,
+    });
+    expect(decision).toMatchObject({
+      tags: ["1.2.4-rc.1"],
+      latest: false,
+      prerelease: true,
+    });
+  });
+
+  // The rc path is a backport's first step (D30), but the prerelease rule is
+  // its own: a promote-mode rc must not take `latest` either, and that holds
+  // without the mode check doing the work.
+  it("withholds latest from a prerelease promoted as the highest version", () => {
+    const decision = resolveReleaseTags({ mode: "promote", version: "9.9.9-rc.1", published: [] });
+    expect(decision.latest).toBe(false);
+    expect(decision.prerelease).toBe(true);
+    expect(decision.reason).toMatch(/prerelease/);
+  });
+});
+
+describe("version parsing", () => {
+  it("takes three components and an optional prerelease", () => {
+    expect(parseReleaseVersion("1.2.4")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 4,
+      prerelease: null,
+    });
+    expect(parseReleaseVersion("1.2.4-rc.1")?.prerelease).toBe("rc.1");
+  });
+
+  it("rejects what has no Docker tag or would misread as a release", () => {
+    // `+` is not legal in a Docker tag, and `1.0.0+abc` does not read as a
+    // prerelease — it would move `:latest`.
+    for (const bad of ["v1.2.4", "1.2", "1", "1.0.0+abc", "latest", "", null]) {
+      expect(parseReleaseVersion(bad), String(bad)).toBeNull();
+    }
+    expect(() => resolveReleaseTags({ mode: "promote", version: "1.0.0+abc" })).toThrow(
+      /not a release version/,
+    );
+  });
+
+  it("rejects an unknown mode rather than guessing one", () => {
+    expect(() => resolveReleaseTags({ mode: "hotfix", version: "1.0.0" })).toThrow(
+      /unknown release mode/,
+    );
+  });
+
+  it("orders versions by semver precedence, prereleases below their release", () => {
+    const sorted = ["1.2.4", "1.2.4-rc.2", "1.10.0", "1.2.4-rc.1", "1.3.0", "2.0.0"].sort(
+      compareReleaseVersions,
+    );
+    expect(sorted).toEqual(["1.2.4-rc.1", "1.2.4-rc.2", "1.2.4", "1.3.0", "1.10.0", "2.0.0"]);
+  });
+
+  it("reads the ladder as git prints it, dropping anything that is not a version", () => {
+    expect(publishedVersionsFromTags(["v1.2.3", "", "  v1.3.0  ", "nightly", "v1.4"])).toEqual([
+      "1.2.3",
+      "1.3.0",
+    ]);
+    expect(publishedVersionsFromTags("v1.2.3\nv1.3.0\n")).toEqual(["1.2.3", "1.3.0"]);
+  });
+});
+
+// The contract `release.yml` depends on: stdout is `key=value` lines and
+// nothing else, because the step pipes it into `$GITHUB_OUTPUT`. A stray
+// `console.log` here would write an arbitrary line into a job's outputs.
+describe("the CLI's $GITHUB_OUTPUT contract", () => {
+  const run = (args) =>
+    execFileSync("node", [path.join(repoRoot, "scripts/release-tags.mjs"), ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+  it("prints only key=value lines on stdout", () => {
+    const stdout = run(["--mode", "promote", "--version", "1.5.0", "--published", LADDER.join(" ")]);
+    expect(stdout.split("\n").filter(Boolean)).toEqual([
+      "mode=promote",
+      "tags=1.5.0 latest",
+      "latest=true",
+      "prerelease=false",
+    ]);
+  });
+
+  it("renders a backport with no latest on either surface", () => {
+    const stdout = run([
+      "--mode",
+      "backport",
+      "--version",
+      "1.2.4",
+      "--published",
+      LADDER.join(" "),
+    ]);
+    expect(stdout).toContain("tags=1.2.4\n");
+    expect(stdout).toContain("latest=false");
+    expect(stdout).not.toContain("latest\n");
+  });
+
+  it("exits non-zero rather than emitting a decision it could not make", () => {
+    expect(() => run(["--mode", "promote", "--version", "1.2"])).toThrow();
+    expect(() => run(["--mode", "sideways", "--version", "1.2.3"])).toThrow();
+  });
+});

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -105,19 +105,28 @@ describe("the workflow inventory (ADR 0016 D34)", () => {
   });
 });
 
-// The macOS cost posture (decision #14) and the approval gate (D28, as
-// amended) are both invisible in a green run: a release that quietly built its
-// mac tarball without waiting for a person looks exactly like one that waited,
-// and a macOS runner that crept into the PR path looks exactly like a slow PR
-// until the bill arrives. Both are one deleted line away, so both are pinned.
+// The macOS cost posture (decision #14) is invisible in a green run: a macOS
+// runner that crept into the PR path looks exactly like a slow PR until the
+// bill arrives. It is one added line away, so it is pinned.
 describe("the macOS release leg (ADR 0016 D28, as amended)", () => {
   const source = read("release.yml");
 
-  it("builds mac-arm64 behind the macos-release environment", () => {
+  // ADR 0023 D15. The approval environment that used to sit on this leg is
+  // gone: the pause moved to the head of `promote.yml`, upstream of this whole
+  // workflow, so the fast-forward onto `main` is downstream of the human too.
+  // **Exactly one pause exists.** This assertion is the inverse of the one it
+  // replaces, and it is here for the same reason that one was: a second pause
+  // reappearing here would be invisible in a green run — it would look like a
+  // release nobody had got round to approving yet.
+  it("builds mac-arm64 with no approval environment of its own (D15)", () => {
     const job = jobBlock(source, "tarball-macos");
-    expect(job).toContain("environment: macos-release");
+    expect(job).not.toContain("environment:");
     expect(job).toMatch(/runs-on: macos-/);
     expect(job).toContain("TARGET: mac-arm64");
+  });
+
+  it("leaves no approval environment anywhere in the release", () => {
+    expect(code(source)).not.toContain("macos-release");
   });
 
   it("holds the release behind that leg, so SHA256SUMS covers every asset", () => {
@@ -132,15 +141,15 @@ describe("the macOS release leg (ADR 0016 D28, as amended)", () => {
     );
   });
 
-  // The reason this matters more than the ordering it looks like: pushing an
-  // image is not undoable, and `:latest` is a pointer with no history. A
-  // reviewer who rejects on a Gatekeeper blocker has to be able to believe
-  // nothing shipped, and that is only true while every publishing job sits
-  // downstream of the approval.
-  it("publishes no image until that leg is approved", () => {
+  // The ordering outlives the approval that motivated it (D15). Pushing an
+  // image is not undoable and `:latest` is a pointer with no history, so an
+  // image published beside a GitHub Release missing a third of its tarballs is
+  // a state nothing can walk back — and `install.sh` reads exactly that
+  // Release. A release is atomic or it is not a release.
+  it("publishes no image until every tarball the release needs exists", () => {
     for (const image of ["panel", "core"]) {
       const job = jobBlock(source, image);
-      expect(job, `${image} publishes ahead of the approval`).toMatch(
+      expect(job, `${image} publishes ahead of the mac tarball`).toMatch(
         /needs: \[[^\]]*tarball-macos[^\]]*\]/,
       );
       expect(job).toContain("push: true");
@@ -162,6 +171,176 @@ describe("the macOS release leg (ADR 0016 D28, as amended)", () => {
     for (const file of ["ci.yml", "housekeeping.yml", "container-image.yml"]) {
       expect(read(file), `${file} runs a job on macOS`).not.toMatch(/runs-on:.*macos/);
     }
+  });
+});
+
+// Everything here is invisible in a green run and expensive when wrong. A
+// second release run racing the first looks like a slow release; a promotion
+// that quietly rebuilt looks like a promotion; a backport that moved `latest`
+// looks like a successful backport, right up until every existing user is told
+// to downgrade.
+describe("release.yml's trigger and its two modes (ADR 0023 D17, D26, D28, D40)", () => {
+  const source = read("release.yml");
+  const body = code(source);
+
+  // D40. The tag trigger is gone and its absence is load-bearing: promote.yml
+  // calls this workflow *and* pushes the tag, so a `push: tags` trigger would
+  // fire a second run — one that would not even serialise against the first,
+  // because the two resolve `github.ref_name` differently.
+  it("has no tag trigger, takes a workflow_call, and keeps its dispatch", () => {
+    expect(body).not.toMatch(/^ {2}push:$/m);
+    expect(body).not.toMatch(/^ {6}- "v\*"$/m);
+    expect(body).toMatch(/^ {2}workflow_call:$/m);
+    expect(body).toMatch(/^ {2}workflow_dispatch:$/m);
+  });
+
+  // The other half of D40's trap, and the reason the trigger alone is not
+  // enough: `github.ref_name` is the tag under a push and the caller's ref
+  // under a `workflow_call`. Anything keyed on it takes two different values
+  // for one release, so nothing here reads it at all.
+  it("keys concurrency on the version rather than on github.ref_name", () => {
+    expect(body).toMatch(/^ {2}group: release-\$\{\{ inputs\.tag \}\}$/m);
+    expect(body).toMatch(/^ {2}cancel-in-progress: false$/m);
+    expect(body, "github.ref_name resolves differently under workflow_call").not.toContain(
+      "github.ref_name",
+    );
+  });
+
+  // D26. The mode is a fact about where the tag lives, read off the branch
+  // graph — not an input, not a label, and so not a thing anyone can forget to
+  // set during the incident that produced the backport.
+  it("picks its mode from where the tag lives, and says which in the log", () => {
+    const job = code(jobBlock(source, "resolve"));
+    expect(job).toContain("git merge-base --is-ancestor");
+    expect(job).toContain("origin/main");
+    expect(job).toMatch(/--list 'origin\/release\/\*'/);
+    expect(job).toContain("mode=promote");
+    expect(job).toContain("mode=backport");
+    expect(job).toContain("::notice title=Promote mode::");
+    expect(job).toContain("::notice title=Backport mode::");
+  });
+
+  // D17. Both image jobs are one call in two modes: `promote` retags,
+  // `build` builds. The names are pinned by the "Protect main" ruleset — the
+  // same two names ci.yml's required checks use — so they are asserted
+  // literally here. A rename blocks every pull request in the repository until
+  // an admin updates the ruleset.
+  it("keeps the two pinned check names and hands both modes to the same call", () => {
+    for (const [job, name] of [
+      ["panel", "Panel image"],
+      ["core", "Core image"],
+    ]) {
+      const block = jobBlock(source, job);
+      expect(block, `${job} lost its pinned check name`).toContain(`name: ${name}`);
+      expect(block).toContain("uses: ./.github/workflows/container-image.yml");
+      expect(block).toContain("mode: ${{ needs.resolve.outputs.image_mode }}");
+      expect(block).toContain("source_tag: ${{ needs.resolve.outputs.source_tag }}");
+      // The commit, not the tag: promote mode asserts the digest's revision
+      // label against it (D16) and backport mode builds it.
+      expect(block).toContain("ref: ${{ needs.resolve.outputs.sha }}");
+    }
+    // ci.yml's copies of the same two names, which is what makes them pinned.
+    const ci = read("ci.yml");
+    expect(ci).toContain("name: Panel image");
+    expect(ci).toContain("name: Core image");
+  });
+
+  // D28, surface one. The old code emitted `tags="$version latest"` for
+  // anything without a `-` in it — no highest-version test anywhere — and this
+  // asserts that shell is gone rather than merely bypassed.
+  it("takes the latest decision from the tested module, not from a shell default", () => {
+    const job = code(jobBlock(source, "resolve"));
+    expect(job).toContain("node scripts/release-tags.mjs");
+    expect(job).not.toMatch(/tags=\$version latest/);
+  });
+
+  // D28, surface two — the one that reaches `install.sh` and the in-product
+  // update checker. `gh release create` defaults `make_latest` to true, so an
+  // absent flag is the bug; it is passed explicitly on both the create and the
+  // re-run paths.
+  it("passes --latest explicitly to gh release, on create and on edit", () => {
+    const job = code(jobBlock(source, "github-release"));
+    expect(job).toContain('--latest="$RELEASE_LATEST"');
+    expect(job).toContain('--prerelease="$RELEASE_PRERELEASE"');
+    expect(job).toMatch(/gh release create[^]*--latest=/);
+    expect(job).toMatch(/gh release edit[^]*--latest=/);
+  });
+
+  // D28's assertion, on both surfaces, in the two jobs that own them. The
+  // rule itself is structural in scripts/lib/release-latest.mjs and covered by
+  // scripts/__tests__/release-latest.test.mjs; what is pinned here is that the
+  // workflow re-checks it at the point of publishing rather than trusting an
+  // upstream output to still be right.
+  it("refuses a backport that carries latest, on the docker tags and on GitHub", () => {
+    const resolve = code(jobBlock(source, "resolve"));
+    expect(resolve).toContain("A backport must never move latest");
+    const release = code(jobBlock(source, "github-release"));
+    expect(release).toContain('"$RELEASE_MODE" == "backport"');
+    expect(release).toContain("A backport must never be the GitHub latest release");
+  });
+});
+
+describe("container-image.yml's promote mode (ADR 0023 D16, D17)", () => {
+  const source = read("container-image.yml");
+  const body = code(source);
+
+  it("retags an existing digest and builds nothing", () => {
+    expect(body).toMatch(/^ {2} {4}source_tag:$/m);
+    const publish = code(jobBlock(source, "publish"));
+    expect(publish).toContain('sources+=("$IMAGE:$SOURCE_TAG")');
+    expect(publish).toContain("docker buildx imagetools create");
+    // Every build step is gated on `build` mode, so a promotion runs none of
+    // them. Asserted as a count rather than by name: a new build step added
+    // without the gate is exactly the regression that would make a promotion
+    // start producing bytes.
+    const build = jobBlock(source, "build");
+    const dockerBuilds = [...build.matchAll(/^ {8}run: \|?[^]*?docker build /gm)];
+    for (const step of build.split(/\n {6}- /).slice(1)) {
+      if (!/docker build /.test(step)) continue;
+      expect(step, "a build step that a promotion would run").toContain(
+        "if: inputs.mode == 'build'",
+      );
+    }
+    expect(dockerBuilds.length).toBeGreaterThan(0);
+  });
+
+  it("asserts the revision label before anything is re-pointed", () => {
+    const build = code(jobBlock(source, "build"));
+    expect(build).toContain("if: inputs.mode == 'verify' || inputs.mode == 'promote'");
+    expect(build).toContain("org.opencontainers.image.revision");
+    expect(build).toContain("Refusing to promote a digest built from another commit");
+    // The retag lives in `publish`, which needs `build` — so the assertion is
+    // upstream of every tag it protects, on every architecture.
+    expect(code(jobBlock(source, "publish"))).toContain("needs: [resolve, build]");
+  });
+
+  // A promotion has no per-arch bytes of its own: it must never push a
+  // scaffolding tag, and it must never be able to reach the build path's push
+  // with an empty stage.
+  it("pushes no per-arch scaffolding when it built no per-arch bytes", () => {
+    expect(body).toContain("if: inputs.push && inputs.mode == 'build'");
+  });
+
+  // The mode that publishes without building is the one whose inputs cannot be
+  // assumed: no source is nothing to promote, and `push: false` would be a
+  // green check for having done nothing at all.
+  it("refuses a promotion with nothing to promote, and a build carrying a source", () => {
+    const resolve = code(jobBlock(source, "resolve"));
+    expect(resolve).toContain("Nothing to promote");
+    expect(resolve).toContain("source_tag outside promote mode");
+    expect(resolve).toMatch(/build\|promote\|verify\|pass/);
+  });
+
+  // The label D16 compares against has to name the commit that is *in* the
+  // image. `github.sha` is the commit the event named, and on the backport
+  // path those differ — a dispatch on the default branch building a
+  // `release/x.y` commit.
+  it("labels the revision from the checkout rather than from the event", () => {
+    const build = code(jobBlock(source, "build"));
+    expect(build).toContain('revision="$(git rev-parse HEAD)"');
+    expect(build).toContain('--build-arg "IMAGE_REVISION=$revision"');
+    expect(build).toContain('--label "org.opencontainers.image.revision=$revision"');
+    expect(build).not.toContain("SHA: ${{ github.sha }}");
   });
 });
 

--- a/scripts/lib/release-latest.mjs
+++ b/scripts/lib/release-latest.mjs
@@ -1,0 +1,222 @@
+// Which tags a release publishes, and — the whole point of this module —
+// whether `latest` is one of them (ADR 0023 D26, D28, D30).
+//
+// `release.yml` has two modes. **Promote** re-points the verified `beta-x.y.z`
+// digest at `x.y.z`; **backport** builds `1.2.4` from `release/1.2` because no
+// beta train exists for an old line and there is therefore no digest to
+// promote. The second one is where two library defaults, neither written by
+// anyone, quietly do the wrong thing:
+//
+//   * the old `resolve` emitted `tags="$version latest"` for any version
+//     without a `-` in it, and
+//   * `gh release create` was called with no `--latest` flag at all, and the
+//     API defaults `make_latest` to `true`.
+//
+// Publish `1.2.4` after `1.4.0` and `:latest` moves **backwards**, *and*
+// `/releases/latest` starts answering `v1.2.4` — which is what `install.sh`
+// installs by default and what the in-product update checker compares against.
+// Every 1.4.x user is told an older version is available. The failure is
+// silent, it reaches end users, and it stays dormant until the first backport.
+//
+// ── Why this is a module and not four lines of shell ─────────────────────────
+//
+// D28 asks for the guard on **both** surfaces — the Docker tag and the GitHub
+// Release — and two independent implementations of one rule is exactly how the
+// surfaces drift apart. So there is one decision here, taken once, and the two
+// surfaces are two renderings of the same boolean: `tags` for Docker,
+// `latest` for `gh release create --latest=`. They cannot disagree, because
+// there is nothing for them to disagree about.
+//
+// It is pure and away from git and the network so that every branch of it is
+// testable — including the one that matters most and can never be reached in
+// CI without cutting a real backport.
+//
+// ── The three reasons `latest` is withheld, in the order they are tested ─────
+//
+//   1. backport mode, unconditionally and before anything is compared. Not
+//      "backports usually lose the comparison" — a backport never even asks
+//      the question. This is D28's "structurally incapable": the comparison
+//      that could say yes is not reached, so no arrangement of published
+//      versions, and no bug in the comparison itself, can produce `latest`
+//      from a backport.
+//   2. a prerelease (`1.2.4-rc.1`, D30). It publishes its own version and
+//      nothing else, on both surfaces.
+//   3. losing the highest-version test — an explicit "is this the highest
+//      released version?" rather than "is this not a prerelease?", which is
+//      the test the old code was missing entirely.
+//
+// `assertNeverLatest` then re-checks the result on the way out. It is
+// unreachable by construction and kept anyway: D28's own words are "belt and
+// braces is proportionate", and this is the cheapest brace there is.
+
+/** The two modes `release.yml` resolves a tag into (ADR 0023 D26). */
+export const RELEASE_MODES = ["promote", "backport"];
+
+/** `1.2.4` / `1.2.4-rc.1` — three components, optional prerelease, no build metadata. */
+const VERSION = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
+
+/**
+ * Parse a bare version (no leading `v`) into its parts, or `null`.
+ *
+ * `+build` metadata is rejected rather than ignored: `+` is not a legal
+ * character in a Docker tag, so a version carrying it has no tag to publish
+ * under, and `1.0.0+abc` would not read as a prerelease below — it would move
+ * `:latest`.
+ */
+export function parseReleaseVersion(version) {
+  const match = VERSION.exec(String(version ?? ""));
+  if (!match) return null;
+  const [, major, minor, patch, prerelease] = match;
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prerelease === undefined ? null : prerelease,
+  };
+}
+
+/** Whether a version string is a prerelease (`1.2.4-rc.1`). */
+export function isPrerelease(version) {
+  return parseReleaseVersion(version)?.prerelease != null;
+}
+
+const comparePrereleaseIdentifiers = (a, b) => {
+  // Semver §11.4: identifiers are compared field by field, numeric ones
+  // numerically and below alphanumeric ones, and a shorter run of otherwise
+  // equal fields is lower — `rc.1` < `rc.2` < `rc.2.1`.
+  const left = a.split(".");
+  const right = b.split(".");
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    if (left[i] === undefined) return -1;
+    if (right[i] === undefined) return 1;
+    const numeric = /^\d+$/;
+    const isNumericLeft = numeric.test(left[i]);
+    const isNumericRight = numeric.test(right[i]);
+    if (isNumericLeft && isNumericRight) {
+      if (Number(left[i]) !== Number(right[i])) return Number(left[i]) < Number(right[i]) ? -1 : 1;
+      continue;
+    }
+    if (isNumericLeft !== isNumericRight) return isNumericLeft ? -1 : 1;
+    if (left[i] !== right[i]) return left[i] < right[i] ? -1 : 1;
+  }
+  return 0;
+};
+
+/**
+ * Semver precedence. `-1`, `0` or `1`; unparseable versions throw rather than
+ * sorting somewhere arbitrary.
+ */
+export function compareReleaseVersions(a, b) {
+  const left = parseReleaseVersion(a);
+  const right = parseReleaseVersion(b);
+  if (!left) throw new Error(`not a version: ${a}`);
+  if (!right) throw new Error(`not a version: ${b}`);
+  for (const field of ["major", "minor", "patch"]) {
+    if (left[field] !== right[field]) return left[field] < right[field] ? -1 : 1;
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  // A prerelease is below its own release: 1.2.4-rc.1 < 1.2.4.
+  if (left.prerelease === null) return 1;
+  if (right.prerelease === null) return -1;
+  return comparePrereleaseIdentifiers(left.prerelease, right.prerelease);
+}
+
+/**
+ * Normalise the tag ladder into bare versions: `v1.2.4` → `1.2.4`, anything
+ * that is not a version tag dropped.
+ *
+ * The published set comes from `git tag --list 'v*'`, which is the record a
+ * release leaves behind (D40), so it is the honest answer to "what has been
+ * released" even for a version whose GitHub Release someone later edited.
+ */
+export function publishedVersionsFromTags(tags) {
+  return (Array.isArray(tags) ? tags : String(tags ?? "").split(/\s+/))
+    .map((tag) => String(tag).trim())
+    .filter(Boolean)
+    .map((tag) => (tag.startsWith("v") ? tag.slice(1) : tag))
+    .filter((version) => parseReleaseVersion(version) !== null);
+}
+
+/**
+ * Is `version` the highest version released so far?
+ *
+ * Prereleases in the published set are ignored on both sides: `1.5.0-rc.1`
+ * existing must not stop `1.4.1` taking `latest`, because nobody is running
+ * an rc as their `:latest`. The version being released is allowed to be
+ * present already — the tag is pushed before the release runs (D40), so it is
+ * in its own ladder.
+ */
+export function isHighestRelease(version, published) {
+  if (isPrerelease(version)) return false;
+  return publishedVersionsFromTags(published)
+    .filter((other) => !isPrerelease(other))
+    .every((other) => compareReleaseVersions(version, other) >= 0);
+}
+
+/**
+ * The one assertion D28 asks for, in the form it asks for: a backport is
+ * incapable of emitting `latest` on either surface.
+ *
+ * Called on the way out of `resolveReleaseTags`, where it cannot fire, and
+ * exported so the workflow's own guard step and the tests call the same
+ * function rather than a second opinion about the same rule.
+ */
+export function assertNeverLatest({ mode, tags = [], latest = false }) {
+  if (mode !== "backport") return;
+  const list = Array.isArray(tags) ? tags : String(tags).split(/\s+/).filter(Boolean);
+  if (!latest && !list.includes("latest")) return;
+  throw new Error(
+    `backport mode resolved latest=${latest} with tags [${list.join(" ")}] — ` +
+      "a backport publishes a patch for an old line and must never move `latest` on Docker Hub " +
+      "or on GitHub, because `install.sh` and the update checker both read it (ADR 0023 D28).",
+  );
+}
+
+/**
+ * The whole decision: what a release publishes, and what it must not.
+ *
+ * @param {object} input
+ * @param {"promote"|"backport"} input.mode  where the tag lives (D26).
+ * @param {string} input.version             bare version, no leading `v`.
+ * @param {string[]|string} [input.published] the tag ladder, `v*` tags or bare.
+ * @returns {{mode: string, version: string, tags: string[], latest: boolean,
+ *            prerelease: boolean, reason: string}}
+ */
+export function resolveReleaseTags({ mode, version, published = [] }) {
+  if (!RELEASE_MODES.includes(mode)) {
+    throw new Error(`unknown release mode '${mode}' — expected one of ${RELEASE_MODES.join(", ")}`);
+  }
+  const parsed = parseReleaseVersion(version);
+  if (!parsed) {
+    throw new Error(
+      `not a release version: '${version}' — three components and no +build metadata (e.g. 1.2.4 or 1.2.4-rc.1)`,
+    );
+  }
+
+  const prerelease = parsed.prerelease !== null;
+  let latest;
+  let reason;
+  if (mode === "backport") {
+    // First, and without consulting the ladder. See the header.
+    latest = false;
+    reason = `backport of ${version} from a release line — a backport never moves latest (D28)`;
+  } else if (prerelease) {
+    latest = false;
+    reason = `${version} is a prerelease — it publishes its own version only (D30)`;
+  } else if (isHighestRelease(version, published)) {
+    latest = true;
+    reason = `${version} is the highest released version`;
+  } else {
+    latest = false;
+    const higher = publishedVersionsFromTags(published)
+      .filter((other) => !isPrerelease(other) && compareReleaseVersions(other, version) > 0)
+      .sort(compareReleaseVersions);
+    reason = `${version} is not the highest released version — ${higher.join(", ")} ${
+      higher.length === 1 ? "is" : "are"
+    } above it`;
+  }
+
+  const tags = latest ? [version, "latest"] : [version];
+  assertNeverLatest({ mode, tags, latest });
+  return { mode, version, tags, latest, prerelease, reason };
+}

--- a/scripts/release-tags.mjs
+++ b/scripts/release-tags.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Decide what a release publishes — and whether `latest` is part of it.
+//
+// The thin edge of scripts/lib/release-latest.mjs: this file reads the tag
+// ladder out of git and renders the decision as `key=value` lines; the module
+// holds every rule and is unit-tested. `release.yml`'s `resolve` job pipes
+// stdout straight into `$GITHUB_OUTPUT`, so **stdout carries the machine
+// answer and nothing else** — the explanation goes to stderr, where the step
+// log picks it up.
+//
+// Usage:
+//   node scripts/release-tags.mjs --mode promote  --version 1.4.0
+//   node scripts/release-tags.mjs --mode backport --version 1.2.4 --published "v1.4.0 v1.2.3"
+//
+// --mode <promote|backport>  where the tag lives (ADR 0023 D26).
+// --version <x.y.z>          the version being released, no leading `v`.
+// --published <list>         the tag ladder, whitespace- or comma-separated.
+//                            Defaults to `git tag --list 'v*'` in the current
+//                            repository, which needs the tags fetched.
+//
+// Output, on stdout:
+//   tags=1.4.0 latest        space-separated, for container-image.yml
+//   latest=true|false        for `gh release create --latest=`
+//   prerelease=true|false    for `gh release create --prerelease=`
+//   mode=promote|backport
+
+import { execFileSync } from "node:child_process";
+
+import { makeFail, parseArgs, stringFlag } from "./lib/cli.mjs";
+import { RELEASE_MODES, resolveReleaseTags } from "./lib/release-latest.mjs";
+
+const fail = makeFail("release-tags");
+
+const args = parseArgs(process.argv.slice(2));
+const mode = stringFlag(args, "mode", fail);
+const version = stringFlag(args, "version", fail);
+const publishedFlag = stringFlag(args, "published", fail);
+
+if (!mode) fail(`--mode is required (${RELEASE_MODES.join(" | ")})`);
+if (!version) fail("--version is required");
+
+/**
+ * The ladder. `git tag --list` rather than the GitHub Releases API: a tag is
+ * the record a release leaves behind (D40) and needs no token, and the answer
+ * must not depend on whether somebody edited a Release afterwards.
+ *
+ * A repository with no tags at all is the first release, which is legitimately
+ * the highest — so an empty list is an answer, not a failure. A git that
+ * *errors* is not: it would look identical to "no releases yet" and would hand
+ * `latest` to whatever version happened to be building.
+ */
+const publishedTags = () => {
+  if (publishedFlag !== undefined) return publishedFlag.split(/[\s,]+/);
+  try {
+    return execFileSync("git", ["tag", "--list", "v*"], { encoding: "utf8" }).split("\n");
+  } catch (error) {
+    return fail(
+      `could not read the tag ladder with \`git tag --list 'v*'\` (${error.message}). ` +
+        "The latest guard compares this release against every published version, so an " +
+        "unreadable ladder is not an answer — fetch the tags (actions/checkout with " +
+        "fetch-depth: 0) and re-run.",
+    );
+  }
+};
+
+let decision;
+try {
+  decision = resolveReleaseTags({ mode, version, published: publishedTags() });
+} catch (error) {
+  fail(error.message);
+}
+
+console.error(`[release-tags] ${decision.reason}`);
+console.error(
+  `[release-tags] ${decision.tags.join(" ")} on Docker Hub; GitHub Release latest=${decision.latest} prerelease=${decision.prerelease}`,
+);
+
+process.stdout.write(
+  [
+    `mode=${decision.mode}`,
+    `tags=${decision.tags.join(" ")}`,
+    `latest=${decision.latest}`,
+    `prerelease=${decision.prerelease}`,
+    "",
+  ].join("\n"),
+);


### PR DESCRIPTION
Closes #110. Part of #107. Base is `ci/release-trains-and-digest-promotion`, not `main`.

`release.yml` stops building images and starts promoting digests — except on the one path where no digest exists to promote — and loses both its tag trigger and its human pause.

## What changed

**The trigger (D40).** `push: tags: v*` is gone; `workflow_call` replaces it and `workflow_dispatch` stays. Keeping the tag trigger beside the call would fire two release runs per promotion that could not even block each other, because `github.ref_name` is the tag under a push and the *caller's* ref under a `workflow_call`. So the concurrency group is re-derived from the version (`release-${{ inputs.tag }}` — the one string both invocations agree on) and **nothing in the file reads `github.ref_name` any more**, which a test pins. A stray hand-pushed `v*` tag now does nothing at all.

**Two modes (D17, D26).** `resolve` reads the mode off the branch graph — not an input, not a label — and announces it:

| | condition | image jobs |
| --- | --- | --- |
| **promote** | tag reachable from `main` | `docker buildx imagetools create` re-points `beta-x.y.z` at `<version>`; **builds nothing** |
| **backport** | tag on a `release/*` branch | builds and pushes from the release line, CVE gate included |

A tag in neither place fails with both places named.

**The revision assertion (D16).** Promote mode pulls `beta-x.y.z` per architecture and refuses to retag unless `org.opencontainers.image.revision` equals the promoted commit. It is the assertion `verify` already made, extended rather than copied — two implementations would be two chances to weaken the check the design reduces to. The retag lives in `publish`, which `needs: build`, so nothing is re-pointed before every arch has been checked.

**The `latest` guard (D28), on both surfaces.** `scripts/lib/release-latest.mjs` takes one decision and renders it twice — the docker tag list and an explicit `--latest=true|false` on `gh release create`, never the API's default of `true`. Three reasons withhold it, in order: backport mode *unconditionally and before anything is compared*, a prerelease (D30), then losing an explicit highest-version test — the test the old `tags="$version latest"` did not have at all. `--prerelease` is now explicit too, and `gh release edit` re-asserts both on the re-run path.

**Backport mode cannot emit `latest`.** Structurally, in the module: it never reaches the comparison that could say yes. `scripts/__tests__/release-latest.test.mjs` proves it against a ladder the backport would *win*, and sweeps every version against every ladder. Both workflow surfaces re-assert it at the point of publishing.

**The macOS pause (D15).** `environment: macos-release` is off `tarball-macos`. The pause is not dropped — it moves to the head of `promote.yml`, upstream of this whole workflow, so the fast-forward onto `main` is downstream of the human too. The image jobs still wait on the mac leg, now for a different reason: a release is atomic, and an image whose `:latest` moved beside a Release missing a third of its tarballs cannot be walked back.

## Not renamed

`Panel image` and `Core image` keep their exact names. The "Protect main" ruleset pins those check names, and a rename would block every PR in the repository until an admin updated it. The tests now assert both names literally, in `release.yml` and in `ci.yml`.

## One fix beyond the ticket

The revision label is now `git rev-parse HEAD` rather than `github.sha`. They agree on the PR and train paths (both pass `ref: github.sha`); they do **not** agree on a backport, which is dispatched from the default branch while building a `release/x.y` commit — so the image would have carried a label naming a commit it does not contain. A label that is not the truth is the one failure D16's assertion cannot detect.

## For #111

- `promote.yml` must call this with `permissions: contents: write` (or `write-all`) and `secrets: inherit` — a reusable workflow cannot request more than its caller granted, and `github-release` needs `contents: write`.
- Push `vx.y.z` **before** invoking; `resolve` requires the tag to exist and re-fetches to close the race.
- `macos-release` is now referenced by nothing until `promote.yml` picks it up. The environment stays configured (`docs/REPO_SETUP.md` §2) — a missing one is silently unprotected, not red.

## Verification

- `vitest run` — 408 passing. One pre-existing, environment-dependent failure in `core-launcher.test.mjs` (`/opt/actana/app` exists on this machine), which fails identically on other branches and is untouched here.
- `eslint scripts` clean.
- Every `run:` block in the three workflows parsed as YAML and syntax-checked with `bash -n`.
- `resolve`'s shell was extracted and executed against a fixture repository with `main`, a `release/1.0` line and a stray branch: `v1.4.0` → promote / `beta-1.4.0` / `tags=1.4.0 latest`; `v1.0.1` → backport / `tags=1.0.1` / `latest=false` *despite* `v1.4.0` existing; `v1.0.1-rc.1` → backport / `prerelease=true`; a missing tag, a malformed tag and a tag on neither `main` nor a release line each fail with their own message.
- The backport guard step and `container-image.yml`'s input validation were run directly across their branches — both surfaces of the guard fire independently.
- `commitlint --from <base> --to HEAD` — 0 problems across all four commits.

## Docs

Three pages claimed the mac leg declares the environment and that a `v*` tag fires a release. Corrected in place; the full rewrite around the train model, the tag ladder and the rollback runbook is #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
