### PR TITLE
chore(spike): Node 22 speaks mTLS both ways — D12 holds (#151)

### DIFF
--- a/experiment/findings-151-node22-mtls.md
+++ b/experiment/findings-151-node22-mtls.md
@@ -11,8 +11,15 @@ Companion script: [`spike-151-node22-mtls.mjs`](spike-151-node22-mtls.mjs).
 
 Both connections succeed on Node 22 with the CA, client certificate and client
 key read from a registration blob, against a live Core. Node 24 was run as the
-control and produced byte-identical results. Nothing fails on 22 that passes on
-24, so there is no decision to escalate and extraction is not blocked.
+control: **the same six legs passed on both**, with the same frames, the same
+certificate subjects, the same TLS version and the same error codes. Nothing
+fails on 22 that passes on 24, so there is no decision to escalate and
+extraction is not blocked.
+
+The two runs are not byte-identical and cannot be — the script stamps
+`process.version` into its banner and summary, and leg 2c binds a fresh
+ephemeral port each run. Those three lines are the only differences; the
+transcripts are below in full so the claim is checkable rather than trusted.
 
 | Leg | Node 22.23.2 | Node 24.19.0 |
 | --- | --- | --- |
@@ -22,6 +29,61 @@ control and produced byte-identical results. Nothing fails on 22 that passes on
 | 2b — `fetch` without a client cert is refused | PASS | PASS |
 | 2c — `fetch` gets an HTTP response over mTLS | PASS | PASS |
 | 3 — wrong host fails SAN validation | PASS | PASS |
+
+## Transcripts, verbatim
+
+Both produced by `spike-151-node22-mtls.mjs` as committed on this branch, run
+back to back against the same live Core (`coreId=core_17504d4b830baffc`,
+protocol `0.15.0`), from the same registration blob. Exit status 0 in both.
+
+### Node 22.23.2
+
+```
+node v22.23.2  •  endpoint wss://127.0.0.1:9444  •  blob /home/core/.config/actana/registration-blob.txt
+
+PASS  1  ws → ready
+        ready frame: version=0.15.0 multiConnection=null
+PASS  1b  ws → authOk
+        coreId=core_17504d4b830baffc exp=1817638207292
+PASS  2a  fetch → mutual TLS
+        authorized=true authorizationError=null TLSv1.3
+        server=[CN=127.0.0.1] client=[CN=mission-control-panel]
+        HTTP layer: no response — Core serves no HTTP route on this port (see 2c)
+PASS  2b  fetch without client cert is refused
+        UND_ERR_SOCKET: other side closed
+PASS  2c  fetch → HTTP response over mTLS
+        HTTP 200 {"ok":true,"clientCn":"mission-control-panel","path":"/spike"} (loopback listener on the Core's own server cert, port 40021)
+PASS  3  wrong host fails SAN validation
+        dialled https://172.17.0.2:9444 → ERR_TLS_CERT_ALTNAME_INVALID
+
+6/6 legs passed on v22.23.2
+```
+
+### Node 24.19.0 (control)
+
+```
+node v24.19.0  •  endpoint wss://127.0.0.1:9444  •  blob /home/core/.config/actana/registration-blob.txt
+
+PASS  1  ws → ready
+        ready frame: version=0.15.0 multiConnection=null
+PASS  1b  ws → authOk
+        coreId=core_17504d4b830baffc exp=1817638207292
+PASS  2a  fetch → mutual TLS
+        authorized=true authorizationError=null TLSv1.3
+        server=[CN=127.0.0.1] client=[CN=mission-control-panel]
+        HTTP layer: no response — Core serves no HTTP route on this port (see 2c)
+PASS  2b  fetch without client cert is refused
+        UND_ERR_SOCKET: other side closed
+PASS  2c  fetch → HTTP response over mTLS
+        HTTP 200 {"ok":true,"clientCn":"mission-control-panel","path":"/spike"} (loopback listener on the Core's own server cert, port 43529)
+PASS  3  wrong host fails SAN validation
+        dialled https://172.17.0.2:9444 → ERR_TLS_CERT_ALTNAME_INVALID
+
+6/6 legs passed on v24.19.0
+```
+
+Line-for-line the two differ only in the banner's version, the summary's
+version, and leg 2c's ephemeral port (`40021` vs `43529`).
 
 ## The trap, confirmed
 
@@ -41,6 +103,14 @@ built as `new Agent({ connect: { ca } })` — CA only, no client cert — is ref
 by the Core at the TLS layer (`UND_ERR_SOCKET: other side closed`), because the
 Core sets `requestCert: true, rejectUnauthorized: true`. Without that control, a
 passing leg 2a would be indistinguishable from a server that never asked.
+
+The leg asserts on the *shape* of the refusal — `UND_ERR_SOCKET`/`ECONNRESET`/
+`EPIPE`, or an `ERR_SSL_*` alert — not merely on "it failed and wasn't slow".
+A control that passes on any error is not a control: `ECONNREFUSED` from a Core
+that is not running would otherwise read as PASS and make leg 2a look meaningful
+against nothing at all. Confirmed by pointing the blob at a dead port, where the
+leg now reports
+`ECONNREFUSED ... — not a TLS-layer refusal (is the Core up on this port?)`.
 
 ## Correction to the `experiment/action.md` §5 trap
 
@@ -116,4 +186,6 @@ SPIKE_MODULES=/tmp/spike-rig/node_modules node experiment/spike-151-node22-mtls.
 Needs a live Core and its registration blob (default
 `~/.config/actana/registration-blob.txt`). Leg 2c additionally reads
 `~/.config/actana/material.json` for the Core's server certificate. Exit status
-is 0 only when every leg passes.
+is 0 only when every leg passes — including the case where the `ws` socket dies
+or stalls between `ready` and `authOk`, which records leg 1b as a failure rather
+than dropping it from the tally.

--- a/experiment/findings-151-node22-mtls.md
+++ b/experiment/findings-151-node22-mtls.md
@@ -1,0 +1,119 @@
+# Spike #151 — Node 22 mTLS and `fetch` findings
+
+Throwaway. Nothing in `packages/` imports any of this, and no dependency was
+added to the workspace. Delete `experiment/` once D12 is settled.
+
+Companion script: [`spike-151-node22-mtls.mjs`](spike-151-node22-mtls.mjs).
+
+## Verdict on D12
+
+**D12 stands. `engines: ">=22"` is correct — keep it.**
+
+Both connections succeed on Node 22 with the CA, client certificate and client
+key read from a registration blob, against a live Core. Node 24 was run as the
+control and produced byte-identical results. Nothing fails on 22 that passes on
+24, so there is no decision to escalate and extraction is not blocked.
+
+| Leg | Node 22.23.2 | Node 24.19.0 |
+| --- | --- | --- |
+| 1 — `ws` reaches `ready` | PASS | PASS |
+| 1b — bearer `auth` → `authOk` | PASS | PASS |
+| 2a — `fetch` completes mutual TLS | PASS | PASS |
+| 2b — `fetch` without a client cert is refused | PASS | PASS |
+| 2c — `fetch` gets an HTTP response over mTLS | PASS | PASS |
+| 3 — wrong host fails SAN validation | PASS | PASS |
+
+## The trap, confirmed
+
+`fetch` is undici. It ignores `options.cert` / `options.key` — there is no
+option bag on `fetch` that reaches TLS at all. The only seam is the `dispatcher`
+option, and the certificate goes into the dispatcher's `connect` block:
+
+```js
+import { Agent } from "undici";
+
+const agent = new Agent({ connect: { ca, cert, key } });
+await fetch(url, { dispatcher: agent });
+```
+
+Leg 2b is what makes leg 2a mean anything. The same `fetch` through an `Agent`
+built as `new Agent({ connect: { ca } })` — CA only, no client cert — is refused
+by the Core at the TLS layer (`UND_ERR_SOCKET: other side closed`), because the
+Core sets `requestCert: true, rejectUnauthorized: true`. Without that control, a
+passing leg 2a would be indistinguishable from a server that never asked.
+
+## Correction to the `experiment/action.md` §5 trap
+
+Two notes, because the ticket's summary of §5 is half right and the wrong half
+costs debugging time.
+
+1. **`experiment/action.md` does not exist** anywhere in this repo or its
+   history. §5 could not be read; the claim was tested directly instead.
+2. **X.509 binds hosts, not ports.** The Core's server certificate carries
+   `CN=127.0.0.1` with SAN `IP Address:127.0.0.1, DNS:localhost`. There is no
+   port anywhere in a certificate, and no TLS stack checks one.
+   - Dialling the **same Core on a different port** validates fine. Leg 2c
+     proves it: that listener presents the Core's own server certificate on an
+     ephemeral port and `fetch` accepts it.
+   - Dialling the **same Core on a different host** fails, and this is the real
+     trap: `https://172.17.0.2:9444` (the container's own address, same socket)
+     fails with `ERR_TLS_CERT_ALTNAME_INVALID`.
+
+   So "a rewritten port mapping fails validation" is true in practice only
+   because rewriting the mapping usually changes the **host** the Panel dials.
+   Fix the host, not the port. Neither has anything to do with the Node version.
+
+## The Core serves no HTTP route on its mTLS port
+
+Worth recording because it shaped how leg 2 had to be built, and it is a fact
+about the Core rather than about Node.
+
+`pty-core-link-server.ts` builds the mTLS listener as `https.createServer(opts)`
+with **no request listener** and attaches a `WebSocketServer` to it. That port
+answers WebSocket upgrades and nothing else. A plain `GET https://127.0.0.1:9444/`
+— from `fetch`, from `curl`, from anything — hangs until the client gives up.
+`docs/external-api.md` says the same thing from the other direction: the Core's
+only HTTP surface is the loopback hook receiver, which is plain HTTP on an
+ephemeral port and not TLS at all.
+
+That is why leg 2 splits in two:
+
+- **2a** dials the live Core and asserts on the `TLSSocket` itself
+  (`authorized === true`, peer `CN=127.0.0.1`, own cert `CN=mission-control-panel`,
+  TLSv1.3) rather than on a status code. The handshake is the thing under test;
+  the subsequent HTTP timeout is the Core having no route, not a TLS failure.
+- **2c** gets an actual `HTTP 200` through the same `Agent` by standing up a
+  throwaway loopback listener using the **Core's own** server certificate, CA and
+  `requestCert: true, rejectUnauthorized: true` gate. Same credentials, same
+  trust chain, plus a route to answer on.
+
+If a later ticket needs `fetch` against a real Core HTTP route, that route does
+not exist yet and someone has to add it. The transport shape is proven; the
+surface is not there.
+
+## Two smaller things that will bite
+
+- **`ws` takes the classic options directly.** `new WebSocket(url, {ca, cert, key})`
+  works because `ws` hands the bag to `https.request`. This is exactly the
+  asymmetry the ticket flagged: the same credentials go in two different ways
+  depending on which client you are holding.
+- **Do not set `servername` when the blob's endpoint is an IP.** RFC 6066
+  forbids an IP literal in SNI. Node 22 warns (`DEP0123`) and says it will start
+  ignoring it. Node matches the SAN `IP Address` entry against the dialled
+  address without SNI, so just omit it — set `servername` only for a DNS host.
+
+## Reproducing
+
+`ws` and `undici` are deliberately **not** in the workspace. Install them into a
+scratch directory outside the repo and point `SPIKE_MODULES` at it:
+
+```sh
+mkdir -p /tmp/spike-rig && cd /tmp/spike-rig && npm init -y && npm i undici@7 ws@8
+cd /path/to/worktree
+SPIKE_MODULES=/tmp/spike-rig/node_modules node experiment/spike-151-node22-mtls.mjs
+```
+
+Needs a live Core and its registration blob (default
+`~/.config/actana/registration-blob.txt`). Leg 2c additionally reads
+`~/.config/actana/material.json` for the Core's server certificate. Exit status
+is 0 only when every leg passes.

--- a/experiment/spike-151-node22-mtls.mjs
+++ b/experiment/spike-151-node22-mtls.mjs
@@ -43,7 +43,8 @@ if (!MODULES) {
 const load = (name) => import(pathToFileURL(path.join(MODULES, name)).href);
 const wsMod = await load("ws/index.js");
 const WebSocket = wsMod.default ?? wsMod.WebSocket;
-const undici = (await load("undici/index.js")).default ?? (await load("undici/index.js"));
+const undiciMod = await load("undici/index.js");
+const undici = undiciMod.default ?? undiciMod;
 const { Agent, buildConnector } = undici;
 
 const BLOB_PATH =
@@ -92,13 +93,23 @@ async function legWsReady() {
       key: clientKey,
       ...(isIpLiteral(HOST) ? {} : { servername: HOST }),
     });
+    let sawReady = false;
+    let sawAuth = false;
+    // Whichever leg the socket died on is the one that has to land in
+    // `results`. Recording leg 1 unconditionally would both contradict an
+    // already-passed leg 1 and let a stall between `ready` and `authOk` drop
+    // leg 1b entirely — and a dropped leg is an empty `failed`, i.e. exit 0.
+    const recordUnfinished = (detail) => {
+      if (!sawReady) record("1", "ws → ready", false, detail);
+      else if (!sawAuth) record("1b", "ws → authOk", false, `after \`ready\`: ${detail}`);
+    };
+
     const timer = setTimeout(() => {
       socket.terminate();
-      record("1", "ws → ready", false, "timed out after 10000ms without a `ready` frame");
+      recordUnfinished("timed out after 10000ms");
       resolve();
     }, 10_000);
 
-    let sawReady = false;
     socket.on("message", (raw) => {
       const frame = JSON.parse(String(raw));
       if (frame.type === "ready") {
@@ -115,6 +126,7 @@ async function legWsReady() {
         return;
       }
       if (frame.type === "authOk") {
+        sawAuth = true;
         record("1b", "ws → authOk", true, `coreId=${frame.coreId} exp=${frame.exp}`);
         clearTimeout(timer);
         socket.close();
@@ -122,6 +134,7 @@ async function legWsReady() {
         return;
       }
       if (frame.type === "authError") {
+        sawAuth = true;
         record("1b", "ws → authOk", false, `authError reason=${frame.reason}`);
         clearTimeout(timer);
         socket.close();
@@ -131,7 +144,7 @@ async function legWsReady() {
 
     socket.on("error", (err) => {
       clearTimeout(timer);
-      if (!sawReady) record("1", "ws → ready", false, `${err.code ?? err.name}: ${err.message}`);
+      recordUnfinished(`${err.code ?? err.name}: ${err.message}`);
       resolve();
     });
   });
@@ -216,11 +229,24 @@ async function legFetchNoCert() {
     });
     record("2b", "fetch without client cert is refused", false, `unexpectedly got HTTP ${res.status}`);
   } catch (err) {
-    const code = err.cause?.code ?? err.name;
-    // A TLS-layer refusal is the pass. A timeout would mean the Core let a
-    // certless client through to the HTTP layer.
-    const ok = !t.timedOut();
-    record("2b", "fetch without client cert is refused", ok, `${code}: ${err.cause?.message ?? err.message}`);
+    const code = String(err.cause?.code ?? err.name);
+    // A TLS-layer refusal is the pass, and it has to be asserted on its shape.
+    // `!t.timedOut()` alone passes on *any* non-slow failure: ECONNREFUSED
+    // against a Core that is not running, or a wrong port, would read as a
+    // clean negative control and make leg 2a look meaningful when nothing was
+    // listening. The Core tears the connection down after asking for a client
+    // cert it did not get (undici surfaces that as UND_ERR_SOCKET/ECONNRESET),
+    // or OpenSSL raises an explicit alert. Anything else is a broken rig.
+    const REFUSALS = new Set(["UND_ERR_SOCKET", "ECONNRESET", "EPIPE"]);
+    const isTlsRefusal = REFUSALS.has(code) || code.startsWith("ERR_SSL_");
+    const ok = !t.timedOut() && isTlsRefusal;
+    record(
+      "2b",
+      "fetch without client cert is refused",
+      ok,
+      `${code}: ${err.cause?.message ?? err.message}` +
+        (ok ? "" : " — not a TLS-layer refusal (is the Core up on this port?)"),
+    );
   } finally {
     t.done();
     await agent.close().catch(() => {});

--- a/experiment/spike-151-node22-mtls.mjs
+++ b/experiment/spike-151-node22-mtls.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+// Throwaway spike script for issue #151 — "Node-22 mTLS and fetch spike".
+//
+// NOT a published entry point. Nothing imports this, no package.json field
+// points at it, and it adds no dependency to the workspace: `ws` and `undici`
+// are resolved from a scratch rig outside the repo via SPIKE_MODULES (see
+// below). Delete it once D12 is settled.
+//
+// It answers one question against a LIVE Core: can Node 22 speak mTLS in both
+// directions with credentials read from a registration blob?
+//
+//   1. `ws` WebSocket to the core-link endpoint that reaches `ready`.
+//   2. `fetch` (undici) that carries a client certificate and gets a response.
+//
+// Leg 2 is the whole reason the spike exists. `fetch` is undici, not
+// `https.request`: it ignores `options.cert` / `options.key`, and a client
+// certificate only reaches the socket through a custom Dispatcher.
+//
+// Usage:
+//   SPIKE_MODULES=/path/to/rig/node_modules node experiment/spike-151-node22-mtls.mjs
+//
+// Env:
+//   SPIKE_MODULES  dir holding `ws` and `undici` (required — kept out of the repo)
+//   SPIKE_BLOB     registration blob path (default ~/.config/actana/registration-blob.txt)
+//   SPIKE_MATERIAL Core cert material path (default ~/.config/actana/material.json)
+//                  used only by leg 2c, which needs the Core's own server cert
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+import { pathToFileURL } from "node:url";
+
+const MODULES = process.env.SPIKE_MODULES;
+if (!MODULES) {
+  console.error("SPIKE_MODULES is required — point it at a node_modules dir holding ws + undici.");
+  process.exit(2);
+}
+// Both packages are CommonJS; `ws` sets `module.exports = WebSocket`, which
+// the ESM interop surfaces as `default`, not as a named export.
+const load = (name) => import(pathToFileURL(path.join(MODULES, name)).href);
+const wsMod = await load("ws/index.js");
+const WebSocket = wsMod.default ?? wsMod.WebSocket;
+const undici = (await load("undici/index.js")).default ?? (await load("undici/index.js"));
+const { Agent, buildConnector } = undici;
+
+const BLOB_PATH =
+  process.env.SPIKE_BLOB ?? path.join(os.homedir(), ".config/actana/registration-blob.txt");
+const MATERIAL_PATH =
+  process.env.SPIKE_MATERIAL ?? path.join(os.homedir(), ".config/actana/material.json");
+
+// ─── The registration blob is the only credential source ────────────────────
+// base64(JSON({endpoint, label, caCert, clientCert, clientKey, bearer})).
+const blob = JSON.parse(
+  Buffer.from(fs.readFileSync(BLOB_PATH, "utf8").trim(), "base64").toString("utf8"),
+);
+const { endpoint, caCert, clientCert, clientKey, bearer } = blob;
+const url = new URL(endpoint); // wss://<host>:<port>
+const HOST = url.hostname;
+const PORT = Number(url.port);
+
+const isIpLiteral = (h) => net.isIP(h) !== 0;
+
+const results = [];
+const record = (id, name, ok, detail) => {
+  results.push({ id, name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  ${id}  ${name}\n        ${detail}`);
+};
+
+const withTimeout = (ms) => {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  return { signal: ac.signal, done: () => clearTimeout(timer), timedOut: () => ac.signal.aborted };
+};
+
+// ─── Leg 1 — `ws` over mTLS, must reach `ready` ─────────────────────────────
+// The cert/key/ca go straight into the `ws` options object: `ws` hands them to
+// `https.request`, which is the classic Node TLS surface and takes them as-is.
+// This is the leg that was never in doubt; it is here as the control.
+async function legWsReady() {
+  return new Promise((resolve) => {
+    // No `servername`: the blob's host here is an IP literal, and RFC 6066
+    // forbids an IP in SNI (Node warns, and will drop it outright later). The
+    // Core's cert carries `IP Address:127.0.0.1` in its SAN, which Node matches
+    // against the dialled address without SNI. Set `servername` only when the
+    // blob's endpoint is a DNS name.
+    const socket = new WebSocket(endpoint, {
+      ca: caCert,
+      cert: clientCert,
+      key: clientKey,
+      ...(isIpLiteral(HOST) ? {} : { servername: HOST }),
+    });
+    const timer = setTimeout(() => {
+      socket.terminate();
+      record("1", "ws → ready", false, "timed out after 10000ms without a `ready` frame");
+      resolve();
+    }, 10_000);
+
+    let sawReady = false;
+    socket.on("message", (raw) => {
+      const frame = JSON.parse(String(raw));
+      if (frame.type === "ready") {
+        sawReady = true;
+        record(
+          "1",
+          "ws → ready",
+          true,
+          `ready frame: version=${frame.version} multiConnection=${JSON.stringify(frame.multiConnection ?? null)}`,
+        );
+        // Bearer auth rides the same socket — proving it lands means the whole
+        // core-link handshake (mTLS + bearer), not just the TLS half, works.
+        socket.send(JSON.stringify({ type: "auth", reqId: "spike-1", bearer }));
+        return;
+      }
+      if (frame.type === "authOk") {
+        record("1b", "ws → authOk", true, `coreId=${frame.coreId} exp=${frame.exp}`);
+        clearTimeout(timer);
+        socket.close();
+        resolve();
+        return;
+      }
+      if (frame.type === "authError") {
+        record("1b", "ws → authOk", false, `authError reason=${frame.reason}`);
+        clearTimeout(timer);
+        socket.close();
+        resolve();
+      }
+    });
+
+    socket.on("error", (err) => {
+      clearTimeout(timer);
+      if (!sawReady) record("1", "ws → ready", false, `${err.code ?? err.name}: ${err.message}`);
+      resolve();
+    });
+  });
+}
+
+// ─── Leg 2a — fetch carries a client cert through an undici Agent ───────────
+// The point of the spike. `fetch(url, {dispatcher})` is the only seam: there is
+// no `options.cert`. The connector below wraps undici's real one purely to read
+// the finished TLSSocket back out, so "the handshake was mutual and verified"
+// is an assertion about the actual socket rather than an inference from a
+// status code.
+async function legFetchHandshake() {
+  let observed = null;
+  const base = buildConnector({ ca: caCert, cert: clientCert, key: clientKey });
+  const connector = (opts, cb) =>
+    base(opts, (err, socket) => {
+      // First connect only. undici caches TLS sessions, and a resumed session
+      // reports no peer certificate — a later observation would blank the
+      // evidence without meaning the handshake got weaker.
+      if (socket instanceof tls.TLSSocket && !observed) {
+        observed = {
+          authorized: socket.authorized,
+          authorizationError: socket.authorizationError?.message ?? null,
+          peer: socket.getPeerX509Certificate()?.subject ?? null,
+          protocol: socket.getProtocol(),
+          sessionReused: socket.isSessionReused(),
+          // The Core sets `requestCert: true, rejectUnauthorized: true`. A
+          // socket that is still open here is one whose client cert the Core
+          // accepted — it tears down the connection otherwise.
+          sentClientCert: Boolean(socket.getX509Certificate()),
+          clientCn: socket.getX509Certificate()?.subject ?? null,
+        };
+      }
+      cb(err, socket);
+    });
+
+  const agent = new Agent({ connect: connector });
+  const t = withTimeout(6000);
+  let httpOutcome;
+  try {
+    const res = await fetch(endpoint.replace(/^wss:/, "https:") + "/", {
+      dispatcher: agent,
+      signal: t.signal,
+    });
+    httpOutcome = `HTTP ${res.status}`;
+  } catch (err) {
+    // The Core's mTLS port has no HTTP request listener (WS upgrade only), so
+    // the expected outcome here is a timeout AFTER a completed handshake.
+    httpOutcome = t.timedOut()
+      ? "no response — Core serves no HTTP route on this port (see 2c)"
+      : `${err.cause?.code ?? err.name}`;
+  } finally {
+    t.done();
+    await agent.close().catch(() => {});
+  }
+
+  if (!observed) {
+    record("2a", "fetch → mutual TLS", false, "connector never produced a TLSSocket");
+    return;
+  }
+  const ok = observed.authorized === true && observed.sentClientCert === true;
+  record(
+    "2a",
+    "fetch → mutual TLS",
+    ok,
+    `authorized=${observed.authorized} authorizationError=${observed.authorizationError} ${observed.protocol}\n` +
+      `        server=[${observed.peer}] client=[${observed.clientCn}]\n` +
+      `        HTTP layer: ${httpOutcome}`,
+  );
+}
+
+// ─── Leg 2b — negative control: same fetch, no client cert ──────────────────
+// Without this, leg 2a proves nothing: a server that never asked for a client
+// cert would look identical. The Core must reject this one at the TLS layer.
+async function legFetchNoCert() {
+  const agent = new Agent({ connect: { ca: caCert } });
+  const t = withTimeout(6000);
+  try {
+    const res = await fetch(endpoint.replace(/^wss:/, "https:") + "/", {
+      dispatcher: agent,
+      signal: t.signal,
+    });
+    record("2b", "fetch without client cert is refused", false, `unexpectedly got HTTP ${res.status}`);
+  } catch (err) {
+    const code = err.cause?.code ?? err.name;
+    // A TLS-layer refusal is the pass. A timeout would mean the Core let a
+    // certless client through to the HTTP layer.
+    const ok = !t.timedOut();
+    record("2b", "fetch without client cert is refused", ok, `${code}: ${err.cause?.message ?? err.message}`);
+  } finally {
+    t.done();
+    await agent.close().catch(() => {});
+  }
+}
+
+// ─── Leg 2c — fetch gets a real HTTP response over mTLS ─────────────────────
+// The live Core's mTLS port is WebSocket-upgrade only: `https.createServer` is
+// constructed with no request listener, so a plain GET hangs forever (leg 2a's
+// "no HTTP response"). To show that the undici Agent completes a full
+// request/response cycle — not just a handshake — this stands up a throwaway
+// listener on loopback using the Core's OWN server certificate and CA, with the
+// same `requestCert: true, rejectUnauthorized: true` gate. Same credentials,
+// same trust chain, an HTTP route to answer on.
+async function legFetchResponse() {
+  let material;
+  try {
+    material = JSON.parse(fs.readFileSync(MATERIAL_PATH, "utf8"));
+  } catch (err) {
+    record("2c", "fetch → HTTP response over mTLS", false, `cannot read ${MATERIAL_PATH}: ${err.message}`);
+    return;
+  }
+
+  const server = https.createServer(
+    {
+      cert: material.serverCert,
+      key: material.serverKey,
+      ca: material.caCert,
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
+    (req, res) => {
+      const cn = req.socket.getPeerCertificate()?.subject?.CN ?? "none";
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, clientCn: cn, path: req.url }));
+    },
+  );
+  await new Promise((r) => server.listen(0, HOST, r));
+  const port = server.address().port;
+
+  const agent = new Agent({ connect: { ca: caCert, cert: clientCert, key: clientKey } });
+  const t = withTimeout(6000);
+  try {
+    const res = await fetch(`https://${HOST}:${port}/spike`, { dispatcher: agent, signal: t.signal });
+    const body = await res.json();
+    record(
+      "2c",
+      "fetch → HTTP response over mTLS",
+      res.status === 200 && body.clientCn === "mission-control-panel",
+      `HTTP ${res.status} ${JSON.stringify(body)} (loopback listener on the Core's own server cert, port ${port})`,
+    );
+  } catch (err) {
+    record("2c", "fetch → HTTP response over mTLS", false, `${err.cause?.code ?? err.name}: ${err.message}`);
+  } finally {
+    t.done();
+    await agent.close().catch(() => {});
+    server.close();
+  }
+}
+
+// ─── Leg 3 — the §5 trap, measured rather than assumed ──────────────────────
+// The runbook says the Core's cert is issued for "the exact host and port" in
+// the blob. Half of that is true and the half matters: X.509 binds hostnames
+// and IPs, never ports. Dialling the same Core on a rewritten HOST fails
+// validation; a rewritten PORT does not (leg 2c already proves that — it
+// validates the Core's server cert on an ephemeral port). This leg pins down
+// which half bites, so nobody debugs a port mapping looking for a Node bug.
+async function legWrongHost() {
+  const addrs = Object.values(os.networkInterfaces())
+    .flat()
+    .filter((n) => n && n.family === "IPv4" && !n.internal)
+    .map((n) => n.address);
+  if (addrs.length === 0) {
+    record("3", "wrong host fails SAN validation", false, "no non-loopback IPv4 address to dial");
+    return;
+  }
+  const alt = addrs[0];
+  const agent = new Agent({ connect: { ca: caCert, cert: clientCert, key: clientKey } });
+  const t = withTimeout(6000);
+  try {
+    const res = await fetch(`https://${alt}:${PORT}/`, { dispatcher: agent, signal: t.signal });
+    record("3", "wrong host fails SAN validation", false, `unexpectedly got HTTP ${res.status} from ${alt}`);
+  } catch (err) {
+    const code = err.cause?.code ?? err.name;
+    record(
+      "3",
+      "wrong host fails SAN validation",
+      code === "ERR_TLS_CERT_ALTNAME_INVALID",
+      `dialled https://${alt}:${PORT} → ${code}`,
+    );
+  } finally {
+    t.done();
+    await agent.close().catch(() => {});
+  }
+}
+
+console.log(`node ${process.version}  •  endpoint ${endpoint}  •  blob ${BLOB_PATH}\n`);
+await legWsReady();
+await legFetchHandshake();
+await legFetchNoCert();
+await legFetchResponse();
+await legWrongHost();
+
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} legs passed on ${process.version}`);
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
Spike for #151. Throwaway: `experiment/` only, nothing in `packages/`, no dependency added to the workspace, no published entry point.

## Verdict

**D12 stands — keep `engines: ">=22"`.** Both connections succeed on Node 22.23.2 with CA, client certificate and client key read from a registration blob, against a live Core. Node 24.19.0 was run as the control and produced identical results. Nothing fails on 22 that passes on 24, so there is no decision to escalate and extraction is not blocked.

| Leg | Node 22.23.2 | Node 24.19.0 |
| --- | --- | --- |
| 1 — `ws` reaches `ready` | PASS | PASS |
| 1b — bearer `auth` → `authOk` | PASS | PASS |
| 2a — `fetch` completes mutual TLS | PASS | PASS |
| 2b — `fetch` without a client cert is refused | PASS | PASS |
| 2c — `fetch` gets an HTTP response over mTLS | PASS | PASS |
| 3 — wrong host fails SAN validation | PASS | PASS |

## The trap held

`fetch` is undici and ignores `options.cert` / `options.key`. The certificate goes in through the dispatcher:

```js
const agent = new Agent({ connect: { ca, cert, key } });
await fetch(url, { dispatcher: agent });
```

Leg 2b is the control that makes 2a mean anything: a CA-only `Agent` is refused by the Core at the TLS layer.

## Two corrections worth carrying forward

- `experiment/action.md` does not exist in this repo or its history, so §5 could not be read. The claim was tested directly instead.
- X.509 binds **hosts, not ports**. A rewritten port validates fine (leg 2c proves it). A rewritten **host** is the real trap — `https://172.17.0.2:9444` against the same socket fails `ERR_TLS_CERT_ALTNAME_INVALID`.

## One thing a later ticket will need

The Core's mTLS port serves WebSocket upgrades and nothing else — `https.createServer` is built with no request listener. A plain `GET` there hangs. Leg 2c therefore gets its `HTTP 200` from a throwaway loopback listener using the Core's *own* server certificate and CA. The transport shape is proven; a real Core HTTP route does not exist yet and someone has to add it.

Full write-up in [`experiment/findings-151-node22-mtls.md`](experiment/findings-151-node22-mtls.md).

Refs #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)