### PR TITLE
chore(ci): pre-flight the App id before applying rulesets, and capture 20390423

### DIFF
--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -619,7 +619,14 @@ stop. This is the only change to that ruleset; the `creation` rule and the ref
 pattern are untouched.
 
 Ruleset **20390423** ("Release tags are immutable") is not touched by this
-effort.
+effort — nothing here applies it and nothing here changes it. Its payload is
+committed anyway, as
+[`rulesets/tag-immutable.json`](rulesets/tag-immutable.json), captured verbatim
+from the live ruleset. The point of `rulesets/` is that a clone can restore the
+repository's protection; leaving one of the five out meant the fifth existed
+only in the web form, which is the thing this section is against. Restoring it
+is a `POST` if it has been deleted and a `PUT` over 20390423 if it has been
+edited — a deliberate act, not a cutover step.
 
 ### Verify it actually binds
 

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -375,6 +375,15 @@ without a pull request.
 - [ ] **The App exists and its id is to hand.** `APP_ID` and `APP_PRIVATE_KEY`
       are set (#108, closed). `APP_ID`'s value is the number the payloads want,
       and §2 has where to read it and what to do when it is missing.
+- [ ] **`preflight-app-id.sh` exits 0.** `export APP_ID=…` and run
+      [`rulesets/preflight-app-id.sh`](rulesets/preflight-app-id.sh) before the
+      first `apply`. `main.json` and `tag-release-cut.json` are full-body
+      `PUT`s: a wrong id does not fail at the API the way `0` does, it replaces
+      the live bypass actor list and returns 200. The script asserts that
+      `APP_ID` is an App actually installed on the owner, that no payload names
+      a different one, and that no `PUT` would drop a bypass actor that is live
+      today — and refuses, naming the mismatch, if any of that does not hold.
+      It reads only; nothing runs it for you.
 - [ ] **All of #109–#113 are merged.** Applying `main.json` is the moment
       "pull requests to `main` only from `beta/*`" stops being advisory, and
       from that moment any foundation pull request still open cannot merge.
@@ -439,7 +448,12 @@ step 9 something is published that cannot be unpublished.
       release lines second, `main` third, tags last. `beta/*` before `main`
       because step 8 cuts a train into a ruleset that should already exist;
       tags last because that payload's only change is adding the bypass actor,
-      and it is cheap to re-apply if the id was wrong.
+      and it is cheap to re-apply if the id was wrong. **Run
+      [`rulesets/preflight-app-id.sh`](rulesets/preflight-app-id.sh) first and
+      apply nothing unless it exits 0** — it is the one check that happens
+      before a write rather than after, and the `main.json` `PUT` is not cheap
+      to re-apply if the id was wrong: it will have replaced the live bypass
+      actor list on the way through.
 - [ ] **7. Prove it binds** — [*Verify it actually
       binds*](#verify-it-actually-binds), below. A throwaway non-`beta/*` pull
       request into `main` is blocked, and a direct push to `main` is refused
@@ -471,6 +485,12 @@ it on the way in:
 
 ```bash
 export APP_ID=…            # the value of the APP_ID secret
+
+# Before the first apply. Exits non-zero, naming the mismatch, if APP_ID is not
+# an App installed on `actana`, if a payload names a different one, or if a PUT
+# would delete a bypass actor that is live today. Reads only.
+docs/rulesets/preflight-app-id.sh   # must exit 0 — if it does not, apply nothing
+
 apply() {                  # apply <payload> [ruleset-id]
   jq --argjson app "$APP_ID" \
      '(.bypass_actors[]? | select(.actor_id == 0)).actor_id = $app' "$1" \
@@ -480,6 +500,18 @@ apply() {                  # apply <payload> [ruleset-id]
     fi
 }
 ```
+
+**The tripwire only catches the unsubstituted case. A wrong id is quieter.**
+Two of these payloads are full-body `PUT`s, so `bypass_actors` is replaced
+wholesale rather than added to: an id that is not the App's does not 422, it
+returns 200 having deleted the live bypass actor — a destructive outcome from a
+config apply that reports success, and one nothing surfaces again until the
+next promotion fails on a ruleset violation. `preflight-app-id.sh` is the
+assertion that happens *before* the write; it resolves the App installed on
+`actana` from the API rather than trusting the number in the shell, refuses on
+a mismatch instead of continuing, and refuses just as hard when it cannot read
+the answer at all (listing installations wants the `admin:org` scope — an
+unreadable answer is the case it exists for, not a pass).
 
 ### 3a. `beta/*` — the trains
 
@@ -554,7 +586,13 @@ goes stale in a way nobody notices until someone pushes to a dead line.
 
 ### 3d. `main`
 
+- [ ] `docs/rulesets/preflight-app-id.sh docs/rulesets/main.json` — exits 0
 - [ ] `apply docs/rulesets/main.json 20390421`
+
+The pre-flight is repeated here rather than left to *Before you apply anything*
+because this is the destructive `PUT`: the payload is the whole ruleset
+afterwards, including its bypass actor list, and 20390421 is the ruleset the
+promotion cannot work without.
 
 What changes from the ruleset that is live today:
 

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -519,9 +519,11 @@ The live-ruleset read has a quieter version of the same problem: GitHub redacts
 `bypass_actors` to `null` for a token that can read the ruleset but is not an
 admin of the repository, and a 200 carrying `null` looks exactly like a
 ruleset with no bypass actors. So the script asserts the shape of what came
-back — the body parses, the `bypass_actors` key is present, and it is an array
-— and refuses by name when it is not. An unreadable answer is the case this
-check exists for, not a pass. **Run it as a repository admin**; if either read
+back — the body parses, the `bypass_actors` key is present, it is an array, and
+every entry in it is an object — and refuses by name when it is not. The
+installations read is asserted the same way, so a body it cannot parse is
+reported as not knowing rather than as `actana` having no App installed. An
+unreadable answer is the case this check exists for, not a pass. **Run it as a repository admin**; if either read
 comes back unreadable, the check refuses and you apply nothing, rather than
 being told a destructive `PUT` is safe by a guard that could not see what the
 `PUT` would delete.

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -510,8 +510,21 @@ next promotion fails on a ruleset violation. `preflight-app-id.sh` is the
 assertion that happens *before* the write; it resolves the App installed on
 `actana` from the API rather than trusting the number in the shell, refuses on
 a mismatch instead of continuing, and refuses just as hard when it cannot read
-the answer at all (listing installations wants the `admin:org` scope — an
-unreadable answer is the case it exists for, not a pass).
+the answer at all — on **both** of the reads it depends on, not just the first.
+
+That second part is worth being precise about, because an exit code is only
+worth as much as the reads behind it. Listing installations wants the
+`admin:org` scope, and a token without it gets a 404 rather than an empty list.
+The live-ruleset read has a quieter version of the same problem: GitHub redacts
+`bypass_actors` to `null` for a token that can read the ruleset but is not an
+admin of the repository, and a 200 carrying `null` looks exactly like a
+ruleset with no bypass actors. So the script asserts the shape of what came
+back — the body parses, the `bypass_actors` key is present, and it is an array
+— and refuses by name when it is not. An unreadable answer is the case this
+check exists for, not a pass. **Run it as a repository admin**; if either read
+comes back unreadable, the check refuses and you apply nothing, rather than
+being told a destructive `PUT` is safe by a guard that could not see what the
+`PUT` would delete.
 
 ### 3a. `beta/*` — the trains
 
@@ -647,14 +660,52 @@ reliably more than one human who can approve.
 
 ### 3e. The tag ruleset
 
+- [ ] **Decide the admin-bypass question below before running this**, then
+  `docs/rulesets/preflight-app-id.sh docs/rulesets/tag-release-cut.json`
 - [ ] `apply docs/rulesets/tag-release-cut.json 20390424`
 
-Ruleset **20390424** restricts *creation* of `refs/tags/v*` to the admin role
-and today has **zero bypass actors**. The App pushes the version tag during
-promotion, so it must be added here too, or the promotion fails at the tag
-after it has already fast-forwarded `main` — the worst place in the sequence to
-stop. This is the only change to that ruleset; the `creation` rule and the ref
-pattern are untouched.
+Ruleset **20390424** restricts *creation* of `refs/tags/v*` to the admin role.
+The App pushes the version tag during promotion, so it must be added here, or
+the promotion fails at the tag after it has already fast-forwarded `main` — the
+worst place in the sequence to stop. The `creation` rule and the ref pattern
+are untouched by the payload.
+
+> [!WARNING]
+> **Open decision — this apply deletes a live bypass actor, and the pre-flight
+> will refuse until someone resolves it.**
+>
+> Read with an admin token, live 20390424 carries a bypass actor that
+> `tag-release-cut.json` does not:
+>
+> ```
+> RepositoryRole:5:always
+> ```
+>
+> Because this is a full-body `PUT`, applying the payload as committed replaces
+> `bypass_actors` wholesale and removes that admin bypass — it does not sit
+> beside it. `preflight-app-id.sh` refuses on exactly this, which is the guard
+> working as intended and not a defect in it:
+>
+> ```
+> ❌ Applying tag-release-cut.json over live ruleset 20390424 would delete a bypass actor.
+>      RepositoryRole:5:always
+> ```
+>
+> This is a decision for whoever owns the repository's protection, and it is
+> deliberately left open here rather than resolved by editing the payload:
+>
+> - **If that admin bypass is meant to survive**, add it to
+>   `docs/rulesets/tag-release-cut.json` alongside the App actor, commit it, and
+>   re-run the pre-flight until it exits 0.
+> - **If it is meant to go**, remove it in the admin console first, as its own
+>   deliberate act with its own audit trail — not as a silent side effect of a
+>   config apply — and then re-run the pre-flight.
+>
+> Do not apply this payload while the pre-flight refuses. Note also that a
+> non-admin token reads this ruleset's `bypass_actors` back as `null`, which is
+> why the pre-flight now asserts the shape of that read: the earlier claim that
+> 20390424 has zero bypass actors was an artifact of reading it without admin
+> rights.
 
 Ruleset **20390423** ("Release tags are immutable") is not touched by this
 effort — nothing here applies it and nothing here changes it. Its payload is

--- a/docs/rulesets/README.md
+++ b/docs/rulesets/README.md
@@ -12,6 +12,16 @@ restorable form of the same thing.
 | [`release.json`](release.json) | `refs/heads/release/**` | `POST` — new ruleset |
 | [`release-retired.json`](release-retired.json) | one retired line, named explicitly | `POST` — template, one per retirement |
 | [`tag-release-cut.json`](tag-release-cut.json) | `refs/tags/v*` | `PUT` over existing ruleset **20390424** |
+| [`tag-immutable.json`](tag-immutable.json) | `refs/tags/v*` | not applied — the capture of live ruleset **20390423** |
+
+`tag-immutable.json` is here for restorability rather than for the cutover.
+Ruleset 20390423 ("Release tags are immutable") is unchanged by this effort and
+nothing in §3 applies it; without it committed, a clone could restore four of
+the five live rulesets and the fifth would exist only in the web form. It is a
+verbatim capture of what is live — `GET /repos/actana/control/rulesets/20390423`
+reduced to the fields the create/update API takes. Applying it would be a
+`POST` if 20390423 has been lost and a `PUT` over 20390423 if it has been
+edited; either is a deliberate restore, not a step in the cutover.
 
 **Nothing here is applied by CI, and nothing here should be applied from a
 branch.** These files are data. Applying them is an admin step, taken

--- a/docs/rulesets/README.md
+++ b/docs/rulesets/README.md
@@ -40,6 +40,21 @@ ruleset with no working bypass. The real value is the `APP_ID` secret's value
 (see [`../REPO_SETUP.md`](../REPO_SETUP.md) §2). §3 has the `jq` line that
 substitutes it.
 
+The tripwire only catches the *unsubstituted* case. A **wrong** id is worse and
+quieter: `main.json` and `tag-release-cut.json` are full-body `PUT`s, so the
+body sent is the ruleset afterwards, and an id that is not the App's replaces
+the live bypass actor list rather than sitting beside it. The API answers 200
+and the apply reports success, having deleted the identity `promote.yml`
+depends on.
+
+[`preflight-app-id.sh`](preflight-app-id.sh) is the assertion against that. Run
+it from an admin clone before the first `apply`; it refuses, naming the
+mismatch, if `APP_ID` is not an App installed on the repository's owner, if a
+payload names some other App, or if a `PUT` would drop a bypass actor that is
+live today. It reads only — every call it makes is a `GET` — and nothing runs
+it automatically. [`../REPO_SETUP.md`](../REPO_SETUP.md) §3 puts it in the
+cutover sequence.
+
 ## Keeping these honest
 
 The `required_status_checks` contexts are check-run names, character for

--- a/docs/rulesets/preflight-app-id.sh
+++ b/docs/rulesets/preflight-app-id.sh
@@ -69,17 +69,40 @@ esac
 #    the App's own JWT — so the question is asked of the org. Failing to ask it
 #    is a refusal, not a pass: an unreadable answer is the case this exists for.
 
-installs="$(gh api "orgs/$OWNER/installations" \
-  --jq '.installations[] | [.app_id, .app_slug, .repository_selection] | @tsv' 2>&1)" || die \
+installs_json="$(gh api "orgs/$OWNER/installations" 2>&1)" || die \
   "Could not list the App installations on $OWNER." \
-  "$installs" \
+  "$installs_json" \
   "" \
   "This needs the admin:org scope, which the admin doing the cutover has:" \
   "  gh auth refresh -h github.com -s admin:org" \
   "Do not skip this and apply anyway — it is the assertion, not a formality."
 
+# The same rule the live-ruleset read below follows, applied here for the same
+# reason: a 200 is not an answer. An empty body, a whitespace-only body, an
+# `installations` key that is absent, null or not a list all reduce to "no
+# installations found" — which reads identically to "$OWNER has no App
+# installed" and is not the same claim at all. Assert the shape, so the two
+# cases get two different messages.
+printf '%s' "$installs_json" |
+  jq -e 'type == "object" and has("installations")
+         and (.installations | type == "array" and all(type == "object"))' \
+  >/dev/null 2>&1 || die \
+  "The App installations on $OWNER read back unusably." \
+  "The request succeeded, so this is not a network failure: the body was empty" \
+  "or unparseable, or it carried no \`installations\` list to read." \
+  "This is not an answer of 'no App is installed' — it is not knowing whether" \
+  "one is, which is the case this check exists for." \
+  "" \
+  "Re-run with the admin:org scope and confirm the read returns a list:" \
+  "  gh auth refresh -h github.com -s admin:org"
+
+installs="$(printf '%s' "$installs_json" |
+  jq -r '.installations[] | [.app_id, .app_slug, .repository_selection] | @tsv')"
+
 [ -n "$installs" ] || die "No GitHub App is installed on $OWNER." \
-  "The payloads name one as their only bypass actor, so there is nothing for" \
+  "The read came back readable and empty, so this is an installation list with" \
+  "nothing in it — not a list that could not be read." \
+  "The payloads name an App as their only bypass actor, so there is nothing for" \
   "APP_ID=$APP_ID to be. Install the App first (§2, step 1 of the cutover)."
 
 installed_line="$(printf '%s\n' "$installs" | awk -F'\t' \
@@ -169,13 +192,31 @@ for payload in "${payloads[@]}"; do
   # read the ruleset but is not an admin, so this is the likely case, not the
   # exotic one. Same rule as the installations call above: an answer that
   # cannot be read is a refusal, not a pass.
+  #
+  # The entries are asserted too, not just the array around them. A list
+  # carrying something that is not an object passes `type == "array"`, and the
+  # comparison below then renders it through .actor_type/.actor_id/.bypass_mode
+  # into a string like `null:null:null` — so the script still refuses, but
+  # names a bypass actor that does not exist rather than the malformed read
+  # that invented it. Refuse where the fault is.
+  #
+  # The three keys are asserted for the same reason: an entry that is an object
+  # but carries only `actor_id` renders as `null:4516237:null`, which is the
+  # same invented actor by a different route. Presence, not value — GitHub
+  # returns `"actor_id": null` for a DeployKey bypass actor, and that is a real
+  # actor this must keep comparing rather than refuse on.
   printf '%s' "$live_json" |
-    jq -e 'type == "object" and has("bypass_actors") and (.bypass_actors | type == "array")' \
+    jq -e 'type == "object" and has("bypass_actors")
+           and (.bypass_actors | type == "array" and all(
+                 type == "object" and has("actor_type") and has("actor_id")
+                 and has("bypass_mode")))' \
     >/dev/null 2>&1 || die \
     "Live ruleset $ruleset_id ($name's target) read back without a usable bypass_actors list." \
     "The request succeeded, so this is not a network failure: either the response" \
     "was empty or unparseable, or the token can read the ruleset but not its" \
-    "bypass actors — GitHub redacts them to null for non-admins." \
+    "bypass actors — GitHub redacts them to null for non-admins — or the list" \
+    "came back holding entries that are not bypass actor objects (an object" \
+    "carrying actor_type, actor_id and bypass_mode)." \
     "An answer that cannot be read is not an answer of 'no bypass actors'." \
     "" \
     "Re-run as an admin of $REPO:" \

--- a/docs/rulesets/preflight-app-id.sh
+++ b/docs/rulesets/preflight-app-id.sh
@@ -161,6 +161,27 @@ for payload in "${payloads[@]}"; do
     "$live_json" \
     "Without it there is no way to know what the PUT would replace."
 
+  # A 200 is not an answer. An empty body, a whitespace-only body, a redacted
+  # `"bypass_actors": null` and a response with the key absent all reduce to an
+  # empty actor list below, and an empty list is indistinguishable from "this
+  # ruleset has no bypass actors" — which is the one thing that must not be
+  # assumed here. GitHub redacts bypass_actors to null for a token that can
+  # read the ruleset but is not an admin, so this is the likely case, not the
+  # exotic one. Same rule as the installations call above: an answer that
+  # cannot be read is a refusal, not a pass.
+  printf '%s' "$live_json" |
+    jq -e 'type == "object" and has("bypass_actors") and (.bypass_actors | type == "array")' \
+    >/dev/null 2>&1 || die \
+    "Live ruleset $ruleset_id ($name's target) read back without a usable bypass_actors list." \
+    "The request succeeded, so this is not a network failure: either the response" \
+    "was empty or unparseable, or the token can read the ruleset but not its" \
+    "bypass actors — GitHub redacts them to null for non-admins." \
+    "An answer that cannot be read is not an answer of 'no bypass actors'." \
+    "" \
+    "Re-run as an admin of $REPO:" \
+    "  gh auth refresh -h github.com -s admin:org" \
+    "and confirm the read returns a bypass_actors array before applying anything."
+
   live_actors="$(printf '%s' "$live_json" |
     jq -r '[.bypass_actors[]? | "\(.actor_type):\(.actor_id):\(.bypass_mode)"] | sort | .[]')"
 

--- a/docs/rulesets/preflight-app-id.sh
+++ b/docs/rulesets/preflight-app-id.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# Pre-flight for the payloads in this directory. It reads; it never writes.
+#
+# `main.json` and `tag-release-cut.json` are applied as full-body PUTs, so the
+# body sent *is* the ruleset afterwards. An `actor_id` that is not the App's
+# does not fail at the API — it replaces the live bypass actor list with a
+# wrong one and returns 200. A config apply that reports success while deleting
+# the identity `promote.yml` depends on is the failure this guards.
+#
+# So, before any write: the App id the payloads will carry is the App id
+# actually installed on the repository, and no bypass actor that is live today
+# would be dropped by the PUT. A mismatch is named and refused, not warned
+# about.
+#
+#   export APP_ID=…                       # the value of the APP_ID secret (§2)
+#   docs/rulesets/preflight-app-id.sh     # all payloads here
+#   docs/rulesets/preflight-app-id.sh docs/rulesets/main.json   # or named ones
+#
+# Exit 0 means the `apply` helper in ../REPO_SETUP.md §3 is safe to run. Any
+# other exit means apply nothing — not this payload and not the ones after it.
+#
+# Nothing runs this automatically. It is a human step, run from an admin clone
+# before the first `apply`, and every API call it makes is a GET.
+
+set -euo pipefail
+
+REPO="${REPO:-actana/control}"
+OWNER="${REPO%%/*}"
+
+die() {
+  printf '\n❌ %s\n' "$1" >&2
+  shift
+  local line
+  for line in "$@"; do printf '   %s\n' "$line" >&2; done
+  printf '\n   Applying nothing. Fix the above and re-run.\n' >&2
+  exit 1
+}
+
+ok()   { printf '  ✅ %s\n' "$1"; }
+note() { printf '  ℹ️  %s\n' "$1"; }
+
+command -v gh >/dev/null 2>&1 || die "\`gh\` is not on PATH." \
+  "This check needs the GitHub CLI, authenticated as the admin who will apply."
+command -v jq >/dev/null 2>&1 || die "\`jq\` is not on PATH." \
+  "§3's apply helper needs it too — the substitution is a jq expression."
+
+# 1. APP_ID is set, and is a plausible App id.
+
+[ -n "${APP_ID:-}" ] || die "APP_ID is not set." \
+  "Export the value of the APP_ID secret before running this:" \
+  "  export APP_ID=…" \
+  "§2 has where to read it and what to do when it is missing."
+
+case "$APP_ID" in
+  '' | *[!0-9]*)
+    die "APP_ID is not a number: '$APP_ID'." \
+      "The payloads want the App's numeric id, not its slug, name or client id."
+    ;;
+esac
+
+[ "$APP_ID" -ne 0 ] || die "APP_ID is 0." \
+  "Zero is the placeholder the payloads ship with — the tripwire, not a value." \
+  "Read the real id from the APP_ID secret (§2)."
+
+# 2. That id is an App installed on the repository's owner.
+#
+#    A user token cannot read /repos/{repo}/installation — that endpoint wants
+#    the App's own JWT — so the question is asked of the org. Failing to ask it
+#    is a refusal, not a pass: an unreadable answer is the case this exists for.
+
+installs="$(gh api "orgs/$OWNER/installations" \
+  --jq '.installations[] | [.app_id, .app_slug, .repository_selection] | @tsv' 2>&1)" || die \
+  "Could not list the App installations on $OWNER." \
+  "$installs" \
+  "" \
+  "This needs the admin:org scope, which the admin doing the cutover has:" \
+  "  gh auth refresh -h github.com -s admin:org" \
+  "Do not skip this and apply anyway — it is the assertion, not a formality."
+
+[ -n "$installs" ] || die "No GitHub App is installed on $OWNER." \
+  "The payloads name one as their only bypass actor, so there is nothing for" \
+  "APP_ID=$APP_ID to be. Install the App first (§2, step 1 of the cutover)."
+
+installed_line="$(printf '%s\n' "$installs" | awk -F'\t' \
+  '{ printf "  %s  %s  (%s repositories)\n", $1, $2, $3 }')"
+
+match="$(printf '%s\n' "$installs" | awk -F'\t' -v id="$APP_ID" '$1 == id')"
+[ -n "$match" ] || die "APP_ID=$APP_ID names no App installed on $OWNER." \
+  "Applying the payloads with it would put an id with no App behind it into" \
+  "every bypass actor list — and main.json is a full-body PUT, so it would" \
+  "replace the live one rather than sit beside it." \
+  "" \
+  "Installed on $OWNER:" \
+  "$installed_line" \
+  "Either APP_ID is stale or the App was reinstalled and has a new id (§2)."
+
+slug="$(printf '%s\n' "$match" | cut -f2)"
+selection="$(printf '%s\n' "$match" | cut -f3)"
+ok "APP_ID=$APP_ID is '$slug', installed on $OWNER."
+
+if [ "$selection" != "all" ]; then
+  note "That installation covers selected repositories, not all of them, and a"
+  note "user token cannot list which. Confirm $REPO is among them on the"
+  note "installation's settings page before applying."
+fi
+
+# 3. Every Integration actor in every payload is either the placeholder or that
+#    same id. A payload naming some third App is the mismatch this refuses on.
+
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$#" -gt 0 ]; then payloads=("$@"); else payloads=("$here"/*.json); fi
+
+# The two payloads §3 applies as PUTs, and the live rulesets they overwrite.
+live_ruleset_for() {
+  case "$1" in
+    main.json)            echo 20390421 ;;
+    tag-release-cut.json) echo 20390424 ;;
+    tag-immutable.json)   echo 20390423 ;;
+    *)                    echo ""       ;;
+  esac
+}
+
+for payload in "${payloads[@]}"; do
+  name="$(basename -- "$payload")"
+  [ -f "$payload" ] || die "No such payload: $payload"
+  jq -e . "$payload" >/dev/null 2>&1 || die "$name is not valid JSON."
+
+  checked=0
+  while IFS= read -r actor_id; do
+    [ -n "$actor_id" ] || continue
+    checked=1
+    if [ "$actor_id" = "0" ]; then
+      ok "$name: placeholder actor_id 0 — §3's jq substitutes APP_ID into it."
+    elif [ "$actor_id" = "$APP_ID" ]; then
+      ok "$name: names App $actor_id, which is APP_ID."
+    else
+      die "$name names App $actor_id, but APP_ID is $APP_ID." \
+        "One of the two is wrong, and applying resolves it the destructive way:" \
+        "the payload is sent whole, so whichever id is in the file becomes the" \
+        "ruleset's entire bypass actor list." \
+        "" \
+        "Either substitute $APP_ID into $name, or restore the 0 placeholder and" \
+        "let the apply helper substitute it."
+    fi
+  done <<<"$(jq -r '[.bypass_actors[]? | select(.actor_type == "Integration") | .actor_id] | .[]' "$payload")"
+
+  # 4. A PUT is a replacement. Anything live that the payload does not carry is
+  #    deleted by applying it — silently, with a 200.
+
+  ruleset_id="$(live_ruleset_for "$name")"
+  if [ -z "$ruleset_id" ]; then
+    # Said out loud, because a payload that quietly checks nothing and a
+    # payload whose bypass actor someone deleted look identical in silence.
+    [ "$checked" -eq 1 ] || note "$name: no App bypass actor, and applied as a POST — nothing to assert."
+    continue
+  fi
+
+  live_json="$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>&1)" || die \
+    "Could not read live ruleset $ruleset_id ($name's target)." \
+    "$live_json" \
+    "Without it there is no way to know what the PUT would replace."
+
+  live_actors="$(printf '%s' "$live_json" |
+    jq -r '[.bypass_actors[]? | "\(.actor_type):\(.actor_id):\(.bypass_mode)"] | sort | .[]')"
+
+  payload_actors="$(jq -r --argjson app "$APP_ID" \
+    '[.bypass_actors[]? | "\(.actor_type):\(if .actor_id == 0 then $app else .actor_id end):\(.bypass_mode)"] | sort | .[]' \
+    "$payload")"
+
+  # `comm` wants both sides sorted the same way; jq's sort is byte order, so
+  # pin the locale rather than trust the shell's.
+  dropped="$(LC_ALL=C comm -23 \
+    <(printf '%s\n' "$live_actors" | LC_ALL=C sort -u) \
+    <(printf '%s\n' "$payload_actors" | LC_ALL=C sort -u) | sed '/^$/d')"
+  if [ -n "$dropped" ]; then
+    die "Applying $name over live ruleset $ruleset_id would delete a bypass actor." \
+      "A full-body PUT replaces bypass_actors wholesale, and these are live" \
+      "today but absent from the payload:" \
+      "$(printf '%s\n' "$dropped" | sed 's/^/  /')" \
+      "" \
+      "Add them to $name if they should survive, or delete them deliberately" \
+      "in the admin console first — not as a side effect of a config apply."
+  fi
+  ok "$name: PUT over $ruleset_id drops no live bypass actor."
+done
+
+printf '\n✅ Pre-flight passed. §3'"'"'s apply helper is safe to run with APP_ID=%s.\n' "$APP_ID"

--- a/docs/rulesets/tag-immutable.json
+++ b/docs/rulesets/tag-immutable.json
@@ -1,0 +1,17 @@
+{
+  "name": "Release tags are immutable",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "update" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}


### PR DESCRIPTION
Follow-up to #132 — the two things its review found and judged non-blocking.
Neither is applied to the live repository; both land before a human ever
applies these payloads by hand.

Refs #114

## 0. The drop guard now fails closed (review fix)

The review found one blocking defect: the drop guard — the assertion carrying
the entire hazard — checked `gh`'s **exit code** but never the **content** of
the response, so an HTTP 200 that answered nothing was indistinguishable from
an answer of "no bypass actors". Four response shapes printed a green tick and
exited 0 having verified nothing:

| Response body | Before | After |
| --- | --- | --- |
| empty (zero bytes) | ✅ exit 0 | ❌ exit 1 — refuses |
| whitespace only | ✅ exit 0 | ❌ exit 1 — refuses |
| `{"bypass_actors": null}` | ✅ exit 0 | ❌ exit 1 — refuses |
| key absent | ✅ exit 0 | ❌ exit 1 — refuses |
| `<html>502 …</html>` | ❌ exit 5, raw `jq` error | ❌ exit 1 — refuses, own message |
| `gh` exits non-zero | ❌ exit 1 | ❌ exit 1 — unchanged |
| populated array | ✅ exit 0 | ✅ exit 0 — unchanged |
| genuinely empty `[]` | ✅ exit 0 | ✅ exit 0 — unchanged |

The guard now asserts the **shape of the read** before comparing anything: the
body parses, the `bypass_actors` key is present, and it is an array. This
applies to the live-ruleset read the rule the script already stated for the
installations call — *an unreadable answer is a refusal, not a pass*.

This was not hypothetical. Against the **live API** with a non-admin token, the
old script printed:

```
✅ main.json: PUT over 20390421 drops no live bypass actor.
✅ Pre-flight passed.  EXIT=0
```

about a ruleset that in fact carries App `4516237` (see the correction below).
It certified a destructive `PUT` as safe precisely when it was blind to what
the `PUT` would delete. The same live read now refuses by name.

`REPO_SETUP.md` told the operator the check "refuses just as hard when it
cannot read the answer at all" — true of the installations call, not of this
one. That paragraph now says which reads it covers, why the admin scope
matters, and that a non-admin read of `bypass_actors` comes back `null`.

## 1. A pre-flight assertion, before the PUT rather than after

`main.json` and `tag-release-cut.json` are applied as full-body `PUT`s, so the
body sent **is** the ruleset afterwards. The `actor_id: 0` tripwire only
catches the *unsubstituted* case. A **wrong** id is quieter and worse: it does
not 422, it returns 200 having replaced `bypass_actors` wholesale — deleting
the identity `promote.yml` depends on, from a config apply that reports
success. Nothing surfaces it again until the next promotion fails on a ruleset
violation, after it has already fast-forwarded `main`.

There is no apply script to put the check inside — §3's `apply` is a shell
function a human pastes — so the assertion is a script committed beside the
payloads: [`docs/rulesets/preflight-app-id.sh`](docs/rulesets/preflight-app-id.sh).
It asserts, before any write:

| Assertion | On failure |
| --- | --- |
| `APP_ID` is set, numeric, not the `0` placeholder | refuse |
| It names an App **actually installed on the owner** — `GET /orgs/{owner}/installations`, not the number as typed | refuse, listing what *is* installed |
| No payload names a different App | refuse, naming both ids and the file |
| No `PUT` would drop a bypass actor that is live today — diffed against the ruleset it overwrites | refuse, listing the actors that would be deleted |

It **reads only** — every call it makes is a `GET` — and nothing runs it
automatically: no workflow references it, and it is a human step from an admin
clone. An unreadable answer refuses too, on **both** reads: listing
installations wants the `admin:org` scope, and a non-admin read of a ruleset
gets `bypass_actors` redacted to `null`. A check that passes when it cannot see
is the failure it exists to prevent — see §0.

§3 puts it in the sequence in four places, so the human meets it before the
`PUT` whichever way they enter the section: a box in *Before you apply
anything*, the first instruction in **cutover step 6**, a line in the
*Substituting the App id* block where `APP_ID` is exported, and again in **§3d**
directly above `apply docs/rulesets/main.json 20390421`.

### On the live state of 20390421 — the earlier claim here was wrong

**Corrected.** An earlier revision of this description said 20390421 carries no
bypass actor, on the strength of `GET /repos/actana/control/rulesets/20390421`
returning `"bypass_actors": null`. That was an artifact of reading it **without
admin rights**, not a fact about the ruleset. Read with an admin token, live
20390421 carries:

```json
[{"actor_id": 4516237, "actor_type": "Integration", "bypass_mode": "always"}]
```

The review was right and this description was wrong. GitHub redacts
`bypass_actors` to `null` for a token that can read the ruleset but is not an
admin of the repository, and `null` is indistinguishable from "none" unless you
go looking. A non-admin PAT still reads `null` for 20390421, 20390423 and
20390424 today, which is how the mistake was made and why it was not obvious.

That redaction is not a footnote: it is the input that made the drop guard
fail open, and it is fixed in **§0** above. Resolving the id from the
installations API rather than pinning `APP_ID == 4516237` remains the right
call — a hardcoded constant is a second thing that can go stale — but the
reason given for it here was a misreading, and §3d's "The App becomes a bypass
actor" is accurate as written.

## 2. Ruleset 20390423, captured

[`docs/rulesets/tag-immutable.json`](docs/rulesets/tag-immutable.json) — the
payload for **20390423** ("Release tags are immutable"), which had none, so a
clone restored four of the five live rulesets and the fifth existed only in the
web form.

Captured the same way the others were and verified identical to live:

```
$ diff <(gh api repos/actana/control/rulesets/20390423 | jq -S '{name,target,enforcement,conditions,rules}') \
       <(jq -S '{name,target,enforcement,conditions,rules}' docs/rulesets/tag-immutable.json)
IDENTICAL to live 20390423
```

Live reports no bypass actors; written `[]` to match `release-retired.json`.
Nothing applies it — 20390423 stays untouched by this effort, and §3e now says
so while pointing at the payload: restoring it is a `POST` if it has been
deleted and a `PUT` if it has been edited, both deliberate acts rather than
cutover steps.

## An open decision for the operator: 20390424 and `RepositoryRole:5`

**Not resolved in this PR, deliberately. No payload is changed.**

The review found that applying
[`docs/rulesets/tag-release-cut.json`](docs/rulesets/tag-release-cut.json) over
live ruleset **20390424** *would delete a live bypass actor*:

```
RepositoryRole:5:always
```

which the committed payload does not carry. Because that apply is a full-body
`PUT`, the payload replaces `bypass_actors` wholesale — the admin bypass does
not survive alongside the App actor, it goes. The pre-flight refuses on it:

```
❌ Applying tag-release-cut.json over live ruleset 20390424 would delete a bypass actor.
     RepositoryRole:5:always
```

That is the guard working, not failing. But two things follow, and both are
recorded in **§3e** rather than fixed here:

1. **Someone must decide whether that admin bypass is meant to survive** — add
   it to the payload if yes, or remove it in the admin console as its own
   deliberate act if no. Either way, before the cutover, not as a surprise
   refusal partway through it.
2. **§3e's "This is the only change to that ruleset" was false against live.**
   The payload also removes the admin bypass. Corrected, with the decision
   written up as a warning block above the `apply` line.

This is not this PR's defect — this PR is what surfaced it — and it is not
mine to resolve, so the payload ships unchanged and the cutover is documented
as blocked on the answer.

## Testing

Docs, JSON and one shell script. `bash -n` clean; all six payloads validate as
JSON; commitlint clean against the repo's own config.

Re-verified after the review fix. The reviewer's four fail-open shapes, plus
the three they checked alongside, driven through a stubbed `gh` — each of the
four now refuses with the script's own message and exits 1:

- empty body → **refused** (was: green tick, exit 0)
- whitespace-only body → **refused** (was: green tick, exit 0)
- `{"bypass_actors": null}` → **refused** (was: green tick, exit 0)
- key absent → **refused** (was: green tick, exit 0)
- `<html>502 …</html>` → **refused** with the script's message (was: raw `jq` exit 5)
- `gh` exits non-zero → refused, unchanged
- populated array, and a genuine `[]` → **still pass, exit 0** — the happy path
  is unaffected, including 20390423's legitimate `[]`

Against the **live API**, reads only, no `--method`/`-f`/`-F`/`--input`
anywhere in the script:

- full run on the real token → refuses at the installations call (no
  `admin:org`), with the `gh auth refresh` line
- installations stubbed so the ruleset reads go live → **refuses on the real
  redacted read of 20390421**, where the pre-fix script passed it green

The earlier paths still hold: `APP_ID` unset / non-numeric / `0` refused;
`APP_ID` naming no installed App refused, listing what is installed; a payload
naming a different App refused, naming both ids; a live bypass actor absent
from the payload refused, naming the actor the `PUT` would delete.

`bash -n` clean; all six payloads validate as JSON; commitlint clean.

This branch has also been merged up to
`origin/ci/release-trains-and-digest-promotion` (14aa01d, the nanoid pin from
#134), which is what the Dependency Audit check needs — it was red here only
because the branch predated that commit. Clean merge, nothing reverted.

Deps are not installed in this worktree, so vitest was not run locally — as on
#132. CI runs the suite; no test reads `docs/rulesets/`, and the three
`panel-image.test.mjs` assertions that read `docs/REPO_SETUP.md` are unaffected
by these edits.

## Not done here, by design

Nothing is applied to the live repository. No `POST` or `PUT` against rulesets,
no workflow, no automatic invocation. Reading the live rulesets to capture
20390423 and to test the drop guard is the only live interaction.

Base is `ci/release-trains-and-digest-promotion`, not `main`. Draft.

