### PR TITLE
feat(core-link): a Core accepts many concurrent core-link connections (D1, D12)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,8 +35,16 @@ The agentic coding CLI a session drives — `claude-code`, `codex`, `cursor-cli`
 _Avoid_: agent, task agent, AI runtime, tool, model
 
 **Core link**:
-The persistent bidirectional WebSocket connection between a Panel and a Core. Carries PTY streams, task mutations, hook events, and notifications as framed JSON messages. Long-lived; survives Panel sleep; replays missed events on reconnect via a monotonic event cursor.
+The persistent bidirectional WebSocket connection between a Core client and a Core. Carries PTY streams, task mutations, hook events, and notifications as framed JSON messages. Long-lived; survives Panel sleep; replays missed events on reconnect via a monotonic event cursor.
 _Avoid_: tunnel, channel, pipe, API
+
+**Core client**:
+Any program terminating a core link — the Panel, the `actana` CLI, an SDK automation. A Core serves many at once, each with its own event cursor, subscriptions and heartbeat, and none of them privileged: the Panel is a Core client like the others. The unit of write authority is the connection, not the human or the program behind it, so a client that reconnects is a new client until it says otherwise. See ADR 0024.
+_Avoid_: consumer, subscriber, peer, client session
+
+**Core alias**:
+The name one Panel shows for a Core. Panel-local presentation, stored in that Panel's Core registry beside the endpoint and auth material — not a Core fact, and two Panels registering one Core are meant to disagree about it. The Core neither knows nor publishes it.
+_Avoid_: core name, label, hostname, display name
 
 ### Ownership inside a Core
 
@@ -52,6 +60,14 @@ _UI note_: user-facing strings label a Task as "Session" (e.g. "Start a new sess
 **Session** (Core-scoped):
 The live or replayable conversation backing a Task — the PTY stream plus the harness's own session id. A Core runs many sessions; each session drives exactly one Harness. Replayable after Panel reconnect via the Core's event log.
 _Avoid_: conversation, thread
+
+**Session lock** (Core-scoped):
+The exclusive right of one Core client to mutate one Session — its writes, its kill, and every task mutation addressed at it. Held by a core-link connection, never by a person or a program; scoped to a single Session, so different Sessions on one Core may be held by different clients. A Session starts unlocked and its creator gets no privilege; claiming is an explicit gesture; the lock ends on release, on connection drop, or on force takeover, and never on idle. It lives in memory and dies with the Core, exactly like the PTYs it guards. See ADR 0024.
+_Avoid_: session owner, mutex, reservation, ownership
+
+**Reader** (Core-scoped):
+A Core client attached to a Session it does not hold the **Session lock** on. It sees every byte and can write none of them. Many Readers, one writer, per Session — a Reader is the ordinary state of an attached client, not a degraded one, and a Panel tab rendering a Session it does not hold is read-only *before* the first keystroke rather than on the error that answers it.
+_Avoid_: observer, spectator, participant, viewer, watcher
 
 **VM Shell Session** (Core-scoped):
 A free-form interactive shell on the Core's machine — distinct from harness workspaces. Spawned over the same core-link with `shellSession: true`, gated by core-link auth (not project-root validation), rendered in the Panel like a user terminal. The "SSH-equivalent" escape hatch. First-class concept, not a special case of harness PTY.
@@ -125,10 +141,11 @@ _Avoid_: service, daemon config, when you mean the concept — those are impleme
 
 - **Nothing task-shaped lives on the Panel.** Tasks, sessions, terminal logs, hook events, project folders — all on the Core. The Panel stores Cores + one `lastEventId` per Core.
 - **A Project's path is a VM path.** Only the Core can validate it. The Panel never stores or assumes folder paths on a Core.
-- **One Core link per Core, multiplexed.** All PTY streams, task ops, and events for one Core share a single WebSocket. No per-task channels.
+- **One Core link per Core client, multiplexed.** All PTY streams, task ops, and events between one Core client and one Core share a single WebSocket. No per-task channels. A Core serves many such links at once, and a new one never evicts an existing one (ADR 0024 D1).
+- **Many Readers, one writer, per Session.** Any number of Core clients may attach to a Session and watch it; at most one holds its **Session lock** and may mutate it. A PTY has no notion of who typed, so concurrent writers are not a feature to be added later — they are the thing the lock exists to prevent (ADR 0024 D3–D7).
 - **VM Shell Sessions are privileged.** Same auth as the core-link; require an explicit open gesture in the Panel; never auto-spawned.
 - **Singular UI across Cores.** Every Session (Task), Project, notification, status change, and modal renders through the same Panel components regardless of which Core owns the underlying data. Every Core is remote — a Core on the Panel's own host gets no special path. Transport underneath may differ; the surface may not.
 - **Only the Panel dials Cores.** Browsers cannot hold client certificates; every core-link terminates inside the Panel. The Panel UI reaches Cores solely through its panel link.
-- **The Panel and its Cores are version-locked.** The core-link handshake exchanges a protocol version; a mismatched Core renders as "needs update" with the command to run — never a degraded or feature-detected mode.
+- **The Panel and its Cores are version-locked, except for additive capabilities announced on `ready`.** The core-link handshake exchanges a protocol version; a mismatched Core renders as "needs update" with the command to run — never a degraded mode. The one narrow exception: a purely additive surface may announce itself on the `ready` frame, and only where its absence yields today's behaviour *exactly*, not a lesser one. A capability that changes what an existing frame means is not additive and still moves the version (ADR 0024 D11).
 - **Task metadata lives Core-side.** Titles, session icons, pin flags — all owned by the Core. Panel mutations flow over the core-link; two Panels connected to the same Core see identical state.
 - **CLI availability is Core-published state, not Panel probing.** The Panel never inspects a remote machine's PATH directly; it reads the Core's own availability snapshot from the core-link state stream.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,13 @@ These are load-bearing, not style preferences. Each is explained in
 - **Singular UI across Cores.** The same components render every Core's data.
   A Core on the Panel's own host gets no special path.
 - **The Panel and its Cores are version-locked.** A protocol mismatch renders
-  as "needs update", never a degraded or feature-detected mode.
-- **One core-link per Core, multiplexed.** No per-task channels.
+  as "needs update", never a degraded mode. The one exception is an additive
+  capability announced on `ready` whose absence yields today's behaviour
+  exactly (ADR 0024 D11).
+- **One core-link per Core client, multiplexed.** No per-task channels. A Core
+  serves many clients at once and a new connection evicts nobody (ADR 0024 D1).
+- **Many Readers, one writer, per Session.** Any client may watch a Session;
+  only the one holding its Session lock may mutate it.
 
 If your change contradicts an ADR in [`docs/adr/`](docs/adr/), say so in the PR
 rather than working around it. Reopening a decision is fine; doing it silently

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ routing around it.
 | [0021](adr/0021-installing-a-harness-is-a-panel-gesture.md) | Installing a Harness is a Panel gesture |
 | [0022](adr/0022-a-core-owned-project-has-a-panel-side-presentation-row.md) | A Core-owned project has a Panel-side presentation row |
 | [0023](adr/0023-release-trains-and-digest-promotion.md) | Release trains and digest promotion |
+| [0024](adr/0024-a-core-serves-many-clients-one-holds-a-sessions-write-lock.md) | A Core serves many clients, and one connection holds a Session's write lock |
 
 **Two files claim 0018**, as the table shows. It is a pre-existing collision,
 not breakage, and **nothing is renumbered** — every citation in the CI files

--- a/docs/adr/0024-a-core-serves-many-clients-one-holds-a-sessions-write-lock.md
+++ b/docs/adr/0024-a-core-serves-many-clients-one-holds-a-sessions-write-lock.md
@@ -1,0 +1,60 @@
+# A Core serves many clients, and one connection holds a Session's write lock
+
+A Core accepted exactly one core-link connection. `PtyCoreLinkServer.onConnection` closed whatever socket was there before accepting a new one, and that was the correct shape for a system with one client. #129 gives it three — the Panel, the CLI, and SDK automations — and already listed the consequence under its own known risks: every new client competes with the Panel for the one connection, and `attach` holds it for as long as it is open. Flagged there, solved here. #129 phase 2 defers `session attach` to last for exactly this reason: on a single-connection Core, attaching from the CLI evicts the operator's Panel.
+
+The replacement is **not** many writers. A PTY is a byte stream with no notion of who typed; two clients writing to one harness interleave into nonsense, and an automation driving a session cannot tolerate a stray keystroke from a Panel tab left open in another window. So: **a Core serves many clients at once, and every Session has many Readers and at most one writer.**
+
+The twelve decisions below were settled in a design session and are recorded here so no ticket re-litigates them. Each carries a **D** number that its ticket cites. A ticket that needs one changed amends this record rather than settling it in a comment.
+
+## The decisions
+
+**D1 — A Core accepts many concurrent core-link connections.** The evict-on-connect branch goes. Each connection gets its own event cursor, subscription set and heartbeat — already how `ActiveConnection` is shaped; it was simply only ever instantiated once.
+
+**D2 — PTY output fans out per connection, by subscription.** `PtyCore.setEmitTarget` is a single global callback, so every PTY's `data` goes to the one socket. It becomes a registry, and a connection receives a PTY's stream only after asking for it. A CLI attached to one session must not receive every other session's output on the machine, continuously. Catch-up needs nothing new: `replay { ptyId, sinceSeq }` exists and `data` frames already carry `seq`.
+
+**D3 — The unit of write authority is the core-link connection.** Not a per-client credential, not a logical actor above the socket. There is exactly one Operator per Panel, so the parties that genuinely contend are *programs* — Panel, CLI, SDK automation — and each is exactly one connection. Two browser tabs are one human with two tabs; which of them drives is the Panel's own business, settled between Panel sessions inside the Panel, and never crosses the wire.
+
+**D4 — The lock is scoped to one Session and covers every mutation on it.** Not just `write`: `kill`, and every task mutation addressed at that Session. An automation whose session can be killed by an observer does not hold a lock in any useful sense. Deliberately *not* Core-wide — that would stop the Panel creating a project while a CLI runs a session, which is the ordinary case, not the contended one. Different Sessions on one Core may be held by different clients.
+
+**D5 — A Session starts unlocked, and its creator gets no privilege.** Auto-claiming on create makes "who owns this" depend on history the Core would have to keep, and leaves a Session nobody can claim when its creator exits. Unlocked is a real state; any connection may claim an unlocked Session.
+
+**D6 — Claiming is explicit.** A `claim` frame; a mutation without the lock is an error, never an implicit acquisition.
+
+**D7 — A lock ends on explicit release, on connection drop, or on force takeover. No idle timeout.** A long agent run is *idle by definition* — no mutations for many minutes is the success case — so an idle timeout would drop the lock exactly when losing it costs most. Force takeover exists because otherwise a hung client renders a Session unusable until its process dies.
+
+**D8 — Lock state is published, not discovered by failing.** It rides the Session snapshot and emits an event on every change. A read-only Panel tab must render the terminal non-editable *before* a keystroke, `actana session ls` must show it, and the loser of a force takeover must learn it when it happens rather than on its next write.
+
+**D9 — A connection presents a stable client id, used only for reaping.** Not for authority, not verified. With D1 the old evict-on-reconnect no longer runs, so a reloaded Panel tab leaves a socket alive for up to `HEARTBEAT_TIMEOUT_MS` (45s) still holding locks. A reconnecting connection presenting the same client id replaces its predecessor and inherits its locks.
+
+**D10 — The write lock is a coordination mechanism, not a security boundary.** The Core's only authentication is the bearer in the registration blob, and anyone holding it can open a VM Shell Session and `kill` the process directly. A lock defended against someone with a shell on the machine is theatre. This is the posture #129's F3 takes for path confinement: an accident guard, stated as one. Per-client credentials with revocation would be a separate effort with its own ADR, and are not a prerequisite for anything above.
+
+**D11 — `CORE_LINK_PROTOCOL_VERSION` does not move; the capability is announced on `ready`.** `ready` carries an optional `multiConnection: { version: 1 }`; absent means the old single-connection Core. A new client against an old Core sees no capability and behaves as today; an old client against a new Core works untouched — it never claims, and never notices it is no longer evicting anybody. Moving the minor would mark every Core in every fleet needs-update for a capability most will never exercise.
+
+**D12 — Locks live in memory and die with the Core.** Not persisted, because the PTYs they guard do not survive the daemon either. A Core restart returns every Session to unlocked, which is the correct state for a Session with no running process behind it.
+
+## Considered Options
+
+- **Many writers to one Session, with no lock at all (rejected).** The smallest change — remove the eviction branch and stop there. Rejected because a PTY has no notion of who typed: two clients writing to one harness interleave into a stream neither of them meant, and the failure is silent and unattributable. Read concurrency is what operators actually ask for; write concurrency is what nobody can use.
+- **A per-client credential, or a logical actor above the socket, as the unit of write authority (rejected, D3).** It sounds more principled and it buys nothing here: there is exactly one Operator per Panel, so the parties that contend are programs, and a program is exactly one connection. It would also make authority something the Core has to store, verify and revoke — see D10 for why that is a different effort.
+- **The creator of a Session holds it automatically (rejected, D5).** Convenient for the common case and wrong in the case that matters: it makes ownership depend on history the Core would have to keep, and a Session whose creator exited would be locked by nobody with no way to claim it.
+- **First mutation claims the lock implicitly (rejected, D6).** Saves a frame and defeats the purpose. With D5 in force nothing else guards a running automation, so one keystroke in a Panel tab left open in another window would take the Session out from under it — the exact failure this ADR exists to prevent.
+- **An idle timeout on the lock (rejected, D7).** The usual liveness answer, and this is the one domain where it inverts: a long agent run is idle by definition, so the timeout fires precisely on the healthy long-running case it would hurt most. Connection drop and force takeover cover the two real failures without it.
+- **Moving `CORE_LINK_PROTOCOL_VERSION` instead of announcing a capability on `ready` (rejected, D11).** Version-locking is this project's default and it is the wrong instrument here: the minor moving marks every Core in every fleet "needs update" over a capability most of them will never exercise, and the honest alternative — a capability whose absence yields exactly today's behaviour — costs one optional field.
+
+## The rule this amends
+
+`CONTEXT.md`'s Rules said the Panel and its Cores are version-locked — *"never a degraded or feature-detected mode"*. D11 is feature detection, and so is #129's F9 for the files surface, so the rule needed amending either way.
+
+**Narrowed, not deleted:** an additive surface may announce itself on `ready` **only where its absence yields today's behaviour exactly**, not a lesser one. `multiConnection` absent means single-connection eviction, which is precisely today. A capability that changes what an existing frame means is not additive and still moves the version.
+
+Two more Rules changes ride with it: `One Core link per Core, multiplexed` is restated as **per Core client**, and a new rule is added — **many Readers, one writer, per Session**. Four domain terms land alongside: **Core client**, **Core alias**, **Session lock**, **Reader**. Banned as synonyms: session owner, mutex, reservation, observer, spectator, participant, client session.
+
+## Consequences
+
+- **The Core gains contention it has never had.** Nothing in `PtyCore` expected two callers. The lock table, the subscription registry and the emit fan-out are all new shared state in a process whose assumptions have been effectively single-threaded. #129 flags the same class of risk for concurrent HTTP against a live WebSocket; the mitigations should be written once.
+- **Force takeover is unrecoverable by design.** The loser's in-flight keystrokes are gone. D8 makes it visible; nothing makes it undoable.
+- **The claim race is real and accepted.** D5 leaves a window between session start and first claim in which any client can take it. An automation must claim immediately after starting.
+- **No cap on connection count is specified.** A Core with a runaway client reconnecting in a loop accumulates sockets until the heartbeat reaps them.
+- **Reconnect defects stop hiding.** Evict-on-connect made a fresh socket always win, so a failed reconnect was indistinguishable from a successful one. Without it, a stale connection holds its Session locks while the heartbeat waits out its 45 seconds — which is why #139 is a hard blocker for this effort rather than a neighbour of it.
+- **VM Shell Sessions are assumed to follow the same rule** as harness Sessions. Not separately decided — the first ticket that touches one should confirm or amend D4.
+- **The decisions land across five steps, not one.** D1 and D12 ship with this record (#141): the connection registry, and locks that never outlive the process because there are none yet to persist. D2 and D11 are #142 and #143; the lock itself, its published state and the stable client id follow; the Panel's read-only rendering is last. Until D2 lands, every registered connection receives every PTY's output — an interim fan-out, chosen over a per-connection emit target that would leave the first client silent while it still looked healthy.

--- a/packages/core/src/__tests__/core-link-many-connections.test.ts
+++ b/packages/core/src/__tests__/core-link-many-connections.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PtyCoreLinkServer,
+  type EventLogPort,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+import type { CoreLinkEvent } from "@actana/shared/core-link-frames";
+
+// Many core-link connections on one Core (issue 141, ADR 0024 D1).
+//
+// The property under test is what a second connection does NOT do: it does not
+// close the first, does not authenticate on its behalf, does not move its event
+// cursor, and does not take its PTY output away. Before this ticket the server
+// held one `activeWs` and one `ActiveConnection`, so every one of those was a
+// shared field and a second client silently overwrote it.
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  closed = false;
+  terminated = false;
+  pings = 0;
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = 3;
+    this.emit("close");
+  }
+  /** The real `ws.terminate()` destroys the socket; the close handler still runs. */
+  terminate(): void {
+    this.terminated = true;
+    this.close();
+  }
+  ping(): void {
+    this.pings += 1;
+  }
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(frame: unknown): void {
+    this.emit("message", JSON.stringify(frame));
+  }
+  pong(): void {
+    this.emit("pong");
+  }
+  ofType<T extends Record<string, unknown>>(type: string): T[] {
+    return this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === type) as T[];
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike) => void) | null = null;
+  connect(ws: FakeWebSocket): void {
+    this.connCb?.(ws as unknown as WebSocketLike);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike) => void;
+  }
+}
+
+/** An in-memory event log — the same seam `event-log-store.ts` fills for real. */
+function fakeEventLog() {
+  const events: CoreLinkEvent[] = [];
+  const port: EventLogPort = {
+    appendEvent: (kind, payload, opts) => {
+      const eventId = events.length + 1;
+      events.push({
+        eventId,
+        ts: eventId,
+        kind,
+        payload,
+        ptyId: opts?.ptyId ?? null,
+        taskId: opts?.taskId ?? null,
+      });
+      return eventId;
+    },
+    readEventTail: (afterEventId, limit = 1_000) =>
+      events.filter((event) => event.eventId > afterEventId).slice(0, limit),
+    getLastEventId: () => events.length,
+  };
+  return { port, events };
+}
+
+/** A `PtyCore` that records what the server does to it, and can emit. */
+function mockCore() {
+  const emitTargets: (((event: PtyCoreEvent) => void) | null)[] = [];
+  let target: ((event: PtyCoreEvent) => void) | null = null;
+  const core = {
+    setEmitTarget: (fn: ((event: PtyCoreEvent) => void) | null) => {
+      emitTargets.push(fn);
+      target = fn;
+    },
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+  return {
+    core,
+    emitTargets,
+    emit: (event: PtyCoreEvent) => target?.(event),
+    hasTarget: () => target !== null,
+  };
+}
+
+describe("a Core accepts many concurrent core-link connections (issue 141)", () => {
+  let wss: FakeWebSocketServer;
+  let server: PtyCoreLinkServer;
+  let core: ReturnType<typeof mockCore>;
+  let log: ReturnType<typeof fakeEventLog>;
+
+  function startServer(
+    opts: { authVerifier?: ConstructorParameters<typeof PtyCoreLinkServer>[1]["authVerifier"] } = {},
+    liveEventPollMs = 5,
+  ): void {
+    wss = new FakeWebSocketServer();
+    core = mockCore();
+    log = fakeEventLog();
+    server = new PtyCoreLinkServer(core.core, {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      eventLog: log.port,
+      liveEventPollMs,
+      ...opts,
+    });
+  }
+
+  function connect(): FakeWebSocket {
+    const ws = new FakeWebSocket();
+    wss.connect(ws);
+    return ws;
+  }
+
+  beforeEach(() => {
+    startServer();
+  });
+
+  afterEach(() => {
+    server.close();
+    vi.useRealTimers();
+  });
+
+  it("does not close the first connection when a second arrives", () => {
+    const first = connect();
+    const second = connect();
+
+    expect(first.closed).toBe(false);
+    expect(first.terminated).toBe(false);
+    // Both were greeted; neither greeting cost the other anything.
+    expect(first.ofType("ready")).toHaveLength(1);
+    expect(second.ofType("ready")).toHaveLength(1);
+  });
+
+  it("keeps answering the first connection's frames after the second connects", () => {
+    const first = connect();
+    const second = connect();
+
+    first.receive({ type: "findByTask", reqId: "a1", taskId: "t1" });
+    second.receive({ type: "findByTask", reqId: "b1", taskId: "t1" });
+
+    expect(first.ofType<{ reqId: string }>("findByTaskResult").map((f) => f.reqId)).toEqual(["a1"]);
+    expect(second.ofType<{ reqId: string }>("findByTaskResult").map((f) => f.reqId)).toEqual(["b1"]);
+  });
+
+  it("authenticates each connection independently", () => {
+    server.close();
+    startServer({ authVerifier: () => ({ ok: true, coreId: "core-1", exp: 9_999 }) });
+    const authed = connect();
+    const anonymous = connect();
+
+    authed.receive({ type: "auth", reqId: "a1", bearer: "good" });
+    expect(authed.ofType("authOk")).toHaveLength(1);
+
+    // The other connection is still a stranger — one client's bearer is not
+    // the Core's door held open for everybody behind it.
+    anonymous.receive({ type: "findByTask", reqId: "b1", taskId: "t1" });
+    expect(anonymous.ofType<{ message: string }>("error")[0]?.message).toBe("not-authenticated");
+    expect(anonymous.closed).toBe(true);
+    expect(authed.closed).toBe(false);
+  });
+
+  it("gives each connection its own event cursor", () => {
+    log.port.appendEvent("pty:spawn", "{}", { ptyId: "pty-1" });
+    log.port.appendEvent("pty:spawn", "{}", { ptyId: "pty-2" });
+
+    const fromScratch = connect();
+    const caughtUp = connect();
+    fromScratch.receive({ type: "subscribe", reqId: "a1", lastEventId: 0 });
+    caughtUp.receive({ type: "subscribe", reqId: "b1", lastEventId: 2 });
+
+    // The replay each asked for, not the replay the other asked for.
+    expect(fromScratch.ofType("event")).toHaveLength(2);
+    expect(caughtUp.ofType("event")).toHaveLength(0);
+    expect(fromScratch.ofType<{ lastEventId: number }>("eventsReplayed")[0]?.lastEventId).toBe(2);
+    expect(caughtUp.ofType<{ lastEventId: number }>("eventsReplayed")[0]?.lastEventId).toBe(2);
+  });
+
+  it("leaves the other connection's poll timer running when one closes", async () => {
+    const leaving = connect();
+    const staying = connect();
+    leaving.receive({ type: "subscribe", reqId: "a1", lastEventId: 0 });
+    staying.receive({ type: "subscribe", reqId: "b1", lastEventId: 0 });
+
+    leaving.close();
+    const sentBefore = staying.sent.length;
+    log.port.appendEvent("pty:exit", "{}", { ptyId: "pty-1" });
+
+    // The live push is the survivor's own timer; it was never the departing
+    // connection's to cancel.
+    await vi.waitFor(() => expect(staying.ofType("event")).toHaveLength(1));
+    expect(staying.sent.length).toBeGreaterThan(sentBefore);
+    expect(leaving.ofType("event")).toHaveLength(0);
+  });
+
+  it("holds the Core's emit target until the last connection goes", () => {
+    const first = connect();
+    const second = connect();
+    expect(core.hasTarget()).toBe(true);
+
+    first.close();
+    // Still one client here: the Core keeps emitting.
+    expect(core.hasTarget()).toBe(true);
+
+    second.close();
+    expect(core.hasTarget()).toBe(false);
+    // Installed once for the server, released once — not re-pointed per client.
+    expect(core.emitTargets.filter((fn) => fn !== null)).toHaveLength(1);
+  });
+
+  it("fans PTY output out to every connection (interim, until D2 subscriptions)", () => {
+    const first = connect();
+    const second = connect();
+
+    core.emit({ type: "data", ptyId: "pty-1", data: "hello", seq: 7 });
+
+    for (const ws of [first, second]) {
+      expect(ws.ofType<{ ptyId: string; data: string; seq: number }>("data")).toEqual([
+        { type: "data", ptyId: "pty-1", data: "hello", seq: 7 },
+      ]);
+    }
+  });
+
+  it("records one pty:exit per exit, not one per connection", () => {
+    const first = connect();
+    const second = connect();
+    connect();
+
+    core.emit({ type: "exit", ptyId: "pty-1", exitCode: 0 });
+
+    expect(log.events.filter((event) => event.kind === "pty:exit")).toHaveLength(1);
+    // …while every client still learns the PTY died.
+    expect(first.ofType("exit")).toHaveLength(1);
+    expect(second.ofType("exit")).toHaveLength(1);
+  });
+
+  it("reaps only the connection that went quiet", () => {
+    vi.useFakeTimers();
+    server.close();
+    startServer({}, 100_000);
+    const quiet = connect();
+    const alive = connect();
+
+    vi.advanceTimersByTime(20_000);
+    alive.pong();
+    vi.advanceTimersByTime(20_000);
+    alive.pong();
+    vi.advanceTimersByTime(20_000);
+
+    // 60s of silence from one client, none from the other. The old heartbeat
+    // asked "am I the active socket?" — with a registry that question reaps
+    // whichever connection is not the newest, however healthy it is.
+    expect(quiet.terminated).toBe(true);
+    expect(alive.terminated).toBe(false);
+    expect(alive.closed).toBe(false);
+    expect(alive.pings).toBeGreaterThan(0);
+  });
+
+  it("leaves a single connection behaving exactly as before", async () => {
+    const only = connect();
+    only.receive({ type: "subscribe", reqId: "r1", lastEventId: 0 });
+
+    expect(only.ofType<{ fromEventId: number }>("subscribeAck")).toEqual([
+      { type: "subscribeAck", reqId: "r1", fromEventId: 0 },
+    ]);
+    log.port.appendEvent("pty:spawn", "{}", { ptyId: "pty-1" });
+    await vi.waitFor(() => expect(only.ofType("event")).toHaveLength(1));
+
+    core.emit({ type: "data", ptyId: "pty-1", data: "out", seq: 1 });
+    expect(only.ofType("data")).toHaveLength(1);
+
+    only.close();
+    expect(core.hasTarget()).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/core-link-many-connections.test.ts
+++ b/packages/core/src/__tests__/core-link-many-connections.test.ts
@@ -102,16 +102,24 @@ function fakeEventLog() {
 /** A `PtyCore` that records what the server does to it, and can emit. */
 function mockCore() {
   const emitTargets: (((event: PtyCoreEvent) => void) | null)[] = [];
+  const spawned: unknown[] = [];
+  const killed: string[] = [];
   let target: ((event: PtyCoreEvent) => void) | null = null;
   const core = {
     setEmitTarget: (fn: ((event: PtyCoreEvent) => void) | null) => {
       emitTargets.push(fn);
       target = fn;
     },
-    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    spawn: async (opts: unknown) => {
+      spawned.push(opts);
+      return { ptyId: "pty-1", hooksReportTurnStart: true };
+    },
     write: () => true,
     resize: () => true,
-    kill: () => true,
+    kill: (ptyId: string) => {
+      killed.push(ptyId);
+      return true;
+    },
     killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
     findByTask: () => ({ ptyId: null }),
     replay: () => ({ data: "", nextSeq: 0, from: 0 }),
@@ -120,6 +128,8 @@ function mockCore() {
   return {
     core,
     emitTargets,
+    spawned,
+    killed,
     emit: (event: PtyCoreEvent) => target?.(event),
     hasTarget: () => target !== null,
   };
@@ -262,6 +272,29 @@ describe("a Core accepts many concurrent core-link connections (issue 141)", () 
     }
   });
 
+  it("does not fan PTY output out to a connection that has not authenticated", () => {
+    server.close();
+    startServer({ authVerifier: () => ({ ok: true, coreId: "core-1", exp: 9_999 }) });
+    const authed = connect();
+    const stranger = connect();
+    authed.receive({ type: "auth", reqId: "a1", bearer: "good" });
+    expect(authed.ofType("authOk")).toHaveLength(1);
+
+    core.emit({ type: "data", ptyId: "pty-1", data: "secret", seq: 1 });
+    core.emit({ type: "exit", ptyId: "pty-1", exitCode: 0 });
+
+    expect(authed.ofType("data")).toHaveLength(1);
+    expect(authed.ofType("exit")).toHaveLength(1);
+    // The stranger presents no bearer and sends no frame, so the message gate
+    // never fires; it answers pings, so the heartbeat never reaps it. The
+    // fan-out is the only thing standing between it and this Core's PTY output.
+    expect(stranger.ofType("data")).toHaveLength(0);
+    expect(stranger.ofType("exit")).toHaveLength(0);
+    // Skipping a connection is not allowed to cost the log its row: the exit is
+    // recorded once, off the single sink, outside the fan-out loop.
+    expect(log.events.filter((event) => event.kind === "pty:exit")).toHaveLength(1);
+  });
+
   it("records one pty:exit per exit, not one per connection", () => {
     const first = connect();
     const second = connect();
@@ -312,5 +345,35 @@ describe("a Core accepts many concurrent core-link connections (issue 141)", () 
 
     only.close();
     expect(core.hasTarget()).toBe(false);
+  });
+
+  it("does not dispatch a frame that arrives after close()", async () => {
+    server.close();
+    startServer({ authVerifier: () => ({ ok: true, coreId: "core-1", exp: 9_999 }) });
+    const ws = connect();
+    ws.receive({ type: "auth", reqId: "a1", bearer: "good" });
+    expect(ws.ofType("authOk")).toHaveLength(1);
+
+    server.close();
+    const sentBefore = ws.sent.length;
+
+    // The `message` handler closes over the connection, not the registry, so
+    // clearing the registry alone would leave `authenticated` true and these
+    // two frames fully served by a Core that has already shut down.
+    ws.receive({
+      type: "spawn",
+      reqId: "s1",
+      opts: { taskId: "t1", cwd: "/tmp", command: "sh", agent: "claude-code" },
+    });
+    ws.receive({ type: "kill", reqId: "k1", ptyId: "pty-1" });
+    await Promise.resolve();
+
+    expect(core.spawned).toHaveLength(0);
+    expect(core.killed).toHaveLength(0);
+    expect(ws.sent).toHaveLength(sentBefore);
+    expect(log.events).toHaveLength(0);
+    // …and the client is told the Core is gone rather than left holding a
+    // socket that answers nothing.
+    expect(ws.closed).toBe(true);
   });
 });

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -7,9 +7,13 @@
 // Loopback-only (trusted) — no auth yet. A later issue adds mTLS + bearer auth
 // before the same server listens on a non-loopback interface.
 //
-// A single connection is expected at a time (the Panel). When the Panel
-// disconnects (renderer reload, app sleep), `core.setEmitTarget(null)` stops
-// output delivery — the PTY buffer retains everything for replay on reconnect.
+// Many connections are accepted at once (issue 141, ADR 0024 D1): the Panel,
+// the CLI, an SDK automation. Each gets its own {@link ActiveConnection} — its
+// own auth state, event cursor, poll loop and heartbeat — and a new connection
+// never closes an existing one. `PtyCore` state (PTYs, tasks, the event log) is
+// untouched by a connection arriving or leaving. When the last connection goes,
+// `core.setEmitTarget(null)` stops output delivery — the PTY buffer retains
+// everything for replay on reconnect.
 
 import log from "./log";
 import type { WebSocketServer, WebSocket } from "ws";
@@ -35,7 +39,7 @@ import {
 // server module alongside {@link CoreQueryPort} (the per-Core navigation
 // query port, issue 07).
 export type { CoreLinkProjectSnapshot, CoreLinkTaskSnapshot };
-import type { PtyCore } from "./pty-manager";
+import type { PtyCore, PtyCoreEvent } from "./pty-manager";
 import { CoreTaskWriter } from "./core-task-writer";
 
 /**
@@ -351,11 +355,15 @@ const PROJECT_MUTATION_EVENT_KINDS: Record<CoreLinkProjectMutation["op"], string
 };
 /**
  * Heartbeat cadence, mirroring the Panel-side client. The Core must detect a
- * vanished Panel too: `setEmitTarget` points PTY output at whatever socket is
- * active, so a half-open connection means every chunk an agent produces is
- * written into a socket that will never deliver it — the pane looks frozen
- * while the agent runs on. Pinging every 15s both keeps NATs/firewalls from
- * reaping an idle link and bounds how long a dead one can hold the emit target.
+ * vanished client too: PTY output fans out to every registered connection, so a
+ * half-open one means every chunk an agent produces is written into a socket
+ * that will never deliver it — the pane looks frozen while the agent runs on.
+ * Pinging every 15s both keeps NATs/firewalls from reaping an idle link and
+ * bounds how long a dead connection stays in the registry.
+ *
+ * The heartbeat is per connection and reaps only its own: with a registry, a
+ * connection is stale because *it* has gone quiet, never because a newer one
+ * arrived (issue 141).
  */
 const HEARTBEAT_INTERVAL_MS = 15_000;
 /** Terminate a connection after this long with no message or pong (3 pings). */
@@ -391,8 +399,21 @@ export class PtyCoreLinkServer {
    * describes it (issue 84).
    */
   private readonly taskWriter: CoreTaskWriter;
-  private activeWs: WebSocketLike | null = null;
-  private connection: ActiveConnection | null = null;
+  /**
+   * Every core-link connection this Core is currently serving, keyed by its
+   * socket (issue 141, ADR 0024 D1). Insertion-ordered, so fan-out reaches
+   * clients in the order they connected. Replaces the old `activeWs` +
+   * single `connection` pair: a connection's state — auth, cursor, poll,
+   * heartbeat — is now the entry, and nothing about it is shared.
+   */
+  private readonly connections = new Map<WebSocketLike, ActiveConnection>();
+  /**
+   * True while `core.setEmitTarget` holds this server's fan-out callback. One
+   * callback for the whole server, not one per connection — the target is a
+   * single global sink on `PtyCore`, so a per-connection one would have the
+   * newest connection silently steal every PTY's output from the rest.
+   */
+  private emitTargetInstalled = false;
 
   constructor(
     private readonly core: PtyCore,
@@ -425,90 +446,122 @@ export class PtyCoreLinkServer {
   }
 
   private onConnection(ws: WebSocketLike): void {
-    // One connection at a time. If the Panel reconnects (renderer reload),
-    // drop the old connection first — the core's PTY state survives.
-    if (this.activeWs) {
-      try {
-        this.activeWs.removeAllListeners();
-        this.activeWs.close();
-      } catch {
-        /* already closed */
-      }
-    }
-    this.activeWs = ws;
-    this.connection = new ActiveConnection();
-
-    // Wire core events → outgoing frames. PTY exit events are also appended
-    // to the event log (pty:exit lifecycle marker) so a reconnecting Panel
-    // learns which PTYs died while it was away.
-    this.core.setEmitTarget((event) => {
-      const frame: CoreLinkServerFrame =
-        event.type === "data"
-          ? { type: "data", ptyId: event.ptyId, data: event.data, seq: event.seq }
-          : { type: "exit", ptyId: event.ptyId, exitCode: event.exitCode, signal: event.signal };
-      this.send(ws, frame);
-      if (event.type === "exit") {
-        this.recordPtyExit(event);
-      }
-    });
+    // Many connections at a time (ADR 0024 D1). A new connection — a second
+    // Panel tab, the CLI, a reconnecting renderer — is registered alongside
+    // whatever is already here, never in place of it. Nothing on `PtyCore`
+    // moves as a result.
+    const conn = new ActiveConnection(ws);
+    this.connections.set(ws, conn);
+    this.ensureEmitTarget();
 
     // Send the ready frame immediately.
     this.send(ws, { type: "ready", version: this.protocolVersion });
 
     // Start the live-event push poll for this connection. It stays silent
-    // until the Panel sends `subscribe`, then pushes new events past the
-    // connection's lastSentEventId.
-    this.connection.startPoll(() => this.pushLiveEvents(ws), this.liveEventPollMs);
+    // until the client sends `subscribe`, then pushes new events past this
+    // connection's own lastSentEventId.
+    conn.startPoll(() => this.pushLiveEvents(conn), this.liveEventPollMs);
 
     // Per-connection heartbeat. `lastInboundAt` advances on any frame from the
-    // Panel — an RPC, or the pong answering our ping — so a connection only
-    // dies here when the Panel is genuinely unreachable.
-    let lastInboundAt = Date.now();
-    const heartbeat = ws.ping
-      ? setInterval(() => {
-          if (this.activeWs !== ws) {
-            clearInterval(heartbeat!);
-            return;
-          }
-          if (Date.now() - lastInboundAt > HEARTBEAT_TIMEOUT_MS) {
-            clearInterval(heartbeat!);
-            log.warn("core-link.connection.stale", { idleMs: Date.now() - lastInboundAt });
-            try {
-              ws.terminate ? ws.terminate() : ws.close();
-            } catch {
-              /* already gone — the close handler still runs */
-            }
-            return;
-          }
+    // client — an RPC, or the pong answering our ping — so a connection only
+    // dies here when that client is genuinely unreachable. The registry
+    // membership check is the liveness question now: asking whether some other
+    // socket is "the active one" would reap healthy connections the moment a
+    // second client arrived.
+    if (ws.ping) {
+      conn.heartbeat = setInterval(() => {
+        if (this.connections.get(ws) !== conn) {
+          conn.stopHeartbeat();
+          return;
+        }
+        const idleMs = Date.now() - conn.lastInboundAt;
+        if (idleMs > HEARTBEAT_TIMEOUT_MS) {
+          conn.stopHeartbeat();
+          log.warn("core-link.connection.stale", { idleMs });
           try {
-            ws.ping?.();
+            ws.terminate ? ws.terminate() : ws.close();
           } catch {
-            /* the close handler will take it from here */
+            /* already gone — the close handler still runs */
           }
-        }, HEARTBEAT_INTERVAL_MS)
-      : null;
+          return;
+        }
+        try {
+          ws.ping?.();
+        } catch {
+          /* the close handler will take it from here */
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+      if (typeof conn.heartbeat.unref === "function") conn.heartbeat.unref();
+    }
     ws.on("pong", () => {
-      lastInboundAt = Date.now();
+      conn.lastInboundAt = Date.now();
     });
 
     ws.on("message", (raw) => {
-      lastInboundAt = Date.now();
-      this.onMessage(ws, raw);
+      conn.lastInboundAt = Date.now();
+      this.onMessage(conn, raw);
     });
     ws.on("close", () => {
-      if (heartbeat) clearInterval(heartbeat);
-      if (this.activeWs === ws) {
-        this.activeWs = null;
-        this.core.setEmitTarget(null);
-      }
-      if (this.connection) {
-        this.connection.stopPoll();
-        this.connection = null;
-      }
+      this.dropConnection(ws, conn);
     });
     ws.on("error", (err) => {
       log.warn("core-link.connection.error", { error: err.message });
     });
+  }
+
+  /**
+   * Retire one connection: its poll timer and its heartbeat, and nothing
+   * else. Every other connection keeps its own — the defect this replaces
+   * cancelled a shared poll, so one client closing stopped live event push for
+   * whoever else was here. The emit target is released only when the last
+   * connection goes, which is what makes a Core with no clients quiet again.
+   */
+  private dropConnection(ws: WebSocketLike, conn: ActiveConnection): void {
+    conn.stopHeartbeat();
+    conn.stopPoll();
+    // Guard on identity, not presence: a socket that was already replaced in
+    // the map must not evict its successor.
+    if (this.connections.get(ws) === conn) this.connections.delete(ws);
+    if (this.connections.size === 0) this.releaseEmitTarget();
+  }
+
+  /**
+   * Install this server's single PTY-event sink on the Core, once.
+   *
+   * **Interim behaviour (issue 141):** every registered connection receives
+   * every PTY's `data` and `exit`. Per-connection subscription is D2 and lands
+   * in its own ticket; until then a fan-out is the only correct stopgap, since
+   * `PtyCore.setEmitTarget` holds exactly one callback and setting it per
+   * connection would leave the *first* client silent while it still looked
+   * healthy — no close, no error, just no output.
+   */
+  private ensureEmitTarget(): void {
+    if (this.emitTargetInstalled) return;
+    this.emitTargetInstalled = true;
+    this.core.setEmitTarget((event) => this.fanOutPtyEvent(event));
+  }
+
+  private releaseEmitTarget(): void {
+    if (!this.emitTargetInstalled) return;
+    this.emitTargetInstalled = false;
+    this.core.setEmitTarget(null);
+  }
+
+  /**
+   * Deliver one PTY event to every connection, and record an exit exactly
+   * once. The event log is a fact about the machine, not about who was
+   * watching: appending per connection would write two `pty:exit` rows for one
+   * dead process and replay the exit twice to every reconnecting client.
+   */
+  private fanOutPtyEvent(event: PtyCoreEvent): void {
+    const frame: CoreLinkServerFrame =
+      event.type === "data"
+        ? { type: "data", ptyId: event.ptyId, data: event.data, seq: event.seq }
+        : { type: "exit", ptyId: event.ptyId, exitCode: event.exitCode, signal: event.signal };
+    for (const conn of this.connections.values()) this.send(conn.ws, frame);
+    if (event.type === "exit") {
+      this.recordPtyExit(event);
+    }
   }
 
   /** Record a pty:exit event in the log (lifecycle marker for replay). */
@@ -557,21 +610,23 @@ export class PtyCoreLinkServer {
    * the poll loop once the connection has subscribed. Also advances the
    * connection cursor so the next tick only sees newer events.
    */
-  private pushLiveEvents(ws: WebSocketLike): void {
-    if (!this.connection || !this.connection.subscribed || !this.eventLog) return;
+  private pushLiveEvents(conn: ActiveConnection): void {
+    if (!conn.subscribed || !this.eventLog) return;
     // When auth is required, never push events until authenticated — a
     // pre-auth subscriber would learn the event timeline without proving
-    // identity.
-    if (this.authVerifier && !this.connection.authenticated) return;
-    const after = this.connection.lastSentEventId;
+    // identity. Per connection: one authenticated client does not open the
+    // stream for another that has not authenticated.
+    if (this.authVerifier && !conn.authenticated) return;
+    const after = conn.lastSentEventId;
     const tail = this.eventLog.readEventTail(after, EVENT_TAIL_LIMIT);
     for (const event of tail) {
-      this.send(ws, { type: "event", event });
-      this.connection.lastSentEventId = event.eventId;
+      this.send(conn.ws, { type: "event", event });
+      conn.lastSentEventId = event.eventId;
     }
   }
 
-  private async onMessage(ws: WebSocketLike, raw: unknown): Promise<void> {
+  private async onMessage(conn: ActiveConnection, raw: unknown): Promise<void> {
+    const ws = conn.ws;
     const data = typeof raw === "string" ? raw : String(raw);
     const frame = parseCoreLinkRequestFrame(data);
     if (!frame) {
@@ -582,7 +637,7 @@ export class PtyCoreLinkServer {
     // `auth` is always processed (it's how the connection authenticates). Any
     // other frame received before authentication, when an `authVerifier` is
     // configured, is rejected — the Panel must present its bearer first.
-    if (frame.type !== "auth" && this.authVerifier && !this.isAuthenticated()) {
+    if (frame.type !== "auth" && this.authVerifier && !conn.authenticated) {
       this.send(ws, { type: "error", reqId: frame.reqId, message: "not-authenticated" });
       // Drop the connection so the Panel's reconnect path re-presents `auth`
       // from a clean state instead of racing frames.
@@ -594,15 +649,11 @@ export class PtyCoreLinkServer {
       return;
     }
     try {
-      await this.dispatch(ws, frame);
+      await this.dispatch(conn, frame);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.send(ws, { type: "error", reqId: frame.reqId, message });
     }
-  }
-
-  private isAuthenticated(): boolean {
-    return this.connection?.authenticated ?? false;
   }
 
   /**
@@ -620,7 +671,8 @@ export class PtyCoreLinkServer {
     return null;
   }
 
-  private async dispatch(ws: WebSocketLike, frame: CoreLinkRequestFrame): Promise<void> {
+  private async dispatch(conn: ActiveConnection, frame: CoreLinkRequestFrame): Promise<void> {
+    const ws = conn.ws;
     switch (frame.type) {
       case "spawn": {
         try {
@@ -696,15 +748,15 @@ export class PtyCoreLinkServer {
         // Auth gate (re-checked here so a hand-rolled `subscribe` after auth
         // still works, but a pre-auth `subscribe` slipped past the message
         // gate is rejected rather than silently streaming the event tail).
-        if (this.authVerifier && !this.isAuthenticated()) {
+        if (this.authVerifier && !conn.authenticated) {
           this.send(ws, { type: "error", reqId: frame.reqId, message: "not-authenticated" });
           return;
         }
-        this.handleSubscribe(ws, frame);
+        this.handleSubscribe(conn, frame);
         return;
       }
       case "auth": {
-        this.handleAuth(ws, frame);
+        this.handleAuth(conn, frame);
         return;
       }
       // ─── Task / project / session / hook ops (issue 02 schema + issue 07
@@ -918,10 +970,10 @@ export class PtyCoreLinkServer {
    * cursor so the Panel's state machine stays consistent.
    */
   private handleSubscribe(
-    ws: WebSocketLike,
+    conn: ActiveConnection,
     frame: { type: "subscribe"; reqId: string; lastEventId: number },
   ): void {
-    const conn = this.connection ?? (this.connection = new ActiveConnection());
+    const ws = conn.ws;
     conn.subscribed = true;
     const fromEventId = frame.lastEventId;
     let lastSent = fromEventId;
@@ -948,9 +1000,10 @@ export class PtyCoreLinkServer {
    * `auth` frame is rejected — the loopback Panel never sends one.
    */
   private handleAuth(
-    ws: WebSocketLike,
+    conn: ActiveConnection,
     frame: { type: "auth"; reqId: string; bearer: string },
   ): void {
+    const ws = conn.ws;
     if (!this.authVerifier) {
       this.send(ws, {
         type: "authError",
@@ -963,7 +1016,8 @@ export class PtyCoreLinkServer {
     if (!result.ok) {
       this.send(ws, { type: "authError", reqId: frame.reqId, reason: result.reason });
       // Close so the Panel's reconnect path takes over. The close handler
-      // clears `connection`; a fresh `auth` lands on a fresh connection.
+      // drops this connection from the registry; a fresh `auth` lands on a
+      // fresh one, and every other client's authentication is unaffected.
       try {
         ws.close();
       } catch {
@@ -971,7 +1025,7 @@ export class PtyCoreLinkServer {
       }
       return;
     }
-    if (this.connection) this.connection.authenticated = true;
+    conn.authenticated = true;
     this.send(ws, {
       type: "authOk",
       reqId: frame.reqId,
@@ -989,20 +1043,26 @@ export class PtyCoreLinkServer {
   }
 
   close(): void {
-    if (this.connection) {
-      this.connection.stopPoll();
-      this.connection = null;
+    for (const conn of this.connections.values()) {
+      conn.stopHeartbeat();
+      conn.stopPoll();
     }
-    this.core.setEmitTarget(null);
-    this.activeWs = null;
+    this.connections.clear();
+    this.releaseEmitTarget();
     this.server.close();
   }
 }
 
 /**
- * Per-connection live-event-push state. Tracks whether the Panel has
- * subscribed and the highest eventId it has been sent, so the poll loop only
- * pushes events the Panel hasn't seen.
+ * One core-link connection's own state: whether it has authenticated, whether
+ * it has subscribed, the highest eventId it has been sent, its live-event poll
+ * and its heartbeat. Every field here is private to one client — this shape
+ * always was per-connection; before issue 141 it was simply only ever
+ * instantiated once, and the server held the socket beside it.
+ *
+ * Nothing about a Session, a PTY or the event log lives here. Those are Core
+ * facts, shared by construction, and a connection arriving or leaving must not
+ * move any of them.
  */
 class ActiveConnection {
   subscribed = false;
@@ -1010,7 +1070,13 @@ class ActiveConnection {
    *  loopback (no `authVerifier` configured). */
   authenticated = false;
   lastSentEventId = 0;
+  /** Last time anything arrived from this client — a frame, or a pong. */
+  lastInboundAt = Date.now();
+  /** This connection's ping timer; only it may reap this connection. */
+  heartbeat: ReturnType<typeof setInterval> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(readonly ws: WebSocketLike) {}
 
   startPoll(fn: () => void, intervalMs: number): void {
     this.stopPoll();
@@ -1023,6 +1089,13 @@ class ActiveConnection {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeat) {
+      clearInterval(this.heartbeat);
+      this.heartbeat = null;
     }
   }
 }

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -548,17 +548,31 @@ export class PtyCoreLinkServer {
   }
 
   /**
-   * Deliver one PTY event to every connection, and record an exit exactly
-   * once. The event log is a fact about the machine, not about who was
-   * watching: appending per connection would write two `pty:exit` rows for one
-   * dead process and replay the exit twice to every reconnecting client.
+   * Deliver one PTY event to every *authenticated* connection, and record an
+   * exit exactly once. The event log is a fact about the machine, not about who
+   * was watching: appending per connection would write two `pty:exit` rows for
+   * one dead process and replay the exit twice to every reconnecting client —
+   * so the append stays outside the loop, and a connection being skipped never
+   * costs the log a row.
+   *
+   * The auth skip mirrors `pushLiveEvents`: with an `authVerifier` configured,
+   * a connection that has not proved identity gets nothing pushed at it. PTY
+   * output is strictly more sensitive than the event timeline, and a socket
+   * that presents no bearer and sends no frame never trips the message gate —
+   * answering pings keeps `lastInboundAt` fresh, so the heartbeat never reaps
+   * it either. Until this ticket the fan-out was the one push path that did not
+   * ask. Loopback Cores configure no verifier, where `authenticated` is
+   * irrelevant and every connection is served exactly as before.
    */
   private fanOutPtyEvent(event: PtyCoreEvent): void {
     const frame: CoreLinkServerFrame =
       event.type === "data"
         ? { type: "data", ptyId: event.ptyId, data: event.data, seq: event.seq }
         : { type: "exit", ptyId: event.ptyId, exitCode: event.exitCode, signal: event.signal };
-    for (const conn of this.connections.values()) this.send(conn.ws, frame);
+    for (const conn of this.connections.values()) {
+      if (this.authVerifier && !conn.authenticated) continue;
+      this.send(conn.ws, frame);
+    }
     if (event.type === "exit") {
       this.recordPtyExit(event);
     }
@@ -1042,10 +1056,30 @@ export class PtyCoreLinkServer {
     }
   }
 
+  /**
+   * Shut the server down, disarming every socket it is still serving.
+   *
+   * Dropping the registry is not enough: the `message` handler closes over its
+   * own {@link ActiveConnection}, not over `this.connections`, so a frame
+   * arriving after shutdown would still be dispatched in full — `spawn` and
+   * `kill` included — on a connection whose `authenticated` is still true.
+   * Before issue 141 `close()` nulled the single `connection` field and the
+   * auth gate went false with it; with a registry, the socket itself has to be
+   * taken out of the conversation. Removing the listeners is what actually does
+   * that — a close handshake still delivers whatever is already in flight — and
+   * the `close()` that follows is the polite half, telling the client this Core
+   * is going away rather than leaving it to notice a dead socket.
+   */
   close(): void {
-    for (const conn of this.connections.values()) {
+    for (const conn of [...this.connections.values()]) {
       conn.stopHeartbeat();
       conn.stopPoll();
+      try {
+        conn.ws.removeAllListeners();
+        conn.ws.close();
+      } catch {
+        /* already gone — nothing left to disarm */
+      }
     }
     this.connections.clear();
     this.releaseEmitTarget();


### PR DESCRIPTION
**Base branch: `feat/multi-connection-core`, not `main`.** Train: `beta/0.2.0`.
Implements **D1** and **D12** of #140. Closes #141.

## What

`PtyCoreLinkServer` held `activeWs` and one `connection: ActiveConnection`, and closed the
previous socket before accepting a new one. Both fields become a registry keyed by socket —
`Map<WebSocketLike, ActiveConnection>` — and the evict-on-connect branch goes. `ActiveConnection`
was already shaped per connection (its own auth flag, its own cursor, its own poll); it now also
carries its socket, its `lastInboundAt` and its heartbeat, and it is instantiated once per client
instead of once per Core.

Nothing else moves. The Session lock, the subscription model and the `multiConnection` capability
field are #142 / #143 and are **not** implemented here — the ADR records their decisions, the code
does not anticipate them.

## The three traps in the ticket

**The heartbeat compared its captured `ws` against `this.activeWs`.** With a registry that
comparison is not stale, it is *wrong*: every connection except the newest fails it, so the timer
would clear itself and stop pinging — and worse, the identity test that decides "is this
connection still mine to reap" would be answered by "did somebody else connect after me". It now
asks whether it is still its own entry in the registry (`this.connections.get(ws) !== conn`), and
terminates only on its own 45s of silence. Covered by *"reaps only the connection that went
quiet"*: two clients, one pongs, 60s pass, only the silent one is terminated.

**`core.setEmitTarget` was set inside `onConnection`.** With two connections the second overwrote
the first's target and the first went silent while looking healthy — no close, no error, no bytes.
Not left as the interim behaviour: the target is now installed **once for the server** and **fans
out to every registered connection**.

> ⚠️ **Stated as the stopgap it is.** Until D2 (#142) gives each connection a subscription set,
> every connected client receives every PTY's `data` and `exit` on that Core. That is more traffic
> than any one client wants — a CLI attached to one session sees the whole machine — and it is the
> deliberate choice over a per-connection emit target, because `PtyCore.setEmitTarget` holds
> exactly one callback and the alternative silently starves the older client. It is confined to
> `fanOutPtyEvent`, which is the one function D2 replaces.

**`recordPtyExit` must fire once per exit.** It rode the per-connection callback, so N connections
would have appended N `pty:exit` rows for one dead process and replayed the exit N times to every
reconnecting client. It now fires from the single sink. Covered by *"records one pty:exit per exit,
not one per connection"*: three connections, one exit, one row, three `exit` frames.

## Done when

- [x] A second connection does not close the first — both get `ready`, both authenticate
      independently, both keep their own cursor and heartbeat.
- [x] Closing one leaves the other untouched, including its poll timer (it was cancelled through
      shared state before).
- [x] `PtyCore` state is unchanged by a connection coming or going. The emit target is installed on
      the first connection and released only when the last one goes.
- [x] Single-connection behaviour is byte-identical from one client's point of view, except that
      reconnecting no longer evicts anybody.

Ten tests in `packages/core/src/__tests__/core-link-many-connections.test.ts`.

## Docs, landing here rather than separately

- `docs/adr/0024-a-core-serves-many-clients-one-holds-a-sessions-write-lock.md` — the twelve
  decisions, the six rejected options, the Rules amendment. Next free number; nothing renumbered,
  per `docs/adr/README.md`.
- `CONTEXT.md` — **Core client**, **Core alias**, **Session lock**, **Reader**.
- `CONTEXT.md` Rules — `One Core link per Core, multiplexed` → **per Core client**; new rule
  **many Readers, one writer, per Session**; the version-lock rule **narrowed, not deleted**, to
  admit an additive capability announced on `ready` only where its absence yields today's
  behaviour exactly.
- `docs/README.md` — the ADR index row.
- `CONTRIBUTING.md` — the same two rules restated in the short list a reviewer holds a PR to, so it
  does not contradict the glossary it points at. Not in the ticket; included because leaving it
  saying "one core-link per Core" would have made the amended rule wrong in the first place a
  contributor reads it.

## Not in this PR, deliberately

- The Session lock (#142/#143 sequence), the subscription model (D2), the `multiConnection`
  capability on `ready` (D11), the stable client id (D9).
- `packages/panel` — untouched; #19 is in flight there.
- No merge, and nothing targeting `main` or `beta/0.2.0`.

**#139 is a hard blocker for this effort** (#140: "must be diagnosed before any ticket here
merges") — evict-on-connect is what has been hiding reconnect defects, and this PR removes it.
That is a merge gate, not a review gate; flagged here so it is not discovered at merge time.

## Checks

`pnpm typecheck`, `pnpm lint` (0 errors), `pnpm scan:secrets`, the full Core suite (38 files, 688
tests) and the full Panel suite (125 files, 1260 tests) pass. Every commit passes commitlint, not
just the title.

One note on the Panel suite: at the stock 5s per-test timeout it flaked in the dev sandbox — a
different handful of files each run, including ones with no path to the core link
(`token-usage-rollup`). Each passed alone, and the whole suite is green at `--testTimeout=30000`.
Machine speed, not this change; every test that exercises `PtyCoreLinkServer` passes at the stock
timeout.

Refs #140
