### PR TITLE
feat(core-link): announce multiConnection on ready; the protocol version does not move (D11)

### DIFF
--- a/packages/core/src/__tests__/core-link-ready-multiconnection-capability.test.ts
+++ b/packages/core/src/__tests__/core-link-ready-multiconnection-capability.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PtyCoreLinkServer,
+  type EventLogPort,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+import { CORE_LINK_PROTOCOL_VERSION, type CoreLinkEvent } from "@actana/shared/core-link-frames";
+
+// The `multiConnection` capability on `ready` (issue 143, ADR 0024 D11).
+//
+// This build serves many connections, so it announces the capability — and it
+// announces it without moving `CORE_LINK_PROTOCOL_VERSION`, which is the whole
+// point of D11. The other half of the property is what a Core that does NOT
+// announce it looks like: a well-formed `ready` with the field simply absent,
+// which every client before this ticket already handled by never looking.
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+  terminate(): void {
+    this.close();
+  }
+  ping(): void {}
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  /** The one `ready` frame this connection was sent, parsed. */
+  ready(): Record<string, unknown> {
+    const frames = this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === "ready");
+    expect(frames).toHaveLength(1);
+    return frames[0]!;
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike) => void) | null = null;
+  connect(ws: FakeWebSocket): void {
+    this.connCb?.(ws as unknown as WebSocketLike);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike) => void;
+  }
+}
+
+function fakeEventLog(): EventLogPort {
+  const events: CoreLinkEvent[] = [];
+  return {
+    appendEvent: (kind, payload, opts) => {
+      const eventId = events.length + 1;
+      events.push({
+        eventId,
+        ts: eventId,
+        kind,
+        payload,
+        ptyId: opts?.ptyId ?? null,
+        taskId: opts?.taskId ?? null,
+      });
+      return eventId;
+    },
+    readEventTail: (afterEventId, limit = 1_000) =>
+      events.filter((event) => event.eventId > afterEventId).slice(0, limit),
+    getLastEventId: () => events.length,
+  };
+}
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+describe("the ready frame announces multiConnection (issue 143, ADR 0024 D11)", () => {
+  let wss: FakeWebSocketServer;
+  let server: PtyCoreLinkServer;
+
+  function startServer(opts: { announceMultiConnection?: boolean } = {}): void {
+    wss = new FakeWebSocketServer();
+    server = new PtyCoreLinkServer(mockCore(), {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      eventLog: fakeEventLog(),
+      liveEventPollMs: 5,
+      ...opts,
+    });
+  }
+
+  function connect(): FakeWebSocket {
+    const ws = new FakeWebSocket();
+    wss.connect(ws);
+    return ws;
+  }
+
+  afterEach(() => {
+    server.close();
+  });
+
+  describe("this build, which accepts many connections", () => {
+    beforeEach(() => {
+      startServer();
+    });
+
+    it("announces the capability at version 1 on ready", () => {
+      expect(connect().ready()).toEqual({
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+        multiConnection: { version: 1 },
+      });
+    });
+
+    it("announces the same protocol version it always did — the capability does not move it", () => {
+      expect(connect().ready().version).toBe(CORE_LINK_PROTOCOL_VERSION);
+    });
+
+    it("announces it to every connection, not just the first", () => {
+      const first = connect();
+      const second = connect();
+      const third = connect();
+      for (const ws of [first, second, third]) {
+        expect(ws.ready().multiConnection).toEqual({ version: 1 });
+      }
+    });
+
+    it("announces it before auth — a client learns what the Core is on frame one", () => {
+      const ws = connect();
+      // Nothing has been received from the client at this point: no `auth`, no
+      // `subscribe`. The capability is already on the wire.
+      expect(ws.ready().multiConnection).toEqual({ version: 1 });
+    });
+  });
+
+  describe("a Core that does not announce it (the single-connection build)", () => {
+    beforeEach(() => {
+      startServer({ announceMultiConnection: false });
+    });
+
+    it("omits the field entirely rather than sending it null or false", () => {
+      const frame = connect().ready();
+      expect("multiConnection" in frame).toBe(false);
+      expect(frame).toEqual({ type: "ready", version: CORE_LINK_PROTOCOL_VERSION });
+    });
+
+    it("still advertises the same protocol version, so it is not drift", () => {
+      expect(connect().ready().version).toBe(CORE_LINK_PROTOCOL_VERSION);
+    });
+  });
+});

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -293,6 +293,14 @@ export type PtyCoreLinkServerOptions = {
    * else to observe, since a real stale Core is a different build entirely.
    */
   protocolVersion?: string;
+  /**
+   * Announce the `multiConnection` capability on `ready`. Defaults to true —
+   * this build serves many connections (ADR 0024 D1), so it says so. Exists
+   * only so a test can stand up the capability-less Core a real fleet still
+   * has plenty of, the same way {@link protocolVersion} stands up a drifted
+   * one; a real old Core is a different build entirely.
+   */
+  announceMultiConnection?: boolean;
 };
 
 /**
@@ -410,6 +418,7 @@ export class PtyCoreLinkServer {
   private readonly directoryPort: CoreDirectoryPort | null;
   private readonly promptPort: { submitted(taskId: string, prompt: string): void } | null;
   private readonly protocolVersion: string;
+  private readonly announceMultiConnection: boolean;
   /**
    * The one seam every task-row change goes through — the Panel's
    * `tasksMutate` frame below and the Core's own writers (hook receiver, PTY
@@ -450,6 +459,7 @@ export class PtyCoreLinkServer {
     this.directoryPort = opts.directoryPort ?? null;
     this.promptPort = opts.promptPort ?? null;
     this.protocolVersion = opts.protocolVersion ?? CORE_LINK_PROTOCOL_VERSION;
+    this.announceMultiConnection = opts.announceMultiConnection ?? true;
     this.taskWriter =
       opts.taskWriter ??
       new CoreTaskWriter({
@@ -472,8 +482,16 @@ export class PtyCoreLinkServer {
     this.connections.set(ws, conn);
     this.ensureEmitTarget();
 
-    // Send the ready frame immediately.
-    this.send(ws, { type: "ready", version: this.protocolVersion });
+    // Send the ready frame immediately. It announces `multiConnection`
+    // because the registration above is exactly what the capability claims
+    // (ADR 0024 D11): this server keeps every connection it accepts. The
+    // protocol version does not move for it — a Core that omits the field is
+    // the single-connection build, which is a Core like any other.
+    this.send(ws, {
+      type: "ready",
+      version: this.protocolVersion,
+      ...(this.announceMultiConnection ? { multiConnection: { version: 1 as const } } : {}),
+    });
 
     // Start the live-event push poll for this connection. It stays silent
     // until the client sends `subscribe`, then pushes new events past this

--- a/packages/panel/src/server/core-link/__tests__/client.test.ts
+++ b/packages/panel/src/server/core-link/__tests__/client.test.ts
@@ -166,9 +166,12 @@ describe("PtyCoreLinkServer", () => {
 
   it("sends a ready frame on connection with the protocol version", () => {
     // The server sent "ready" via pair.server.send() → pair.server.sent.
+    // It also announces `multiConnection` (issue 143, ADR 0024 D11): this build
+    // serves many connections, and says so without moving the version above.
     expect(pair.server.lastSent()).toEqual({
       type: "ready",
       version: CORE_LINK_PROTOCOL_VERSION,
+      multiConnection: { version: 1 },
     });
   });
 

--- a/packages/panel/src/server/core-link/__tests__/client.test.ts
+++ b/packages/panel/src/server/core-link/__tests__/client.test.ts
@@ -2000,6 +2000,12 @@ describe("core-link heartbeat", () => {
  * The link is the only thing that knows when its socket dropped, and a Core
  * hangs subscriptions off the connection — so re-establishing them is the
  * client's job, not something the router or a browser can be asked to notice.
+ *
+ * Every Core here announces `multiConnection` on `ready`, because these frames
+ * are gated on it (issue 143, ADR 0024 D11) — a Core that fans a PTY out by
+ * subscription is a multi-connection Core by definition. What a Core WITHOUT
+ * the capability gets instead is the deliberate single-connection fallback,
+ * covered in `multiconnection-capability.test.ts`.
  */
 describe("PtyCoreLinkClient pty subscriptions", () => {
   let pair: FakeWebSocketPair;
@@ -2007,6 +2013,15 @@ describe("PtyCoreLinkClient pty subscriptions", () => {
   beforeEach(() => {
     pair = new FakeWebSocketPair();
   });
+
+  /** The Core's frame one on every connection, capability included. */
+  function announceReady(): void {
+    pair.client.receive({
+      type: "ready",
+      version: CORE_LINK_PROTOCOL_VERSION,
+      multiConnection: { version: 1 },
+    });
+  }
 
   function makeClient(): PtyCoreLinkClient {
     const client = new PtyCoreLinkClient({
@@ -2018,6 +2033,7 @@ describe("PtyCoreLinkClient pty subscriptions", () => {
       cursorStorageKey: "mc.coreLink.lastEventId",
     });
     pair.openClient();
+    announceReady();
     return client;
   }
 
@@ -2064,6 +2080,7 @@ describe("PtyCoreLinkClient pty subscriptions", () => {
 
     pair.closeClient();
     pair.openClient();
+    announceReady();
 
     // Only what is still held, and live rather than holding: nothing here is
     // going to send the `replay` a hold waits for, and a hold nobody releases
@@ -2083,6 +2100,7 @@ describe("PtyCoreLinkClient pty subscriptions", () => {
 
     pair.closeClient();
     pair.openClient();
+    announceReady();
 
     expect(ptyFrames()).toEqual([]);
     client.close();

--- a/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
+++ b/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
@@ -21,11 +21,12 @@ import {
 //     is not sent AT ALL. Not sent-and-tolerate-the-error: nothing reaches the
 //     socket, so the Core never has to answer for a frame it does not know.
 //
-// The frames that will populate the gate do not exist yet — `claim` is the lock
-// ticket's and the PTY subscription is #142's, which owns its name. So the gate
-// is exercised through the constructor seam with a stand-in type. When those
-// frames land, their types join MULTI_CONNECTION_ONLY_FRAME_TYPES and inherit
-// everything asserted here.
+// The gate's mechanics are exercised through the constructor seam with a
+// stand-in type, so they stay readable independently of whichever real frames
+// happen to be registered. The real ones — `ptySubscribe` / `ptyUnsubscribe`
+// from #142 — are covered further down, including the fallback a capability-less
+// Core gets and the ready-before-authOk ordering the reconnect resend needs.
+// `claim` (D6) joins them when the Session lock lands.
 
 type Listener = (...args: unknown[]) => void;
 
@@ -297,11 +298,160 @@ describe("the Panel's multiConnection capability (issue 143, ADR 0024 D11)", () 
   });
 
   describe("the gate's frame registry", () => {
-    it("is empty in this build — the claim and PTY-subscribe frames are not here yet", () => {
-      // Not a placeholder assertion: an empty set is what makes this ticket a
-      // no-op on the wire. If a frame type appears here without the ticket that
-      // owns it, that is the thing to notice.
-      expect([...MULTI_CONNECTION_ONLY_FRAME_TYPES]).toEqual([]);
+    it("holds exactly the PTY subscription frames — the claim frame is not here yet", () => {
+      // Exact membership, not a superset check: this set is the whole statement
+      // of what this build refuses to send to a single-connection Core, so a
+      // type appearing here without the ticket that owns it, or one quietly
+      // dropping out, is the thing to notice. `claim` (D6) joins when the
+      // Session lock lands.
+      expect([...MULTI_CONNECTION_ONLY_FRAME_TYPES].sort()).toEqual([
+        "ptySubscribe",
+        "ptyUnsubscribe",
+      ]);
+    });
+  });
+
+  /**
+   * The fallback a capability-less Core gets (ADR 0024 D11, review of #173).
+   *
+   * #142 put `.catch(() => {})` on every `ptySubscribe` call site, so a gated
+   * refusal is invisible and the pane paints anyway — but only because a
+   * pre-#142 Core fans every PTY out to every connection. That is the right
+   * behaviour arriving by accident, through a swallowed error. Here it is the
+   * decision: the client asks whether this Core can answer, and against one
+   * that cannot it sends nothing and resolves, because the bytes are already
+   * coming.
+   */
+  describe("the single-connection fallback for PTY subscriptions", () => {
+    beforeEach(() => {
+      client = makeClient();
+    });
+
+    it("puts no ptySubscribe on the wire for a Core that never announced it", async () => {
+      readyWithout();
+      await expect(client.ptySubscribe("pty_1", { catchUp: true })).resolves.toBeUndefined();
+      expect(socket.framesOfType("ptySubscribe")).toEqual([]);
+    });
+
+    it("resolves rather than rejecting — the caller is already receiving that PTY", async () => {
+      readyWithout();
+      // The distinction that matters: not a rejection anyone has to swallow.
+      // A caller that got a rejection here would be right to treat the pane as
+      // broken, and it is not.
+      await expect(client.ptySubscribe("pty_1")).resolves.toBeUndefined();
+      await expect(client.ptyUnsubscribe("pty_1")).resolves.toBeUndefined();
+      expect(socket.framesOfType("ptyUnsubscribe")).toEqual([]);
+    });
+
+    it("still paints the pane — the Core fans that PTY out unasked", async () => {
+      readyWithout();
+      const seen: { ptyId: string; data: string }[] = [];
+      client.onData((msg) => seen.push({ ptyId: msg.ptyId, data: msg.data }));
+
+      await client.ptySubscribe("pty_1", { catchUp: true });
+      // A single-connection Core streams every PTY to every connection without
+      // being asked. This is the whole reason the fallback is silence.
+      socket.receive({ type: "data", ptyId: "pty_1", data: "hello", seq: 1 });
+
+      expect(seen).toEqual([{ ptyId: "pty_1", data: "hello" }]);
+      expect(socket.framesOfType("ptySubscribe")).toEqual([]);
+    });
+
+    it("asks for real once that Core comes back announcing the capability", () => {
+      // Why the want is remembered even when no frame goes out. The Core is
+      // upgraded and restarts; the same client reconnects. Nothing else
+      // remembers this pane — the router binds a Core once, not once per
+      // reconnect — so if the fallback had dropped the want, this Core would
+      // now fan out to subscribers only and the pane would go dark.
+      readyWithout();
+      void client.ptySubscribe("pty_1");
+      expect(socket.framesOfType("ptySubscribe")).toEqual([]);
+
+      socket.close();
+      socket.open();
+      readyWithCapability();
+
+      expect(socket.framesOfType("ptySubscribe")).toMatchObject([
+        { ptyId: "pty_1", catchUp: false },
+      ]);
+    });
+
+    it("does not re-ask for a pty released while the Core could not hear it", () => {
+      readyWithout();
+      void client.ptySubscribe("pty_1");
+      void client.ptyUnsubscribe("pty_1");
+
+      socket.close();
+      socket.open();
+      readyWithCapability();
+
+      expect(socket.framesOfType("ptySubscribe")).toEqual([]);
+    });
+  });
+
+  /**
+   * The resend fires from `authOk` and is gated on a capability recorded by
+   * `ready`. Nothing in the client enforces that order — it holds because the
+   * Core sends `ready` as frame one. Pinned here, because if it ever stopped
+   * holding the resend would read "unknown" as "absent", take the fallback, and
+   * silently unsubscribe every held pane on a Core that does announce it.
+   */
+  describe("the reconnect resend and the ready/authOk ordering", () => {
+    function makeAuthedClient(): PtyCoreLinkClient {
+      socket = new FakeWebSocket();
+      const c = new PtyCoreLinkClient({
+        url: "ws://127.0.0.1:0",
+        createSocket: () => socket as unknown as ClientWebSocketLike,
+        reconnectInitialMs: 10_000,
+        reconnectMaxMs: 10_000,
+        storage: memoryStorage(),
+        bearer: "bearer-for-the-auth-path",
+      });
+      socket.open();
+      return c;
+    }
+
+    it("re-asks on authOk, because ready has already answered the capability", () => {
+      client = makeAuthedClient();
+      readyWithCapability();
+      socket.receive({ type: "authOk", coreId: "core_1", exp: Date.now() + 60_000 });
+      fireAndForget(client.ptySubscribe("pty_1"));
+      expect(socket.framesOfType("ptySubscribe")).toHaveLength(1);
+
+      socket.close();
+      socket.open();
+      // Frame one on the new connection, exactly as the Core sends it — then
+      // the auth answer that triggers the resend.
+      readyWithCapability();
+      socket.receive({ type: "authOk", coreId: "core_1", exp: Date.now() + 60_000 });
+
+      expect(socket.framesOfType("ptySubscribe")).toMatchObject([
+        { ptyId: "pty_1", catchUp: false },
+        { ptyId: "pty_1", catchUp: false },
+      ]);
+    });
+
+    it("self-refuses if authOk ever arrives first — the ordering is the guard", () => {
+      // Not a wish for this order, a demonstration of what the order buys. A
+      // Core that answered `auth` before it said `ready` would leave the resend
+      // with no capability to read, and the fallback would eat every held pane.
+      client = makeAuthedClient();
+      readyWithCapability();
+      socket.receive({ type: "authOk", coreId: "core_1", exp: Date.now() + 60_000 });
+      fireAndForget(client.ptySubscribe("pty_1"));
+
+      socket.close();
+      socket.open();
+      socket.receive({ type: "authOk", coreId: "core_1", exp: Date.now() + 60_000 });
+      expect(socket.framesOfType("ptySubscribe")).toHaveLength(1);
+
+      // And it recovers on the next connection that observes the real order,
+      // because the want outlived the connection that could not express it.
+      socket.close();
+      socket.open();
+      readyWithCapability();
+      socket.receive({ type: "authOk", coreId: "core_1", exp: Date.now() + 60_000 });
+      expect(socket.framesOfType("ptySubscribe")).toHaveLength(2);
     });
   });
 });

--- a/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
+++ b/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
@@ -159,6 +159,19 @@ describe("the Panel's multiConnection capability (issue 143, ADR 0024 D11)", () 
       expect(client.canSendMultiConnectionFrames()).toBe(false);
     });
 
+    it("closes the moment the link drops, not when the next one opens", () => {
+      readyWithCapability();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+
+      // The window the reconnect backoff lives in: closed, not yet reopened.
+      // The Core on the other end is gone and the next one may be a downgraded
+      // build, so the answer here is unknown — which is `false`, not the
+      // previous connection's `true`.
+      socket.close();
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBe(null);
+    });
+
     it("picks the capability back up when an upgraded Core reconnects", () => {
       readyWithout();
       socket.close();
@@ -201,6 +214,30 @@ describe("the Panel's multiConnection capability (issue 143, ADR 0024 D11)", () 
       socket.open();
       readyWithCapability();
       expect(socket.framesOfType(GATED)).toHaveLength(0);
+    });
+
+    it("refuses it in the drop window, and nothing flushes when the socket reopens", async () => {
+      readyWithCapability();
+      // The link drops. Nothing has re-announced anything yet, so a frame asked
+      // for now must be refused outright — if the stale `true` let it past the
+      // gate it would land on the queue, and the reopen drain writes the queue
+      // to the socket unconditionally, before that connection's `ready`.
+      socket.close();
+      const refused = client.request({ type: GATED } as unknown as CoreLinkRequestFrame);
+      fireAndForget(refused);
+
+      // Reconnect to a Core that DOES announce the capability: the frame would
+      // be allowed if asked for now, so nothing about the new connection can
+      // explain a GATED frame on the wire. Only a flush of the queue could —
+      // which is why this assertion comes before the rejection one. A frame
+      // that slipped past the gate is still pending here, not rejected, so
+      // asserting the rejection first would fail as a timeout and say nothing
+      // about the wire.
+      socket.open();
+      readyWithCapability();
+      expect(socket.framesOfType(GATED)).toHaveLength(0);
+
+      await expect(refused).rejects.toThrow(/multiConnection capability/);
     });
 
     it("sends it once the Core announces the capability", () => {

--- a/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
+++ b/packages/panel/src/server/core-link/__tests__/multiconnection-capability.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  MULTI_CONNECTION_ONLY_FRAME_TYPES,
+  PtyCoreLinkClient,
+  type CoreLinkCursorStorage,
+  type WebSocketLike as ClientWebSocketLike,
+} from "../client";
+import {
+  CORE_LINK_PROTOCOL_VERSION,
+  type CoreLinkRequestFrame,
+} from "@actana/shared/core-link-frames";
+
+// The Panel records `multiConnection` per Core and gates on it (issue 143,
+// ADR 0024 D11).
+//
+// Two properties, and the second is the one with teeth:
+//
+//  1. The capability is read off every `ready`, per connection, and never
+//     remembered across one — a Core can be downgraded while the Panel is away.
+//  2. Against a Core that does not announce it, a multi-connection-only frame
+//     is not sent AT ALL. Not sent-and-tolerate-the-error: nothing reaches the
+//     socket, so the Core never has to answer for a frame it does not know.
+//
+// The frames that will populate the gate do not exist yet — `claim` is the lock
+// ticket's and the PTY subscription is #142's, which owns its name. So the gate
+// is exercised through the constructor seam with a stand-in type. When those
+// frames land, their types join MULTI_CONNECTION_ONLY_FRAME_TYPES and inherit
+// everything asserted here.
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 0;
+  sent: string[] = [];
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(obj: unknown): void {
+    this.emit("message", JSON.stringify(obj));
+  }
+  open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+  framesOfType(type: string): Record<string, unknown>[] {
+    return this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === type);
+  }
+}
+
+function memoryStorage(): CoreLinkCursorStorage {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+  };
+}
+
+/** The stand-in for a frame only a multi-connection Core understands. */
+const GATED = "claimStandIn";
+
+/**
+ * Fire a request and swallow its settlement. These tests assert on what reached
+ * the socket, never on the answer — and a frame still in flight when the
+ * connection drops rejects by design.
+ */
+function fireAndForget(promise: Promise<unknown>): void {
+  void promise.catch(() => {});
+}
+
+describe("the Panel's multiConnection capability (issue 143, ADR 0024 D11)", () => {
+  let socket: FakeWebSocket;
+  let client: PtyCoreLinkClient;
+
+  function makeClient(opts: { gated?: ReadonlySet<string> } = {}): PtyCoreLinkClient {
+    socket = new FakeWebSocket();
+    const c = new PtyCoreLinkClient({
+      url: "ws://127.0.0.1:0",
+      createSocket: () => socket as unknown as ClientWebSocketLike,
+      reconnectInitialMs: 10_000, // no auto-reconnect mid-test
+      reconnectMaxMs: 10_000,
+      storage: memoryStorage(),
+      multiConnectionOnlyFrameTypes: opts.gated,
+    });
+    socket.open();
+    return c;
+  }
+
+  function readyWithCapability(): void {
+    socket.receive({
+      type: "ready",
+      version: CORE_LINK_PROTOCOL_VERSION,
+      multiConnection: { version: 1 },
+    });
+  }
+
+  function readyWithout(): void {
+    socket.receive({ type: "ready", version: CORE_LINK_PROTOCOL_VERSION });
+  }
+
+  describe("recording the capability", () => {
+    beforeEach(() => {
+      client = makeClient();
+    });
+
+    it("is closed before ready lands — the answer is unknown, not yes", () => {
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBe(null);
+    });
+
+    it("records it when the Core announces it", () => {
+      readyWithCapability();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+      expect(client.multiConnectionCapability()).toEqual({ version: 1 });
+    });
+
+    it("records its absence as absence, not as an error", () => {
+      readyWithout();
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBe(null);
+    });
+
+    it("treats a version it does not know as absent, falling back to single-connection", () => {
+      socket.receive({
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+        multiConnection: { version: 2 },
+      });
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+    });
+
+    it("does not carry a capability across a reconnect — it is re-read on the new ready", () => {
+      readyWithCapability();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+
+      // The Core comes back downgraded (rolled back, or a different build on
+      // the same endpoint). A remembered `true` here would send frames it
+      // cannot answer.
+      socket.close();
+      socket.open();
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      readyWithout();
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+    });
+
+    it("picks the capability back up when an upgraded Core reconnects", () => {
+      readyWithout();
+      socket.close();
+      socket.open();
+      readyWithCapability();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+    });
+  });
+
+  describe("gating frames that only a multi-connection Core understands", () => {
+    beforeEach(() => {
+      client = makeClient({ gated: new Set([GATED]) });
+    });
+
+    it("does not put the frame on the wire at all against a capability-less Core", async () => {
+      readyWithout();
+      await expect(
+        client.request({ type: GATED } as unknown as CoreLinkRequestFrame),
+      ).rejects.toThrow(/multiConnection capability/);
+      // The property that matters: nothing was written. The Core is never asked
+      // to answer for a frame it does not know, so there is no error to tolerate.
+      expect(socket.framesOfType(GATED)).toHaveLength(0);
+    });
+
+    it("does not send it before ready either — an unknown answer is not permission", async () => {
+      await expect(
+        client.request({ type: GATED } as unknown as CoreLinkRequestFrame),
+      ).rejects.toThrow(/multiConnection capability/);
+      expect(socket.framesOfType(GATED)).toHaveLength(0);
+    });
+
+    it("does not queue it for a later flush — a refused frame is gone, not deferred", async () => {
+      readyWithout();
+      await expect(
+        client.request({ type: GATED } as unknown as CoreLinkRequestFrame),
+      ).rejects.toThrow(/multiConnection capability/);
+      // A queued frame would go out when the socket next opens. Reconnect to a
+      // Core that DOES announce the capability and confirm nothing flushes.
+      socket.close();
+      socket.open();
+      readyWithCapability();
+      expect(socket.framesOfType(GATED)).toHaveLength(0);
+    });
+
+    it("sends it once the Core announces the capability", () => {
+      readyWithCapability();
+      fireAndForget(client.request({ type: GATED } as unknown as CoreLinkRequestFrame));
+      expect(socket.framesOfType(GATED)).toHaveLength(1);
+    });
+
+    it("stops sending it again if the Core comes back downgraded", async () => {
+      readyWithCapability();
+      fireAndForget(client.request({ type: GATED } as unknown as CoreLinkRequestFrame));
+      expect(socket.framesOfType(GATED)).toHaveLength(1);
+
+      socket.close();
+      socket.open();
+      readyWithout();
+      await expect(
+        client.request({ type: GATED } as unknown as CoreLinkRequestFrame),
+      ).rejects.toThrow(/multiConnection capability/);
+      expect(socket.framesOfType(GATED)).toHaveLength(1);
+    });
+  });
+
+  describe("a Core without the capability is a Core like any other", () => {
+    beforeEach(() => {
+      client = makeClient({ gated: new Set([GATED]) });
+    });
+
+    it("reports the connection compatible — a missing capability is not drift", () => {
+      const seen: { version: string | null; compatible: boolean }[] = [];
+      client.onProtocolVersion((msg) => seen.push(msg));
+      readyWithout();
+      expect(seen).toEqual([{ version: CORE_LINK_PROTOCOL_VERSION, compatible: true }]);
+    });
+
+    it("still sends every ordinary frame — the gate touches nothing else", () => {
+      readyWithout();
+      fireAndForget(client.request({ type: "tasksList" } as unknown as CoreLinkRequestFrame));
+      fireAndForget(client.request({ type: "projectsList" } as unknown as CoreLinkRequestFrame));
+      expect(socket.framesOfType("tasksList")).toHaveLength(1);
+      expect(socket.framesOfType("projectsList")).toHaveLength(1);
+    });
+
+    it("still spawns a Session — the surface an operator touches is untouched", async () => {
+      readyWithout();
+      const spawn = client.spawn({
+        taskId: "t1",
+        cwd: "/tmp",
+        command: "claude",
+        agent: "claude-code",
+      });
+      const sent = socket.framesOfType("spawn");
+      expect(sent).toHaveLength(1);
+      socket.receive({ type: "spawned", reqId: sent[0]!.reqId, ptyId: "pty-1" });
+      await expect(spawn).resolves.toMatchObject({ ptyId: "pty-1" });
+    });
+  });
+
+  describe("the gate's frame registry", () => {
+    it("is empty in this build — the claim and PTY-subscribe frames are not here yet", () => {
+      // Not a placeholder assertion: an empty set is what makes this ticket a
+      // no-op on the wire. If a frame type appears here without the ticket that
+      // owns it, that is the thing to notice.
+      expect([...MULTI_CONNECTION_ONLY_FRAME_TYPES]).toEqual([]);
+    });
+  });
+});

--- a/packages/panel/src/server/core-link/client.ts
+++ b/packages/panel/src/server/core-link/client.ts
@@ -45,8 +45,15 @@ import {
  * Empty means the gate changes nothing about what this build sends, which is
  * the point: a Core without the capability sees byte-for-byte the traffic it
  * saw before this ticket.
+ *
+ * **The set gates only frames that flow through {@link PtyCoreLinkClient.request}
+ * / `rpc()`**, which is where the check lives — `sendSubscribe()`, `sendAuth()`
+ * and the reconnect queue drain build frames and write to the socket directly,
+ * and no entry here would stop them. So "add the type to this set" is the whole
+ * wiring step for an RPC frame, and only for an RPC frame.
  */
-export const MULTI_CONNECTION_ONLY_FRAME_TYPES: ReadonlySet<string> = new Set<string>([]);
+export const MULTI_CONNECTION_ONLY_FRAME_TYPES: ReadonlySet<CoreLinkRequestFrame["type"]> =
+  new Set<CoreLinkRequestFrame["type"]>([]);
 
 export type PtyCoreLinkClientHandlers = {
   onData: (msg: { ptyId: string; data: string; seq: number }) => void;
@@ -357,6 +364,12 @@ export class PtyCoreLinkClient {
       this.ready = false;
       this.subscribed = false;
       this.authenticated = false;
+      // Forget the capability the moment the link drops, not when the next one
+      // opens. Between those two points the answer is unknown, and a stale
+      // `true` would let a gated frame past `canSendMultiConnectionFrames()`
+      // onto `queuedFrames`, which the reopen drain writes to the socket
+      // unconditionally — before the new `ready` says whether it is allowed.
+      this.multiConnection = null;
       this.stopHeartbeat();
       this.rejectInFlight("core-link connection lost");
       if (this.closed) return;

--- a/packages/panel/src/server/core-link/client.ts
+++ b/packages/panel/src/server/core-link/client.ts
@@ -35,16 +35,17 @@ import {
  * `multiConnection` on `ready` (ADR 0024 D11) — the one list
  * {@link PtyCoreLinkClient.canSendMultiConnectionFrames} guards.
  *
- * **Empty on purpose, today.** The frames that belong here do not exist yet:
- * the Session lock's `claim` (D6) is a later ticket, and the per-connection PTY
- * subscription (D2) is issue 142, which owns that frame's name and shape. Each
- * adds its own type here as it lands and inherits the gate, its tests and its
- * reconnect behaviour without restating any of it. Adding a type to this set is
- * the whole wiring step — nothing else in the client needs to change.
+ * `ptySubscribe` / `ptyUnsubscribe` (issue 142, D2) are the first entries: a
+ * Core that fans a PTY out per subscription is exactly a multi-connection Core,
+ * and one that never announced the capability has no subscription list to put a
+ * PTY on. The Session lock's `claim` (D6) joins them when that ticket lands.
  *
- * Empty means the gate changes nothing about what this build sends, which is
- * the point: a Core without the capability sees byte-for-byte the traffic it
- * saw before this ticket.
+ * Being in this set is not the whole story for a frame with a caller that has
+ * something better to do than fail. A caller that can degrade consults
+ * {@link PtyCoreLinkClient.canSendMultiConnectionFrames} and takes the
+ * single-connection route itself — see {@link PtyCoreLinkClient.ptySubscribe},
+ * which does exactly that. The rejection below is the backstop for callers that
+ * ask without checking, not the designed path for the frames listed here.
  *
  * **The set gates only frames that flow through {@link PtyCoreLinkClient.request}
  * / `rpc()`**, which is where the check lives — `sendSubscribe()`, `sendAuth()`
@@ -53,7 +54,7 @@ import {
  * wiring step for an RPC frame, and only for an RPC frame.
  */
 export const MULTI_CONNECTION_ONLY_FRAME_TYPES: ReadonlySet<CoreLinkRequestFrame["type"]> =
-  new Set<CoreLinkRequestFrame["type"]>([]);
+  new Set<CoreLinkRequestFrame["type"]>(["ptySubscribe", "ptyUnsubscribe"]);
 
 export type PtyCoreLinkClientHandlers = {
   onData: (msg: { ptyId: string; data: string; seq: number }) => void;
@@ -329,9 +330,13 @@ export class PtyCoreLinkClient {
         this.sendAuth();
       } else {
         // No bearer configured (tests) — go straight to the event-cursor
-        // subscribe so the Core streams the replay tail.
+        // subscribe so the Core streams the replay tail. The PTY resend does
+        // NOT go here: the capability is not known until this connection's
+        // `ready` lands, and a resend that reads "unknown" takes the
+        // single-connection fallback and unsubscribes every held pane. It is
+        // driven from the `ready` handler instead, which is the earliest point
+        // the answer exists.
         this.sendSubscribe();
-        this.resendPtySubscriptions();
       }
       // Flush any RPCs that were queued while the WS wasn't open (e.g. the
       // first pty.* call after a reconnect, before the WS handshake
@@ -527,6 +532,11 @@ export class PtyCoreLinkClient {
       // Core like any other — it does not touch `compatible` below, so nothing
       // downstream can turn a missing capability into "needs update".
       this.multiConnection = readMultiConnectionCapability(msg.multiConnection);
+      // With a bearer, the PTY resend waits for `authOk` — the Core refuses a
+      // pre-auth `ptySubscribe`. Without one there is no `authOk` coming, and
+      // this frame is the first moment the capability is known, so the resend
+      // belongs here. Either way it runs after the capability, never before.
+      if (!this.bearer) this.resendPtySubscriptions();
       const payload = {
         version: this.protocolVersion,
         compatible: coreLinkProtocolCompatible(this.protocolVersion),
@@ -551,7 +561,10 @@ export class PtyCoreLinkClient {
       this.sendSubscribe();
       // PTY subscriptions die with the Core-side connection, so they are
       // re-established here — after `auth`, for the same reason `subscribe` is:
-      // the Core refuses a pre-auth `ptySubscribe`.
+      // the Core refuses a pre-auth `ptySubscribe`. This is also after `ready`,
+      // which the Core sends as frame one on every connection, so the
+      // capability the resend is gated on is already recorded. That ordering is
+      // load-bearing rather than incidental — see the test that pins it.
       this.resendPtySubscriptions();
       for (const cb of this.authOkListeners) cb({ coreId, exp });
       return;
@@ -868,10 +881,27 @@ export class PtyCoreLinkClient {
    * The set is remembered and re-sent on every reconnect, because the Core
    * hangs subscriptions off the connection. Idempotent on both sides: a second
    * call for a PTY already subscribed is a no-op here and an ack there.
+   *
+   * **Against a Core that does not announce `multiConnection`, this sends
+   * nothing and resolves** (ADR 0024 D11). That is the deliberate
+   * single-connection fallback, not a swallowed failure: such a Core fans every
+   * PTY out to every connection, so the caller is already receiving the bytes
+   * it just asked for and the subscription it would send is a frame that Core
+   * has no vocabulary for. Resolving says what is true — this link renders that
+   * PTY — which is the only thing the caller acts on.
+   *
+   * The want is recorded either way, because this set is not a record of what
+   * the Core holds: it is what this link wants, and every connection re-derives
+   * its frames from it against *that* connection's announced capability. Drop
+   * the want when no frame goes out and a Core that gains the capability across
+   * a restart comes back fanning out to subscribers only, with nothing left
+   * anywhere that remembers to subscribe — the router binds a Core once, not
+   * once per reconnect, so this set is the only memory there is.
    */
   ptySubscribe(ptyId: string, opts: { catchUp?: boolean } = {}): Promise<void> {
     if (this.subscribedPtys.has(ptyId)) return Promise.resolve();
     this.subscribedPtys.add(ptyId);
+    if (!this.canSendMultiConnectionFrames()) return Promise.resolve();
     return this.rpc({
       type: "ptySubscribe",
       reqId: "",
@@ -880,9 +910,17 @@ export class PtyCoreLinkClient {
     }).then(() => undefined);
   }
 
-  /** Stop receiving one PTY's stream. Idempotent; see {@link ptySubscribe}. */
+  /**
+   * Stop receiving one PTY's stream. Idempotent; see {@link ptySubscribe}.
+   *
+   * Same fallback, for the same reason: against a capability-less Core there is
+   * no subscription to drop — its fan-out is unconditional and cannot be
+   * narrowed by a frame it does not know. Forgetting the want here is the whole
+   * of what this call can honestly do.
+   */
   ptyUnsubscribe(ptyId: string): Promise<void> {
     if (!this.subscribedPtys.delete(ptyId)) return Promise.resolve();
+    if (!this.canSendMultiConnectionFrames()) return Promise.resolve();
     return this.rpc({ type: "ptyUnsubscribe", reqId: "", ptyId }).then(() => undefined);
   }
 
@@ -894,8 +932,18 @@ export class PtyCoreLinkClient {
    * replay do it off their own reconnect, one layer up, and a hold nobody
    * releases is a pane that stays blank forever. Going live immediately is also
    * exactly what this path did before subscriptions existed.
+   *
+   * Callers must have the capability answer in hand before calling this, which
+   * is why it hangs off `authOk` (the Core's `ready` is frame one, so the
+   * capability is recorded before any auth answer can arrive) and off `ready`
+   * itself when no bearer is configured. Called any earlier it would read an
+   * unknown capability as absent and take the fallback below against a Core
+   * that does announce it — every held pane silently unsubscribed.
    */
   private resendPtySubscriptions(): void {
+    // The same deliberate single-connection fallback {@link ptySubscribe}
+    // takes: a Core without the capability is already sending these PTYs.
+    if (!this.canSendMultiConnectionFrames()) return;
     for (const ptyId of this.subscribedPtys) {
       void this.rpc({ type: "ptySubscribe", reqId: "", ptyId, catchUp: false }).catch(() => {
         /* the socket died again; the next open re-sends the whole set */

--- a/packages/panel/src/server/core-link/client.ts
+++ b/packages/panel/src/server/core-link/client.ts
@@ -13,6 +13,8 @@
 import {
   CORE_LINK_PROTOCOL_VERSION,
   coreLinkProtocolCompatible,
+  readMultiConnectionCapability,
+  type CoreLinkMultiConnectionCapability,
   type CoreLinkHarnessAvailabilityMap,
   type CoreLinkEvent,
   type CoreLinkProjectMutation,
@@ -27,6 +29,24 @@ import {
   type CoreLinkLaunchProcessKillResult,
   type CoreLinkPtyReplay,
 } from "../../../../shared/src/core-link-frames";
+
+/**
+ * Request frames that only mean anything against a Core announcing
+ * `multiConnection` on `ready` (ADR 0024 D11) — the one list
+ * {@link PtyCoreLinkClient.canSendMultiConnectionFrames} guards.
+ *
+ * **Empty on purpose, today.** The frames that belong here do not exist yet:
+ * the Session lock's `claim` (D6) is a later ticket, and the per-connection PTY
+ * subscription (D2) is issue 142, which owns that frame's name and shape. Each
+ * adds its own type here as it lands and inherits the gate, its tests and its
+ * reconnect behaviour without restating any of it. Adding a type to this set is
+ * the whole wiring step — nothing else in the client needs to change.
+ *
+ * Empty means the gate changes nothing about what this build sends, which is
+ * the point: a Core without the capability sees byte-for-byte the traffic it
+ * saw before this ticket.
+ */
+export const MULTI_CONNECTION_ONLY_FRAME_TYPES: ReadonlySet<string> = new Set<string>([]);
 
 export type PtyCoreLinkClientHandlers = {
   onData: (msg: { ptyId: string; data: string; seq: number }) => void;
@@ -65,6 +85,12 @@ export type PtyCoreLinkClientOptions = {
    * behind authentication.
    */
   bearer?: string;
+  /**
+   * Overrides {@link MULTI_CONNECTION_ONLY_FRAME_TYPES}. Exists only so a test
+   * can exercise the gate while that set is still empty — the frames it will
+   * hold are #142's and the lock ticket's to name. Production never passes it.
+   */
+  multiConnectionOnlyFrameTypes?: ReadonlySet<string>;
 };
 
 export interface WebSocketLike {
@@ -181,6 +207,18 @@ export class PtyCoreLinkClient {
   >();
   /** The protocol version from this connection's `ready` frame; null before it. */
   private protocolVersion: string | null = null;
+  /**
+   * This Core's `multiConnection` capability, as announced on the current
+   * connection's `ready` frame; null when absent and before `ready` lands.
+   *
+   * Per Core because there is one client per registered Core, and re-read on
+   * every `ready` rather than remembered across connections: a Core can be
+   * downgraded, and a stale `true` here would send frames the Core no longer
+   * understands. Null until the frame arrives, so the gate below is closed
+   * during the window where the answer is genuinely unknown.
+   */
+  private multiConnection: CoreLinkMultiConnectionCapability | null = null;
+  private readonly multiConnectionOnlyFrameTypes: ReadonlySet<string>;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
@@ -218,6 +256,8 @@ export class PtyCoreLinkClient {
     this.reconnectMaxMs = opts.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
     this.storage = resolveStorage(opts);
     this.bearer = opts.bearer ?? null;
+    this.multiConnectionOnlyFrameTypes =
+      opts.multiConnectionOnlyFrameTypes ?? MULTI_CONNECTION_ONLY_FRAME_TYPES;
     // The cursor is per-Core (CONTEXT.md "Event cursor": "the single number
     // the Panel stores per Core"). Derive the storage key from the core-link
     // URL so each registered Core gets its own cursor — a second Core on a
@@ -274,6 +314,10 @@ export class PtyCoreLinkClient {
       // happens in tests — a real Core always presents one).
       this.authenticated = false;
       this.subscribed = false;
+      // Forget the previous connection's capability: this one re-announces it
+      // on its own `ready`, and the Core on the other end may have been
+      // downgraded while we were away.
+      this.multiConnection = null;
       if (this.bearer) {
         this.sendAuth();
       } else {
@@ -466,6 +510,10 @@ export class PtyCoreLinkClient {
     // plumbing.
     if (type === "ready") {
       this.protocolVersion = typeof msg.version === "string" ? msg.version : null;
+      // Record the capability for this connection (ADR 0024 D11). Absent is a
+      // Core like any other — it does not touch `compatible` below, so nothing
+      // downstream can turn a missing capability into "needs update".
+      this.multiConnection = readMultiConnectionCapability(msg.multiConnection);
       const payload = {
         version: this.protocolVersion,
         compatible: coreLinkProtocolCompatible(this.protocolVersion),
@@ -547,6 +595,19 @@ export class PtyCoreLinkClient {
     timeoutMs = DEFAULT_RPC_TIMEOUT_MS,
   ): Promise<CoreLinkResponseFrame> {
     if (this.closed) return Promise.reject(new Error("core-link client closed"));
+    // The gate (ADR 0024 D11). A multi-connection-only frame aimed at a Core
+    // that never announced the capability is refused here, before a reqId is
+    // allocated and before anything reaches the socket — the Core never sees
+    // it, so there is no error frame to tolerate. The rejection is for the
+    // caller that asked without checking; the supported path is to consult
+    // `canSendMultiConnectionFrames()` and take the single-connection route.
+    if (this.multiConnectionOnlyFrameTypes.has(frame.type) && !this.canSendMultiConnectionFrames()) {
+      return Promise.reject(
+        new Error(
+          `core-link frame ${frame.type} needs the multiConnection capability, which this Core does not announce`,
+        ),
+      );
+    }
     const reqId = `r${++this.reqSeq}`;
     const framed = { ...frame, reqId } as CoreLinkRequestFrame;
     return new Promise((resolve, reject) => {
@@ -682,6 +743,35 @@ export class PtyCoreLinkClient {
   ): () => void {
     this.protocolVersionListeners.add(cb);
     return () => this.protocolVersionListeners.delete(cb);
+  }
+
+  /**
+   * May this Core be sent frames that only a multi-connection Core understands
+   * — the Session lock's `claim`, the per-connection PTY subscription, and
+   * whatever else lands under ADR 0024?
+   *
+   * **The one predicate to consult before sending any such frame.** False means
+   * do not send it: not send-and-handle-the-error, not send-and-hope. The Core
+   * on the other end is a single-connection build that would answer an unknown
+   * frame with an error frame at best, and the caller is expected to have a
+   * single-connection path already — that path is what shipped before this
+   * capability existed.
+   *
+   * False before `ready` lands and after a drop, for as long as the answer is
+   * unknown. A caller that needs the capability at startup waits for
+   * {@link onProtocolVersion} rather than reading this on the first tick.
+   */
+  canSendMultiConnectionFrames(): boolean {
+    return this.multiConnection !== null;
+  }
+
+  /**
+   * This connection's `multiConnection` capability, or null. For callers that
+   * need the version rather than the yes/no — the gate is
+   * {@link canSendMultiConnectionFrames}.
+   */
+  multiConnectionCapability(): CoreLinkMultiConnectionCapability | null {
+    return this.multiConnection;
   }
 
   private emitDisconnected(error?: string): void {

--- a/packages/panel/src/server/core-link/client.ts
+++ b/packages/panel/src/server/core-link/client.ts
@@ -95,8 +95,10 @@ export type PtyCoreLinkClientOptions = {
   bearer?: string;
   /**
    * Overrides {@link MULTI_CONNECTION_ONLY_FRAME_TYPES}. Exists only so a test
-   * can exercise the gate while that set is still empty — the frames it will
-   * hold are #142's and the lock ticket's to name. Production never passes it.
+   * can drive the rejection in {@link PtyCoreLinkClient.request} with a
+   * stand-in frame type: the real entries both degrade at their call sites
+   * rather than reach that backstop, so nothing in this build exercises it.
+   * Production never passes it.
    */
   multiConnectionOnlyFrameTypes?: ReadonlySet<string>;
 };

--- a/packages/panel/src/server/panel-link/router.ts
+++ b/packages/panel/src/server/panel-link/router.ts
@@ -191,6 +191,11 @@ export class PanelLinkRouter {
    * already live gets no hold — and needs none: it is a tab that will replay
    * for itself, and the browser buffers its own live bytes while that replay is
    * in flight (see `pty-stream-router`).
+   *
+   * A Core that does not announce `multiConnection` is not an error path here:
+   * the client resolves this call without sending anything, because such a Core
+   * already fans that PTY out to every connection (ADR 0024 D11). The `catch`
+   * below is for a link that is genuinely down, not for that fallback.
    */
   claimPty(coreId: string, ptyId: string, catchUp: boolean): void {
     const state = this.cores.get(coreId);

--- a/packages/panel/src/server/services/__tests__/core-link-manager.test.ts
+++ b/packages/panel/src/server/services/__tests__/core-link-manager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { Core } from "~/shared/cores";
 import type { CoreSecrets } from "../cores";
 import { CoreLinkManager, type CoreCursor, type CoreLinkClientLike } from "../core-link-manager";
+import { CORE_LINK_PROTOCOL_VERSION } from "@actana/shared/core-link-frames";
 
 /**
  * The manager is driven through its injected seams: a fake core-link client and
@@ -233,6 +234,24 @@ describe("core-link manager", () => {
       client.emit.protocolVersion({ version: "0.8.0", compatible: true });
       client.emit.authOk({ coreId: "core_a", exp: Date.now() + 60_000 });
       expect(h.manager.status("core_a").state).toBe("connected");
+    });
+
+    // Issue 143 / ADR 0024 D11. The capability rides `ready` alongside the
+    // version, so the risk this pins down is that a Core which announces no
+    // `multiConnection` gets read as stale. It is not stale: it is the
+    // single-connection Core, and the version it speaks is this one. The
+    // manager only ever sees `compatible`, which is exactly why it stays true.
+    it("reports a Core announcing no multiConnection capability as connected, not needs-update", () => {
+      h.manager.dial("core_a");
+      const client = h.clients.get("core_a")!;
+      // What a capability-less Core's `ready` yields: a version this Panel
+      // speaks, and no capability anywhere in the payload.
+      client.emit.protocolVersion({ version: CORE_LINK_PROTOCOL_VERSION, compatible: true });
+      client.emit.authOk({ coreId: "core_a", exp: Date.now() + 60_000 });
+      const status = h.manager.status("core_a");
+      expect(status.state).toBe("connected");
+      expect(status).not.toMatchObject({ state: "needs-update" });
+      expect(status).not.toHaveProperty("coreVersion");
     });
 
     it("still reports a dropped link as unreachable, not as needing an update", () => {

--- a/packages/panel/src/server/services/__tests__/core-link-manager.test.ts
+++ b/packages/panel/src/server/services/__tests__/core-link-manager.test.ts
@@ -250,7 +250,6 @@ describe("core-link manager", () => {
       client.emit.authOk({ coreId: "core_a", exp: Date.now() + 60_000 });
       const status = h.manager.status("core_a");
       expect(status.state).toBe("connected");
-      expect(status).not.toMatchObject({ state: "needs-update" });
       expect(status).not.toHaveProperty("coreVersion");
     });
 

--- a/packages/shared/src/__tests__/core-link-frames.test.ts
+++ b/packages/shared/src/__tests__/core-link-frames.test.ts
@@ -5,6 +5,7 @@ import {
   HARNESS_INSTALL_FAILED_EVENT_KIND,
   coreLinkProtocolCompatible,
   parseCoreLinkRequestFrame,
+  readMultiConnectionCapability,
   serializeCoreLinkFrame,
   type CoreLinkEvent,
   type CoreLinkRequestFrame,
@@ -405,6 +406,70 @@ describe("core-link-frames", () => {
   describe("CORE_LINK_PROTOCOL_VERSION", () => {
     it("is a semver string", () => {
       expect(CORE_LINK_PROTOCOL_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    // The reason lives in the test name on purpose: this assertion exists to
+    // fail a future edit that bumps the version *for the multiConnection
+    // surface*, and whoever reads that failure needs the reason, not the
+    // number.
+    it("stays 0.15.0 because multiConnection is announced as a ready capability, so no Core in any fleet is marked needs-update for it (ADR 0024 D11, issue 143)", () => {
+      expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.15.0");
+    });
+
+    it("leaves a Core that announces no multiConnection capability fully compatible — absence is a supported state, not drift", () => {
+      const capabilityLessReady: CoreLinkServerFrame = {
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+      };
+      expect(coreLinkProtocolCompatible(CORE_LINK_PROTOCOL_VERSION)).toBe(true);
+      expect(readMultiConnectionCapability((capabilityLessReady as { multiConnection?: unknown }).multiConnection)).toBe(
+        null,
+      );
+    });
+  });
+
+  describe("readMultiConnectionCapability (issue 143, ADR 0024 D11)", () => {
+    it("reads version 1", () => {
+      expect(readMultiConnectionCapability({ version: 1 })).toEqual({ version: 1 });
+    });
+
+    it("reads an absent capability as null — the single-connection Core that shipped before it", () => {
+      expect(readMultiConnectionCapability(undefined)).toBe(null);
+      expect(readMultiConnectionCapability(null)).toBe(null);
+    });
+
+    it("reads a version this build does not know as null, falling back to single-connection rather than guessing", () => {
+      expect(readMultiConnectionCapability({ version: 2 })).toBe(null);
+      expect(readMultiConnectionCapability({ version: 0 })).toBe(null);
+    });
+
+    it("reads a malformed capability as null", () => {
+      expect(readMultiConnectionCapability({})).toBe(null);
+      expect(readMultiConnectionCapability({ version: "1" })).toBe(null);
+      expect(readMultiConnectionCapability("multiConnection")).toBe(null);
+      expect(readMultiConnectionCapability(1)).toBe(null);
+    });
+  });
+
+  describe("the ready frame's multiConnection capability (issue 143)", () => {
+    it("serializes with the capability when the Core announces it", () => {
+      const frame: CoreLinkServerFrame = {
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+        multiConnection: { version: 1 },
+      };
+      expect(JSON.parse(serializeCoreLinkFrame(frame))).toEqual({
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+        multiConnection: { version: 1 },
+      });
+    });
+
+    it("serializes without the field at all when the Core does not announce it", () => {
+      const frame: CoreLinkServerFrame = { type: "ready", version: CORE_LINK_PROTOCOL_VERSION };
+      const wire = JSON.parse(serializeCoreLinkFrame(frame));
+      expect(wire).toEqual({ type: "ready", version: CORE_LINK_PROTOCOL_VERSION });
+      expect("multiConnection" in wire).toBe(false);
     });
   });
 

--- a/packages/shared/src/core-link-frames.ts
+++ b/packages/shared/src/core-link-frames.ts
@@ -560,9 +560,34 @@ export type CoreLinkEventFrame = { type: "event"; event: CoreLinkEvent };
  */
 export type CoreLinkEventsReplayedFrame = { type: "eventsReplayed"; lastEventId: number };
 
+/**
+ * The `multiConnection` capability, announced on `ready` (ADR 0024 D11).
+ *
+ * `version` is the capability's own number, independent of
+ * {@link CORE_LINK_PROTOCOL_VERSION} — it moves when the multi-connection
+ * surface itself changes shape, and nothing about it marks a Core stale.
+ */
+export type CoreLinkMultiConnectionCapability = { version: 1 };
+
 /** Response frame — correlates to a request via `reqId`. */
 export type CoreLinkResponseFrame =
-  | { type: "ready"; version: string }
+  | {
+      type: "ready";
+      version: string;
+      /**
+       * Present on a Core that serves many core-link connections at once
+       * (ADR 0024 D1). Absent means the single-connection Core: it evicts the
+       * previous socket on connect, holds no Session locks and has no
+       * per-connection subscriptions.
+       *
+       * Absence is a supported state, not a fault. Every frame that only makes
+       * sense against a multi-connection Core is withheld by the client when
+       * this is absent (see `MULTI_CONNECTION_ONLY_FRAME_TYPES` in the Panel's
+       * core-link client); everything else behaves exactly as it does today, so
+       * such a Core is connected and fully usable, never "needs update".
+       */
+      multiConnection?: CoreLinkMultiConnectionCapability;
+    }
   | {
       type: "spawned";
       reqId: string;
@@ -859,11 +884,17 @@ export type CoreLinkServerFrame =
  * and deliberately **does not move this version** (ADR 0024 D11). Every bump
  * above marks every Core in every fleet needs-update, and multi-connection is a
  * capability a one-Panel fleet never exercises. It is announced on `ready`
- * instead, by #143, which also gates the Panel's sends on it. Until that lands,
- * this file's version is the only thing a client has to go on, so a build
- * carrying these frames must be deployed to Panel and Core together — the
- * version-lock CONTEXT.md already states. Nothing here reads a capability;
- * adding one is #143's whole job and must not be duplicated here.
+ * instead, by #143 below, which also gates the Panel's sends on it, so these
+ * frames are never put on the wire to a Core that cannot answer them.
+ *
+ * Issue 143 adds the optional `multiConnection` capability to the `ready`
+ * frame and deliberately does NOT move this version (ADR 0024 D11). It is the
+ * first entry in this log that does not: the field is additive and its absence
+ * is the single-connection Core that shipped before it, which is exactly
+ * today's behaviour rather than a lesser one. Moving the minor would mark every
+ * Core in every fleet "needs update" to buy a capability a one-Panel fleet
+ * never exercises. A capability that changed what an existing frame means
+ * would not qualify, and the minor would move as it does above.
  */
 export const CORE_LINK_PROTOCOL_VERSION = "0.15.0";
 
@@ -888,6 +919,24 @@ export function coreLinkProtocolCompatible(reported: string | null | undefined):
   const ours = parseMajorMinor(CORE_LINK_PROTOCOL_VERSION);
   if (!ours) return false;
   return theirs.major === ours.major && theirs.minor === ours.minor;
+}
+
+/**
+ * Read the `multiConnection` capability off a raw `ready` frame, or null.
+ *
+ * Null for every shape that is not exactly `{ version: 1 }` — absent, a
+ * non-object, or a version this build does not know. An unrecognised future
+ * version reads as absent on purpose: the safe fallback is the single-connection
+ * behaviour that predates the capability, never a guess at what a higher version
+ * means. Unlike {@link coreLinkProtocolCompatible}, nothing here can mark a Core
+ * incompatible — a null answer withholds frames, it does not fail a Core.
+ */
+export function readMultiConnectionCapability(
+  raw: unknown,
+): CoreLinkMultiConnectionCapability | null {
+  if (!raw || typeof raw !== "object") return null;
+  const version = (raw as { version?: unknown }).version;
+  return version === 1 ? { version: 1 } : null;
 }
 
 function parseMajorMinor(version: string | null | undefined): { major: number; minor: number } | null {


### PR DESCRIPTION
Implements **D11** of #140. Base is `feat/multi-connection-core`, not `main`.

## What

`ready` grows an optional `multiConnection: { version: 1 }`, and
`CORE_LINK_PROTOCOL_VERSION` stays at `0.15.0`.

Absent means the single-connection Core. A new Panel against such a Core sees no
capability and behaves exactly as it does today; an old Panel against a new Core is
untouched — it never reads the field, and never notices it is no longer evicting anybody.

## Checked against the rule

ADR 0024's narrowed rule (already in `CONTEXT.md`, landed with #170) permits an additive
surface on `ready` only where its absence yields today's behaviour exactly. The check for
this ticket:

- **Absent → the Panel sends nothing new.** `MULTI_CONNECTION_ONLY_FRAME_TYPES` holds
  `ptySubscribe` / `ptyUnsubscribe`, and against a capability-less Core both are withheld.
  Nothing is withheld that used to be sent: those frames arrived with #174 on this base, so
  the wire traffic against a capability-less Core is byte-for-byte what it was before that
  PR.
- **Absent → nothing renders worse.** A Core without the capability fans every PTY out to
  every connection, so the pane's bytes are already coming and a withheld `ptySubscribe`
  costs nothing. The dial state reads `compatible` only, which the capability never touches:
  such a Core is `connected`, not `needs-update`, not degraded.
- **The capability adds a surface; it does not change what an existing frame means.** No
  existing frame's shape or semantics move, so the version correctly stays put.

If any of those stopped holding, the capability would be the wrong mechanism and the minor
would have to move. Today they hold.

## Which gates are wired now, and which are waiting

The predicate is `PtyCoreLinkClient.canSendMultiConnectionFrames()` — the single thing to
consult before sending any multi-connection-only frame. It is enforced in `request()`, the
chokepoint both the typed `pty.*` methods and the panel-link router pass through: a frame in
`MULTI_CONNECTION_ONLY_FRAME_TYPES` is refused there, before a reqId is allocated and before
anything reaches the socket. The Core never sees it, so there is no error frame to tolerate,
and the refused frame is not queued for a later flush.

**Wired now:** the recording, the predicate, the enforcement point, and the PTY subscription
frames that #174 put on this base.

| Frame | Owner | Status |
| --- | --- | --- |
| PTY `subscribe` / `unsubscribe` (D2) | #174, merged into this base | **Wired.** Both types are in the set, and both call sites take the single-connection route below rather than relying on the refusal. |
| `claim` / session lock (D6) | A later ticket | **Not wired.** The lock frame does not exist yet. It adds its type to the set. |

Wiring the next one is a one-line change: add the frame type to
`MULTI_CONNECTION_ONLY_FRAME_TYPES` and it inherits the gate, its tests and its reconnect
behaviour with nothing else to restate. A test pins the set's exact membership, so a type
appearing there without a ticket behind it — or one quietly dropping out — is visible rather
than silent.

Being in the set is only the backstop. A caller with something better to do than fail
consults the predicate itself: `ptySubscribe()` and `ptyUnsubscribe()` check it and resolve
without sending, and the post-`authOk` resend returns early. #174 had put `.catch(() => {})`
on every `ptySubscribe` call site, which made a gated refusal invisible and let the pane
paint anyway — the right behaviour, but arriving by accident through a swallowed error. Here
it is the decision: the client asks whether this Core can answer, and against one that cannot
it sends nothing and resolves, because the bytes are already coming.

Because both real entries degrade at their call sites, nothing in this build reaches the
`request()` rejection. The tests drive it through a constructor seam
(`multiConnectionOnlyFrameTypes`) with a stand-in frame type standing in for a future entry
that has no degrade path. Production never passes it.

## Notes on the capability record

- **Per Core**, because there is one client per registered Core.
- **Re-read on every `ready`**, never remembered across connections — a Core can be rolled back
  while the Panel is away, and a stale `true` would send frames it can no longer answer.
- **Closed while the answer is unknown** — false before `ready` lands and after a drop.
- **An unknown future version reads as absent.** `{ version: 2 }` falls back to
  single-connection rather than guessing what a higher version means.

## Tests

- `ready` carries the field, and its **absence is exercised as a supported state** — the Core's
  `announceMultiConnection: false` stands up a capability-less Core the way `protocolVersion`
  stands up a drifted one.
- The version pin: `"stays 0.15.0 because multiConnection is announced as a ready capability, so
  no Core in any fleet is marked needs-update for it (ADR 0024 D11, issue 143)"`.
- The set's exact membership: `ptySubscribe` and `ptyUnsubscribe`, with `claim` called out as
  the entry that joins when D6 lands.
- The gate: not on the wire at all against a capability-less Core, not before `ready`, not
  queued for later, and it stops sending again if the Core comes back downgraded.
- The single-connection fallback: `ptySubscribe` / `ptyUnsubscribe` resolve without sending
  against a capability-less Core, and the PTY still paints.
- A capability-less Core renders `connected`, still spawns a Session, and still sends every
  ordinary frame.

Full suites green for `@actana/shared` (226) and `@actana/core` (696); `pnpm -r typecheck` and
`pnpm lint` clean (0 errors). The panel suite has a pre-existing flaky pool under full-suite
parallelism (React dialog tests, `operator-auth`, `terminals-in-browser`) that fails on this
base too and passes when those files are run in isolation; no core-link or shared test is
affected.

## Boundaries

Does not implement the PTY subscribe/unsubscribe frames and does not touch the fan-out — that
is #174's, end to end, and it merged into this base first. The diff here is the `ready` frame,
the capability plumbing, and the gate those frames now sit behind.

Refs #143
Refs #140
Refs #129
