### PR TITLE
feat(panel): rename a registered Core from Settings → Cores

### DIFF
--- a/packages/panel/src/components/views/CoresSettingsPage.tsx
+++ b/packages/panel/src/components/views/CoresSettingsPage.tsx
@@ -34,6 +34,8 @@ export function CoresSettingsPage() {
   const [pendingRemoval, setPendingRemoval] = useState<CoreWithDial | null>(null);
   const [removing, setRemoving] = useState(false);
 
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+
   // A poll that lands after unmount must not write to a dead component.
   const mounted = useRef(true);
   useEffect(() => {
@@ -79,6 +81,31 @@ export function CoresSettingsPage() {
       setRegisterError(err instanceof Error ? err.message : "Could not pair that Core.");
     } finally {
       setRegistering(false);
+    }
+  };
+
+  /**
+   * Rename a Core. Panel-local and nothing more: the alias is this Panel's name
+   * for the machine, so the write lands in the registry and the list re-reads
+   * it. The Core is not told, and another Panel paired to it keeps its own name.
+   *
+   * Returns whether it stuck, so the row only leaves edit mode on a write that
+   * landed — a rejected rename keeps the operator's text in front of them.
+   */
+  const handleRename = async (core: CoreWithDial, label: string): Promise<boolean> => {
+    setRenamingId(core.id);
+    try {
+      const { core: renamed } = await api.renameCore(core.id, label);
+      await refresh();
+      // Quote what was stored, not what was typed: an operator who emptied the
+      // box gets the endpoint host back, and the toast should say so.
+      toast.success(`Core renamed to "${renamed.label}".`);
+      return true;
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to rename Core.");
+      return false;
+    } finally {
+      if (mounted.current) setRenamingId(null);
     }
   };
 
@@ -135,6 +162,8 @@ export function CoresSettingsPage() {
                     core={core}
                     onRemove={() => setPendingRemoval(core)}
                     removing={removing && pendingRemoval?.id === core.id}
+                    onRename={(label) => handleRename(core, label)}
+                    renaming={renamingId === core.id}
                   />
                 ))}
               </div>
@@ -222,15 +251,54 @@ function ErrorBox({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * What the service will fall back to if the alias is saved empty — shown as the
+ * placeholder so clearing the box reads as a choice rather than an accident.
+ * Mirrors `labelFor` on the server, down to surviving an unparseable endpoint.
+ */
+function endpointHost(endpoint: string): string {
+  try {
+    return new URL(endpoint).hostname || endpoint;
+  } catch {
+    return endpoint;
+  }
+}
+
+/**
+ * One Core in the list. The alias is editable in place — it is the only field
+ * here that is the Panel's to change, and the operator's read of the fleet
+ * depends on it. Endpoint and credentials are what the pairing token said they
+ * were; changing those means a fresh token.
+ */
 function CoreRow({
   core,
   onRemove,
   removing,
+  onRename,
+  renaming,
 }: {
   core: CoreWithDial;
   onRemove: () => void;
   removing: boolean;
+  onRename: (label: string) => Promise<boolean>;
+  renaming: boolean;
 }) {
+  // Non-null is the edit mode flag *and* the draft: an empty string is a state
+  // the operator can legitimately be in (it saves as the endpoint host), so
+  // "editing" can't be `draft !== ""`.
+  const [draft, setDraft] = useState<string | null>(null);
+  const editing = draft !== null;
+
+  const commit = async () => {
+    if (draft === null) return;
+    // Nothing to write, and no toast worth showing for it.
+    if (draft.trim() === core.label) {
+      setDraft(null);
+      return;
+    }
+    if (await onRename(draft)) setDraft(null);
+  };
+
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
     <div
@@ -255,7 +323,39 @@ function CoreRow({
             flexWrap: "wrap",
           }}
         >
-          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{core.label}</span>
+          {editing ? (
+            <input
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void commit();
+                else if (e.key === "Escape") setDraft(null);
+              }}
+              disabled={renaming}
+              aria-label={`Name for Core ${core.label}`}
+              // The same 120 the service caps at, so the box can't accept
+              // characters the registry would silently drop.
+              maxLength={120}
+              placeholder={endpointHost(core.endpoint)}
+              style={{
+                flex: 1,
+                minWidth: 120,
+                background: "var(--surface-1)",
+                border: "1px solid var(--accent)",
+                borderRadius: 5,
+                outline: 0,
+                color: "var(--text)",
+                padding: "3px 8px",
+                fontSize: 13,
+                fontWeight: 600,
+              }}
+            />
+          ) : (
+            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>
+              {core.label}
+            </span>
+          )}
           <DialBadge dial={core.dial} />
         </div>
         <div
@@ -274,16 +374,46 @@ function CoreRow({
           )}
         </div>
       </div>
-      <Btn
-        variant="ghost"
-        size="sm"
-        icon={removing ? undefined : "trash"}
-        onClick={onRemove}
-        disabled={removing}
-        aria-label={`Remove Core ${core.label}`}
-      >
-        {removing ? "Removing…" : "Remove"}
-      </Btn>
+      {editing ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+          <Btn variant="accent" size="sm" onClick={() => void commit()} disabled={renaming}>
+            {renaming ? "Saving…" : "Save"}
+          </Btn>
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="x"
+            onClick={() => setDraft(null)}
+            disabled={renaming}
+            aria-label={`Cancel renaming Core ${core.label}`}
+          >
+            Cancel
+          </Btn>
+        </div>
+      ) : (
+        <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="pencil"
+            onClick={() => setDraft(core.label)}
+            disabled={removing}
+            aria-label={`Rename Core ${core.label}`}
+          >
+            Rename
+          </Btn>
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon={removing ? undefined : "trash"}
+            onClick={onRemove}
+            disabled={removing}
+            aria-label={`Remove Core ${core.label}`}
+          >
+            {removing ? "Removing…" : "Remove"}
+          </Btn>
+        </div>
+      )}
     </div>
       {/* The chore, where the operator manages Cores: the command that closes
           the version gap, one click from the clipboard. */}

--- a/packages/panel/src/components/views/__tests__/cores-settings-rename.test.tsx
+++ b/packages/panel/src/components/views/__tests__/cores-settings-rename.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CoreWithDial } from "~/shared/cores";
+
+// Renaming a registered Core from Settings → Cores (issue 19).
+//
+// The alias is Panel-local presentation: this page writes it to the Panel's own
+// registry and nothing reaches the machine. What the page has to get right is
+// that the row shows what was *stored* — the service trims, caps and falls back
+// to the endpoint host, so echoing the operator's keystrokes would show a name
+// the Panel does not have.
+
+const api = {
+  listCores: vi.fn(async (): Promise<{ cores: CoreWithDial[] }> => ({ cores: CORES })),
+  renameCore: vi.fn(async (_id: string, _label: string): Promise<{ core: CoreWithDial }> => {
+    throw new Error("not stubbed");
+  }),
+  removeCore: vi.fn(async () => undefined),
+  addCore: vi.fn(),
+  // The page mounts a ConfirmDialog, whose hotkey reaches the keybindings store.
+  getKeybindings: vi.fn(async () => ({ bindings: {} })),
+};
+
+const toasts = { success: vi.fn(), error: vi.fn() };
+
+vi.mock("~/lib/api", () => ({ api }));
+vi.mock("sonner", () => ({ toast: toasts }));
+
+const { CoresSettingsPage } = await import("../CoresSettingsPage");
+const { KeybindingsProvider } = await import("~/lib/keybindings/store");
+
+function core(over: Partial<CoreWithDial> = {}): CoreWithDial {
+  return {
+    id: "core_a",
+    endpoint: "wss://prod-vm-1.internal:7777",
+    label: "Core A",
+    lastEventId: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    dial: { coreId: "core_a", state: "connected", lastSeenAt: 1 },
+    ...over,
+  };
+}
+
+let CORES: CoreWithDial[] = [core()];
+
+async function openPage(): Promise<void> {
+  render(
+    <KeybindingsProvider>
+      <CoresSettingsPage />
+    </KeybindingsProvider>,
+  );
+  // Let the first listCores settle before the first assertion.
+  await act(async () => {});
+}
+
+function nameBox(): HTMLInputElement {
+  return screen.getByLabelText(/^Name for Core /) as HTMLInputElement;
+}
+
+/** Rename through the affordance the operator uses: pencil, type, Save. */
+async function renameTo(text: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /^Rename Core / }));
+  });
+  fireEvent.change(nameBox(), { target: { value: text } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  });
+}
+
+describe("renaming a Core from Settings → Cores (issue 19)", () => {
+  beforeEach(() => {
+    CORES = [core()];
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    // The service is what normalizes; stand in for it by storing what it would.
+    api.renameCore.mockImplementation(async (id: string, label: string) => {
+      const stored = label.trim().slice(0, 120) || "prod-vm-1.internal";
+      CORES = [core({ id, label: stored })];
+      return { core: CORES[0]! };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("edits the alias in place and shows the renamed row", async () => {
+    await openPage();
+    expect(screen.getByText("Core A")).toBeTruthy();
+
+    await renameTo("build-box");
+
+    expect(api.renameCore).toHaveBeenCalledWith("core_a", "build-box");
+    expect(screen.getByText("build-box")).toBeTruthy();
+    // Back to a read-only row: the box is gone once the write landed.
+    expect(screen.queryByLabelText(/^Name for Core /)).toBeNull();
+    expect(toasts.success).toHaveBeenCalledWith('Core renamed to "build-box".');
+  });
+
+  it("shows what the service stored, not what was typed", async () => {
+    await openPage();
+
+    // Emptying the box is a legitimate gesture — it asks for the fallback.
+    await renameTo("   ");
+
+    expect(api.renameCore).toHaveBeenCalledWith("core_a", "   ");
+    expect(screen.getByText("prod-vm-1.internal")).toBeTruthy();
+    expect(toasts.success).toHaveBeenCalledWith('Core renamed to "prod-vm-1.internal".');
+  });
+
+  it("caps the box at the 120 the registry stores", async () => {
+    await openPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Rename Core / }));
+    });
+    expect(nameBox().maxLength).toBe(120);
+  });
+
+  it("leaves the row alone when the operator cancels", async () => {
+    await openPage();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Rename Core / }));
+    });
+    fireEvent.change(nameBox(), { target: { value: "build-box" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Cancel renaming Core / }));
+    });
+
+    expect(api.renameCore).not.toHaveBeenCalled();
+    expect(screen.getByText("Core A")).toBeTruthy();
+  });
+
+  it("keeps the operator's text in front of them when the write is refused", async () => {
+    await openPage();
+    api.renameCore.mockRejectedValueOnce(new Error("no such Core"));
+
+    await renameTo("build-box");
+
+    // Still editing, still holding what was typed — a rejected rename that
+    // silently dropped the text would cost the operator their edit.
+    expect(nameBox().value).toBe("build-box");
+    expect(toasts.error).toHaveBeenCalledWith("no such Core");
+  });
+});

--- a/packages/panel/src/components/views/__tests__/harness-install-from-picker.test.tsx
+++ b/packages/panel/src/components/views/__tests__/harness-install-from-picker.test.tsx
@@ -36,8 +36,12 @@ const bridge = {
 
 vi.mock("~/lib/panel-bridge", () => ({ getPanelBridge: () => bridge }));
 vi.mock("~/queries", () => ({ useSettings: () => ({ data: undefined }) }));
+// Mutable, so a test can put the registry poll's answer through a rename
+// (issue 19) rather than only ever seeing the name a Core paired with.
+let CORES = [{ id: "core_a", label: "Core A" }];
+
 vi.mock("~/lib/use-fleet", () => ({
-  useCores: () => ({ cores: [{ id: "core_a", label: "Core A" }] }),
+  useCores: () => ({ cores: CORES }),
 }));
 vi.mock("~/lib/api", () => ({ api: { getKeybindings: async () => ({ bindings: {} }) } }));
 
@@ -114,6 +118,7 @@ function installButton(): HTMLElement {
 describe("installing a missing Harness from the picker (issue 83)", () => {
   beforeEach(() => {
     AVAILABILITY = availability({ status: "missing", reason: "not-found" });
+    CORES = [{ id: "core_a", label: "Core A" }];
     listeners.clear();
     __resetCliAvailabilityStoresForTests();
     bridge.installHarness.mockClear();
@@ -130,6 +135,37 @@ describe("installing a missing Harness from the picker (issue 83)", () => {
     expect(installButton()).toBeTruthy();
     expect(row("Claude Code").hasAttribute("disabled")).toBe(false);
     expect(screen.getByText("CLI not found on PATH.")).toBeTruthy();
+  });
+
+  // Issue 19: the alias is Panel-local and editable, and this dialog resolves it
+  // per render for its install copy. So an operator who renamed a machine is
+  // told to install on the name they use for it now, not the one it paired with.
+  it("names the Core by its current alias after a rename", async () => {
+    // A fresh element each time: React skips a re-render handed back the same
+    // element object, and it is the re-render that re-resolves the alias.
+    const ui = () => (
+      <KeybindingsProvider>
+        <NewHarnessDialog
+          open
+          project={PROJECT}
+          coreId="core_a"
+          onClose={() => {}}
+          onStart={() => {}}
+          onPersistRemember={() => {}}
+        />
+      </KeybindingsProvider>
+    );
+    const { rerender } = render(ui());
+    await act(async () => {});
+    expect(installButton().title).toMatch(/ on Core A$/);
+
+    // The registry poll comes back with the operator's new name for that Core.
+    CORES = [{ id: "core_a", label: "build-box" }];
+    await act(async () => {
+      rerender(ui());
+    });
+
+    expect(installButton().title).toMatch(/ on build-box$/);
   });
 
   it("asks the Core that owns the picker's Task to install that Harness", async () => {

--- a/packages/panel/src/lib/__tests__/use-session-finish-notifications.integration.test.ts
+++ b/packages/panel/src/lib/__tests__/use-session-finish-notifications.integration.test.ts
@@ -21,13 +21,16 @@ const h = vi.hoisted(() => ({
   mcToastCustom: vi.fn((..._args: unknown[]) => undefined),
   showOsNotification: vi.fn(async (..._args: unknown[]) => undefined),
   playDing: vi.fn((..._args: unknown[]) => undefined),
+  // Mutable, so a test can put the registry poll's answer through a rename
+  // (issue 19) rather than only ever seeing the name a Core paired with.
+  cores: [{ id: "core-a", label: "Core A" }],
 }));
 
 vi.mock("~/queries", () => ({
   useSettings: () => ({ data: h.settings }),
 }));
 vi.mock("~/lib/use-fleet", () => ({
-  useCores: () => ({ cores: [{ id: "core-a", label: "Core A" }] }),
+  useCores: () => ({ cores: h.cores }),
 }));
 vi.mock("~/lib/use-events", () => ({
   useServerEvents: (handler: (e: unknown) => void) => {
@@ -121,6 +124,7 @@ describe("useSessionFinishNotifications — integration", () => {
     h.sseHandler = null;
     h.fleetHandler = null;
     h.watched = [];
+    h.cores = [{ id: "core-a", label: "Core A" }];
     vi.clearAllMocks();
   });
 
@@ -145,6 +149,28 @@ describe("useSessionFinishNotifications — integration", () => {
       coreAlias: "Core A",
     });
     expect(hook.result.current.notifications).toHaveLength(1);
+    hook.unmount();
+  });
+
+  // Issue 19: the alias is Panel-local and editable. The subscription is keyed
+  // on *which* Cores exist, so a rename doesn't re-run it — the alias map is
+  // read through a ref refreshed on render instead. This is that path: a finish
+  // arriving after a rename has to be titled with the new name.
+  it("uses the Core's current alias after a rename", () => {
+    const hook = renderHook(() => useSessionFinishNotifications());
+    act(() => h.fleetHandler?.(remoteFinishFrame({ eventId: 1, id: "task-1" })));
+    expect(toastText(0)).toContain("Remote Project on Core A");
+
+    // The registry poll comes back with the operator's new name for that Core.
+    h.cores = [{ id: "core-a", label: "build-box" }];
+    hook.rerender();
+    act(() => h.fleetHandler?.(remoteFinishFrame({ eventId: 2, id: "task-2" })));
+
+    expect(h.mcToastCustom).toHaveBeenCalledTimes(2);
+    expect(toastText(1)).toContain("Remote Project on build-box");
+    expect(loadSessionFinishNotifications().find((n) => n.id === "task-2")?.coreAlias).toBe(
+      "build-box",
+    );
     hook.unmount();
   });
 

--- a/packages/panel/src/lib/api.ts
+++ b/packages/panel/src/lib/api.ts
@@ -165,6 +165,17 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ registrationBlob }),
     }),
+  /**
+   * Rename a Core. The alias is the Panel's own name for the machine, so this
+   * writes to the registry and stops there — nothing reaches the Core. The
+   * response carries the normalized label (trimmed, 120 chars, endpoint host
+   * when empty), which is what to render rather than what was typed.
+   */
+  renameCore: (id: string, label: string) =>
+    req<{ core: CoreWithDial }>(`/api/cores/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ label }),
+    }),
   removeCore: (id: string) => req<void>(`/api/cores/${id}`, { method: "DELETE" }),
 
   listProjects: () => req<{ projects: ProjectWithCounts[] }>("/api/projects"),

--- a/packages/panel/src/server/__tests__/cores-api.test.ts
+++ b/packages/panel/src/server/__tests__/cores-api.test.ts
@@ -391,6 +391,55 @@ describe("Cores API", () => {
     }, 20_000);
   });
 
+  describe("renaming a Core", () => {
+    it("renames in place and shows the new alias in the list", async () => {
+      const { id } = await pair("prod-vm-1");
+      const response = await call(`/api/cores/${id}`, { method: "PATCH", json: { label: "build-box" } });
+      expect(response.status).toBe(200);
+      expect((await response.json()) as { core: { label: string } }).toMatchObject({
+        core: { id, label: "build-box" },
+      });
+      const body = (await (await call("/api/cores")).json()) as { cores: { label: string }[] };
+      expect(body.cores[0]?.label).toBe("build-box");
+    }, 20_000);
+
+    it("normalizes the way pairing does — trimmed, capped, host when empty", async () => {
+      const { id } = await pair();
+      const labelAfter = async (label: string): Promise<string> => {
+        const res = await call(`/api/cores/${id}`, { method: "PATCH", json: { label } });
+        return ((await res.json()) as { core: { label: string } }).core.label;
+      };
+      expect(await labelAfter("  spaced out  ")).toBe("spaced out");
+      expect(await labelAfter("x".repeat(200))).toBe("x".repeat(120));
+      expect(await labelAfter("   ")).toBe("127.0.0.1");
+    }, 20_000);
+
+    it("leaves the link alone — renaming is a Panel-local write", async () => {
+      const { id } = await pair();
+      await vi.waitFor(async () => expect((await dialOf(id)).state).toBe("connected"), {
+        timeout: 10_000,
+      });
+      const seenAt = (await dialOf(id)).lastSeenAt;
+      expect((await call(`/api/cores/${id}`, { method: "PATCH", json: { label: "build-box" } })).status).toBe(200);
+      const dial = await dialOf(id);
+      expect(dial.state).toBe("connected");
+      expect(dial.lastSeenAt).toBe(seenAt);
+    }, 30_000);
+
+    it("rejects a body with no label, and an anonymous caller", async () => {
+      const { id } = await pair();
+      expect((await call(`/api/cores/${id}`, { method: "PATCH", json: {} })).status).toBe(400);
+      expect(
+        (await call(`/api/cores/${id}`, { method: "PATCH", anonymous: true, json: { label: "x" } })).status,
+      ).toBe(401);
+    }, 20_000);
+
+    it("404s on an id it doesn't know", async () => {
+      const response = await call("/api/cores/core_nope", { method: "PATCH", json: { label: "x" } });
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe("removing a Core", () => {
     it("drops the registry row, its secrets, and its cursor", async () => {
       const { id } = await pair();

--- a/packages/panel/src/server/api-router.ts
+++ b/packages/panel/src/server/api-router.ts
@@ -209,7 +209,14 @@ async function dispatch(
     if (method === "POST") return coresController.add(request);
   }
   let m = pathname.match(CORE_PATH);
-  if (m && method === "DELETE") return coresController.remove(decode(m[1]));
+  if (m) {
+    const id = decode(m[1]);
+    // PATCH is the alias, and only the alias: a Core's endpoint and credentials
+    // are what the registration blob said they were, and re-pairing is the only
+    // way to change them.
+    if (method === "PATCH") return coresController.rename(id, request);
+    if (method === "DELETE") return coresController.remove(id);
+  }
 
   // Projects
   if (pathname === "/api/projects") {

--- a/packages/panel/src/server/controllers/cores.controller.ts
+++ b/packages/panel/src/server/controllers/cores.controller.ts
@@ -1,13 +1,18 @@
 import { z } from "zod";
 import { json, noContent, notFound, parseJsonBody } from "./_helpers";
 import { HTTP_CREATED } from "~/shared/http-status";
-import { listCores, registerCoreFromRegistrationBlob, removeCore } from "../services/cores";
+import {
+  listCores,
+  registerCoreFromRegistrationBlob,
+  removeCore,
+  renameCore,
+} from "../services/cores";
 import { coreLinkManager } from "../services/core-link-manager";
 import type { Core, CoreWithDial } from "~/shared/cores";
 
 /**
  * The Cores surface: list the fleet with live link state, register a new Core
- * from a registration blob, forget one.
+ * from a registration blob, rename one, forget one.
  *
  * Note what is absent — there is no endpoint that returns a Core's secrets, and
  * none that takes them piecemeal. The credentials enter once, inside the blob,
@@ -15,6 +20,7 @@ import type { Core, CoreWithDial } from "~/shared/cores";
  */
 
 const addBody = z.object({ registrationBlob: z.string() });
+const renameBody = z.object({ label: z.string() });
 
 function withDial(core: Core): CoreWithDial {
   return { ...core, dial: coreLinkManager().status(core.id) };
@@ -39,6 +45,23 @@ export async function add(request: Request): Promise<Response> {
   const core = registerCoreFromRegistrationBlob(body.data.registrationBlob);
   coreLinkManager().dial(core.id);
   return json({ core: withDial(core) }, { status: HTTP_CREATED });
+}
+
+/**
+ * Rename a Core. A Panel-local write and nothing more — the registry row's
+ * label changes, the link is left alone, and the machine is never told.
+ *
+ * The response carries the label as stored rather than as posted: the service
+ * trims it, caps it at 120 characters, and falls back to the endpoint host when
+ * it comes out empty, so a client that echoed its own input would show
+ * something the Panel doesn't have.
+ */
+export async function rename(id: string, request: Request): Promise<Response> {
+  const body = await parseJsonBody(request, renameBody);
+  if (!body.ok) return body.response;
+  const core = renameCore(id, body.data.label);
+  if (!core) return notFound("no such Core");
+  return json({ core: withDial(core) });
 }
 
 /** Forget a Core: hang up first, then drop the registry row, secrets, and cursor. */

--- a/packages/panel/src/server/services/__tests__/cores.test.ts
+++ b/packages/panel/src/server/services/__tests__/cores.test.ts
@@ -17,6 +17,7 @@ const {
   listCores,
   registerCoreFromRegistrationBlob,
   removeCore,
+  renameCore,
 } = await import("../cores");
 
 const BEARER = "bearer.eyJjb3JlSWQiOiJjb3JlXzEifQ.sig";
@@ -163,6 +164,47 @@ describe("Core registry", () => {
       advanceCoreCursor(core.id, Number.NaN);
       advanceCoreCursor(core.id, -1);
       expect(getCore(core.id)?.lastEventId).toBe(42);
+    });
+  });
+
+  describe("renaming", () => {
+    it("takes the operator's alias and bumps updated_at", () => {
+      const core = registerCoreFromRegistrationBlob(registrationBlob());
+      // Age the row first: registration and the rename can land in the same
+      // millisecond, and a bump asserted against the wall clock would flake.
+      getPanelDb().prepare("UPDATE cores SET updated_at = 0 WHERE id = ?").run(core.id);
+      const renamed = renameCore(core.id, "build-box");
+      expect(renamed?.label).toBe("build-box");
+      expect(getCore(core.id)?.label).toBe("build-box");
+      expect(renamed?.updatedAt).toBeGreaterThan(0);
+    });
+
+    it("trims and caps at 120 characters, like registration does", () => {
+      const core = registerCoreFromRegistrationBlob(registrationBlob());
+      expect(renameCore(core.id, "  spaced out  ")?.label).toBe("spaced out");
+      expect(renameCore(core.id, "x".repeat(200))?.label).toBe("x".repeat(120));
+    });
+
+    it("falls back to the endpoint host rather than leaving a blank row", () => {
+      const core = registerCoreFromRegistrationBlob(registrationBlob());
+      expect(renameCore(core.id, "   ")?.label).toBe("10.0.0.5");
+      expect(renameCore(core.id, "")?.label).toBe("10.0.0.5");
+    });
+
+    it("touches nothing but the label — endpoint, cursor and secrets are left alone", () => {
+      const core = registerCoreFromRegistrationBlob(registrationBlob());
+      advanceCoreCursor(core.id, 17);
+      renameCore(core.id, "build-box");
+      const after = getCore(core.id);
+      expect(after?.endpoint).toBe("wss://10.0.0.5:7777");
+      expect(after?.lastEventId).toBe(17);
+      expect(after?.createdAt).toBe(core.createdAt);
+      expect(getCoreSecrets(core.id)?.bearer).toBe(BEARER);
+    });
+
+    it("reports an unknown id rather than writing a row", () => {
+      expect(renameCore("core_nope", "build-box")).toBeNull();
+      expect(coreRowCount()).toBe(0);
     });
   });
 

--- a/packages/panel/src/server/services/cores.ts
+++ b/packages/panel/src/server/services/cores.ts
@@ -69,9 +69,13 @@ function newCoreId(): string {
 }
 
 /**
- * A Core with no alias in its blob still needs something to be called in the
- * UI. The host is what the operator recognizes; they can't rename yet, so
- * getting this wrong means an unidentifiable row.
+ * Normalize an alias for the registry: trimmed, capped at 120 characters, and
+ * falling back to the endpoint's host when what's left is empty.
+ *
+ * Both ways in go through here — the label carried in a registration blob, and
+ * whatever the operator types into a rename — so neither can leave a row with
+ * nothing to identify it by. The host is the fallback because it is what the
+ * operator recognizes about a machine they haven't named themselves.
  */
 function labelFor(rawLabel: string, endpoint: string): string {
   const trimmed = rawLabel.trim();
@@ -153,6 +157,27 @@ export function registerCoreFromRegistrationBlob(raw: unknown): Core {
   const core = getCore(id);
   if (!core) throw new Error("failed to read back the registered Core");
   return core;
+}
+
+/**
+ * Rename a Core. Returns the updated row, or null for an unknown id.
+ *
+ * The alias is Panel-local presentation, not a Core fact (CONTEXT.md, "Core
+ * alias"): nothing is sent to the machine and no core-link frame carries it,
+ * so another Panel registered against the same Core keeps its own name for it.
+ * That is the point of the field, not drift.
+ *
+ * The label goes through {@link labelFor}, the same normalization registration
+ * uses — so an operator who clears the box gets the endpoint host back rather
+ * than a blank row, and the caller is handed what was actually stored.
+ */
+export function renameCore(id: string, label: string): Core | null {
+  const existing = getCore(id);
+  if (!existing) return null;
+  getPanelDb()
+    .prepare("UPDATE cores SET label = ?, updated_at = ? WHERE id = ?")
+    .run(labelFor(label, existing.endpoint), Date.now(), id);
+  return getCore(id);
 }
 
 /**


### PR DESCRIPTION
## Summary

A registered Core could not be renamed: the label was derived once at pairing time from the alias
in the registration blob, and nothing in the Panel could change it afterwards. The only workaround
was remove + re-pair — destructive, for a cosmetic field.

This adds the write. `PATCH /api/cores/:id` takes `{ label }`, `renameCore()` puts it through
`labelFor()` — the same normalization registration uses — and bumps `updated_at`, and the row in
Settings → Cores gains an inline edit affordance. The alias stays **Panel-owned presentation**, not
a Core fact (issue #19's settled decision): no new core-link frame, nothing sent to the machine, and
two Panels registered against one Core may keep different names for it.

> **Base is `feat/rename-a-registered-core`, not the train.** This PR is stacked on that branch by
> request rather than opened against `beta/0.2.0` directly, so the `Train rules` check is expected
> to object until the base is retargeted or the stack collapses. Flagging it rather than working
> around it.

## Related issues

Closes #19

## Type of change

- [x] ✨ New feature (non-breaking change adding functionality)

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated

64 tests across the 5 touched files, all passing:

| Suite | Covers |
| --- | --- |
| `services/__tests__/cores.test.ts` | `renameCore` — trim, 120-char cap, host fallback, `updated_at` bump, unknown id, and that endpoint/cursor/secrets are untouched |
| `server/__tests__/cores-api.test.ts` | `PATCH /api/cores/:id` against a **real Core over mTLS** — renames in place, normalizes, leaves the live link untouched (state and `lastSeenAt` unchanged), 400 on a bodyless call, 401 anonymous, 404 unknown |
| `views/__tests__/cores-settings-rename.test.tsx` *(new)* | the affordance — edit in place, render what was *stored* not what was typed, the 120 cap on the box, cancel, and a refused write keeping the operator's text |
| `views/__tests__/harness-install-from-picker.test.tsx` | `NewHarnessDialog` names the Core by its **current** alias after a rename |
| `lib/__tests__/use-session-finish-notifications.integration.test.ts` | a session-finish toast arriving after a rename carries the new alias |

`pnpm typecheck` clean. `pnpm lint` — 0 errors, and none of the 53 pre-existing warnings are in a
touched file. `pnpm scan:secrets` clean.

Two failures on the full suite are **pre-existing and environmental**, both confirmed by re-running
at the base commit with these changes stashed:

- `scripts/__tests__/core-launcher.test.mjs` — this machine has a real `/opt/actana` install, so the
  launcher resolves it instead of the test's temp root. Fails identically at base.
- Assorted `Test timed out in 5000ms` under full parallel load — a *different* set each run. The base
  commit alone fails 12 tests / 6 files this way; this branch fails fewer. Every file passes when run
  on its own.

## Screenshots / recordings

Not captured — the change is an inline text box and two buttons on an existing row, described above.

## Checklist

- [ ] This PR targets the **open train** (`beta/x.y.z`), not `main` — **deliberately not**; stacked on
  `feat/rename-a-registered-core`, see the note above
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name
  follows the branching convention — verified with `commitlint --from $(git merge-base …)`, 3 commits,
  0 problems
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [x] I updated documentation where relevant — the `CONTEXT.md` glossary entry for **Core alias** is
  deliberately left to #141, which owns that file; the stale "they can't rename yet" comment in
  `services/cores.ts` is gone, replaced without implying the Core knows its own name
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (or this PR is marked as draft/stacked) — draft and stacked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
