### PR TITLE
fix(panel-link): 15s/45s sweep on the Panel side, wake hook in the browser client

### DIFF
--- a/packages/panel/src/lib/__tests__/panel-link-client.test.ts
+++ b/packages/panel/src/lib/__tests__/panel-link-client.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PanelLinkClient, type PanelLinkSocketLike } from "../panel-link-client";
+import {
+  PanelLinkClient,
+  type PanelLinkOptions,
+  type PanelLinkSocketLike,
+} from "../panel-link-client";
 import type { PanelLinkClientFrame, PanelLinkServerFrame } from "~/shared/panel-link";
 import type { CoreLinkEvent } from "@actana/shared/core-link-frames";
 
@@ -266,6 +270,203 @@ describe("panel link · reconnect and replay", () => {
 
     expect(second.outgoing("core_a").map((f) => f.type)).toEqual(["tasksList"]);
     link.close();
+  });
+});
+
+/**
+ * A stand-in for `window` / `document`, so the wake signals can be fired from a
+ * test that runs in Node — and so "left no listener behind" is a number this
+ * suite can read rather than a promise the code makes.
+ */
+class FakeWakeTarget {
+  private readonly listeners = new Map<string, Set<() => void>>();
+
+  addEventListener(type: string, cb: () => void) {
+    const set = this.listeners.get(type) ?? new Set<() => void>();
+    set.add(cb);
+    this.listeners.set(type, set);
+  }
+  removeEventListener(type: string, cb: () => void) {
+    this.listeners.get(type)?.delete(cb);
+  }
+  fire(type: string) {
+    for (const cb of [...(this.listeners.get(type) ?? [])]) cb();
+  }
+  /** How many listeners are still installed, of any type. */
+  registered() {
+    let total = 0;
+    for (const set of this.listeners.values()) total += set.size;
+    return total;
+  }
+}
+
+class FakeDocument extends FakeWakeTarget {
+  visibilityState: "visible" | "hidden" = "visible";
+
+  /** The tab came back to the foreground. */
+  reveal() {
+    this.visibilityState = "visible";
+    this.fire("visibilitychange");
+  }
+  /** The tab went away. */
+  hide() {
+    this.visibilityState = "hidden";
+    this.fire("visibilitychange");
+  }
+}
+
+describe("panel link · a socket that dies without saying so", () => {
+  /**
+   * The bug this covers has no event in it. The socket stops delivering frames,
+   * `readyState` stays `OPEN`, `close` never fires, and a send into it does not
+   * throw — so the fake socket here simply *does nothing*, which is exactly the
+   * failure. What the tests drive is the only thing left: a wake signal.
+   */
+  let win: FakeWakeTarget;
+  let doc: FakeDocument;
+
+  beforeEach(() => {
+    win = new FakeWakeTarget();
+    doc = new FakeDocument();
+    vi.stubGlobal("window", win);
+    vi.stubGlobal("document", doc);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function staleClient(opts: PanelLinkOptions = {}) {
+    return new PanelLinkClient({
+      url: "ws://panel.test/panel-link?v=1",
+      createSocket: (url) => new FakeSocket(url),
+      reconnectInitialMs: 100,
+      reconnectMaxMs: 10_000,
+      requestTimeoutMs: 1_000,
+      staleAfterMs: 60_000,
+      ...opts,
+    });
+  }
+
+  it("drops a silent socket on the next wake and re-subscribes from its cursor", () => {
+    const link = staleClient();
+    link.watch("core_a");
+    const first = live();
+    first.push({ t: "core", coreId: "core_a", frame: { type: "event", event: event(9) } });
+
+    // Hours pass with the tab hidden. The socket says nothing and, crucially,
+    // does nothing: no close event, no readyState change, no error.
+    vi.advanceTimersByTime(4 * 60 * 60_000);
+    expect(FakeSocket.opened).toHaveLength(1);
+    expect(first.readyState).toBe(1);
+
+    doc.reveal();
+    const second = live();
+
+    expect(FakeSocket.opened).toHaveLength(2);
+    expect(second).not.toBe(first);
+    expect(second.outgoing("core_a")).toEqual([
+      { type: "subscribe", reqId: expect.any(String), lastEventId: 9 },
+    ]);
+    link.close();
+  });
+
+  it("wakes on focus and on coming back online, not only on visibility", () => {
+    for (const signal of ["focus", "online"] as const) {
+      FakeSocket.opened = [];
+      const link = staleClient();
+      live();
+      vi.advanceTimersByTime(90_000);
+
+      win.fire(signal);
+
+      expect(FakeSocket.opened, `${signal} should have redialled`).toHaveLength(2);
+      link.close();
+    }
+  });
+
+  it("leaves a healthy, recently-active link alone", () => {
+    const link = staleClient();
+    const socket = live();
+    socket.push({ t: "core", coreId: "core_a", frame: { type: "event", event: event(1) } });
+    vi.advanceTimersByTime(30_000);
+
+    doc.reveal();
+    win.fire("focus");
+    win.fire("online");
+
+    expect(FakeSocket.opened).toHaveLength(1);
+    link.close();
+  });
+
+  it("does not redial on the visibilitychange that hides the tab", () => {
+    const link = staleClient();
+    live();
+    vi.advanceTimersByTime(90_000);
+
+    doc.hide();
+
+    expect(FakeSocket.opened).toHaveLength(1);
+    link.close();
+  });
+
+  it("redials at once on wake rather than waiting out the backoff", () => {
+    const link = staleClient();
+    live().drop();
+    vi.advanceTimersByTime(100);
+    // Second dial, never accepted — the backoff is now walking upward.
+    FakeSocket.last!.drop();
+    expect(FakeSocket.opened).toHaveLength(2);
+
+    win.fire("focus");
+
+    // No timer advanced: the wake redials immediately, not on the next delay.
+    expect(FakeSocket.opened).toHaveLength(3);
+
+    // And the attempt counter went back to zero with it: the next ordinary
+    // drop retries on the initial delay, not on the doubled one it had reached.
+    FakeSocket.last!.drop();
+    vi.advanceTimersByTime(100);
+    expect(FakeSocket.opened).toHaveLength(4);
+    link.close();
+  });
+
+  it("fails in-flight requests when it drops a silent socket", async () => {
+    // A request timeout long enough to stay out of the way: it is not a
+    // liveness signal, and the point here is that the wake path fails the
+    // caller rather than leaving it to expire.
+    const link = staleClient({ requestTimeoutMs: 10 * 60_000 });
+    live();
+    const answer = link.request("core_a", { type: "tasksList" });
+    vi.advanceTimersByTime(90_000);
+
+    doc.reveal();
+
+    await expect(answer).rejects.toThrow("connection lost");
+    link.close();
+  });
+
+  it("leaves no wake listener behind when it is closed", () => {
+    const link = staleClient();
+    live();
+    expect(win.registered() + doc.registered()).toBe(3);
+
+    link.close();
+
+    expect(win.registered()).toBe(0);
+    expect(doc.registered()).toBe(0);
+  });
+
+  it("ignores a wake signal after close", () => {
+    const link = staleClient();
+    live();
+    link.close();
+    vi.advanceTimersByTime(90_000);
+
+    doc.reveal();
+    win.fire("focus");
+
+    expect(FakeSocket.opened).toHaveLength(1);
   });
 });
 

--- a/packages/panel/src/lib/panel-link-client.ts
+++ b/packages/panel/src/lib/panel-link-client.ts
@@ -46,11 +46,29 @@ export type PanelLinkOptions = {
   reconnectInitialMs?: number;
   reconnectMaxMs?: number;
   requestTimeoutMs?: number;
+  /** How long silence on an `OPEN` socket is tolerated at a wake signal. */
+  staleAfterMs?: number;
 };
 
 const DEFAULT_RECONNECT_INITIAL_MS = 500;
 const DEFAULT_RECONNECT_MAX_MS = 10_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * How long an `OPEN` socket may go without delivering a frame before a wake
+ * signal treats it as a corpse.
+ *
+ * Generous on purpose, and deliberately not the server's 45s timeout. The
+ * server's pings never reach page JavaScript — the browser answers them down in
+ * the network layer and the `WebSocket` API surfaces no pong event — so this
+ * clock advances only on *application* frames, and an idle Core legitimately
+ * sends none for hours. A window near the server's would therefore redial a
+ * perfectly healthy link on every focus of a quiet tab. The asymmetry is
+ * deliberate: one false-positive redial is cheap and safe, because the
+ * reconnect path is idempotent and replays from the cursor — a redial on every
+ * focus is not.
+ */
+const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
 
 /**
  * A request frame minus the `reqId` the client assigns. Distributed over the
@@ -83,12 +101,16 @@ export class PanelLinkClient {
   private readonly reconnectInitialMs: number;
   private readonly reconnectMaxMs: number;
   private readonly requestTimeoutMs: number;
+  private readonly staleAfterMs: number;
 
   private socket: PanelLinkSocketLike | null = null;
   private open = false;
   private closed = false;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** When this tab last had evidence of life: an application frame, or an open. */
+  private lastInboundAt = Date.now();
+  private readonly detachWakeListeners: () => void;
 
   private reqSeq = 0;
   private readonly pending = new Map<string, Pending>();
@@ -111,6 +133,8 @@ export class PanelLinkClient {
     this.reconnectInitialMs = opts.reconnectInitialMs ?? DEFAULT_RECONNECT_INITIAL_MS;
     this.reconnectMaxMs = opts.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
     this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.staleAfterMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.detachWakeListeners = this.listenForWake();
     this.connect();
   }
 
@@ -201,18 +225,97 @@ export class PanelLinkClient {
 
   close(): void {
     this.closed = true;
+    this.detachWakeListeners();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(new Error("panel link closed"));
-    }
-    this.pending.clear();
+    this.failPending("panel link closed");
     this.socket?.close();
     this.socket = null;
     this.open = false;
+  }
+
+  // ─── liveness ─────────────────────────────────────────────────────────────
+
+  /**
+   * The wake signals, and the reason this recovery is hung on them rather than
+   * on a clock.
+   *
+   * A socket can die without a TCP FIN — the overnight fate of a flow carrying
+   * zero bytes across a NAT, a firewall or a reverse proxy. Nothing about that
+   * is observable from the page: `readyState` stays `OPEN`, no `close` event
+   * fires, a `send` into it buffers rather than throwing, and the request
+   * timeout fails one caller without touching the link. The one moment the tab
+   * can act on is the moment it becomes usable again — and a timer is precisely
+   * what cannot be trusted to notice it, because a hidden tab's timers are
+   * throttled to roughly once a minute and a frozen page's do not run at all.
+   */
+  private listenForWake(): () => void {
+    if (typeof window === "undefined" || typeof document === "undefined") return () => {};
+    const onWake = () => this.wake();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") this.wake();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("focus", onWake);
+    window.addEventListener("online", onWake);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("focus", onWake);
+      window.removeEventListener("online", onWake);
+    };
+  }
+
+  /**
+   * A wake signal fired. Redial unless there is positive evidence the link is
+   * alive — a frame that arrived recently enough. `isConnected()` is no such
+   * evidence: it reads `true` on a corpse for as long as the corpse lasts.
+   */
+  private wake(): void {
+    if (this.closed) return;
+    if (this.open && Date.now() - this.lastInboundAt <= this.staleAfterMs) return;
+    this.redialNow();
+  }
+
+  /**
+   * Drop whatever socket we have and dial again immediately, off the backoff.
+   * A tab hidden for hours has usually walked the backoff up to its cap, and
+   * the first frame of visibility is exactly the wrong moment to make its
+   * operator wait out the capped delay.
+   */
+  private redialNow(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectAttempt = 0;
+    const dying = this.socket;
+    const wasOpen = this.open;
+    // Forgotten before the close, so the socket's own close handler — which
+    // checks identity — bails rather than racing this path into a second
+    // reconnect.
+    this.socket = null;
+    this.open = false;
+    if (dying) {
+      try {
+        dying.close();
+      } catch {
+        // A half-open socket may refuse; we are done with it either way.
+      }
+    }
+    this.failPending("panel link connection lost");
+    if (wasOpen) for (const cb of this.connectionListeners) cb(false);
+    this.connect();
+  }
+
+  /** Fail every in-flight request: nothing on the old socket can be answered. */
+  private failPending(message: string): void {
+    for (const [reqId, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(reqId);
+      pending.reject(new Error(message));
+    }
   }
 
   // ─── transport ────────────────────────────────────────────────────────────
@@ -232,6 +335,7 @@ export class PanelLinkClient {
       if (this.socket !== socket) return;
       this.open = true;
       this.reconnectAttempt = 0;
+      this.lastInboundAt = Date.now();
       // Re-subscribe every watched Core from where this tab got to. This is
       // the whole of the replay contract on the browser side.
       for (const coreId of this.watching.keys()) this.sendSubscribe(coreId);
@@ -239,7 +343,13 @@ export class PanelLinkClient {
       for (const cb of this.connectionListeners) cb(true);
     });
 
-    socket.addEventListener("message", (event) => this.onMessage(event.data));
+    socket.addEventListener("message", (event) => {
+      // A socket this client has already given up on may still deliver what it
+      // had buffered. Its frames are not this link's frames, and above all they
+      // are not evidence that the *current* link is alive.
+      if (this.socket !== socket) return;
+      this.onMessage(event.data);
+    });
 
     socket.addEventListener("close", () => {
       if (this.socket !== socket) return;
@@ -248,11 +358,7 @@ export class PanelLinkClient {
       // Requests written to a socket that died can never be answered; failing
       // them now lets the caller retry on the new link instead of waiting out
       // the timeout.
-      for (const [reqId, pending] of this.pending) {
-        clearTimeout(pending.timer);
-        pending.reject(new Error("panel link connection lost"));
-        this.pending.delete(reqId);
-      }
+      this.failPending("panel link connection lost");
       if (wasOpen) for (const cb of this.connectionListeners) cb(false);
       this.scheduleReconnect();
     });
@@ -313,6 +419,10 @@ export class PanelLinkClient {
   }
 
   private onMessage(raw: unknown): void {
+    // Anything arriving is evidence of life, decodable or not — and an
+    // application frame is the only evidence this end ever gets, since the
+    // server's pings are answered below the API and surface no event here.
+    this.lastInboundAt = Date.now();
     const frame = decodeServerFrame(raw);
     if (!frame) return;
     if (frame.t === "dial") {

--- a/packages/panel/src/server/panel-link/__tests__/ws-server.test.ts
+++ b/packages/panel/src/server/panel-link/__tests__/ws-server.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -16,7 +16,8 @@ const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ac-panel-link-test-"));
 process.env.AC_USER_DATA_DIR = path.join(tmpRoot, "app");
 process.env.AC_PANEL_DATA_DIR = path.join(tmpRoot, "panel");
 
-const { attachPanelLink } = await import("../ws-server");
+const { attachPanelLink, bindPanelLinkSocket } = await import("../ws-server");
+type PanelLinkServerSocket = import("../ws-server").PanelLinkServerSocket;
 const { closePanelDb } = await import("../../panel-db");
 const { operatorSessionCookie } = await import("../../__tests__/_operator-session");
 const { PANEL_LINK_PATH, PANEL_LINK_PROTOCOL_VERSION, PANEL_LINK_VERSION_PARAM } = await import(
@@ -24,7 +25,7 @@ const { PANEL_LINK_PATH, PANEL_LINK_PROTOCOL_VERSION, PANEL_LINK_VERSION_PARAM }
 );
 
 const server = http.createServer((_req, res) => res.end("ok"));
-attachPanelLink(server);
+const router = attachPanelLink(server);
 await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
 const port = (server.address() as { port: number }).port;
 
@@ -90,5 +91,173 @@ describe("the panel-link endpoint", () => {
 
     expect(seen).toEqual(["/something-else"]);
     expect(status).toBe(418);
+  });
+});
+
+/**
+ * One upgraded connection, as the sweep sees it. Deliberately minimal: it has
+ * no `ping` unless asked for one, because that is the shape the sweep has to
+ * survive, and its `terminate` behaves like `ws`'s — the socket is gone and the
+ * close handler runs.
+ */
+class FakeUpgradedSocket implements PanelLinkServerSocket {
+  readonly OPEN = 1;
+  readyState = 1;
+  readonly sent: string[] = [];
+  pings = 0;
+  terminated = 0;
+  gracefulCloses = 0;
+  ping?: () => void;
+
+  private readonly handlers = new Map<string, Array<(arg?: unknown) => void>>();
+
+  constructor(opts: { ping?: boolean; autoPong?: boolean } = {}) {
+    if (opts.ping !== false) {
+      this.ping = () => {
+        this.pings++;
+        // A real browser answers in the network layer, without the page ever
+        // hearing about it. That pong is the only thing keeping an idle tab's
+        // connection alive.
+        if (opts.autoPong) this.fire("pong");
+      };
+    }
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.gracefulCloses++;
+    this.readyState = 3;
+    this.fire("close");
+  }
+  terminate() {
+    this.terminated++;
+    this.readyState = 3;
+    this.fire("close");
+  }
+  on(event: string, cb: (arg?: never) => void) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(cb as (arg?: unknown) => void);
+    this.handlers.set(event, list);
+    return this;
+  }
+
+  fire(event: string, arg?: unknown) {
+    for (const cb of [...(this.handlers.get(event) ?? [])]) cb(arg);
+  }
+
+  /** The tab sent a frame — an RPC, or a subscribe. */
+  receive(frame: unknown) {
+    this.fire("message", JSON.stringify(frame));
+  }
+}
+
+function subscribe(coreId: string) {
+  return { t: "core", coreId, frame: { type: "subscribe", reqId: "s1", lastEventId: 0 } };
+}
+
+/**
+ * The liveness sweep. The case it exists for cannot be written as an event: a
+ * connection that dies without a FIN produces nothing at all, so what these
+ * tests do is stop answering and move the clock.
+ */
+describe("the panel-link sweep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("terminates a connection that stops answering, and the session lets go", () => {
+    const ws = new FakeUpgradedSocket();
+    const session = bindPanelLinkSocket(router, ws);
+    ws.receive(subscribe("core_a"));
+    expect(session.watches("core_a")).toBe(true);
+
+    // Pings go out on the 15s interval; the peer answers none of them. The
+    // reap lands on the first tick past the 45s timeout.
+    vi.advanceTimersByTime(61_000);
+
+    expect(ws.terminated).toBe(1);
+    // `terminate`, not `close` — a graceful close waits on a peer that is
+    // never going to answer.
+    expect(ws.gracefulCloses).toBe(0);
+    expect(session.watches("core_a")).toBe(false);
+  });
+
+  it("never reaps a quiet-but-healthy connection, however long it stays quiet", () => {
+    const ws = new FakeUpgradedSocket({ autoPong: true });
+    const session = bindPanelLinkSocket(router, ws);
+    ws.receive(subscribe("core_a"));
+
+    // Four hours with not one application frame — an idle Core is entitled to
+    // send none. Only the pongs stand between this tab and the reaper.
+    vi.advanceTimersByTime(4 * 60 * 60_000);
+
+    expect(ws.terminated).toBe(0);
+    expect(ws.pings).toBeGreaterThan(900);
+    expect(session.watches("core_a")).toBe(true);
+  });
+
+  it("takes a connection's own frames as proof of life", () => {
+    const ws = new FakeUpgradedSocket();
+    bindPanelLinkSocket(router, ws);
+
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(30_000);
+      ws.receive(subscribe("core_a"));
+    }
+
+    expect(ws.terminated).toBe(0);
+  });
+
+  it("reaps one tab's connection without touching any other tab's", () => {
+    // Binding order matters: the healthy connections sit either side of the
+    // dead one. A sweep carrying the core link's "am I the current connection?"
+    // guard would reap both of them and spare the newest — the Panel holds one
+    // connection per tab, not one in total.
+    const first = new FakeUpgradedSocket({ autoPong: true });
+    const dead = new FakeUpgradedSocket();
+    const last = new FakeUpgradedSocket({ autoPong: true });
+    const firstSession = bindPanelLinkSocket(router, first);
+    const deadSession = bindPanelLinkSocket(router, dead);
+    const lastSession = bindPanelLinkSocket(router, last);
+    for (const ws of [first, dead, last]) ws.receive(subscribe("core_a"));
+
+    vi.advanceTimersByTime(61_000);
+
+    expect(dead.terminated).toBe(1);
+    expect(deadSession.watches("core_a")).toBe(false);
+    expect(first.terminated).toBe(0);
+    expect(firstSession.watches("core_a")).toBe(true);
+    expect(last.terminated).toBe(0);
+    expect(lastSession.watches("core_a")).toBe(true);
+  });
+
+  it("stops sweeping the moment its own socket closes", () => {
+    const ws = new FakeUpgradedSocket({ autoPong: true });
+    bindPanelLinkSocket(router, ws);
+    vi.advanceTimersByTime(31_000);
+    const pingsWhenClosed = ws.pings;
+    expect(pingsWhenClosed).toBeGreaterThan(0);
+
+    ws.fire("close");
+    vi.advanceTimersByTime(60 * 60_000);
+
+    expect(ws.pings).toBe(pingsWhenClosed);
+  });
+
+  it("carries a socket that cannot ping rather than throwing at it", () => {
+    const ws = new FakeUpgradedSocket({ ping: false });
+    const session = bindPanelLinkSocket(router, ws);
+    ws.receive(subscribe("core_a"));
+
+    vi.advanceTimersByTime(4 * 60 * 60_000);
+
+    expect(ws.terminated).toBe(0);
+    expect(session.watches("core_a")).toBe(true);
   });
 });

--- a/packages/panel/src/server/panel-link/ws-server.ts
+++ b/packages/panel/src/server/panel-link/ws-server.ts
@@ -1,9 +1,9 @@
-import { WebSocketServer, type WebSocket } from "ws";
+import { WebSocketServer } from "ws";
 import type { IncomingMessage, Server } from "node:http";
 import type { Duplex } from "node:stream";
 import { requireOperatorSession } from "../panel-auth";
 import { coreLinkManager } from "../services/core-link-manager";
-import { PanelLinkRouter } from "./router";
+import { PanelLinkRouter, type PanelLinkSession } from "./router";
 import {
   PANEL_LINK_PATH,
   PANEL_LINK_PROTOCOL_VERSION,
@@ -40,7 +40,9 @@ export function attachPanelLink(server: Server): PanelLinkRouter {
       socket.destroy();
       return;
     }
-    wss.handleUpgrade(request, socket as Duplex, head, (ws) => bind(router, ws));
+    wss.handleUpgrade(request, socket as Duplex, head, (ws) => {
+      bindPanelLinkSocket(router, ws);
+    });
   });
 
   attached = { server, router };
@@ -110,7 +112,51 @@ function httpRefusal(status: number, message: string): string {
   );
 }
 
-function bind(router: PanelLinkRouter, ws: WebSocket): void {
+/**
+ * The sweep's clock, matching the core link's
+ * (`packages/core/src/pty-core-link-server.ts`). 15s is well inside the idle
+ * timeouts a reverse proxy (`DEPLOY.md`) or Docker's NAT keeps, so the ping
+ * doubles as what stops an idle flow being collected in the first place; 45s
+ * gives a connection three of them to answer before it is called dead.
+ */
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const HEARTBEAT_TIMEOUT_MS = 45_000;
+
+/**
+ * What the sweep needs from an upgraded socket. `ping` and `terminate` are
+ * optional because a socket injected by a test has neither, and a sweep that
+ * assumed them would throw on the one path nobody watches.
+ */
+export interface PanelLinkServerSocket {
+  readonly readyState: number;
+  readonly OPEN: number;
+  send(data: string): void;
+  close(): void;
+  ping?(): void;
+  terminate?(): void;
+  on(event: "message", cb: (raw: unknown) => void): unknown;
+  on(event: "pong" | "close" | "error", cb: () => void): unknown;
+}
+
+/**
+ * Take over one upgraded socket: route its frames, and run the per-connection
+ * liveness sweep that gives the panel link the contract the core link already
+ * has.
+ *
+ * The sweep is what makes the browser's existing recovery reachable. A
+ * WebSocket that dies without a TCP FIN leaves both ends believing they are
+ * connected — `readyState` stays `OPEN` and no `close` event ever fires — and
+ * `close` is the only thing that starts a reconnect. Reaping the corpse here
+ * fires that `close`, and the reconnect → re-subscribe → reattach path that was
+ * already written finally runs.
+ *
+ * Exported for the sweep's own tests, which drive it with an injected socket
+ * and a clock they can move. `attachPanelLink` is the only production caller.
+ */
+export function bindPanelLinkSocket(
+  router: PanelLinkRouter,
+  ws: PanelLinkServerSocket,
+): PanelLinkSession {
   const session = router.attach({
     send: (frame) => {
       if (ws.readyState !== ws.OPEN) return;
@@ -123,9 +169,66 @@ function bind(router: PanelLinkRouter, ws: WebSocket): void {
     },
     close: () => ws.close(),
   });
-  ws.on("message", (raw) => void session.receiveRaw(toText(raw)));
-  ws.on("close", () => session.detach());
-  ws.on("error", () => session.detach());
+
+  /**
+   * Advanced by anything arriving from this tab — an RPC, or the pong that
+   * answers our ping. The pong is what keeps a quiet-but-healthy tab alive: a
+   * browser cannot send a WebSocket ping of its own, and an idle Panel sends no
+   * application frames for as long as its operator leaves it alone.
+   */
+  let lastInboundAt = Date.now();
+
+  let sweep: ReturnType<typeof setInterval> | null = null;
+  function stopSweep(): void {
+    if (sweep) clearInterval(sweep);
+    sweep = null;
+  }
+
+  // One sweep per connection, and its lifetime is owned by *this* socket's
+  // close handler and nothing else. Deliberately without the core link's
+  // "am I still the current connection?" guard: the Core holds exactly one
+  // connection, so that check is right there and fatal here — the Panel holds
+  // one connection per tab, and the same line would reap every tab but the
+  // newest.
+  if (ws.ping) {
+    sweep = setInterval(() => {
+      if (Date.now() - lastInboundAt > HEARTBEAT_TIMEOUT_MS) {
+        stopSweep();
+        // `terminate`, not `close`: a graceful close on a half-open socket
+        // waits on a peer that is never going to answer, and the session would
+        // hold its watch set for as long as that took.
+        try {
+          ws.terminate ? ws.terminate() : ws.close();
+        } catch {
+          // Already gone — the close handler still detaches.
+        }
+        return;
+      }
+      try {
+        ws.ping?.();
+      } catch {
+        // The close handler will take it from here.
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  ws.on("pong", () => {
+    lastInboundAt = Date.now();
+  });
+  ws.on("message", (raw) => {
+    lastInboundAt = Date.now();
+    void session.receiveRaw(toText(raw));
+  });
+  ws.on("close", () => {
+    stopSweep();
+    session.detach();
+  });
+  ws.on("error", () => {
+    stopSweep();
+    session.detach();
+  });
+
+  return session;
 }
 
 function toText(raw: unknown): string {


### PR DESCRIPTION
Base is `fix/panel-overnight-detach`, not `main`. Train: `beta/0.2.0`.

Implements #172 — the panel link gets the liveness contract the core link already has. No new
recovery machinery: everything downstream of a reconnect (re-subscribe from the cursor, pty
reattach with a replay window, refetch on the way back) already worked and was merely unreachable.
This builds the two things that *start* it.

## What changed

**1. Server sweep — `packages/panel/src/server/panel-link/ws-server.ts`.** A per-connection 15s
ping / 45s terminate sweep. `lastInboundAt` advances on `message` and on `pong`; the interval is
cleared by *this* socket's `close` handler; the reap calls `terminate()`, because a graceful close
on a half-open socket waits for a peer that is never going to answer. The ping doubles as what
keeps the idle flow warm through the reverse proxy `DEPLOY.md` requires and through Docker's NAT.

Deliberately **without** the core link's `activeWs` guard: the Core holds exactly one connection,
the Panel holds one per tab, and the same line here would reap every tab but the newest. `ws.ping`
is guarded before use.

`bind()` became the exported `bindPanelLinkSocket()` so the sweep can be driven by a test with an
injected socket and a clock it can move; `attachPanelLink` is still the only production caller.

**2. Wake hook and last-inbound tracking — `packages/panel/src/lib/panel-link-client.ts`.** The
client tracks when a frame last arrived and, on `visibilitychange → visible`, `focus` and `online`,
drops a socket that is not `OPEN` — or is `OPEN` and has heard nothing inside the staleness window
— and dials again at once with `reconnectAttempt` reset. Listeners are removed by `close()`
alongside the reconnect timer.

The wake signals are the backbone, not a timer: a hidden tab's timers are throttled to roughly once
a minute and a frozen page's do not run at all. The staleness window is **15 minutes**, deliberately
not the server's 45s — the server's pings are answered below the `WebSocket` API and surface no
event to page JavaScript, so this end's clock advances only on *application* frames, and an idle
Core legitimately sends none for hours. One false-positive redial is cheap and safe (the reconnect
path is idempotent and replays by cursor); one on every focus of a quiet tab would not be.

**3. Tests for the case that has no event in it.** A socket that goes silent without firing
`close`, `readyState` left at `OPEN` — on both sides. 14 new cases (8 client, 6 server); both
existing suites pass unchanged.

One deliberate behaviour change beyond the two above: the client's `message` listener now ignores
frames from a socket it has already given up on. Those frames are not the current link's, and above
all they are not evidence that the current link is alive.

## Out of scope, untouched

The "reconnecting…" affordance, 401-on-upgrade handling, cursor persistence, the 2048-event buffer,
and everything from #140 (no registry, no fan-out change, no lock, no capability negotiation).
`PANEL_LINK_PROTOCOL_VERSION` does not move, and the diff stays inside the panel-link layer —
`ws-server.ts`, `panel-link-client.ts` and their tests — clear of #144's `packages/core` and
core-link client work.

## Why this does not close #139

#139 stays open. The overnight symptom is proven fixed only by an overnight run: leave a tab open
and record the morning after whether it comes back on its own, and whether the discriminator the
diagnosis names (a Core painted unreachable ⇒ core link, not this) ever appears.

Refs #172
Refs #139
