### PR TITLE
chore(deps): pin nanoid to >=3.3.17 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   brace-expansion@5: '>=5.0.7 <6'
   fast-uri@>=3.0.0 <=3.1.3: '>=3.1.4'
   js-yaml@>=4.0.0 <4.3.1: '>=4.3.1 <5'
+  nanoid@<3.3.17: '>=3.3.17 <4'
   tar@<=7.5.18: '>=7.5.19'
   '@codemirror/state': 6.7.0
   '@codemirror/view': 6.43.0
@@ -2853,8 +2854,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6707,7 +6708,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -6857,7 +6858,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ overrides:
   "brace-expansion@5": ">=5.0.7 <6"
   "fast-uri@>=3.0.0 <=3.1.3": ">=3.1.4"
   "js-yaml@>=4.0.0 <4.3.1": ">=4.3.1 <5"
+  "nanoid@<3.3.17": ">=3.3.17 <4"
   "tar@<=7.5.18": ">=7.5.19"
   # Keep a single CodeMirror state/view copy so language extensions pass
   # instanceof checks (duplicate copies crash the file editor).


### PR DESCRIPTION
## The advisory

`Dependency Audit` runs `pnpm audit --prod --audit-level high` and fails on **every** branch of this repo with exactly one advisory:

| | |
|---|---|
| **Advisory** | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) |
| **Package** | `nanoid` |
| **Vulnerable** | `<3.3.17` |
| **Patched** | `>=3.3.17` |
| **Severity** | high |
| **Paths** | 7 |

*nanoid: custom generators can loop indefinitely when size is zero.*

All **seven** paths are the same shape — `packages/panel` → `@tanstack/react-start` → … → `vite` → `postcss` → `nanoid`:

```
packages__panel>@tanstack/react-start>@tanstack/react-start-rsc>@tanstack/start-plugin-core>@tanstack/router-plugin>vite>postcss>nanoid
packages__panel>@tanstack/react-start>@tanstack/react-start-rsc>@tanstack/start-plugin-core>vitefu>vite>postcss>nanoid
packages__panel>@tanstack/react-start>@tanstack/react-start-rsc>@tanstack/start-plugin-core>vite>postcss>nanoid
… 7 total
```

Every one of them runs through a **build toolchain**, and that toolchain reaches the **production** dependency graph only because `@tanstack/react-start` is declared as a **runtime dependency** of the Panel. Nothing in the shipped server bundle imports it — `vite`, `postcss` and `nanoid` are dead weight that the `--prod` audit nevertheless walks.

## Relationship to #25

That is precisely #25 — *"@tanstack/react-start ships a build toolchain the runtime never imports"* — which measured the Panel running fine (healthz 200, SSR root 200) with `postcss`, `@babel/core` and `vite` deleted from the deployed tree.

**Refs #25** — deliberately *not* `Closes #25`. The real fix is moving `@tanstack/react-start` out of the runtime graph, which drops these seven paths (and ~391 packages / 426 MB) at the root. That needs its own verification pass because SSR is involved. **This PR is only the pin that unblocks merging.** #25 stays open.

## The change

Two files, and only two:

```yaml
# pnpm-workspace.yaml
"nanoid@<3.3.17": ">=3.3.17 <4"
```

plus the resulting lockfile move, `nanoid 3.3.16` → `3.3.18`. No version bumps of anything else, no unrelated dependency changes.

Two notes on the shape of it:

- **It lives in `pnpm-workspace.yaml`, not `package.json`.** This repo is on pnpm 11, which reads `overrides` from the workspace file — where the project's other 20 overrides already are. The `pnpm.overrides` field in the root `package.json` is ignored once that key exists. This was verified rather than assumed: placing it in `package.json` left the lockfile untouched (`Lockfile is up to date, resolution step is skipped`) and the advisory standing.
- **The range is scoped and capped.** `nanoid@<3.3.17` rewrites only vulnerable copies, and `<4` keeps a v3 consumer such as `postcss` from being handed a major bump. This matches the house style of neighbours like `brace-expansion@1`.

## Verification

| Check | Result |
|---|---|
| `pnpm audit --prod --audit-level high` **before** | exit **1** — 1 high, 7 paths |
| `pnpm audit --prod --audit-level high` **after** | exit **0** — `No known vulnerabilities found` |
| `pnpm typecheck` | exit **0** — shared, core, panel all clean |
| `pnpm test` (root vitest) | 408/409 — only `core-launcher.test.mjs` |
| `pnpm -r test` (panel) | 1258/1260, and **36/36 on isolated re-run** |

Three test notes, stated plainly:

- `scripts/__tests__/core-launcher.test.mjs` fails here for a **pre-existing** environment reason unrelated to dependencies — it resolves `/opt/actana/app` instead of the test's temp install root.
- `operator-auth.test.ts` and `live-read-path.test.ts` each hit the 5 s timeout during the full parallel run, then **passed 36/36 when re-run in isolation**. Load flakes on a busy machine, not regressions — nanoid sits under `postcss`/`vite`, which these server tests never touch.

## Scope

**This change is unrelated to #107.** It rides on `ci/release-trains-and-digest-promotion` solely so that the final pull request to `main` can be green — `Dependency Audit` is a required check, and it fails on every branch today regardless of what that branch contains.

Base is `ci/release-trains-and-digest-promotion`, **not** `main`. Left as a **draft**.
