### PR TITLE
refactor(sdk): CoreClient and a durable Core client on one core-link transport (#153)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,6 +95,24 @@ _Avoid_: offset, sequence number
 One Core client's standing request for one PTY's byte stream. A Core sends a PTY's `data` and `exit` to the connections that asked for it and to no others, so a client attached to one Session never receives another's output. Held on the connection, so it dies with the socket and is re-asked for on reconnect. Catch-up is the existing `replay { ptyId, sinceSeq }`, ordered behind the subscription rather than in front of it (ADR 0024 D2).
 _Avoid_: channel, stream registration, attach (an attach is the Panel gesture; this is what it asks for)
 
+### Core client entry points
+
+**`CoreClient`**:
+The default way a program becomes a **Core client**: connect, authenticate, ask, close. One socket, one Core, mTLS plus the bearer out of a **Registration blob** — the shape the `actana` CLI and a script want, and the name a third party types against in `@actana/sdk`. It reconnects nothing and remembers nothing between runs; a program that stays up wants the durable entry point below. Frames that only a multi-connection Core understands are withheld until that Core has announced the capability, so one client drives an old Core and a new one without a second code path (ADR 0024 D11, ADR 0025).
+_Avoid_: session, socket wrapper, connection object, SDK consumer
+
+**Durable Core client**:
+The second entry point on the same transport, for a program that stays connected — the Panel, and anything watching a Core rather than asking it one question. `CoreClient` plus a heartbeat, reconnection with backoff, an **Event cursor**, and subscribe-then-replay. On every connection it re-presents its **Core client id**, re-asks for its **PTY subscriptions**, and replays the gap it was away for, so nothing above it has to know the socket ever dropped. There is no fleet here and there must not be: one client is one Core, and holding several is the Panel's job.
+_Avoid_: manager, pool, supervisor, reconnecting socket
+
+**Core connection**:
+What a **Registration blob** unpacks into: the core-link endpoint, that machine's HTTPS origin, the mTLS material, and the bearer. One name because it is one authenticated reach into one machine — the core link and the machine's HTTPS surface are two faces of it, not two connections. A Core client is handed this rather than a URL, and the material is exposed rather than only dialed with, so a surface that needs the same credentials over HTTPS needs no new format.
+_Avoid_: socket, endpoint, credentials bundle
+
+**Event cursor store**:
+Where a **Durable Core client** keeps its **Event cursor** between reconnects and between runs. Always **injected, never imported**: `localStorage` in a browser-shaped Panel, a file for the CLI, memory by default — because the client itself runs in a Node process that has no DOM to reach into. Memory is a real answer rather than a stub: every reconnect still replays its tail, and only a restart starts from the beginning of the log.
+_Avoid_: cache, persistence layer, local storage (that is one implementation of it)
+
 ### Panel views
 
 **Fleet view**:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@actana/sdk",
   "version": "0.2.1",
-  "description": "Actana Control SDK — the core-link wire protocol a client speaks to a Core: frame schema, protocol version, codec.",
+  "description": "Actana Control SDK — the Core client and the core-link wire protocol it speaks: frame schema, protocol version, codec, transport.",
   "license": "MIT",
   "private": true,
   "type": "module",
@@ -12,8 +12,12 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
+  "dependencies": {
+    "ws": "8.21.0"
+  },
   "devDependencies": {
     "@types/node": "25.8.0",
+    "@types/ws": "8.18.1",
     "typescript": "6.0.3",
     "vitest": "4.1.6"
   }

--- a/packages/sdk/src/__tests__/core-client.test.ts
+++ b/packages/sdk/src/__tests__/core-client.test.ts
@@ -15,7 +15,7 @@ import {
   unwrapResponse,
 } from "../core-client";
 import { coreConnectionFromBlob } from "../core-registration-blob";
-import { startCoreRig, type CoreRig } from "./fake-core-link";
+import { FakeSocketPair, startCoreRig, type CoreRig } from "./fake-core-link";
 
 const SECRET = "core-client-suite-secret-32-bytes-x";
 
@@ -369,6 +369,80 @@ describe("CoreClient", () => {
 
   it("needs somewhere to dial", () => {
     expect(() => new CoreClient({})).toThrow(/url or a registration blob/);
+  });
+
+  it("dials again after a failed connect instead of replaying the rejection", async () => {
+    // `connect()` is memoized so two callers racing share one socket. The memo
+    // must not outlive the attempt: a client that failed once — a Core still
+    // starting up, a laptop that had not joined the network yet — would
+    // otherwise hand every later caller that same rejection for the rest of the
+    // process, with no way back short of building another client.
+    const core = authenticatingRig();
+    const pairs: FakeSocketPair[] = [];
+    const createSocket = () => {
+      const pair = new FakeSocketPair();
+      pairs.push(pair);
+      if (pairs.length === 1) {
+        // Nothing listening yet: the socket dies without ever opening.
+        queueMicrotask(() => pair.client.close());
+      } else {
+        core.wss.accept(pair.server);
+        queueMicrotask(() => pair.open());
+      }
+      return pair.client.asClientSocket();
+    };
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket,
+    });
+    const c = client;
+
+    await expect(c.connect()).rejects.toThrow(/core-link closed/);
+    await expect(c.connect()).resolves.toMatchObject({ compatible: true });
+
+    expect(pairs).toHaveLength(2);
+    expect(c.isConnected()).toBe(true);
+  });
+
+  it("answers a connect() made on a live link without dialing a second one", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    await expect(c.connect()).resolves.toMatchObject({ coreId: "core_test" });
+
+    expect(dial.pairs).toHaveLength(1);
+  });
+
+  it("holds a queued caller request behind what the connection owed the Core", async () => {
+    // The loopback shape, and the ordering that only shows up there: with no
+    // bearer the link is writable the instant the socket opens, which can be
+    // *before* the Core has said `ready`. Flushing the queue on writability
+    // alone would put this caller's `replay` on the wire ahead of the `reclaim`
+    // the connection owes — the opposite of what `onConnectionEstablished`
+    // promises, and the same ordering assumption the establishment race had.
+    rig = startCoreRig();
+    const core = rig;
+    const pair = new FakeSocketPair();
+    const createSocket = () => {
+      // Open first; the Core accepts — and so speaks its `ready` — only after.
+      queueMicrotask(() => pair.open());
+      setTimeout(() => core.wss.accept(pair.server), 5);
+      return pair.client.asClientSocket();
+    };
+    client = new CoreClient({ url: "wss://core.test:9444", bearer: null, createSocket });
+    const c = client;
+
+    // Asked for before there is any link at all, so it is queued rather than sent.
+    const pending = c.replay("pty-1");
+    await c.connect();
+    await pending;
+
+    const ordered = pair.client
+      .frames()
+      .map((f) => f.type)
+      .filter((t) => t === "reclaim" || t === "replay");
+    expect(ordered).toEqual(["reclaim", "replay"]);
   });
 
   it("authenticates nothing and is writable at once against a loopback Core", async () => {

--- a/packages/sdk/src/__tests__/core-client.test.ts
+++ b/packages/sdk/src/__tests__/core-client.test.ts
@@ -1,0 +1,384 @@
+// `CoreClient` against a real Core (issue 153, #129 D1/D2/D6).
+//
+// Every test here drives the Core's own `PtyCoreLinkServer` — including its
+// bearer auth gate, which refuses any frame that arrives before `auth` and closes
+// the socket. That gate is why the ordering assertions below are not
+// bookkeeping: get it wrong and a real Core hangs up on you.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import { CORE_LINK_PROTOCOL_VERSION, SESSION_LOCKED_ERROR_CODE } from "../core-link-frames";
+import {
+  CoreClient,
+  CoreLinkAuthError,
+  CoreLinkRequestError,
+  unwrapResponse,
+} from "../core-client";
+import { coreConnectionFromBlob } from "../core-registration-blob";
+import { startCoreRig, type CoreRig } from "./fake-core-link";
+
+const SECRET = "core-client-suite-secret-32-bytes-x";
+
+function bearerFor(coreId = "core_test", ttlMs = 60_000): string {
+  return signBearer({ coreId, exp: Date.now() + ttlMs }, SECRET);
+}
+
+describe("CoreClient", () => {
+  let rig: CoreRig | null = null;
+  let client: CoreClient | null = null;
+
+  afterEach(() => {
+    client?.close();
+    client = null;
+    rig?.close();
+    rig = null;
+  });
+
+  /** A Core with the remote shape: mTLS is elsewhere, the auth gate is here. */
+  function authenticatingRig(): CoreRig {
+    rig = startCoreRig({ authVerifier: (bearer) => verifyBearer(bearer, SECRET) });
+    return rig;
+  }
+
+  async function connected(
+    core: CoreRig,
+    opts: { bearer?: string | null } = {},
+  ): Promise<{ client: CoreClient; dial: ReturnType<CoreRig["dialer"]> }> {
+    const dial = core.dialer();
+    const bearer = opts.bearer === undefined ? bearerFor() : opts.bearer;
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer,
+      createSocket: dial.createSocket,
+    });
+    await client.connect();
+    return { client, dial };
+  }
+
+  it("resolves connect() with what the Core said on ready and authOk", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor("core_abc"),
+      createSocket: dial.createSocket,
+    });
+
+    const info = await client.connect();
+
+    expect(info).toEqual({
+      protocolVersion: CORE_LINK_PROTOCOL_VERSION,
+      compatible: true,
+      multiConnection: { version: 1 },
+      coreId: "core_abc",
+      bearerExpiresAt: expect.any(Number),
+    });
+    expect(client.isAuthenticated()).toBe(true);
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it("sends auth as the first frame on the wire, before anything it was asked to do", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+    });
+
+    // A request issued before the socket is even open. A Core answers
+    // `not-authenticated` and closes on a frame that arrives ahead of `auth`, so
+    // this must queue behind it rather than race it.
+    const early = client.replay("pty-1");
+    await client.connect();
+    await expect(early).resolves.toEqual({ data: "scrollback", nextSeq: 7, from: undefined });
+
+    const types = dial.last().client.frames().map((f) => f.type);
+    expect(types[0]).toBe("auth");
+    expect(types.filter((t) => t === "auth")).toHaveLength(1);
+  });
+
+  it("surfaces the Core's unsolicited ready frame — nothing asked for it", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    const ready = vi.fn();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+    });
+    client.onReady(ready);
+    await client.connect();
+
+    expect(ready).toHaveBeenCalledTimes(1);
+    expect(ready.mock.calls[0]![0]).toMatchObject({
+      protocolVersion: CORE_LINK_PROTOCOL_VERSION,
+      compatible: true,
+    });
+    // The client never asked: `ready` carries no reqId and answers no request.
+    const sentBeforeReady = dial.last().server.framesOfType("ready");
+    expect(sentBeforeReady).toHaveLength(1);
+    expect(sentBeforeReady[0]!.reqId).toBeUndefined();
+  });
+
+  it("rejects connect() with the reason when the Core refuses the bearer", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: signBearer({ coreId: "core_x", exp: Date.now() - 1_000 }, SECRET),
+      createSocket: dial.createSocket,
+      connectTimeoutMs: 2_000,
+    });
+
+    const err = await client.connect().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CoreLinkAuthError);
+    expect((err as CoreLinkAuthError).reason).toBe("expired");
+    expect(client.isAuthenticated()).toBe(false);
+  });
+
+  it("correlates concurrent requests by reqId", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    const [spawned, found, replayed] = await Promise.all([
+      c.spawn({ taskId: "t1", cwd: "/tmp", command: "claude", agent: "claude-code" }),
+      c.findByTask("t1"),
+      c.replay("pty-1", 3),
+    ]);
+
+    expect(spawned).toEqual({ ptyId: "pty-1" });
+    expect(found).toEqual({ ptyId: "pty-1" });
+    expect(replayed).toEqual({ data: "scrollback", nextSeq: 7, from: undefined });
+    // Three questions, three distinct ids, and the Core answered each with the
+    // id it was asked under.
+    const asked = dial
+      .last()
+      .client.frames()
+      .filter((f) => f.type === "spawn" || f.type === "findByTask" || f.type === "replay")
+      .map((f) => f.reqId);
+    expect(new Set(asked).size).toBe(3);
+  });
+
+  it("turns the Core's error frame into a rejection a caller can read", async () => {
+    // A Core whose write path refuses the mutation. The server turns a thrown
+    // mutation into an `error` frame carrying its message, which is the failure
+    // shape every write on this link can produce.
+    rig = startCoreRig({
+      authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+      mutationPort: {
+        mutateProject: () => {
+          throw new Error("Folder not found");
+        },
+        mutateTask: () => {
+          throw new Error("no such task");
+        },
+        listSessions: () => [],
+      },
+    });
+    const { client: c } = await connected(rig);
+
+    const err = await c
+      .tasksMutate({ op: "update", taskId: "t1", title: "x" })
+      .then(() => null)
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CoreLinkRequestError);
+    expect((err as Error).message).toBe("no such task");
+    // No `code` on this frame, and none invented: a reader takes the code when
+    // it is there and falls back to the message when it is not.
+    expect((err as CoreLinkRequestError).code).toBeUndefined();
+    await expect(c.projectsMutate({ op: "rename", projectId: "p1", name: "n" })).rejects.toThrow(
+      "Folder not found",
+    );
+  });
+
+  it("carries a coded error frame's code onto the rejection", () => {
+    // The code is what lets a caller tell a Session another client holds — worth
+    // retrying after a claim — from every other failure, without reading prose.
+    const err = (() => {
+      try {
+        unwrapResponse({
+          type: "error",
+          reqId: "r1",
+          message: "session is held by another connection",
+          code: SESSION_LOCKED_ERROR_CODE,
+        });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(CoreLinkRequestError);
+    expect((err as CoreLinkRequestError).code).toBe(SESSION_LOCKED_ERROR_CODE);
+  });
+
+  it("hands a router the raw response frame, error frames included", async () => {
+    const core = authenticatingRig();
+    const { client: c } = await connected(core);
+
+    const frame = await c.request({ type: "write", reqId: "caller-owns-this", ptyId: "p", data: "x" });
+    expect(frame).toMatchObject({ type: "writeResult", ok: true });
+    // The caller's own reqId never reaches the wire — correlation belongs to the
+    // one client that owns the socket.
+    expect((frame as { reqId: string }).reqId).not.toBe("caller-owns-this");
+  });
+
+  it("surfaces data and exit frames as frames, parsed once", async () => {
+    const core = authenticatingRig();
+    const { client: c } = await connected(core);
+    const data = vi.fn();
+    const exit = vi.fn();
+    c.onData(data);
+    c.onExit(exit);
+
+    // A Core fans a PTY out only to the connections that asked for it (ADR 0024
+    // D2), so the subscription is what makes this client a recipient at all.
+    await c.ptySubscribe("pty-9");
+    core.ptyCore.emitEvent({ type: "data", ptyId: "pty-9", data: "hello", seq: 4 });
+    core.ptyCore.emitEvent({ type: "exit", ptyId: "pty-9", exitCode: 3, signal: 9 });
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+    expect(data).toHaveBeenCalledWith({ type: "data", ptyId: "pty-9", data: "hello", seq: 4 });
+    expect(exit).toHaveBeenCalledWith({ type: "exit", ptyId: "pty-9", exitCode: 3, signal: 9 });
+  });
+
+  it("presents its Core client id for reaping on connect", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+      clientId: "sdk-fixed-id",
+    });
+    const reclaimed = vi.fn();
+    client.onReclaimed(reclaimed);
+    await client.connect();
+
+    await vi.waitFor(() => expect(reclaimed).toHaveBeenCalled());
+    expect(dial.last().client.framesOfType("reclaim")[0]).toMatchObject({
+      clientId: "sdk-fixed-id",
+    });
+    expect(reclaimed).toHaveBeenCalledWith({ replaced: false, taskIds: [] });
+  });
+
+  it("does not reconnect: a dropped socket is the end of a one-shot client", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+    const disconnected = vi.fn();
+    c.onDisconnected(disconnected);
+
+    dial.last().server.close();
+
+    await vi.waitFor(() => expect(disconnected).toHaveBeenCalled());
+    // 50ms is longer than any backoff a durable client would use, and this one
+    // has none: no second dial, ever.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(dial.pairs).toHaveLength(1);
+    expect(c.isConnected()).toBe(false);
+  });
+
+  it("fails in-flight requests the moment the socket dies, not on their deadline", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    // The Core stops reading — a machine gone to sleep mid-request. The frame is
+    // genuinely in flight and its answer is never coming.
+    dial.last().server.removeAllListeners();
+    const pending = c.replay("pty-1");
+    const settled = expect(pending).rejects.toThrow(/connection lost/);
+    dial.last().server.close();
+    await settled;
+  });
+
+  it("rejects everything outstanding on close()", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    dial.last().server.removeAllListeners();
+    const pending = c.replay("pty-1");
+    const settled = expect(pending).rejects.toThrow(/client closed/);
+    c.close();
+    await settled;
+  });
+
+  it("times out a request the Core never answers", async () => {
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    dial.last().server.removeAllListeners();
+    await expect(c.request({ type: "replay", reqId: "", ptyId: "pty-1" }, 20)).rejects.toThrow(
+      /timed out/,
+    );
+  });
+
+  it("refuses a multi-connection-only frame against a Core that announces nothing", async () => {
+    rig = startCoreRig({
+      authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+      announceMultiConnection: false,
+    });
+    const { client: c } = await connected(rig);
+
+    expect(c.canSendMultiConnectionFrames()).toBe(false);
+    expect(c.multiConnectionCapability()).toBeNull();
+    // The gate degrades where a caller has somewhere to degrade to…
+    await expect(c.claim("t1")).resolves.toEqual({ supported: false, granted: false });
+    await expect(c.ptySubscribe("pty-1")).resolves.toBeUndefined();
+    // …and refuses the frame outright for a caller that asked without checking.
+    await expect(
+      c.request({ type: "forceTakeover", reqId: "", taskId: "t1" }),
+    ).rejects.toThrow(/multiConnection capability/);
+  });
+
+  it("reports an incompatible Core rather than half-using it", async () => {
+    rig = startCoreRig({
+      authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+      protocolVersion: "0.1.0",
+    });
+    const { client: c } = await connected(rig);
+
+    expect(c.connectionInfo()).toMatchObject({ protocolVersion: "0.1.0", compatible: false });
+  });
+
+  it("dials with the endpoint, cert material and bearer off a registration blob", async () => {
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    const bearer = bearerFor("core_from_blob");
+    const blob = {
+      endpoint: "wss://core.test:9444",
+      caCert: "CA-PEM",
+      clientCert: "CLIENT-PEM",
+      clientKey: "KEY-PEM",
+      bearer,
+    };
+
+    // What a blob unpacks into — the endpoint AND the material, exposed rather
+    // than only dialed with (#129's phase-3 guardrail).
+    expect(coreConnectionFromBlob(blob)).toEqual({
+      url: "wss://core.test:9444",
+      httpsBaseUrl: "https://core.test:9444",
+      tls: { ca: "CA-PEM", cert: "CLIENT-PEM", key: "KEY-PEM" },
+      bearer,
+    });
+
+    client = CoreClient.fromRegistrationBlob(blob, { createSocket: dial.createSocket });
+    const info = await client.connect();
+    expect(info.coreId).toBe("core_from_blob");
+    expect(client.url).toBe("wss://core.test:9444");
+  });
+
+  it("needs somewhere to dial", () => {
+    expect(() => new CoreClient({})).toThrow(/url or a registration blob/);
+  });
+
+  it("authenticates nothing and is writable at once against a loopback Core", async () => {
+    // No `authVerifier` on the Core, no bearer on the client: the trusted
+    // loopback shape, where `auth` is a no-op and there is no `authOk` coming.
+    rig = startCoreRig();
+    const { client: c, dial } = await connected(rig, { bearer: null });
+
+    expect(dial.last().client.framesOfType("auth")).toHaveLength(0);
+    expect(c.isConnected()).toBe(true);
+    await expect(c.write("pty-1", "ls\n")).resolves.toBe(true);
+  });
+});

--- a/packages/sdk/src/__tests__/core-link-mtls.test.ts
+++ b/packages/sdk/src/__tests__/core-link-mtls.test.ts
@@ -29,6 +29,19 @@ import { makeMockPtyCore } from "./fake-core-link";
 
 const SECRET = "mtls-suite-secret-at-least-32-bytes";
 
+/**
+ * What a refusal *at the TLS layer* looks like by the time it reaches a caller:
+ * the peer resetting the connection, or an SSL alert naming the reason. Node
+ * words it differently across OpenSSL versions — a missing client cert is an
+ * `alert certificate required` on this one and a bare `socket hang up` on
+ * others — hence the alternation.
+ *
+ * What is *not* in it matters as much as what is. No `closed`, no `ECONNREFUSED`,
+ * no `timed out`: every one of those is how the client reports a Core it never
+ * reached, and a control that accepted them would pass with no Core at all.
+ */
+const TLS_REFUSAL = /ECONNRESET|EPIPE|socket hang up|ERR_SSL|SSL routines|alert|handshake/i;
+
 /** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
 function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -181,12 +194,42 @@ describe("Core client over mTLS", () => {
     // control that passes on any error would pass against a Core that is not
     // running, and then the test above would be meaningful against nothing at
     // all. A TLS-layer refusal shows up as the peer closing the connection or as
-    // an SSL alert, never as a `connect` deadline.
+    // an SSL alert, never as a `connect` deadline and never as a refused TCP
+    // connection.
+    //
+    // `closed` is deliberately *not* in that alternation. Every transport
+    // failure reaches a caller as `core-link closed: …` (`core-client.ts`), so
+    // matching on it would accept the very thing this control exists to rule
+    // out — which is what the test below pins.
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(
-      /closed|ECONNRESET|EPIPE|socket hang up|ERR_SSL|alert|handshake/i,
+    expect((err as Error).message).toMatch(TLS_REFUSAL);
+    expect((err as Error).message).not.toMatch(/timed out|ECONNREFUSED/i);
+    expect(client.isAuthenticated()).toBe(false);
+  }, 20_000);
+
+  it("tells a refused handshake from a Core that is not running", async () => {
+    // The control above is only worth its runtime if its matcher can *fail*.
+    // Here is the failure it has to catch: the same client, the same valid
+    // material, aimed at a port with nothing behind it — a Core that is down, a
+    // wrong port in a blob, a daemon that never started. That error is a
+    // `core-link closed: connect ECONNREFUSED …`, so the alternation the control
+    // uses must reject it. Put `closed|` back and this test goes red.
+    const { blob } = await startCore();
+    const nowhere = await freePort();
+
+    client = CoreClient.fromRegistrationBlob(
+      { ...blob, endpoint: `wss://127.0.0.1:${nowhere}` },
+      { connectTimeoutMs: 5_000 },
     );
-    expect((err as Error).message).not.toMatch(/timed out/);
+
+    const err = await client.connect().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/ECONNREFUSED/i);
+    expect((err as Error).message).not.toMatch(TLS_REFUSAL);
     expect(client.isAuthenticated()).toBe(false);
   }, 20_000);
 });

--- a/packages/sdk/src/__tests__/core-link-mtls.test.ts
+++ b/packages/sdk/src/__tests__/core-link-mtls.test.ts
@@ -1,0 +1,192 @@
+// The Core client over a real `wss://` socket, with a real mTLS handshake
+// (issue 153, #129 D1 — "mTLS + bearer from a registration blob").
+//
+// The rest of this package's suites run the real Core server over an in-memory
+// socket pair, which proves the frames and their ordering. This one proves the
+// part an in-memory pair cannot: that a registration blob's PEM material, the
+// Node `ws` dial the SDK ships, and a Core requiring a pinned client cert
+// actually interoperate over a TCP port — and that a client without the client
+// cert never gets past the handshake, which is the control that makes the
+// positive result mean anything.
+//
+// Both certificates come from the Core's own `generateCertMaterial`, so the
+// material under test is the material `actana setup` writes.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { Server } from "node:net";
+import https from "node:https";
+import { WebSocketServer } from "ws";
+import {
+  PtyCoreLinkServer,
+  type WebSocketLike as ServerSocketLike,
+  type WebSocketServerLike,
+} from "@actana/core/pty-core-link-server";
+import { generateCertMaterial } from "@actana/core/core-cert-material";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import { CoreClient } from "../core-client";
+import type { CoreRegistrationBlob } from "../core-registration-blob";
+import { makeMockPtyCore } from "./fake-core-link";
+
+const SECRET = "mtls-suite-secret-at-least-32-bytes";
+
+/** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = new Server();
+    s.on("error", reject);
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      if (addr && typeof addr === "object") {
+        const { port } = addr;
+        s.close(() => resolve(port));
+      } else {
+        s.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+/**
+ * The real `wss://` server the Core builds, with the bound port recorded so the
+ * test can dial it. Mirrors the Core's default factory — `requestCert` plus
+ * `rejectUnauthorized` are what make this a mutual handshake.
+ */
+function recordingCreateServer(
+  bound: { port: number },
+): (opts: { port: number; host: string; tls?: unknown }) => WebSocketServerLike {
+  return (opts) => {
+    const tls = opts.tls as { caCert: string; serverCert: string; serverKey: string };
+    const tlsServer = https.createServer({
+      cert: tls.serverCert,
+      key: tls.serverKey,
+      ca: tls.caCert,
+      requestCert: true,
+      rejectUnauthorized: true,
+    });
+    tlsServer.listen(opts.port, opts.host, () => {
+      const addr = tlsServer.address();
+      if (addr && typeof addr === "object") bound.port = addr.port;
+    });
+    const wss = new WebSocketServer({ server: tlsServer });
+    return {
+      close: (cb) => wss.close(() => tlsServer.close(cb)),
+      on: (event, cb) => {
+        if (event === "connection") {
+          wss.on("connection", (ws) => (cb as (s: ServerSocketLike) => void)(adapt(ws)));
+        } else if (event === "error") {
+          wss.on("error", (err: Error) => (cb as (e: Error) => void)(err));
+        }
+      },
+    };
+  };
+}
+
+function adapt(ws: import("ws").WebSocket): ServerSocketLike {
+  return {
+    get readyState() {
+      return ws.readyState;
+    },
+    send: (data: string) => ws.send(data),
+    close: () => ws.close(),
+    on: (event, cb) => {
+      if (event === "message") ws.on("message", (d: unknown) => (cb as (d: unknown) => void)(d));
+      else if (event === "close") ws.on("close", () => (cb as () => void)());
+      else if (event === "error") ws.on("error", (e: Error) => (cb as (e: Error) => void)(e));
+    },
+    removeAllListeners: () => ws.removeAllListeners(),
+  } as ServerSocketLike;
+}
+
+describe("Core client over mTLS", () => {
+  let server: PtyCoreLinkServer | null = null;
+  let client: CoreClient | null = null;
+
+  afterEach(() => {
+    client?.close();
+    client = null;
+    server?.close();
+    server = null;
+  });
+
+  /** A real Core on a real port, and the blob a client would be handed for it. */
+  async function startCore(): Promise<{ blob: CoreRegistrationBlob; caCert: string }> {
+    const material = await generateCertMaterial({ host: "127.0.0.1" });
+    const port = await freePort();
+    const bound = { port: 0 };
+    server = new PtyCoreLinkServer(makeMockPtyCore(), {
+      port,
+      host: "127.0.0.1",
+      createServer: recordingCreateServer(bound),
+      tls: {
+        caCert: material.ca.cert,
+        serverCert: material.server.cert,
+        serverKey: material.server.key,
+      },
+      authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+    });
+    // Wait for the TLS server to bind before anything dials it.
+    await new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 5_000;
+      const tick = () => {
+        if (bound.port > 0) return resolve();
+        if (Date.now() > deadline) return reject(new Error("TLS server never bound"));
+        setTimeout(tick, 10);
+      };
+      tick();
+    });
+    return {
+      caCert: material.ca.cert,
+      blob: {
+        endpoint: `wss://127.0.0.1:${bound.port}`,
+        label: "test-core",
+        caCert: material.ca.cert,
+        clientCert: material.client.cert,
+        clientKey: material.client.key,
+        bearer: signBearer({ coreId: "core_mtls", exp: Date.now() + 60_000 }, SECRET),
+      },
+    };
+  }
+
+  it("dials wss:// from a registration blob, authenticates, and round-trips a request", async () => {
+    const { blob } = await startCore();
+
+    client = CoreClient.fromRegistrationBlob(blob, { connectTimeoutMs: 10_000 });
+    const info = await client.connect();
+
+    expect(info.coreId).toBe("core_mtls");
+    expect(info.compatible).toBe(true);
+    expect(client.isAuthenticated()).toBe(true);
+    await expect(
+      client.spawn({ taskId: "t1", cwd: "/tmp", command: "claude", agent: "claude-code" }),
+    ).resolves.toEqual({ ptyId: "pty-1" });
+  }, 20_000);
+
+  it("never authenticates without the pinned client cert — the handshake fails first", async () => {
+    const { blob } = await startCore();
+
+    // The right CA, no client certificate. The Core requires one signed by that
+    // CA, so this never becomes a core link at all. Without this control, the
+    // test above would pass against a server that never asked.
+    client = CoreClient.fromRegistrationBlob(
+      { ...blob, clientCert: "", clientKey: "" },
+      { connectTimeoutMs: 5_000 },
+    );
+
+    const err = await client.connect().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    // Assert on the *shape* of the refusal, not merely that something failed: a
+    // control that passes on any error would pass against a Core that is not
+    // running, and then the test above would be meaningful against nothing at
+    // all. A TLS-layer refusal shows up as the peer closing the connection or as
+    // an SSL alert, never as a `connect` deadline.
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(
+      /closed|ECONNRESET|EPIPE|socket hang up|ERR_SSL|alert|handshake/i,
+    );
+    expect((err as Error).message).not.toMatch(/timed out/);
+    expect(client.isAuthenticated()).toBe(false);
+  }, 20_000);
+});

--- a/packages/sdk/src/__tests__/durable-core-client.test.ts
+++ b/packages/sdk/src/__tests__/durable-core-client.test.ts
@@ -1,0 +1,308 @@
+// `DurableCoreClient` against a real Core (issue 153, #129 D6).
+//
+// The durable entry point is the one-shot client plus a heartbeat, a reconnect
+// loop, an event cursor and subscribe-then-replay — so every test here is about
+// a connection *ending* and what the next one owes the Core. The server is the
+// Core's own `PtyCoreLinkServer` with its auth gate armed, and every reconnect
+// is a genuinely new connection with its own `ready`, its own `auth` and its own
+// subscription state.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import type { CoreLinkEvent } from "../core-link-frames";
+import { DurableCoreClient } from "../durable-core-client";
+import {
+  coreLinkCursorStorageKey,
+  InMemoryCoreLinkCursorStorage,
+} from "../core-link-cursor-storage";
+import { startCoreRig, type CoreRig } from "./fake-core-link";
+
+const SECRET = "durable-client-suite-secret-32-byte";
+const URL_A = "wss://core-a.test:9444";
+
+function bearerFor(coreId = "core_test"): string {
+  return signBearer({ coreId, exp: Date.now() + 60_000 }, SECRET);
+}
+
+describe("DurableCoreClient", () => {
+  let rig: CoreRig | null = null;
+  let client: DurableCoreClient | null = null;
+
+  afterEach(() => {
+    client?.close();
+    client = null;
+    rig?.close();
+    rig = null;
+  });
+
+  function remoteRig(): CoreRig {
+    rig = startCoreRig({ authVerifier: (bearer) => verifyBearer(bearer, SECRET) });
+    return rig;
+  }
+
+  function makeClient(
+    core: CoreRig,
+    opts: {
+      storage?: InMemoryCoreLinkCursorStorage;
+      cursorStorageKey?: string;
+      pingable?: boolean;
+      heartbeat?: { intervalMs?: number; timeoutMs?: number } | false;
+    } = {},
+  ): { client: DurableCoreClient; dial: ReturnType<CoreRig["dialer"]> } {
+    const dial = core.dialer({ pingable: opts.pingable });
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+      storage: opts.storage ?? new InMemoryCoreLinkCursorStorage(),
+      cursorStorageKey: opts.cursorStorageKey,
+      reconnectInitialMs: 5,
+      reconnectMaxMs: 5,
+      heartbeat: opts.heartbeat ?? false,
+    });
+    return { client, dial };
+  }
+
+  it("owes the Core reclaim, then subscribe, then its PTY subscriptions — in that order, after auth", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+    await c.ptySubscribe("pty-7");
+
+    const types = dial.last().client.frames().map((f) => f.type);
+    expect(types.slice(0, 3)).toEqual(["auth", "reclaim", "subscribe"]);
+    expect(types).toContain("ptySubscribe");
+  });
+
+  it("subscribes with the cursor it found in the injected storage", async () => {
+    const core = remoteRig();
+    const storage = new InMemoryCoreLinkCursorStorage();
+    storage.setItem(coreLinkCursorStorageKey(URL_A), "41");
+    const { client: c, dial } = makeClient(core, { storage });
+
+    await c.connect();
+
+    expect(c.getLastEventId()).toBe(41);
+    expect(dial.last().client.framesOfType("subscribe")[0]).toMatchObject({ lastEventId: 41 });
+  });
+
+  it("keeps no cursor of its own when nothing was stored", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+
+    await c.connect();
+
+    // First connect asks for the whole log, which is what `lastEventId: 0` means.
+    expect(dial.last().client.framesOfType("subscribe")[0]).toMatchObject({ lastEventId: 0 });
+  });
+
+  it("replays the tail, ends on eventsReplayed, and persists the cursor it reached", async () => {
+    const core = remoteRig();
+    core.eventLog.appendEvent("task:created", '{"a":1}', { taskId: "t1" });
+    core.eventLog.appendEvent("task:updated", '{"a":2}', { taskId: "t1" });
+    const storage = new InMemoryCoreLinkCursorStorage();
+    const { client: c } = makeClient(core, { storage });
+
+    const seen: CoreLinkEvent[] = [];
+    c.onEvent(({ event }) => seen.push(event));
+    const replayed = vi.fn();
+    c.onEventsReplayed(replayed);
+
+    await c.connect();
+    await vi.waitFor(() => expect(c.isCaughtUp()).toBe(true));
+
+    expect(seen.map((e) => e.eventId)).toEqual([1, 2]);
+    expect(replayed).toHaveBeenCalledWith({ lastEventId: 2 });
+    expect(c.getLastEventId()).toBe(2);
+    expect(storage.getItem(coreLinkCursorStorageKey(URL_A))).toBe("2");
+  });
+
+  it("drops an event at or below the cursor rather than delivering it twice", async () => {
+    const core = remoteRig();
+    core.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });
+    const { client: c, dial } = makeClient(core);
+    const seen: number[] = [];
+    c.onEvent(({ event }) => seen.push(event.eventId));
+
+    await c.connect();
+    await vi.waitFor(() => expect(seen).toEqual([1]));
+
+    // A replay overlap, or a re-delivery after a reconnect: the same event again.
+    dial.last().client.receive({
+      type: "event",
+      event: { eventId: 1, ts: 1, kind: "task:created", ptyId: null, taskId: "t1", payload: "{}" },
+    });
+    expect(seen).toEqual([1]);
+  });
+
+  it("advances the cursor on an empty tail, because the marker is authoritative", async () => {
+    const core = remoteRig();
+    core.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });
+    const storage = new InMemoryCoreLinkCursorStorage();
+    storage.setItem(coreLinkCursorStorageKey(URL_A), "0");
+    const { client: c } = makeClient(core, { storage });
+    await c.connect();
+    await vi.waitFor(() => expect(c.getLastEventId()).toBe(1));
+
+    // Nothing new happened, and the Core says so with a marker and no events.
+    expect(storage.getItem(coreLinkCursorStorageKey(URL_A))).toBe("1");
+    expect(c.isCaughtUp()).toBe(true);
+  });
+
+  it("reconnects with backoff and restores the timeline it missed", async () => {
+    const core = remoteRig();
+    const storage = new InMemoryCoreLinkCursorStorage();
+    const { client: c, dial } = makeClient(core, { storage });
+    const seen: number[] = [];
+    c.onEvent(({ event }) => seen.push(event.eventId));
+    const disconnected = vi.fn();
+    c.onDisconnected(disconnected);
+
+    await c.connect();
+    await c.ptySubscribe("pty-7");
+    core.eventLog.appendEvent("task:updated", "{}", { taskId: "t1" });
+    await vi.waitFor(() => expect(c.getLastEventId()).toBe(1));
+
+    // The Core goes away, and something happens while this client cannot see it.
+    dial.last().server.close();
+    core.eventLog.appendEvent("session:finished", "{}", { taskId: "t1" });
+
+    await vi.waitFor(() => expect(disconnected).toHaveBeenCalled());
+    await vi.waitFor(() => expect(dial.pairs).toHaveLength(2));
+    await vi.waitFor(() => expect(c.isCaughtUp()).toBe(true));
+
+    // The gap is closed by the replay, with no double and no hole.
+    expect(seen).toEqual([1, 2]);
+    expect(c.getLastEventId()).toBe(2);
+
+    // The second connection re-presents everything a connection owes, in order,
+    // and asks for the tail past what it had already seen.
+    const second = dial.last().client.frames();
+    expect(second.map((f) => f.type).slice(0, 3)).toEqual(["auth", "reclaim", "subscribe"]);
+    expect(second.find((f) => f.type === "subscribe")).toMatchObject({ lastEventId: 1 });
+    // PTY subscriptions are connection state on the Core, so they died with the
+    // socket and are re-asked for here — without `catchUp`, which only a caller
+    // that will send the matching `replay` may set.
+    expect(second.find((f) => f.type === "ptySubscribe")).toMatchObject({
+      ptyId: "pty-7",
+      catchUp: false,
+    });
+  });
+
+  it("queues a request made while the link is down and answers it on the next connection", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+
+    dial.last().server.close();
+    // No link, no refusal: the frame waits for one rather than making every call
+    // site retry.
+    await expect(c.replay("pty-1")).resolves.toEqual({
+      data: "scrollback",
+      nextSeq: 7,
+      from: undefined,
+    });
+    expect(dial.pairs.length).toBeGreaterThan(1);
+  });
+
+  it("stops re-asking for a PTY it released, and re-asks for the rest", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+    await c.ptySubscribe("pty-1");
+    await c.ptySubscribe("pty-2");
+    await c.ptyUnsubscribe("pty-1");
+    // A second ask for a PTY already held is a no-op on the wire.
+    await c.ptySubscribe("pty-2");
+    expect(dial.last().client.framesOfType("ptySubscribe")).toHaveLength(2);
+
+    dial.last().server.close();
+    await vi.waitFor(() => expect(dial.pairs).toHaveLength(2));
+    await vi.waitFor(() => expect(c.isCaughtUp()).toBe(true));
+
+    const resent = dial.last().client.framesOfType("ptySubscribe");
+    expect(resent.map((f) => f.ptyId)).toEqual(["pty-2"]);
+  });
+
+  it("pings an idle link and destroys a half-open one rather than waiting for a FIN", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core, {
+      pingable: true,
+      heartbeat: { intervalMs: 10, timeoutMs: 40 },
+    });
+    await c.connect();
+    const first = dial.last();
+
+    // The peer answers nothing — a NAT that reaped the flow, a suspended host.
+    await vi.waitFor(() => expect(first.client.pings).toBeGreaterThan(0), { timeout: 2_000 });
+    await vi.waitFor(() => expect(first.client.terminated).toBe(true), { timeout: 2_000 });
+    // And the reconnect loop takes it from there, which is the whole point of
+    // noticing.
+    await vi.waitFor(() => expect(dial.pairs.length).toBeGreaterThan(1), { timeout: 2_000 });
+  });
+
+  it("keeps a pong-less link alive: a socket that cannot ping is not torn down", async () => {
+    const core = remoteRig();
+    // No ping surface (a plain browser WebSocket) — the heartbeat does not arm,
+    // because a peer that was never pinged has not failed to answer.
+    const { client: c, dial } = makeClient(core, {
+      pingable: false,
+      heartbeat: { intervalMs: 10, timeoutMs: 20 },
+    });
+    await c.connect();
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(dial.pairs).toHaveLength(1);
+    expect(c.isConnected()).toBe(true);
+  });
+
+  it("stops reconnecting on close()", async () => {
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+
+    c.close();
+    dial.last().server.close();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(dial.pairs).toHaveLength(1);
+    expect(c.isConnected()).toBe(false);
+  });
+
+  it("resumes a restarted client's timeline from the store it was given", async () => {
+    const core = remoteRig();
+    core.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });
+    core.eventLog.appendEvent("task:updated", "{}", { taskId: "t1" });
+    const storage = new InMemoryCoreLinkCursorStorage();
+
+    const first = makeClient(core, { storage });
+    await first.client.connect();
+    await vi.waitFor(() => expect(first.client.getLastEventId()).toBe(2));
+    first.client.close();
+
+    // A second client — a restarted process — handed the same store. It asks for
+    // the tail past what its predecessor saw, not for the whole log.
+    core.eventLog.appendEvent("session:finished", "{}", { taskId: "t1" });
+    const second = makeClient(core, { storage });
+    const seen: number[] = [];
+    second.client.onEvent(({ event }) => seen.push(event.eventId));
+    await second.client.connect();
+    await vi.waitFor(() => expect(second.client.isCaughtUp()).toBe(true));
+
+    expect(second.dial.last().client.framesOfType("subscribe")[0]).toMatchObject({
+      lastEventId: 2,
+    });
+    expect(seen).toEqual([3]);
+  });
+
+  it("gives every Core its own cursor key", () => {
+    // Two Cores sharing a key would each replay from the other's position, and
+    // the one that fell behind would lose the events in between.
+    expect(coreLinkCursorStorageKey("wss://host:9444")).not.toBe(
+      coreLinkCursorStorageKey("wss://host:9555"),
+    );
+    expect(coreLinkCursorStorageKey("wss://host:9444")).toBe(
+      coreLinkCursorStorageKey("wss://host:9444"),
+    );
+  });
+});

--- a/packages/sdk/src/__tests__/durable-core-client.test.ts
+++ b/packages/sdk/src/__tests__/durable-core-client.test.ts
@@ -15,7 +15,7 @@ import {
   coreLinkCursorStorageKey,
   InMemoryCoreLinkCursorStorage,
 } from "../core-link-cursor-storage";
-import { startCoreRig, type CoreRig } from "./fake-core-link";
+import { FakeSocketPair, startCoreRig, type CoreRig } from "./fake-core-link";
 
 const SECRET = "durable-client-suite-secret-32-byte";
 const URL_A = "wss://core-a.test:9444";
@@ -323,6 +323,103 @@ describe("DurableCoreClient", () => {
     expect(dial.last().client.framesOfType("auth")).toHaveLength(0);
     expect(dial.last().client.framesOfType("subscribe")).toHaveLength(1);
     expect(seen).toEqual([1]);
+  });
+
+  it("sends reclaim and subscribe ahead of a caller's queued request", async () => {
+    // The loopback shape again, for the ordering it is the only place to see:
+    // writability rides the socket opening, so it can land before `ready`. A
+    // queue flushed on writability alone would put this caller's `replay` on the
+    // wire first, and the Core would answer it while the Sessions this client is
+    // reclaiming still belonged to the socket this one replaced — the ordering
+    // `onConnectionEstablished` documents as load-bearing, tested rather than
+    // asserted in a comment.
+    rig = startCoreRig();
+    const core = rig;
+    const pair = new FakeSocketPair();
+    const createSocket = () => {
+      queueMicrotask(() => pair.open());
+      setTimeout(() => core.wss.accept(pair.server), 5);
+      return pair.client.asClientSocket();
+    };
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: null,
+      createSocket,
+      reconnectInitialMs: 5,
+      reconnectMaxMs: 5,
+      heartbeat: false,
+    });
+    const durable = client;
+
+    const pending = durable.replay("pty-1");
+    await durable.connect();
+    await pending;
+
+    const ordered = pair.client
+      .frames()
+      .map((f) => f.type)
+      .filter((t) => t === "reclaim" || t === "subscribe" || t === "replay");
+    expect(ordered).toEqual(["reclaim", "subscribe", "replay"]);
+  });
+
+  it("answers a connect() made mid-backoff with the connection that comes, not the one that died", async () => {
+    // The gap between a socket dying and the backoff opening the next one. A
+    // caller that asks to connect in there is asking about the link it is going
+    // to have — answering out of the dead connection's state would hand it a
+    // `coreId` of null and an incompatible protocol version for a Core that is
+    // about to be perfectly reachable.
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+
+    dial.last().server.close();
+    const duringBackoff = c.connect();
+
+    await expect(duringBackoff).resolves.toMatchObject({ compatible: true, coreId: "core_test" });
+    expect(dial.pairs).toHaveLength(2);
+  });
+
+  it("stops handing back a rejected connect once the supervisor has reconnected", async () => {
+    // The deadline on `connect()` and the supervisor underneath it are separate
+    // clocks: the deadline can expire on a Core that is merely slow to come up,
+    // and the backoff then reconnects perfectly well a moment later. A memoized
+    // rejection would leave every later caller — #156's Panel migration included
+    // — being told the client is unusable while its link is up and carrying
+    // events.
+    rig = startCoreRig();
+    const core = rig;
+    const pairs: FakeSocketPair[] = [];
+    const createSocket = () => {
+      const pair = new FakeSocketPair();
+      pairs.push(pair);
+      if (pairs.length === 1) {
+        // The Core is not up yet: this socket dies without ever opening.
+        queueMicrotask(() => pair.client.close());
+      } else {
+        core.wss.accept(pair.server);
+        queueMicrotask(() => pair.open());
+      }
+      return pair.client.asClientSocket();
+    };
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: null,
+      createSocket,
+      // A deadline that expires well before the backoff dials again, so the
+      // rejection and the recovery are ordered the way the note describes.
+      connectTimeoutMs: 1,
+      reconnectInitialMs: 40,
+      reconnectMaxMs: 40,
+      heartbeat: false,
+    });
+    const durable = client;
+
+    await expect(durable.connect()).rejects.toThrow(/timed out/);
+    await vi.waitFor(() => expect(durable.isConnected()).toBe(true));
+
+    await expect(durable.connect()).resolves.toMatchObject({ compatible: true });
+    // The retry read the live link rather than dialing over it.
+    expect(pairs).toHaveLength(2);
   });
 
   it("gives every Core its own cursor key", () => {

--- a/packages/sdk/src/__tests__/durable-core-client.test.ts
+++ b/packages/sdk/src/__tests__/durable-core-client.test.ts
@@ -295,6 +295,36 @@ describe("DurableCoreClient", () => {
     expect(seen).toEqual([3]);
   });
 
+  it("subscribes on a loopback Core too, whichever of ready and writability lands last", async () => {
+    // No auth gate and no bearer: the trusted loopback shape, where there is no
+    // `authOk` to hang the connection's opening frames off and writability rides
+    // the socket opening instead. Establishment waits for *both* signals rather
+    // than assuming an order — a `subscribe` sent against a socket that is not
+    // writable yet is dropped, and a client that dropped its subscribe never
+    // receives an event again.
+    rig = startCoreRig();
+    rig.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });
+    const dial = rig.dialer();
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: null,
+      createSocket: dial.createSocket,
+      reconnectInitialMs: 5,
+      reconnectMaxMs: 5,
+      heartbeat: false,
+    });
+    const durable = client;
+    const seen: number[] = [];
+    durable.onEvent(({ event }) => seen.push(event.eventId));
+
+    await durable.connect();
+    await vi.waitFor(() => expect(durable.isCaughtUp()).toBe(true));
+
+    expect(dial.last().client.framesOfType("auth")).toHaveLength(0);
+    expect(dial.last().client.framesOfType("subscribe")).toHaveLength(1);
+    expect(seen).toEqual([1]);
+  });
+
   it("gives every Core its own cursor key", () => {
     // Two Cores sharing a key would each replay from the other's position, and
     // the one that fell behind would lose the events in between.

--- a/packages/sdk/src/__tests__/fake-core-link.ts
+++ b/packages/sdk/src/__tests__/fake-core-link.ts
@@ -108,15 +108,14 @@ export class FakeSocket {
 
   /** The client-side view of this socket, as the SDK's transport wants it. */
   asClientSocket(): CoreLinkSocket {
-    const self = this;
-    const socket: CoreLinkSocket = {
-      get readyState() {
-        return self.readyState;
-      },
-      send: (data: string) => self.send(data),
-      close: () => self.close(),
-      on: (event: string, cb: Listener) => self.on(event, cb),
-    } as CoreLinkSocket;
+    const socket = {
+      send: (data: string) => this.send(data),
+      close: () => this.close(),
+      on: (event: string, cb: Listener) => this.on(event, cb),
+    } as unknown as CoreLinkSocket;
+    // A live getter rather than a number copied at wiring time: `readyState`
+    // moves under the transport's feet as the socket opens and closes.
+    Object.defineProperty(socket, "readyState", { get: () => this.readyState });
     if (this.pingable) {
       socket.ping = () => {
         this.pings++;

--- a/packages/sdk/src/__tests__/fake-core-link.ts
+++ b/packages/sdk/src/__tests__/fake-core-link.ts
@@ -1,0 +1,319 @@
+// Test rig for the Core client suites: a real Core server on one end of a
+// socket, this package's client on the other.
+//
+// **The server here is the Core's own `PtyCoreLinkServer`, not a stand-in.** A
+// hand-rolled fake would answer whatever the client expects, which is exactly
+// the agreement worth testing — the auth gate that closes a connection on a
+// pre-auth frame, the `ready` frame that arrives before anything is asked for,
+// the fan-out that sends a PTY's bytes only to the connections that subscribed.
+// The Panel's core-link suites are wired the same way, and the only thing faked
+// below is the socket between the two and the PTY manager behind the server.
+
+import { vi } from "vitest";
+import type {
+  CoreMutationPort,
+  EventLogPort,
+  WebSocketLike as ServerSocketLike,
+  WebSocketServerLike,
+} from "@actana/core/pty-core-link-server";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "@actana/core/pty-manager";
+import type { CoreLinkEvent } from "../core-link-frames";
+import type { CoreLinkSocket, CoreLinkSocketFactory } from "../core-link-socket";
+
+type Listener = (...args: unknown[]) => void;
+
+/**
+ * One end of a connected pair. `send` delivers to the peer's message listeners;
+ * `receive` injects an inbound message without recording it as sent, so a test
+ * can tell "what I wrote" from "what I was told".
+ */
+export class FakeSocket {
+  readyState = 0;
+  sent: string[] = [];
+  pings = 0;
+  terminated = false;
+  /** Set to arm the heartbeat: the transport only pings a socket that can. */
+  pingable = false;
+  peer: FakeSocket | null = null;
+  private listeners: Record<string, Listener[]> = {};
+  /**
+   * Frames that arrived before anything was listening for them.
+   *
+   * A real socket holds bytes until the application reads them, and this rig
+   * needs the same: the Core writes `ready` the instant it accepts a connection
+   * — before the client on the other end has been constructed, in a test that
+   * stands the server up first — and a frame dropped there would make the Core's
+   * defining unsolicited-first behaviour untestable.
+   */
+  private buffered: unknown[] = [];
+
+  send(data: string): void {
+    this.sent.push(data);
+    this.peer?.emit("message", data);
+  }
+
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.emit("close");
+    if (this.peer && this.peer.readyState !== 3) {
+      this.peer.readyState = 3;
+      this.peer.emit("close");
+    }
+  }
+
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+    if (event === "message" && this.buffered.length > 0) {
+      const held = this.buffered;
+      this.buffered = [];
+      for (const data of held) cb(data);
+    }
+  }
+
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    const listeners = this.listeners[event] ?? [];
+    if (event === "message" && listeners.length === 0) {
+      this.buffered.push(args[0]);
+      return;
+    }
+    for (const cb of [...listeners]) cb(...args);
+  }
+
+  /** Simulate an inbound frame from the peer, unrecorded. */
+  receive(obj: unknown): void {
+    this.emit("message", typeof obj === "string" ? obj : JSON.stringify(obj));
+  }
+
+  /** Every frame this side wrote, parsed. */
+  frames(): Array<Record<string, unknown>> {
+    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+
+  /** Every frame of one type this side wrote, parsed. */
+  framesOfType(type: string): Array<Record<string, unknown>> {
+    return this.frames().filter((f) => f.type === type);
+  }
+
+  /** The last frame this side wrote, or null. */
+  lastSent(): Record<string, unknown> | null {
+    const raw = this.sent[this.sent.length - 1];
+    return raw === undefined ? null : (JSON.parse(raw) as Record<string, unknown>);
+  }
+
+  /** The client-side view of this socket, as the SDK's transport wants it. */
+  asClientSocket(): CoreLinkSocket {
+    const self = this;
+    const socket: CoreLinkSocket = {
+      get readyState() {
+        return self.readyState;
+      },
+      send: (data: string) => self.send(data),
+      close: () => self.close(),
+      on: (event: string, cb: Listener) => self.on(event, cb),
+    } as CoreLinkSocket;
+    if (this.pingable) {
+      socket.ping = () => {
+        this.pings++;
+      };
+      socket.terminate = () => {
+        this.terminated = true;
+        this.close();
+      };
+    }
+    return socket;
+  }
+
+  /** Answer a ping, the way a live peer's engine would. */
+  pong(): void {
+    this.emit("pong");
+  }
+}
+
+export class FakeSocketPair {
+  readonly server = new FakeSocket();
+  readonly client = new FakeSocket();
+
+  constructor(opts: { pingable?: boolean } = {}) {
+    this.server.peer = this.client;
+    this.client.peer = this.server;
+    this.client.pingable = opts.pingable === true;
+  }
+
+  /** Complete the handshake on both ends. */
+  open(): void {
+    this.client.readyState = 1;
+    this.server.readyState = 1;
+    this.client.emit("open");
+    this.server.emit("open");
+  }
+}
+
+/** A `WebSocketServer` that hands the Core server whichever socket a test says. */
+export class FakeSocketServer {
+  private connCb: ((ws: ServerSocketLike) => void) | null = null;
+
+  accept(socket: FakeSocket): void {
+    this.connCb?.(socket as unknown as ServerSocketLike);
+  }
+
+  close(cb?: () => void): void {
+    cb?.();
+  }
+
+  on(event: string, cb: (...args: unknown[]) => void): void {
+    if (event === "connection") this.connCb = cb as (ws: ServerSocketLike) => void;
+  }
+}
+
+/** The PTY manager the Core server drives. Enough of it to answer the RPCs. */
+export function makeMockPtyCore(): PtyCore & { emitEvent: (e: PtyCoreEvent) => void } {
+  const core: Record<string, unknown> = {
+    setEmitTarget: vi.fn((fn: ((event: PtyCoreEvent) => void) | null) => {
+      core._emit = fn;
+    }),
+    spawn: vi.fn(async () => ({ ptyId: "pty-1" })),
+    write: vi.fn(() => true),
+    resize: vi.fn(() => true),
+    kill: vi.fn(() => true),
+    killLaunchProcesses: vi.fn(async () => ({ ptyCount: 0, ports: [] })),
+    killPtysUnderPath: vi.fn(async () => ({ ptyCount: 0 })),
+    findByTask: vi.fn(() => ({ ptyId: "pty-1" })),
+    // Which Session a `write`/`kill` would touch — the lookup the Core's
+    // Session-lock gate resolves a ptyId through. Null: nothing here claims a
+    // Session, so every one it touches is unlocked and served.
+    taskIdForPty: vi.fn(() => null),
+    replay: vi.fn(() => ({ data: "scrollback", nextSeq: 7 })),
+    killAll: vi.fn(),
+    _emit: null,
+    emitEvent: (e: PtyCoreEvent) => {
+      (core._emit as ((e: PtyCoreEvent) => void) | null)?.(e);
+    },
+  };
+  return core as unknown as PtyCore & { emitEvent: (e: PtyCoreEvent) => void };
+}
+
+/** An in-memory event log — the port the Core's SQLite implements for real. */
+export class FakeEventLog implements EventLogPort {
+  readonly events: CoreLinkEvent[] = [];
+  private seq = 0;
+
+  appendEvent(
+    kind: string,
+    payload: string,
+    opts: { ptyId?: string | null; taskId?: string | null } = {},
+  ): number {
+    const eventId = ++this.seq;
+    this.events.push({
+      eventId,
+      ts: 1_700_000_000_000 + eventId,
+      kind,
+      ptyId: opts.ptyId ?? null,
+      taskId: opts.taskId ?? null,
+      payload,
+    });
+    return eventId;
+  }
+
+  readEventTail(afterEventId: number, limit = 1000): CoreLinkEvent[] {
+    return this.events.filter((e) => e.eventId > afterEventId).slice(0, limit);
+  }
+
+  getLastEventId(): number {
+    return this.seq;
+  }
+}
+
+export type CoreRig = {
+  server: PtyCoreLinkServer;
+  ptyCore: ReturnType<typeof makeMockPtyCore>;
+  eventLog: FakeEventLog;
+  wss: FakeSocketServer;
+  /**
+   * A socket factory to hand a client: every dial is a fresh connection this
+   * Core accepts, so a reconnect is a real second connection with its own
+   * `ready`, its own auth and its own subscription state — which is the whole of
+   * what makes the durable client's reconnect worth testing.
+   *
+   * The pairs are kept in dial order, so a test can read what went over the wire
+   * on connection one after connection two has replaced it.
+   */
+  dialer(opts?: { pingable?: boolean }): {
+    createSocket: CoreLinkSocketFactory;
+    pairs: FakeSocketPair[];
+    last(): FakeSocketPair;
+  };
+  close(): void;
+};
+
+/**
+ * Stand up a real Core server over fake sockets.
+ *
+ * `authVerifier` is what makes a rig behave like a *remote* Core — the auth gate
+ * that refuses every frame before `auth` and closes the socket. Omit it for the
+ * loopback shape, where `auth` is a no-op.
+ */
+export function startCoreRig(
+  opts: {
+    authVerifier?: (bearer: string) =>
+      | { ok: true; coreId: string; exp: number }
+      | { ok: false; reason: "expired" | "bad-signature" | "malformed" };
+    announceMultiConnection?: boolean;
+    protocolVersion?: string;
+    liveEventPollMs?: number;
+    /** Wire one to exercise the Core's own thrown-mutation → `error` frame path. */
+    mutationPort?: CoreMutationPort;
+  } = {},
+): CoreRig {
+  const ptyCore = makeMockPtyCore();
+  const eventLog = new FakeEventLog();
+  const wss = new FakeSocketServer();
+  const server = new PtyCoreLinkServer(ptyCore, {
+    port: 0,
+    createServer: () => wss as unknown as WebSocketServerLike,
+    eventLog,
+    liveEventPollMs: opts.liveEventPollMs ?? 10,
+    ...(opts.authVerifier ? { authVerifier: opts.authVerifier } : {}),
+    ...(opts.mutationPort ? { mutationPort: opts.mutationPort } : {}),
+    ...(opts.announceMultiConnection === undefined
+      ? {}
+      : { announceMultiConnection: opts.announceMultiConnection }),
+    ...(opts.protocolVersion ? { protocolVersion: opts.protocolVersion } : {}),
+  });
+  return {
+    server,
+    ptyCore,
+    eventLog,
+    wss,
+    dialer: ({ pingable = false } = {}) => {
+      const pairs: FakeSocketPair[] = [];
+      const createSocket: CoreLinkSocketFactory = () => {
+        const pair = new FakeSocketPair({ pingable });
+        pairs.push(pair);
+        // The Core accepts and writes `ready` before the dialer has wired a
+        // single listener — the client end buffers it, exactly as a real socket
+        // holds bytes nobody has read yet.
+        wss.accept(pair.server);
+        // The handshake completes a tick later, so the transport is fully wired
+        // before `open` fires and its `auth` frame goes out.
+        queueMicrotask(() => pair.open());
+        return pair.client.asClientSocket();
+      };
+      return {
+        createSocket,
+        pairs,
+        last: () => {
+          const pair = pairs[pairs.length - 1];
+          if (!pair) throw new Error("nothing dialed yet");
+          return pair;
+        },
+      };
+    },
+    close: () => server.close(),
+  };
+}

--- a/packages/sdk/src/__tests__/live-core.test.ts
+++ b/packages/sdk/src/__tests__/live-core.test.ts
@@ -1,0 +1,95 @@
+// The Core client against a Core that is actually running (issue 153).
+//
+// Opt-in, and skipped when it has nothing to dial: set `ACTANA_CORE_BLOB` to a
+// registration blob — the base64 paste itself, or a path to the file `actana
+// setup` wrote — and this suite drives both entry points against that machine's
+// live daemon.
+//
+//     ACTANA_CORE_BLOB=~/.config/actana/registration-blob.txt \
+//       pnpm --filter @actana/sdk test
+//
+// Why it exists when the rest of the suite already runs the real server class:
+// the in-process suites choose the Core's configuration, and this one is handed
+// it. A live Core has a real event log with real rows in it, a bearer signed by
+// a secret this test does not know, a protocol version this build did not pick,
+// and its own answer about the `multiConnection` capability — so it is the only
+// place the client's tolerance of a Core it did not configure is exercised.
+//
+// **Every request here is read-only.** This dials a machine somebody is working
+// on: nothing spawns a PTY, writes to a Session, claims a lock or mutates a row.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { CoreClient } from "../core-client";
+import { DurableCoreClient } from "../durable-core-client";
+import { coreConnectionFromBlob, type CoreRegistrationBlob } from "../core-registration-blob";
+
+/**
+ * Read the blob out of the environment. A value starting with `/` or `~` is a
+ * path; anything else is the paste itself. Base64 decoding lives here rather
+ * than in the package because the SDK takes a blob *object* — where a blob is
+ * kept, and how it is encoded at rest, is the CLI's business (#129 D9).
+ */
+function loadBlob(): CoreRegistrationBlob | null {
+  const raw = process.env.ACTANA_CORE_BLOB?.trim();
+  if (!raw) return null;
+  const source = raw.startsWith("~")
+    ? readFileSync(raw.replace(/^~/, homedir()), "utf8")
+    : raw.startsWith("/")
+      ? readFileSync(raw, "utf8")
+      : raw;
+  const json = Buffer.from(source.trim(), "base64").toString("utf8");
+  const parsed = JSON.parse(json) as CoreRegistrationBlob;
+  if (!parsed.endpoint || !parsed.bearer) throw new Error("ACTANA_CORE_BLOB is not a blob");
+  return parsed;
+}
+
+const blob = loadBlob();
+
+describe.skipIf(blob === null)("Core client against a live Core", () => {
+  let client: CoreClient | null = null;
+
+  afterEach(() => {
+    client?.close();
+    client = null;
+  });
+
+  it("unpacks the live blob into an endpoint, cert material and a bearer", () => {
+    const connection = coreConnectionFromBlob(blob!);
+    expect(connection.url).toMatch(/^wss:\/\//);
+    expect(connection.httpsBaseUrl).toMatch(/^https:\/\//);
+    expect(connection.tls?.ca).toContain("BEGIN CERTIFICATE");
+    expect(connection.tls?.cert).toContain("BEGIN CERTIFICATE");
+    expect(connection.tls?.key).toMatch(/BEGIN (RSA )?PRIVATE KEY/);
+    expect(connection.bearer).toBe(blob!.bearer);
+  });
+
+  it("connects, authenticates and answers a read-only request", async () => {
+    client = CoreClient.fromRegistrationBlob(blob!, { connectTimeoutMs: 15_000 });
+    const info = await client.connect();
+
+    expect(info.coreId).toMatch(/^core_/);
+    expect(info.protocolVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(info.bearerExpiresAt).toBeGreaterThan(Date.now());
+    expect(client.isAuthenticated()).toBe(true);
+
+    // Read-only, and shaped by whatever that machine happens to hold.
+    const projects = await client.projectsList();
+    expect(Array.isArray(projects)).toBe(true);
+    const sessions = await client.sessionsList();
+    expect(Array.isArray(sessions)).toBe(true);
+    const availability = await client.agentsAvailabilityList();
+    expect(typeof availability).toBe("object");
+  }, 30_000);
+
+  it("replays the live event log to a durable client and lands on its cursor", async () => {
+    const durable = DurableCoreClient.fromRegistrationBlob(blob!, { connectTimeoutMs: 15_000 });
+    client = durable;
+    await durable.connect();
+
+    await vi.waitFor(() => expect(durable.isCaughtUp()).toBe(true), { timeout: 20_000 });
+    // A live Core's log is not empty, and the cursor is where the replay ended.
+    expect(durable.getLastEventId()).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/packages/sdk/src/__tests__/package-boundaries.test.ts
+++ b/packages/sdk/src/__tests__/package-boundaries.test.ts
@@ -3,8 +3,9 @@
 // Both are traps rather than preferences, and both cost a debugging session
 // rather than a lint warning when they break.
 
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { readdirSync, readFileSync } from "node:fs";
+import { describe, it, expect, afterAll, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
 import { DurableCoreClient } from "../durable-core-client";
@@ -12,11 +13,51 @@ import { startCoreRig, type CoreRig } from "./fake-core-link";
 
 const SRC = path.resolve(import.meta.dirname, "..");
 
-/** Every shipped module — the package's own source, tests excluded. */
-function shippedSources(): string[] {
-  return readdirSync(SRC, { withFileTypes: true })
-    .filter((e) => e.isFile() && e.name.endsWith(".ts"))
-    .map((e) => path.join(SRC, e.name));
+/**
+ * Every shipped module — the package's own source at any depth, tests excluded.
+ *
+ * **Recursive on purpose.** This package is flat today, and a sweep of the top
+ * level only would have gone on passing the day somebody added
+ * `src/transport/…` — silently, and with no failure to point at the module that
+ * had just imported the world. A guardrail whose whole reason for existing is
+ * one import rule has to see every file the rule applies to.
+ *
+ * `__tests__` is the one directory left out, and it is left out rather than
+ * overlooked: the suites here drive the real Core server and the real bearer
+ * helpers through the test-only aliases in `vitest.config.ts` (see below), so
+ * they import exactly what shipped code may not.
+ */
+function shippedSources(dir: string = SRC): string[] {
+  const files: string[] = [];
+  // Sorted, so what the sweep reports is the same list in the same order on
+  // every machine — a failure naming a different file each run is a failure
+  // nobody trusts.
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  );
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      files.push(...shippedSources(full));
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * The import specifiers in a source file, however they were quoted.
+ *
+ * Double, single and backtick all count. TypeScript treats them as one thing and
+ * a formatter can rewrite between them, so a check that read only one of the
+ * three would be a guardrail with a documented way around it.
+ */
+function importSpecifiers(source: string): string[] {
+  return [
+    ...source.matchAll(/(?:^|[\s(])(?:from|import)\s*\(?\s*(["'`])([^"'`]+)\1/gm),
+  ].map((m) => m[2]!);
 }
 
 /**
@@ -28,6 +69,28 @@ function withoutComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
 }
 
+/** Every import in these files that is neither a relative path nor `ws`. */
+function offendingImports(files: string[]): string[] {
+  const offences: string[] = [];
+  for (const file of files) {
+    const source = withoutComments(readFileSync(file, "utf8"));
+    for (const specifier of importSpecifiers(source)) {
+      const allowed =
+        specifier.startsWith("./") || specifier.startsWith("../") || specifier === "ws";
+      if (!allowed) offences.push(`${path.basename(file)} imports ${specifier}`);
+    }
+  }
+  return offences;
+}
+
+/** Fixture trees the sweep-of-the-sweep plants, removed when the file is done. */
+const temporaryDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of temporaryDirs) rmSync(dir, { recursive: true, force: true });
+  temporaryDirs.length = 0;
+});
+
 describe("package boundaries", () => {
   it("imports nothing but its own modules and `ws`", () => {
     // `@actana/shared` is private and stays private (ADR 0025 D4), so an import
@@ -36,18 +99,35 @@ describe("package boundaries", () => {
     // depends on this package (D2) — importing it back would be a cycle. Both
     // are available to the suites in this directory and to nothing else, which is
     // what the test-only aliases in `vitest.config.ts` are for.
-    const offences: string[] = [];
-    for (const file of shippedSources()) {
-      const source = withoutComments(readFileSync(file, "utf8"));
-      const specifiers = [...source.matchAll(/(?:^|[\s(])(?:from|import)\s*\(?\s*"([^"]+)"/gm)].map(
-        (m) => m[1]!,
-      );
-      for (const specifier of specifiers) {
-        const allowed = specifier.startsWith("./") || specifier.startsWith("../") || specifier === "ws";
-        if (!allowed) offences.push(`${path.basename(file)} imports ${specifier}`);
-      }
-    }
+    const offences = offendingImports(shippedSources());
     expect(offences).toEqual([]);
+  });
+
+  it("sweeps subdirectories and every quote style — the guardrail on the guardrail", () => {
+    // The check above passes on a clean package either way, so it cannot tell a
+    // sweep that looked everywhere from one that looked at the top level for
+    // double quotes. This plants what each miss would have let through — a
+    // module one directory down, and a single-quoted specifier — and asserts
+    // both are caught. Without the recursion and the quote-agnostic regex above,
+    // this test fails; that is what makes them load-bearing rather than tidy.
+    const root = mkdtempSync(path.join(tmpdir(), "sdk-boundaries-"));
+    temporaryDirs.push(root);
+    mkdirSync(path.join(root, "transport"), { recursive: true });
+    mkdirSync(path.join(root, "__tests__"), { recursive: true });
+    writeFileSync(path.join(root, "ok.ts"), 'import { a } from "./a";\nimport WS from "ws";\n');
+    writeFileSync(path.join(root, "single.ts"), "import { z } from 'zod';\n");
+    writeFileSync(path.join(root, "transport", "nested.ts"), 'import x from "@actana/shared/x";\n');
+    // Left out on both counts: a test directory, and a `.test.ts` file beside
+    // shipped code. Neither is shipped, and both import what shipped code cannot.
+    writeFileSync(path.join(root, "__tests__", "rig.ts"), 'import c from "@actana/core/pty";\n');
+    writeFileSync(path.join(root, "ok.test.ts"), 'import c from "@actana/core/pty";\n');
+
+    const offences = offendingImports(shippedSources(root));
+
+    expect(offences).toEqual([
+      "single.ts imports zod",
+      "nested.ts imports @actana/shared/x",
+    ]);
   });
 
   describe("the cursor store is injected, never reached for", () => {

--- a/packages/sdk/src/__tests__/package-boundaries.test.ts
+++ b/packages/sdk/src/__tests__/package-boundaries.test.ts
@@ -1,0 +1,100 @@
+// The two boundaries this package is only useful if it keeps (issue 153).
+//
+// Both are traps rather than preferences, and both cost a debugging session
+// rather than a lint warning when they break.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import { DurableCoreClient } from "../durable-core-client";
+import { startCoreRig, type CoreRig } from "./fake-core-link";
+
+const SRC = path.resolve(import.meta.dirname, "..");
+
+/** Every shipped module — the package's own source, tests excluded. */
+function shippedSources(): string[] {
+  return readdirSync(SRC, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".ts"))
+    .map((e) => path.join(SRC, e.name));
+}
+
+/**
+ * Comments out, so prose is not read as code. These files carry a lot of it, and
+ * a sentence like `tell "locked" from "gone"` is a perfectly good import
+ * statement to a regex that never learned the difference.
+ */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("package boundaries", () => {
+  it("imports nothing but its own modules and `ws`", () => {
+    // `@actana/shared` is private and stays private (ADR 0025 D4), so an import
+    // of it here would make the one package this effort exists to publish
+    // unresolvable outside this repository. `@actana/core` is the *server* and
+    // depends on this package (D2) — importing it back would be a cycle. Both
+    // are available to the suites in this directory and to nothing else, which is
+    // what the test-only aliases in `vitest.config.ts` are for.
+    const offences: string[] = [];
+    for (const file of shippedSources()) {
+      const source = withoutComments(readFileSync(file, "utf8"));
+      const specifiers = [...source.matchAll(/(?:^|[\s(])(?:from|import)\s*\(?\s*"([^"]+)"/gm)].map(
+        (m) => m[1]!,
+      );
+      for (const specifier of specifiers) {
+        const allowed = specifier.startsWith("./") || specifier.startsWith("../") || specifier === "ws";
+        if (!allowed) offences.push(`${path.basename(file)} imports ${specifier}`);
+      }
+    }
+    expect(offences).toEqual([]);
+  });
+
+  describe("the cursor store is injected, never reached for", () => {
+    let rig: CoreRig | null = null;
+    let client: DurableCoreClient | null = null;
+    const SECRET = "boundaries-suite-secret-32-bytes-xx";
+
+    afterEach(() => {
+      client?.close();
+      client = null;
+      rig?.close();
+      rig = null;
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    });
+
+    it("leaves a global localStorage untouched even when one exists", async () => {
+      // The Panel satisfies `CoreLinkCursorStorage` with the browser's
+      // `localStorage`, and a Node package that reached for that global would
+      // drag a DOM dependency into a process that has no DOM — or, worse, work in
+      // the Panel and silently keep no cursor at all anywhere else. So: a global
+      // is planted, a client is built with no `storage` at all, and the cursor
+      // still has to advance without the global being consulted once.
+      const getItem = vi.fn(() => null);
+      const setItem = vi.fn();
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem, setItem },
+        configurable: true,
+        writable: true,
+      });
+
+      rig = startCoreRig({ authVerifier: (bearer) => verifyBearer(bearer, SECRET) });
+      rig.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });
+      const dial = rig.dialer();
+      client = new DurableCoreClient({
+        url: "wss://core.test:9444",
+        bearer: signBearer({ coreId: "core_1", exp: Date.now() + 60_000 }, SECRET),
+        createSocket: dial.createSocket,
+        reconnectInitialMs: 5,
+        reconnectMaxMs: 5,
+      });
+
+      await client.connect();
+      const connected = client;
+      await vi.waitFor(() => expect(connected.getLastEventId()).toBe(1));
+
+      expect(getItem).not.toHaveBeenCalled();
+      expect(setItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -337,8 +337,17 @@ export class CoreClient {
    * Open the link and settle when the Core has said who it is: resolves after
    * `ready` and, when a bearer is configured, after `authOk`.
    *
-   * Idempotent — a second call returns the first call's promise, so two callers
-   * racing to connect share one socket rather than opening two.
+   * Idempotent **while it is in flight** — a second call returns the first
+   * call's promise, so two callers racing to connect share one socket rather
+   * than opening two. Once it settles the memo is dropped, and what a later
+   * call gets is the state of the link *now*: the current connection's info if
+   * one is up, and a fresh attempt if none is.
+   *
+   * That distinction is the whole point. A memo kept past its rejection is a
+   * client that reports itself permanently unconnectable — a durable client
+   * whose connect deadline expired once would hand every later caller that same
+   * rejection long after its supervisor had reconnected, because nothing here
+   * ever cleared it (issue 153 review, note 3; #156 builds on this).
    *
    * Rejects on a refused bearer, on a socket that closed before it was
    * established, and on the connect deadline. A {@link DurableCoreClient} keeps
@@ -348,14 +357,30 @@ export class CoreClient {
   connect(): Promise<CoreConnectionInfo> {
     if (this.closed) return Promise.reject(new Error("core-link client closed"));
     if (this.connectPromise) return this.connectPromise;
+    // A link that is already up answers straight away rather than dialing a
+    // second one over a working first.
+    if (this.established) return Promise.resolve(this.connectionInfo());
     this.connectPromise = new Promise<CoreConnectionInfo>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.failConnect(new Error(`core-link connect to ${this.url} timed out`));
       }, this.connectTimeoutMs);
       this.connectSettle = { resolve, reject, timer };
     });
-    this.openTransport();
+    // Dial only when nothing is already dialing on this client's behalf. A
+    // transport mid-handshake, or a durable client's backoff timer about to make
+    // one, will settle the promise above through the ordinary handlers — opening
+    // another socket here would orphan whichever of the two lost the race.
+    if (!this.transport && !this.reconnectScheduled()) this.openTransport();
     return this.connectPromise;
+  }
+
+  /**
+   * Is a reconnect already pending, so `connect()` must not dial itself? Never
+   * for a one-shot client, which has no supervisor; {@link DurableCoreClient}
+   * overrides it with its backoff timer.
+   */
+  protected reconnectScheduled(): boolean {
+    return false;
   }
 
   /**
@@ -383,8 +408,16 @@ export class CoreClient {
           this.maybeEstablish();
         },
         onWritable: () => {
+          // Writability alone does not drain the queue. `maybeEstablish` flushes
+          // it once the connection is established, *behind* what that connection
+          // owed the Core — and on the no-bearer path writability lands before
+          // `ready`, so flushing here regardless would put a caller's request on
+          // the wire ahead of `reclaim` and `subscribe`, which is the ordering
+          // the comment on `onConnectionEstablished` promises callers. The guard
+          // covers the case where writability returns on a connection that is
+          // already established.
           this.maybeEstablish();
-          this.flushQueue();
+          if (this.established) this.flushQueue();
         },
         onAuthOk: (frame) => {
           this.authOkFrame = frame;
@@ -406,6 +439,12 @@ export class CoreClient {
           this.ready = null;
           this.multiConnection = null;
           this.authOkFrame = null;
+          // Cleared here and not only on the next dial: between a socket dying
+          // and a durable client's backoff opening the next one, this client is
+          // not established, and a `connect()` arriving in that gap must wait
+          // for the connection that is coming rather than be told about the one
+          // that just died.
+          this.established = false;
           this.transport = null;
           this.failInFlight();
           for (const cb of this.disconnectedListeners) cb({ error: reason });
@@ -465,6 +504,7 @@ export class CoreClient {
     const settle = this.connectSettle;
     if (!settle) return;
     this.connectSettle = null;
+    this.connectPromise = null;
     clearTimeout(settle.timer);
     settle.resolve(this.connectionInfo());
   }
@@ -473,6 +513,9 @@ export class CoreClient {
     const settle = this.connectSettle;
     if (!settle) return;
     this.connectSettle = null;
+    // Dropped on failure as well as on success: a rejected promise held in the
+    // memo would be handed to every later caller forever. See `connect()`.
+    this.connectPromise = null;
     clearTimeout(settle.timer);
     settle.reject(err);
   }

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -261,6 +261,8 @@ export class CoreClient {
 
   protected transport: CoreLinkTransport | null = null;
   protected closed = false;
+  /** True once this connection has been established — reset per connection. */
+  private established = false;
 
   /** Requests written to no socket yet. They survive a reconnect; a timeout is what ends them. */
   private readonly queue: PendingRequest[] = [];
@@ -366,6 +368,7 @@ export class CoreClient {
     this.ready = null;
     this.multiConnection = null;
     this.authOkFrame = null;
+    this.established = false;
     this.transport = new CoreLinkTransport({
       url: this.url,
       createSocket: this.createSocket,
@@ -377,21 +380,10 @@ export class CoreClient {
           this.multiConnection = readMultiConnectionCapability(frame.multiConnection);
           const info = this.connectionInfo();
           for (const cb of this.readyListeners) cb(info);
-          // With no bearer there is no `authOk` coming, so this frame is both
-          // the capability announcement and the go-ahead. `onWritable` has
-          // already fired by now (it rides the socket opening), which is why the
-          // connection's opening frames are sent from here in that case — see
-          // `onConnectionWritable`.
-          if (!this.bearer) this.onConnectionEstablished();
+          this.maybeEstablish();
         },
         onWritable: () => {
-          // With a bearer this runs after `authOk`, so the Core has accepted
-          // this connection and the capability off `ready` is already recorded
-          // (`ready` is frame one, always ahead of any auth answer). Without one
-          // it runs on open, before `ready` — so the frames that depend on the
-          // capability are sent from `onConnectionEstablished` instead, and only
-          // the queue is drained here.
-          if (this.bearer) this.onConnectionEstablished();
+          this.maybeEstablish();
           this.flushQueue();
         },
         onAuthOk: (frame) => {
@@ -437,6 +429,29 @@ export class CoreClient {
    */
   protected onConnectionEstablished(): void {
     this.sendReclaim();
+  }
+
+  /**
+   * Establish the connection once both halves of "established" are true: the
+   * Core has said who it is (`ready`), and the link can be written to (open, and
+   * authenticated when a bearer was configured).
+   *
+   * **Whichever lands last is what triggers it**, and that is not a fixed order.
+   * With a bearer it is `authOk`, well after `ready`. Without one, writability
+   * rides the socket opening and `ready` normally follows — but a Core that got
+   * its frame in first would otherwise have the connection's opening frames sent
+   * against a socket that is not writable yet, and a `subscribe` dropped there is
+   * a client that never receives an event again. Waiting for both removes the
+   * ordering assumption instead of relying on it.
+   */
+  private maybeEstablish(): void {
+    if (this.established || this.closed) return;
+    if (!this.ready || !this.transport?.writable) return;
+    this.established = true;
+    this.onConnectionEstablished();
+    // The queue goes out behind what the connection owed the Core, so a replay
+    // tail is delivered ahead of the answers to requests that were waiting.
+    this.flushQueue();
     this.settleConnect();
   }
 

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -1,0 +1,1098 @@
+// `CoreClient` — the default entry point: connect, authenticate, ask, close.
+//
+// One socket, one Core, mTLS + bearer from a registration blob (#129 D1, D5).
+// **There is no `Fleet` type here and there must not be**: a Core client speaks
+// to the machine it dialed, and holding several is the Panel's job, not a shape
+// this package grows. That is D5, and the Panel remains the fleet.
+//
+// This is what the CLI and a script use (#129 D6, "one-shot is the default"):
+// connect, ask a question, act on the answer, exit. It does not reconnect, does
+// not persist an event cursor, and does not ping — every one of those belongs to
+// a program that stays up, and that program is
+// {@link DurableCoreClient} in `durable-core-client.ts`, which is this class
+// plus a supervisor. Both sit on one {@link CoreLinkTransport}, so the wire is
+// written once.
+//
+// Extracted from the Panel's `PtyCoreLinkClient` (issue 153). The typed method
+// set below is deliberately that class's, frame for frame, so the Panel's
+// migration (#156) is a swap rather than a rewrite of its call sites; the parts
+// that class did *not* have — an explicit `connect()` you can await, a
+// connection that does not resurrect itself — are what a one-shot client needs
+// and a Panel never asked for.
+
+import {
+  coreLinkProtocolCompatible,
+  readMultiConnectionCapability,
+  type CoreLinkErrorCode,
+  type CoreLinkEvent,
+  type CoreLinkHarnessAvailabilityMap,
+  type CoreLinkLaunchProcessKillResult,
+  type CoreLinkMultiConnectionCapability,
+  type CoreLinkProjectMutation,
+  type CoreLinkProjectSnapshot,
+  type CoreLinkPtyReplay,
+  type CoreLinkPtySpawnOptions,
+  type CoreLinkRequestFrame,
+  type CoreLinkResponseFrame,
+  type CoreLinkSessionSnapshot,
+  type CoreLinkSessionTakenFrom,
+  type CoreLinkTaskMutation,
+  type CoreLinkTaskSnapshot,
+} from "./core-link-frames";
+import {
+  CoreLinkTransport,
+  type CoreLinkAuthErrorReason,
+  type CoreLinkAuthOkFrame,
+  type CoreLinkDataFrame,
+  type CoreLinkExitFrame,
+  type CoreLinkHeartbeatOptions,
+  type CoreLinkReadyFrame,
+} from "./core-link-transport";
+import {
+  createNodeCoreLinkSocket,
+  type CoreLinkSocketFactory,
+  type CoreLinkTlsMaterial,
+} from "./core-link-socket";
+import { coreConnectionFromBlob, type CoreRegistrationBlob } from "./core-registration-blob";
+
+/**
+ * Request frames that only mean anything against a Core announcing
+ * `multiConnection` on `ready` (ADR 0024 D11) — the one list
+ * {@link CoreClient.canSendMultiConnectionFrames} guards.
+ *
+ * `ptySubscribe` / `ptyUnsubscribe` (ADR 0024 D2) are the first entries: a Core
+ * that fans a PTY out per subscription is exactly a multi-connection Core, and
+ * one that never announced the capability has no subscription list to put a PTY
+ * on. The Session lock's `claim` / `release` / `forceTakeover` (D3–D7) joined
+ * them for the same reason in its own key: a single-connection Core has no lock
+ * table to address, because it evicts every client but one and therefore has
+ * nothing for a lock to arbitrate between. `reclaim` (D9) is the sharpest of the
+ * three: a single-connection Core evicts its predecessor on connect *already*,
+ * so the frame asks for what that Core has just done, out of a lock table it
+ * does not have.
+ *
+ * Being in this set is not the whole story for a frame whose caller has
+ * something better to do than fail. A caller that can degrade consults
+ * {@link CoreClient.canSendMultiConnectionFrames} and takes the
+ * single-connection route itself — see {@link CoreClient.ptySubscribe} and
+ * {@link CoreClient.claim}, which both do exactly that. The rejection in
+ * {@link CoreClient.request} is the backstop for callers that ask without
+ * checking, not the designed path for the frames listed here.
+ */
+export const MULTI_CONNECTION_ONLY_FRAME_TYPES: ReadonlySet<CoreLinkRequestFrame["type"]> =
+  new Set<CoreLinkRequestFrame["type"]>([
+    "ptySubscribe",
+    "ptyUnsubscribe",
+    "claim",
+    "release",
+    "forceTakeover",
+    "reclaim",
+  ]);
+
+/**
+ * The rejection a caller gets when the Core answers a request with an `error`
+ * frame — carrying that frame's machine-readable {@link CoreLinkErrorCode}
+ * alongside its prose (issue 144).
+ *
+ * `code` exists precisely so a caller does not have to match on `message`, and a
+ * client that threw a bare `Error` would put the parsing back that the field was
+ * added to remove. It is optional on the wire and optional here: absent on every
+ * error that shipped before the field, so a reader takes the code when it is
+ * there and falls back to the message when it is not — never the reverse.
+ *
+ * `session-locked` is its first value and the reason this class exists: a
+ * mutation refused because another Core client holds that Session throws,
+ * whereas a mutation aimed at a Session this Core no longer has resolves
+ * (`ok: false` / `task: null`). One of the two is worth retrying after a claim
+ * and the other never is, and telling them apart is the caller's whole job.
+ */
+export class CoreLinkRequestError extends Error {
+  /** The `code` off the `error` frame, when it carried one. */
+  readonly code?: CoreLinkErrorCode;
+
+  constructor(message: string, code?: CoreLinkErrorCode) {
+    super(message);
+    this.name = "CoreLinkRequestError";
+    this.code = code;
+  }
+}
+
+/** Thrown when a bearer is refused: `expired`, `bad-signature`, `malformed`. */
+export class CoreLinkAuthError extends Error {
+  readonly reason: CoreLinkAuthErrorReason;
+
+  constructor(reason: CoreLinkAuthErrorReason) {
+    super(`core-link authentication failed: ${reason}`);
+    this.name = "CoreLinkAuthError";
+    this.reason = reason;
+  }
+}
+
+/** What a connected Core told this client about itself, on `ready` and `authOk`. */
+export type CoreConnectionInfo = {
+  /** The protocol version off `ready`, or null when the frame carried none. */
+  protocolVersion: string | null;
+  /** Does this build speak that version? See `coreLinkProtocolCompatible`. */
+  compatible: boolean;
+  /** The `multiConnection` capability, or null on a single-connection Core. */
+  multiConnection: CoreLinkMultiConnectionCapability | null;
+  /** The `coreId` off `authOk`; null when no bearer was configured. */
+  coreId: string | null;
+  /** The bearer's expiry off `authOk`; null when no bearer was configured. */
+  bearerExpiresAt: number | null;
+};
+
+export type CoreClientOptions = {
+  /** The core-link URL to dial. Ignored when {@link CoreClientOptions.blob} is set. */
+  url?: string;
+  /** PEM material for the mTLS handshake (ADR 0002). Ignored when `blob` is set. */
+  tls?: CoreLinkTlsMaterial | null;
+  /**
+   * The signed bearer presented in the `auth` frame (ADR 0002). Required by
+   * every real Core; omitted only by a loopback rig or a test.
+   */
+  bearer?: string | null;
+  /**
+   * A registration blob — endpoint, PEM material and bearer in one object, which
+   * is how a Core client is actually configured (#129 D1/D9). Set this and the
+   * three fields above are read off it.
+   */
+  blob?: CoreRegistrationBlob;
+  /**
+   * How to open the socket. Defaults to the Node `ws` dial with the `tls`
+   * material — the only transport that can present a client certificate.
+   * Injectable for tests and for a runtime with its own WebSocket.
+   */
+  createSocket?: CoreLinkSocketFactory;
+  /** Deadline for {@link CoreClient.connect}. Default 30s. */
+  connectTimeoutMs?: number;
+  /** Default deadline for one request. Default 30s. */
+  requestTimeoutMs?: number;
+  /**
+   * Arm the connection heartbeat. Off by default here and on in
+   * {@link DurableCoreClient} — see {@link CoreLinkTransport}.
+   */
+  heartbeat?: CoreLinkHeartbeatOptions | false;
+  /**
+   * This client's stable Core client id, presented on every connection so a Core
+   * reaps the socket this one replaces (ADR 0024 D9).
+   *
+   * Default: a fresh id per instance. That is honest rather than a shortcut —
+   * the id's job is to span a *reconnect*, and only a client that reconnects has
+   * one to span. Pass one explicitly to make it outlive the process, and keep it
+   * per Core client: it must never be anything off the registration blob, which
+   * is machine-scoped, or the Panel, the CLI and every automation on that
+   * machine become one client, each reconnect reaping the others.
+   */
+  clientId?: string;
+  /**
+   * Overrides {@link MULTI_CONNECTION_ONLY_FRAME_TYPES}. Exists only so a test
+   * can drive the rejection in {@link CoreClient.request} with a stand-in frame
+   * type: the real entries all degrade at their call sites rather than reach
+   * that backstop. Production never passes it.
+   */
+  multiConnectionOnlyFrameTypes?: ReadonlySet<string>;
+};
+
+/** Default deadline for a dial: `ready` plus, with a bearer, `authOk`. */
+export const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+/** Default deadline for one request/response round trip. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+type Unsubscribe = () => void;
+
+/** One caller's outstanding request — queued, in flight, or timing out. */
+type PendingRequest = {
+  frame: CoreLinkRequestFrame;
+  resolve: (frame: CoreLinkResponseFrame) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+  settled: boolean;
+};
+
+/**
+ * Mint this client's Core client id (ADR 0024 D9).
+ *
+ * Random rather than derived from anything: two clients must not collide, and
+ * every input that would make an id stable across processes — the endpoint, the
+ * coreId, the bearer — is shared by every client dialing that machine, which is
+ * the one shape D9 forbids. Unguessability buys nothing security-wise and is not
+ * claimed to; nothing verifies this string, and a Core hands out no more to a
+ * client presenting it than to one that asks for a `forceTakeover` outright.
+ *
+ * The `sdk-` prefix is for the Core's log, where a reclaim line is otherwise an
+ * opaque token with no clue which of a machine's clients reconnected.
+ */
+function mintCoreClientId(): string {
+  const random = globalThis.crypto?.randomUUID?.();
+  if (random) return `sdk-${random}`;
+  // Every runtime this supports has `crypto.randomUUID`. The fallback keeps an
+  // id — which only has to differ from its neighbours — from being the thing
+  // that throws in an exotic one.
+  return `sdk-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * A Core client over one core link.
+ *
+ * Lifecycle: construct, `await connect()`, ask, `close()`. Construction opens
+ * nothing — a client you have not connected has sent no bytes, which is what
+ * makes `connect()`'s rejection the one place a dial failure is reported.
+ */
+export class CoreClient {
+  /** The URL this client dials. Public because a log line without it is a riddle. */
+  readonly url: string;
+  /**
+   * This client's Core client id — the same string on every connection it opens,
+   * which is the whole of what makes a reconnect reclaimable (ADR 0024 D9).
+   *
+   * Readonly: an id that moved between connections would reclaim nothing and
+   * leave the predecessor holding its Sessions for the full heartbeat timeout,
+   * which is the exact failure the frame exists to remove.
+   */
+  readonly clientId: string;
+
+  protected readonly createSocket: CoreLinkSocketFactory;
+  protected readonly bearer: string | null;
+  protected readonly heartbeat: CoreLinkHeartbeatOptions | false;
+  private readonly connectTimeoutMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly multiConnectionOnlyFrameTypes: ReadonlySet<string>;
+
+  protected transport: CoreLinkTransport | null = null;
+  protected closed = false;
+
+  /** Requests written to no socket yet. They survive a reconnect; a timeout is what ends them. */
+  private readonly queue: PendingRequest[] = [];
+  /** Requests on the wire right now, so a dying socket can fail them at once. */
+  private readonly inFlight = new Set<PendingRequest>();
+
+  private connectPromise: Promise<CoreConnectionInfo> | null = null;
+  private connectSettle: {
+    resolve: (info: CoreConnectionInfo) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
+
+  /** This connection's `ready` frame; null before it lands and after a drop. */
+  private ready: CoreLinkReadyFrame | null = null;
+  /**
+   * This Core's `multiConnection` capability as announced on the *current*
+   * connection; null when absent and before `ready` lands.
+   *
+   * Re-read on every `ready` rather than remembered across connections: a Core
+   * can be downgraded, and a stale `true` here would send frames the Core no
+   * longer understands. Null until the frame arrives, so the gate is closed
+   * during the window where the answer is genuinely unknown.
+   */
+  private multiConnection: CoreLinkMultiConnectionCapability | null = null;
+  private authOkFrame: CoreLinkAuthOkFrame | null = null;
+
+  private readonly readyListeners = new Set<(info: CoreConnectionInfo) => void>();
+  private readonly dataListeners = new Set<(frame: CoreLinkDataFrame) => void>();
+  private readonly exitListeners = new Set<(frame: CoreLinkExitFrame) => void>();
+  private readonly eventListeners = new Set<(msg: { event: CoreLinkEvent }) => void>();
+  private readonly eventsReplayedListeners = new Set<(msg: { lastEventId: number }) => void>();
+  private readonly authOkListeners = new Set<(msg: { coreId: string; exp: number }) => void>();
+  private readonly authErrorListeners = new Set<
+    (msg: { reason: CoreLinkAuthErrorReason }) => void
+  >();
+  private readonly disconnectedListeners = new Set<(msg: { error?: string }) => void>();
+  private readonly reclaimedListeners = new Set<
+    (msg: { replaced: boolean; taskIds: string[] }) => void
+  >();
+
+  constructor(opts: CoreClientOptions) {
+    const connection = opts.blob ? coreConnectionFromBlob(opts.blob) : null;
+    const url = connection?.url ?? opts.url;
+    if (!url) {
+      throw new Error("CoreClient needs a url or a registration blob to dial");
+    }
+    this.url = url;
+    const tls = connection ? connection.tls : (opts.tls ?? null);
+    this.bearer = connection ? connection.bearer : (opts.bearer ?? null);
+    this.createSocket =
+      opts.createSocket ?? ((dialUrl: string) => createNodeCoreLinkSocket(dialUrl, tls ?? undefined));
+    this.connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.heartbeat = opts.heartbeat ?? false;
+    this.clientId = opts.clientId ?? mintCoreClientId();
+    this.multiConnectionOnlyFrameTypes =
+      opts.multiConnectionOnlyFrameTypes ?? MULTI_CONNECTION_ONLY_FRAME_TYPES;
+  }
+
+  /** Build a client straight off a registration blob (#129 D1). */
+  static fromRegistrationBlob(
+    blob: CoreRegistrationBlob,
+    opts: Omit<CoreClientOptions, "blob" | "url" | "tls" | "bearer"> = {},
+  ): CoreClient {
+    return new CoreClient({ ...opts, blob });
+  }
+
+  // ─── Connection lifecycle ──────────────────────────────────────────────────
+
+  /**
+   * Open the link and settle when the Core has said who it is: resolves after
+   * `ready` and, when a bearer is configured, after `authOk`.
+   *
+   * Idempotent — a second call returns the first call's promise, so two callers
+   * racing to connect share one socket rather than opening two.
+   *
+   * Rejects on a refused bearer, on a socket that closed before it was
+   * established, and on the connect deadline. A {@link DurableCoreClient} keeps
+   * retrying underneath regardless; what rejects there is this promise, not the
+   * client.
+   */
+  connect(): Promise<CoreConnectionInfo> {
+    if (this.closed) return Promise.reject(new Error("core-link client closed"));
+    if (this.connectPromise) return this.connectPromise;
+    this.connectPromise = new Promise<CoreConnectionInfo>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.failConnect(new Error(`core-link connect to ${this.url} timed out`));
+      }, this.connectTimeoutMs);
+      this.connectSettle = { resolve, reject, timer };
+    });
+    this.openTransport();
+    return this.connectPromise;
+  }
+
+  /**
+   * Open one connection and wire it to this client. The transport is per socket;
+   * every listener above is per client, which is what lets a durable subclass
+   * replace the former without anything above noticing.
+   */
+  protected openTransport(): void {
+    if (this.closed) return;
+    this.ready = null;
+    this.multiConnection = null;
+    this.authOkFrame = null;
+    this.transport = new CoreLinkTransport({
+      url: this.url,
+      createSocket: this.createSocket,
+      bearer: this.bearer,
+      heartbeat: this.heartbeat,
+      handlers: {
+        onReady: (frame) => {
+          this.ready = frame;
+          this.multiConnection = readMultiConnectionCapability(frame.multiConnection);
+          const info = this.connectionInfo();
+          for (const cb of this.readyListeners) cb(info);
+          // With no bearer there is no `authOk` coming, so this frame is both
+          // the capability announcement and the go-ahead. `onWritable` has
+          // already fired by now (it rides the socket opening), which is why the
+          // connection's opening frames are sent from here in that case — see
+          // `onConnectionWritable`.
+          if (!this.bearer) this.onConnectionEstablished();
+        },
+        onWritable: () => {
+          // With a bearer this runs after `authOk`, so the Core has accepted
+          // this connection and the capability off `ready` is already recorded
+          // (`ready` is frame one, always ahead of any auth answer). Without one
+          // it runs on open, before `ready` — so the frames that depend on the
+          // capability are sent from `onConnectionEstablished` instead, and only
+          // the queue is drained here.
+          if (this.bearer) this.onConnectionEstablished();
+          this.flushQueue();
+        },
+        onAuthOk: (frame) => {
+          this.authOkFrame = frame;
+          for (const cb of this.authOkListeners) cb({ coreId: frame.coreId, exp: frame.exp });
+        },
+        onAuthError: (reason) => {
+          for (const cb of this.authErrorListeners) cb({ reason });
+          this.failConnect(new CoreLinkAuthError(reason));
+        },
+        onData: (frame) => {
+          for (const cb of this.dataListeners) cb(frame);
+        },
+        onExit: (frame) => {
+          for (const cb of this.exitListeners) cb(frame);
+        },
+        onEvent: (event) => this.deliverEvent(event),
+        onEventsReplayed: (lastEventId) => this.deliverEventsReplayed(lastEventId),
+        onClose: (reason) => {
+          this.ready = null;
+          this.multiConnection = null;
+          this.authOkFrame = null;
+          this.transport = null;
+          this.failInFlight();
+          for (const cb of this.disconnectedListeners) cb({ error: reason });
+          this.onConnectionClosed(reason);
+        },
+      },
+    });
+  }
+
+  /**
+   * The connection is up, authenticated if it had to be, and the capability off
+   * `ready` is known. What a fresh connection owes the Core goes here.
+   *
+   * `reclaim` is the whole of it for a one-shot client, and it is fire-and-forget
+   * by design (ADR 0024 D9): nothing waits on the answer, because the locks have
+   * already moved by the time it is written, and a reclaim that never lands costs
+   * the 45-second heartbeat timeout it was shortening — a slower path to the same
+   * state, never a wrong one.
+   *
+   * Overridden by {@link DurableCoreClient}, which owes the Core rather more.
+   */
+  protected onConnectionEstablished(): void {
+    this.sendReclaim();
+    this.settleConnect();
+  }
+
+  /** The socket is gone. A one-shot client is done; a durable one reconnects. */
+  protected onConnectionClosed(reason?: string): void {
+    if (this.closed) return;
+    this.failConnect(new Error(reason ? `core-link closed: ${reason}` : "core-link closed"));
+  }
+
+  private settleConnect(): void {
+    const settle = this.connectSettle;
+    if (!settle) return;
+    this.connectSettle = null;
+    clearTimeout(settle.timer);
+    settle.resolve(this.connectionInfo());
+  }
+
+  private failConnect(err: Error): void {
+    const settle = this.connectSettle;
+    if (!settle) return;
+    this.connectSettle = null;
+    clearTimeout(settle.timer);
+    settle.reject(err);
+  }
+
+  /** What the current connection said about itself. */
+  connectionInfo(): CoreConnectionInfo {
+    return {
+      protocolVersion: this.ready?.version ?? null,
+      compatible: coreLinkProtocolCompatible(this.ready?.version ?? null),
+      multiConnection: this.multiConnection,
+      coreId: this.authOkFrame?.coreId ?? null,
+      bearerExpiresAt: this.authOkFrame?.exp ?? null,
+    };
+  }
+
+  /** True once the Core has accepted this connection's bearer. */
+  isAuthenticated(): boolean {
+    return this.transport?.isAuthenticated ?? false;
+  }
+
+  /** True while a link is up and able to carry a frame. */
+  isConnected(): boolean {
+    return this.transport?.writable ?? false;
+  }
+
+  /**
+   * May this Core be sent frames only a multi-connection Core understands — the
+   * Session lock's `claim`, the per-connection PTY subscription, and whatever
+   * else lands under ADR 0024?
+   *
+   * **The one predicate to consult before sending any such frame.** False means
+   * do not send it: not send-and-handle-the-error, not send-and-hope. The Core on
+   * the other end is a single-connection build that would answer an unknown frame
+   * with an error frame at best, and the caller is expected to have a
+   * single-connection path already — that path is what shipped before this
+   * capability existed.
+   *
+   * False before `ready` lands and after a drop, for as long as the answer is
+   * unknown. A caller that needs the capability at startup awaits
+   * {@link connect}, whose answer carries it, rather than reading this on the
+   * first tick.
+   */
+  canSendMultiConnectionFrames(): boolean {
+    return this.multiConnection !== null;
+  }
+
+  /**
+   * This connection's `multiConnection` capability, or null. For callers that
+   * need the version rather than the yes/no — the gate is
+   * {@link canSendMultiConnectionFrames}.
+   */
+  multiConnectionCapability(): CoreLinkMultiConnectionCapability | null {
+    return this.multiConnection;
+  }
+
+  /** Hang up. Rejects every outstanding request; fires no `onDisconnected`. */
+  close(): void {
+    this.closed = true;
+    const err = new Error("core-link client closed");
+    for (const entry of [...this.queue, ...this.inFlight]) this.settle(entry, () => entry.reject(err));
+    this.queue.length = 0;
+    this.inFlight.clear();
+    this.failConnect(err);
+    this.transport?.close();
+    this.transport = null;
+  }
+
+  // ─── Requests ──────────────────────────────────────────────────────────────
+
+  /**
+   * Send any core-link request frame and resolve with the Core's raw response
+   * frame — errors included, as frames rather than rejections.
+   *
+   * This is the seam a router forwards through. A router that had to go through
+   * the typed methods below would unwrap each response only to re-wrap it, and
+   * would have to invent a shape for the failures those methods turn into
+   * rejections. Handing it the frame keeps it a router rather than a translator.
+   *
+   * The `reqId` on the frame passed in is ignored — the transport owns
+   * correlation on its own socket, and the returned frame carries the id it
+   * assigned. A caller matching answers to its own callers (the Panel does,
+   * across many browsers) keys on its own id and rewrites it on the way back.
+   *
+   * A frame issued while no link is up is **queued, not refused**: it goes out
+   * when one comes up, or its deadline ends it. That is what makes a call made
+   * during a reconnect work rather than needing every call site to retry.
+   */
+  request(
+    frame: CoreLinkRequestFrame,
+    timeoutMs: number = this.requestTimeoutMs,
+  ): Promise<CoreLinkResponseFrame> {
+    if (this.closed) return Promise.reject(new Error("core-link client closed"));
+    // The gate (ADR 0024 D11). A multi-connection-only frame aimed at a Core
+    // that never announced the capability is refused here, before anything
+    // reaches the socket — the Core never sees it, so there is no error frame to
+    // tolerate. The rejection is for the caller that asked without checking; the
+    // supported path is to consult `canSendMultiConnectionFrames()` and take the
+    // single-connection route.
+    if (this.multiConnectionOnlyFrameTypes.has(frame.type) && !this.canSendMultiConnectionFrames()) {
+      return Promise.reject(
+        new Error(
+          `core-link frame ${frame.type} needs the multiConnection capability, which this Core does not announce`,
+        ),
+      );
+    }
+    return new Promise<CoreLinkResponseFrame>((resolve, reject) => {
+      const entry: PendingRequest = { frame, resolve, reject, timer: null, settled: false };
+      entry.timer = setTimeout(() => {
+        this.forget(entry);
+        this.settle(entry, () =>
+          reject(new Error(`core-link rpc ${frame.type} timed out`)),
+        );
+      }, timeoutMs);
+      this.dispatch(entry);
+    });
+  }
+
+  /** Send now if there is a link, otherwise hold it for the next one. */
+  private dispatch(entry: PendingRequest): void {
+    const transport = this.transport;
+    if (!transport?.writable) {
+      this.queue.push(entry);
+      return;
+    }
+    this.inFlight.add(entry);
+    transport.request(entry.frame).then(
+      (response) => {
+        this.inFlight.delete(entry);
+        this.settle(entry, () => entry.resolve(response));
+      },
+      (err: Error) => {
+        this.inFlight.delete(entry);
+        this.settle(entry, () => entry.reject(err));
+      },
+    );
+  }
+
+  /** Drain what was waiting for a link, in the order it was asked for. */
+  private flushQueue(): void {
+    if (this.queue.length === 0) return;
+    const queued = this.queue.splice(0);
+    for (const entry of queued) {
+      if (entry.settled) continue;
+      this.dispatch(entry);
+    }
+  }
+
+  /**
+   * Fail every request that was on the wire when the socket died. Their replies
+   * can never arrive, so leaving them pending only makes a caller wait out its
+   * whole deadline before it can retry on the next connection.
+   */
+  private failInFlight(): void {
+    if (this.inFlight.size === 0) return;
+    const err = new Error("core-link connection lost");
+    const entries = [...this.inFlight];
+    this.inFlight.clear();
+    for (const entry of entries) this.settle(entry, () => entry.reject(err));
+  }
+
+  private forget(entry: PendingRequest): void {
+    this.inFlight.delete(entry);
+    const at = this.queue.indexOf(entry);
+    if (at >= 0) this.queue.splice(at, 1);
+  }
+
+  private settle(entry: PendingRequest, finish: () => void): void {
+    if (entry.settled) return;
+    entry.settled = true;
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = null;
+    finish();
+  }
+
+  /** Send a request and unwrap the Core's answer into the value it carries. */
+  protected rpc(frame: CoreLinkRequestFrame, timeoutMs?: number): Promise<unknown> {
+    return this.request(frame, timeoutMs).then((response) => unwrapResponse(response));
+  }
+
+  /**
+   * Send a fire-and-forget frame on the current connection. False when there is
+   * no writable connection to put it on — for the frames whose answer is a
+   * stream and whose retry is the next connection re-sending them anyway.
+   */
+  protected sendNow(frame: CoreLinkRequestFrame, reqIdPrefix?: string): boolean {
+    const transport = this.transport;
+    if (!transport) return false;
+    return transport.send(frame, reqIdPrefix) !== null;
+  }
+
+  /**
+   * Present this client's Core client id, so the Core closes the socket this
+   * connection replaces and moves its Session locks here (ADR 0024 D9).
+   *
+   * The answer is not discarded, though (issue 147). `taskIds` names the Sessions
+   * whose locks came across, and that is a fact no layer above can derive: this
+   * connection did not claim them, the Core logged no event for the transfer —
+   * the locks moved in place, which is exactly the atomicity D9 needs — so until
+   * something asks for a fresh snapshot nothing else on the link says this client
+   * is holding them again. Hence {@link onReclaimed}.
+   *
+   * **Against a Core that does not announce `multiConnection`, this sends
+   * nothing** — the same consult-the-gate-and-degrade shape
+   * {@link ptySubscribe} and {@link claim} take, and here the degraded behaviour
+   * is not merely acceptable but identical: such a Core evicts the previous
+   * connection when this one opens, which is precisely what the frame asks for.
+   */
+  protected sendReclaim(): void {
+    if (!this.canSendMultiConnectionFrames()) return;
+    void this.rpc({ type: "reclaim", reqId: "", clientId: this.clientId })
+      .then((result) => {
+        const answer = result as { replaced?: boolean; taskIds?: string[] } | undefined;
+        if (!answer) return;
+        const msg = {
+          replaced: answer.replaced === true,
+          taskIds: Array.isArray(answer.taskIds) ? answer.taskIds : [],
+        };
+        for (const cb of this.reclaimedListeners) {
+          try {
+            cb(msg);
+          } catch {
+            /* a listener's failure is not this connection's failure */
+          }
+        }
+      })
+      .catch(() => {
+        /* the socket died again; the next connection presents the same id */
+      });
+  }
+
+  // ─── The three unsolicited streams, plus the event log ─────────────────────
+
+  /**
+   * One PTY's bytes, as the transport parsed them. Nothing above re-parses a raw
+   * message: this is the frame, typed against the SDK's own schema.
+   *
+   * A Core sends a PTY's `data` only to the connections that asked for it, so
+   * {@link ptySubscribe} is what makes this fire at all against a
+   * multi-connection Core.
+   */
+  onData(cb: (frame: CoreLinkDataFrame) => void): Unsubscribe {
+    this.dataListeners.add(cb);
+    return () => this.dataListeners.delete(cb);
+  }
+
+  /** One PTY's exit, on the same terms as {@link onData}. */
+  onExit(cb: (frame: CoreLinkExitFrame) => void): Unsubscribe {
+    this.exitListeners.add(cb);
+    return () => this.exitListeners.delete(cb);
+  }
+
+  /**
+   * Notified on every connection's `ready` frame with what the Core says about
+   * itself — the protocol version, whether this build speaks it, and the
+   * `multiConnection` capability. Fires on every (re)connect, so a Core that
+   * comes back after an update reports itself compatible with no extra plumbing.
+   */
+  onReady(cb: (info: CoreConnectionInfo) => void): Unsubscribe {
+    this.readyListeners.add(cb);
+    return () => this.readyListeners.delete(cb);
+  }
+
+  /**
+   * Domain events off the Core's monotonic log — task status, hooks, session
+   * finish, PTY lifecycle. A one-shot client receives only what arrives while it
+   * is connected; the cursor, the replay and the dedupe that make a *gap*
+   * recoverable are {@link DurableCoreClient}'s.
+   */
+  onEvent(cb: (msg: { event: CoreLinkEvent }) => void): Unsubscribe {
+    this.eventListeners.add(cb);
+    return () => this.eventListeners.delete(cb);
+  }
+
+  /** Notified when a `subscribe` replay tail has been fully streamed. */
+  onEventsReplayed(cb: (msg: { lastEventId: number }) => void): Unsubscribe {
+    this.eventsReplayedListeners.add(cb);
+    return () => this.eventsReplayedListeners.delete(cb);
+  }
+
+  /**
+   * Notified once per connection when the Core accepts the bearer. `exp` is the
+   * session expiry — a caller can hint "session expires at".
+   */
+  onAuthOk(cb: (msg: { coreId: string; exp: number }) => void): Unsubscribe {
+    this.authOkListeners.add(cb);
+    return () => this.authOkListeners.delete(cb);
+  }
+
+  /**
+   * Notified when the Core refuses the bearer. The Core closes the socket right
+   * after; an expired bearer keeps failing until a reissued blob is pasted (ADR
+   * 0003).
+   */
+  onAuthError(cb: (msg: { reason: CoreLinkAuthErrorReason }) => void): Unsubscribe {
+    this.authErrorListeners.add(cb);
+    return () => this.authErrorListeners.delete(cb);
+  }
+
+  /**
+   * Notified whenever the socket goes down — a dropped connection, a Core
+   * restart, a dial that never completed. `close()` does not fire it: that is
+   * this client hanging up, not the Core going away.
+   */
+  onDisconnected(cb: (msg: { error?: string }) => void): Unsubscribe {
+    this.disconnectedListeners.add(cb);
+    return () => this.disconnectedListeners.delete(cb);
+  }
+
+  /**
+   * What this client's `reclaim` reaped, once per connection that sent one (ADR
+   * 0024 D9, issue 147 is its consumer).
+   *
+   * Fires only on a Core that announces `multiConnection`, because only such a
+   * Core is sent the frame at all. `taskIds` is often empty and an empty list
+   * never means the id was unknown — it means this client held nothing when its
+   * previous socket went quiet, which is the ordinary case.
+   */
+  onReclaimed(cb: (msg: { replaced: boolean; taskIds: string[] }) => void): Unsubscribe {
+    this.reclaimedListeners.add(cb);
+    return () => this.reclaimedListeners.delete(cb);
+  }
+
+  /** Hand one event to the listeners. Overridden where a cursor is kept. */
+  protected deliverEvent(event: CoreLinkEvent): void {
+    for (const cb of this.eventListeners) cb({ event });
+  }
+
+  /** Hand the end-of-replay marker on. Overridden where a cursor is kept. */
+  protected deliverEventsReplayed(lastEventId: number): void {
+    for (const cb of this.eventsReplayedListeners) cb({ lastEventId });
+  }
+
+  // ─── Typed frame methods ───────────────────────────────────────────────────
+
+  spawn(opts: CoreLinkPtySpawnOptions): Promise<{ ptyId: string }> {
+    return this.rpc({ type: "spawn", reqId: "", opts }) as Promise<{ ptyId: string }>;
+  }
+
+  write(ptyId: string, data: string): Promise<boolean> {
+    return this.rpc({ type: "write", reqId: "", ptyId, data }) as Promise<boolean>;
+  }
+
+  resize(ptyId: string, cols: number, rows: number): Promise<boolean> {
+    return this.rpc({ type: "resize", reqId: "", ptyId, cols, rows }) as Promise<boolean>;
+  }
+
+  kill(ptyId: string): Promise<boolean> {
+    return this.rpc({ type: "kill", reqId: "", ptyId }) as Promise<boolean>;
+  }
+
+  killLaunchProcesses(opts: {
+    cwd: string;
+    commands: string[];
+    ports?: number[];
+  }): Promise<CoreLinkLaunchProcessKillResult> {
+    return this.rpc({
+      type: "killLaunchProcesses",
+      reqId: "",
+      cwd: opts.cwd,
+      commands: opts.commands,
+      ports: opts.ports,
+    }) as Promise<CoreLinkLaunchProcessKillResult>;
+  }
+
+  findByTask(taskId: string): Promise<{ ptyId: string | null }> {
+    return this.rpc({ type: "findByTask", reqId: "", taskId }) as Promise<{ ptyId: string | null }>;
+  }
+
+  /**
+   * See {@link CoreLinkRequestFrame} `replay` — `sinceSeq` asks for the tail past
+   * a cursor (a reattach); omitting it asks for the whole scrollback.
+   */
+  replay(ptyId: string, sinceSeq?: number): Promise<CoreLinkPtyReplay> {
+    return this.rpc({ type: "replay", reqId: "", ptyId, sinceSeq }) as Promise<CoreLinkPtyReplay>;
+  }
+
+  /**
+   * Ask this Core for one PTY's byte stream (ADR 0024 D2). Until a client
+   * subscribes, {@link onData}/{@link onExit} never fire for that `ptyId` — a
+   * Core fans output out to the connections that asked and to no others.
+   *
+   * `catchUp` says a `replay` for this PTY follows and the Core must hold the
+   * live stream until it has been served, so the caller never paints live bytes
+   * in front of its own scrollback. A caller that sets it owes that replay;
+   * nothing else releases the hold.
+   *
+   * **Against a Core that does not announce `multiConnection`, this sends nothing
+   * and resolves** (ADR 0024 D11). That is the deliberate single-connection
+   * fallback, not a swallowed failure: such a Core fans every PTY out to every
+   * connection, so the caller is already receiving the bytes it just asked for,
+   * and the subscription it would send is a frame that Core has no vocabulary
+   * for. Resolving says what is true — this client renders that PTY — which is
+   * the only thing the caller acts on.
+   */
+  ptySubscribe(ptyId: string, opts: { catchUp?: boolean } = {}): Promise<void> {
+    if (!this.canSendMultiConnectionFrames()) return Promise.resolve();
+    return this.rpc({
+      type: "ptySubscribe",
+      reqId: "",
+      ptyId,
+      catchUp: opts.catchUp === true,
+    }).then(() => undefined);
+  }
+
+  /**
+   * Stop receiving one PTY's stream. Same fallback as {@link ptySubscribe}, for
+   * the same reason: against a capability-less Core there is no subscription to
+   * drop, because its fan-out is unconditional and cannot be narrowed by a frame
+   * it does not know.
+   */
+  ptyUnsubscribe(ptyId: string): Promise<void> {
+    if (!this.canSendMultiConnectionFrames()) return Promise.resolve();
+    return this.rpc({ type: "ptyUnsubscribe", reqId: "", ptyId }).then(() => undefined);
+  }
+
+  /**
+   * Take this Session's write lock (ADR 0024 D6).
+   *
+   * `granted: false` means another Core client holds it — an answer, not a
+   * failure, and the only way past it is {@link forceTakeover}. Idempotent for a
+   * client that already holds the Session.
+   *
+   * **Against a Core that does not announce `multiConnection`, this sends nothing
+   * and answers `{ supported: false, granted: false }`.** Such a Core evicts
+   * every client but one, so there is nothing for a lock to arbitrate between and
+   * no table to put a claim in.
+   *
+   * `supported: false` must never be rendered as read-only. It says this Core has
+   * no Session lock at all, so every mutation this client makes will be served —
+   * the opposite of what `granted: false` says. A caller that treats the two the
+   * same makes a single-connection Core look permanently locked to an operator
+   * who is in fact its only client.
+   */
+  claim(taskId: string): Promise<{ supported: boolean; granted: boolean }> {
+    if (!this.canSendMultiConnectionFrames()) {
+      return Promise.resolve({ supported: false, granted: false });
+    }
+    return this.rpc({ type: "claim", reqId: "", taskId }).then((granted) => ({
+      supported: true,
+      granted: granted === true,
+    }));
+  }
+
+  /**
+   * Give this Session's write lock back (ADR 0024 D7).
+   *
+   * `released: false` means this client did not hold it — idempotent, not an
+   * error, so a caller releasing on teardown does not have to know whether it had
+   * already lost the lock to a takeover. Same capability fallback as
+   * {@link claim}: nothing goes on the wire to a Core with no lock table, and
+   * `supported: false` says there was never a lock to give back.
+   */
+  release(taskId: string): Promise<{ supported: boolean; released: boolean }> {
+    if (!this.canSendMultiConnectionFrames()) {
+      return Promise.resolve({ supported: false, released: false });
+    }
+    return this.rpc({ type: "release", reqId: "", taskId }).then((released) => ({
+      supported: true,
+      released: released === true,
+    }));
+  }
+
+  /**
+   * Take this Session's write lock whoever holds it (ADR 0024 D7).
+   *
+   * The answer to a hung client, and the reason the lock needs no idle timeout.
+   * Unrecoverable by design: the previous holder's in-flight keystrokes are gone
+   * and its next mutation is refused. `takenFrom` names who lost it so a caller
+   * can say so rather than infer it — taking an unheld Session is an ordinary
+   * claim by another name.
+   *
+   * Same capability fallback as {@link claim}, answering `takenFrom: "nobody"`:
+   * there was nobody to take it from, because there is no lock on such a Core to
+   * take.
+   */
+  forceTakeover(
+    taskId: string,
+  ): Promise<{ supported: boolean; takenFrom: CoreLinkSessionTakenFrom }> {
+    if (!this.canSendMultiConnectionFrames()) {
+      return Promise.resolve({ supported: false, takenFrom: "nobody" });
+    }
+    return this.rpc({ type: "forceTakeover", reqId: "", taskId }).then((takenFrom) => ({
+      supported: true,
+      takenFrom: (takenFrom ?? "nobody") as CoreLinkSessionTakenFrom,
+    }));
+  }
+
+  /**
+   * List every project on this Core as a live snapshot. The Core is the source of
+   * truth; a client holds none. The returned `path` is a machine path on the
+   * Core — only the Core can validate it.
+   */
+  projectsList(): Promise<CoreLinkProjectSnapshot[]> {
+    return this.rpc({ type: "projectsList", reqId: "" }) as Promise<CoreLinkProjectSnapshot[]>;
+  }
+
+  /**
+   * List every active (non-archived) task on this Core, optionally filtered to
+   * one project.
+   *
+   * `archivedCount` is how many archived rows the same scope holds — a scalar,
+   * never the rows (ADR 0019). Use {@link archivedTasksList} for those.
+   */
+  tasksList(projectId?: string): Promise<{ tasks: CoreLinkTaskSnapshot[]; archivedCount: number }> {
+    return this.rpc({ type: "tasksList", reqId: "", projectId }) as Promise<{
+      tasks: CoreLinkTaskSnapshot[];
+      archivedCount: number;
+    }>;
+  }
+
+  /**
+   * List every archived task on this Core, optionally filtered to one project
+   * (ADR 0019) — a separate frame from {@link tasksList}, so an active answer
+   * stays free of archived rows by construction rather than by what a caller
+   * remembers to pass.
+   */
+  archivedTasksList(projectId?: string): Promise<CoreLinkTaskSnapshot[]> {
+    return this.rpc({ type: "archivedTasksList", reqId: "", projectId }) as Promise<
+      CoreLinkTaskSnapshot[]
+    >;
+  }
+
+  /**
+   * Create / rename / archive a project on this Core. The Core validates the
+   * machine path server-side; an invalid path comes back as an `error` frame that
+   * rejects this promise. Returns `null` when a `rename`/`archive` targets a
+   * missing row.
+   */
+  projectsMutate(mutation: CoreLinkProjectMutation): Promise<CoreLinkProjectSnapshot | null> {
+    return this.rpc({ type: "projectsMutate", reqId: "", mutation }) as Promise<
+      CoreLinkProjectSnapshot | null
+    >;
+  }
+
+  /** Create / update / delete a task. Returns `null` when it targets a missing row. */
+  tasksMutate(mutation: CoreLinkTaskMutation): Promise<CoreLinkTaskSnapshot | null> {
+    return this.rpc({ type: "tasksMutate", reqId: "", mutation }) as Promise<
+      CoreLinkTaskSnapshot | null
+    >;
+  }
+
+  /**
+   * List every active session on this Core (optionally filtered to one project).
+   * A session's `ptyId` is set when the Core has a live PTY for that task — which
+   * is how a client knows what it can reattach to.
+   */
+  sessionsList(projectId?: string): Promise<CoreLinkSessionSnapshot[]> {
+    return this.rpc({ type: "sessionsList", reqId: "", projectId }) as Promise<
+      CoreLinkSessionSnapshot[]
+    >;
+  }
+
+  /**
+   * Snapshot of this Core's CLI availability. Live updates arrive as
+   * `agents:availabilityChanged` events on {@link onEvent}; this is how a client
+   * hydrates without waiting for the next probe tick.
+   */
+  agentsAvailabilityList(): Promise<CoreLinkHarnessAvailabilityMap> {
+    return this.rpc({ type: "agentsAvailabilityList", reqId: "" }) as Promise<
+      CoreLinkHarnessAvailabilityMap
+    >;
+  }
+}
+
+/**
+ * Turn a response frame into the value the typed methods promise, or throw the
+ * failure it carries. The two failure frames (`spawnError`, `error`) become
+ * rejections here so a caller of `spawn()` sees an exception rather than a frame
+ * it has to inspect; {@link CoreClient.request} bypasses this and hands the frame
+ * over untouched.
+ */
+export function unwrapResponse(msg: CoreLinkResponseFrame): unknown {
+  switch (msg.type) {
+    case "spawned":
+      return { ptyId: msg.ptyId };
+    case "spawnError":
+      throw new Error(msg.message);
+    case "writeResult":
+    case "resizeResult":
+    case "killResult":
+      return msg.ok;
+    case "killLaunchProcessesResult":
+      return msg.result;
+    case "findByTaskResult":
+      return { ptyId: msg.ptyId };
+    case "replayResult":
+      return { data: msg.data, nextSeq: msg.nextSeq, from: msg.from };
+    // The active list answers with rows *and* the archived count (ADR 0019), so
+    // unwrapping to `msg.tasks` alone would drop a required field of the frame.
+    // The archived list carries rows only.
+    case "tasksListResult":
+      return { tasks: msg.tasks, archivedCount: msg.archivedCount };
+    case "archivedTasksListResult":
+      return msg.tasks;
+    case "projectsListResult":
+      return msg.projects;
+    case "tasksMutateResult":
+      return msg.task;
+    case "projectsMutateResult":
+      return msg.project;
+    case "sessionsListResult":
+      return msg.sessions;
+    case "agentsAvailabilityListResult":
+      return msg.availability;
+    case "ptySubscribeAck":
+    case "ptyUnsubscribeAck":
+      return { ptyId: msg.ptyId, subscribed: msg.subscribed };
+    // The Session lock's three answers unwrap to the one field each carries
+    // beyond the taskId the caller already passed in (issue 144). A denied claim
+    // comes back here as `false` rather than as a rejection — it is an answer,
+    // not a failure, and only a *mutation* refused for the lock throws (that is
+    // an `error` frame, below, carrying `session-locked`).
+    case "claimResult":
+      return msg.granted;
+    case "releaseResult":
+      return msg.released;
+    case "forceTakeoverResult":
+      return msg.takenFrom;
+    // Both fields, because both are reporting a caller cannot derive (issue 146).
+    // `taskIds` in particular is the set of Sessions whose locks came across with
+    // this connection, and a lock register is its consumer: after a reconnect
+    // those Sessions are held-by-you again, and nothing else on the link would
+    // say so until the next snapshot.
+    case "reclaimResult":
+      return { replaced: msg.replaced, taskIds: msg.taskIds };
+    // The code rides the rejection rather than being dropped at the boundary
+    // (issue 144): a caller can already tell "locked" (throws) from "gone"
+    // (resolves), and this is what lets it tell "locked" from any other error
+    // without reading the prose the field exists to spare it.
+    case "error":
+      throw new CoreLinkRequestError(msg.message, msg.code);
+    default:
+      // `ready`, `subscribeAck`, the auth frames — not request/response answers
+      // any typed method awaits. Resolving undefined matches the Panel's
+      // behaviour of leaving such a frame unhandled rather than rejecting on it.
+      return undefined;
+  }
+}

--- a/packages/sdk/src/core-link-cursor-storage.ts
+++ b/packages/sdk/src/core-link-cursor-storage.ts
@@ -1,0 +1,76 @@
+// Where a durable Core client keeps its event cursor.
+//
+// The cursor is one number per Core — the highest `eventId` this client has seen
+// (CONTEXT.md "Event cursor"). It is sent on every (re)connect as
+// `subscribe { lastEventId }`, and the Core answers with the event-log tail past
+// it. Persist it and a client that was killed and restarted recovers the
+// timeline it missed; keep it in memory only and a client recovers everything
+// missed while it was *running*, which is still every reconnect.
+//
+// **The store is injected and never imported** (issue 153's trap). In the Panel
+// this interface is satisfied by the browser's `localStorage`, and a Node package
+// that reached for that global — or for a wrapper around it — would either drag a
+// DOM dependency into a process that has no DOM, or carry a `typeof
+// localStorage !== "undefined"` sniff in a library whose every consumer knows
+// perfectly well which runtime it is. So the SDK declares the two methods it
+// needs, defaults to {@link InMemoryCoreLinkCursorStorage}, and lets a caller
+// with somewhere durable to write hand that in: a browser passes `localStorage`,
+// the CLI passes a file-backed store, a test passes a Map.
+//
+// The interface is `localStorage`-shaped on purpose — `getItem` / `setItem`, keys
+// and string values — because that is what makes the Panel's own store pass
+// without an adapter when it migrates (#156).
+
+/** A `localStorage`-shaped store for the per-Core `lastEventId` cursor. */
+export interface CoreLinkCursorStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * The default: a cursor that lives as long as the process does.
+ *
+ * Not a null object. Replay still works across every reconnect within one run —
+ * which is the case the cursor exists for — and only a restart starts from
+ * scratch. A store that dropped writes would make a reconnect re-replay the
+ * whole log every time, so "in memory" is the honest floor rather than a stub.
+ */
+export class InMemoryCoreLinkCursorStorage implements CoreLinkCursorStorage {
+  private readonly entries = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.entries.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+}
+
+/** The prefix every derived cursor key carries. */
+export const CURSOR_STORAGE_KEY_PREFIX = "actana.coreLink.lastEventId";
+
+/**
+ * The storage key for one Core's cursor, derived from its core-link URL.
+ *
+ * Per Core, because the cursor is per Core: two Cores sharing a key would each
+ * replay from the other's position, and the one that fell behind would silently
+ * lose the events in between. The URL carries the host and port that identify a
+ * Core, so the scheme is stripped and everything outside `[A-Za-z0-9_-]` is
+ * replaced — the result is safe as a `localStorage` key, a file name, or a column
+ * value.
+ */
+export function coreLinkCursorStorageKey(url: string): string {
+  return `${CURSOR_STORAGE_KEY_PREFIX}.${deriveCoreKey(url)}`;
+}
+
+function deriveCoreKey(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.hostname}-${u.port}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+  } catch {
+    // Malformed URL — fall back to a sanitized full string, so distinct (if odd)
+    // URLs still get key isolation from each other.
+    return url.replace(/[^a-zA-Z0-9_-]/g, "_").slice(-64);
+  }
+}

--- a/packages/sdk/src/core-link-socket.ts
+++ b/packages/sdk/src/core-link-socket.ts
@@ -1,0 +1,126 @@
+// The socket under a core link, and the Node dial that opens one.
+//
+// Extracted from the Panel's `core-link/node-socket.ts` and the `WebSocketLike`
+// interface that lived in its client (issue 153, #129 D1). The client is
+// transport-agnostic on purpose: {@link CoreLinkSocket} is the whole of what
+// {@link CoreLinkTransport} needs, so one transport drives the real `wss://`
+// dial below, a loopback `ws://`, and an in-memory pair in a test.
+//
+// A Core requires mutual TLS with a pinned client cert + CA (ADR 0002), which
+// no browser WebSocket can present — Chromium uses the OS cert store, not
+// per-connection certs. That is why a Core client is a Node program: it dials
+// with the `ws` package, handing `ca`/`cert`/`key` straight to TLS. The Panel
+// terminates its links in its service for exactly this reason (ADR 0012), and
+// the `actana` CLI is a Node process for the same one.
+//
+// This module is the only place in the SDK that imports `ws`, so a consumer
+// that brings its own socket (a test, a runtime with a different WebSocket)
+// never has to.
+
+import { WebSocket as NodeWebSocket } from "ws";
+
+/**
+ * The socket surface a core link needs. A subset of both the `ws` client and
+ * the platform `WebSocket`, plus the two Node-only affordances the heartbeat is
+ * built on — see {@link CoreLinkSocket.ping} and
+ * {@link CoreLinkSocket.terminate}.
+ */
+export interface CoreLinkSocket {
+  /** `0` connecting, `1` open, `2` closing, `3` closed — the WebSocket values. */
+  readonly readyState: number;
+  send(data: string): void;
+  close(): void;
+  on(event: "open", cb: () => void): void;
+  on(event: "message", cb: (data: unknown) => void): void;
+  on(event: "close", cb: () => void): void;
+  on(event: "error", cb: (err: Error) => void): void;
+  /**
+   * Pong frames (Node `ws` only). A transport registers for them
+   * unconditionally; an adapter that has no pongs to report simply drops the
+   * registration, which is correct — a browser engine answers pings itself and
+   * never surfaces them.
+   */
+  on(event: "pong", cb: () => void): void;
+  /**
+   * Send a WS ping frame. Present on the Node (`ws`) transport a Core client
+   * dials with; absent on a plain browser WebSocket. **Its presence is what
+   * arms the heartbeat** — see {@link CoreLinkTransport}.
+   */
+  ping?: () => void;
+  /**
+   * Destroy the socket immediately, with no close handshake. Used when the
+   * heartbeat declares the peer dead: a half-open TCP connection will never
+   * complete a graceful close, so waiting for one only extends the outage.
+   */
+  terminate?: () => void;
+}
+
+/** A socket factory. The seam every test and every exotic runtime goes through. */
+export type CoreLinkSocketFactory = (url: string) => CoreLinkSocket;
+
+/** The PEM material a `wss://` core link is dialed with (ADR 0002). */
+export type CoreLinkTlsMaterial = {
+  /** PEM CA cert that signed the Core's server cert. Pinned by the client. */
+  ca: string;
+  /** PEM client cert presented to the Core in the mTLS handshake. */
+  cert: string;
+  /** PEM private key for {@link CoreLinkTlsMaterial.cert}. */
+  key: string;
+};
+
+/**
+ * Dial a `ws://` or `wss://` core link from a Node process. With `tls` the
+ * `wss://` handshake pins the Core's CA and presents the client cert (mTLS);
+ * `rejectUnauthorized: true` refuses an unknown CA, so a fake Core presenting
+ * any other cert never gets past the handshake.
+ */
+export function createNodeCoreLinkSocket(url: string, tls?: CoreLinkTlsMaterial): CoreLinkSocket {
+  // `noDelay` disables Nagle. A terminal is the pathological case for it:
+  // keystrokes and agent output are tiny writes, and coalescing them behind the
+  // peer's delayed ACK adds tens of ms of jitter to every character. `ws`
+  // supports the option (and defaults it to true) but the shipped types don't
+  // declare it yet, hence the widened local type — stating it explicitly keeps
+  // the behaviour pinned if that default ever changes.
+  type SocketOptions = import("ws").ClientOptions & { noDelay?: boolean };
+  const options: SocketOptions = tls
+    ? { ca: tls.ca, cert: tls.cert, key: tls.key, rejectUnauthorized: true, noDelay: true }
+    : { noDelay: true };
+  const ws = new NodeWebSocket(url, options as import("ws").ClientOptions);
+  return adaptNodeWs(ws);
+}
+
+function adaptNodeWs(ws: import("ws").WebSocket): CoreLinkSocket {
+  return {
+    get readyState() {
+      return ws.readyState;
+    },
+    send: (data: string) => ws.send(data),
+    close: () => ws.close(),
+    // The heartbeat surface (see CoreLinkTransport): a remote core link crosses
+    // NATs and firewalls that silently reap idle flows, and an agent parked at
+    // its prompt is idle for minutes at a time. Ping keeps the flow warm; pong
+    // proves liveness; terminate tears down a half-open socket that would never
+    // complete a graceful close.
+    ping: () => {
+      try {
+        ws.ping();
+      } catch {
+        /* socket already closing — the close handler covers it */
+      }
+    },
+    terminate: () => ws.terminate(),
+    on: (event, cb) => {
+      if (event === "open") {
+        ws.on("open", () => (cb as () => void)());
+      } else if (event === "message") {
+        ws.on("message", (data: unknown) => (cb as (data: unknown) => void)(data));
+      } else if (event === "close") {
+        ws.on("close", () => (cb as () => void)());
+      } else if (event === "error") {
+        ws.on("error", (err: Error) => (cb as (err: Error) => void)(err));
+      } else if (event === "pong") {
+        ws.on("pong", () => (cb as () => void)());
+      }
+    },
+  };
+}

--- a/packages/sdk/src/core-link-transport.ts
+++ b/packages/sdk/src/core-link-transport.ts
@@ -1,0 +1,526 @@
+// One core link, from the client's side of it: one socket, one Core.
+//
+// Extracted from the Panel's `PtyCoreLinkClient`
+// (`packages/panel/src/server/core-link/client.ts`, issue 153, #129 D1/D2/D6).
+// That class did four separable jobs at once — frame the wire, correlate
+// requests, keep a link alive across drops, and expose a typed API. This module
+// is the first of those two: **the machinery of one connection**, with no
+// opinion about what happens when it ends.
+//
+// Everything that outlives a socket lives above it: `CoreClient` owns the typed
+// methods and the outbound queue, and `DurableCoreClient` owns reconnection.
+// One transport is one socket's whole life, which is what makes the difference
+// between the two entry points a difference in *who re-opens*, rather than two
+// implementations of a wire.
+//
+// Three things about this protocol shape the code below, and each has cost
+// somebody a debugging session:
+//
+//   1. **The Core speaks first, unsolicited.** `ready` is frame one on every
+//      connection and answers no request — a transport that treats the first
+//      inbound message as a response to something it sent waits forever. It is
+//      surfaced as {@link CoreLinkTransportHandlers.onReady}.
+//   2. **`auth` must be the first frame sent**, or the Core answers
+//      `not-authenticated` and closes the socket. So nothing else may go out on
+//      open: a subscribe, a reclaim, a caller's RPC all queue behind it, and the
+//      transport does not report itself {@link CoreLinkTransport.writable} until
+//      `authOk` lands.
+//   3. **`data` and `exit` arrive unsolicited too**, carrying a `ptyId` and no
+//      `reqId`. They are surfaced as frames, parsed once, here — a caller that
+//      re-parses a raw message is a caller that will disagree with this one.
+
+import type {
+  CoreLinkEvent,
+  CoreLinkRequestFrame,
+  CoreLinkResponseFrame,
+  CoreLinkStreamFrame,
+} from "./core-link-frames";
+import type { CoreLinkSocket, CoreLinkSocketFactory } from "./core-link-socket";
+
+/** The Core's opening frame on every connection — protocol version, capability. */
+export type CoreLinkReadyFrame = Extract<CoreLinkResponseFrame, { type: "ready" }>;
+/** One PTY's bytes. Unsolicited; keyed by `ptyId`; carries a `seq`. */
+export type CoreLinkDataFrame = Extract<CoreLinkStreamFrame, { type: "data" }>;
+/** A PTY's exit. Unsolicited; keyed by `ptyId`. */
+export type CoreLinkExitFrame = Extract<CoreLinkStreamFrame, { type: "exit" }>;
+/** The Core accepted this connection's bearer. */
+export type CoreLinkAuthOkFrame = Extract<CoreLinkResponseFrame, { type: "authOk" }>;
+/** The Core refused this connection's bearer, and is about to close the socket. */
+export type CoreLinkAuthErrorFrame = Extract<CoreLinkResponseFrame, { type: "authError" }>;
+/** Why the Core refused a bearer. */
+export type CoreLinkAuthErrorReason = CoreLinkAuthErrorFrame["reason"];
+
+/**
+ * What a transport tells its owner. Every one is optional and none may throw
+ * anything the transport is expected to survive — a listener's failure must not
+ * take a connection down, so each is called inside a guard.
+ */
+export type CoreLinkTransportHandlers = {
+  /** The socket is open. Nothing has been authenticated yet. */
+  onOpen?: () => void;
+  /**
+   * The transport may now be written to: the socket is open and, when a bearer
+   * was configured, the Core has accepted it. This is where an owner sends the
+   * frames a fresh connection owes — `reclaim`, `subscribe`, a re-subscription
+   * — and they go out ahead of whatever the owner had queued.
+   */
+  onWritable?: () => void;
+  /** Frame one, on every connection (see this module's header). */
+  onReady?: (frame: CoreLinkReadyFrame) => void;
+  /** One PTY's bytes, parsed once, here. */
+  onData?: (frame: CoreLinkDataFrame) => void;
+  /** One PTY's exit, parsed once, here. */
+  onExit?: (frame: CoreLinkExitFrame) => void;
+  /** One event off the Core's monotonic log — replayed or live, same frame. */
+  onEvent?: (event: CoreLinkEvent) => void;
+  /** End of the `subscribe` replay tail; live push resumes after it. */
+  onEventsReplayed?: (lastEventId: number) => void;
+  onAuthOk?: (frame: CoreLinkAuthOkFrame) => void;
+  onAuthError?: (reason: CoreLinkAuthErrorReason) => void;
+  /**
+   * The socket is gone, with the reason the `error` event carried if it carried
+   * one. In-flight requests have already been rejected by the time this runs.
+   */
+  onClose?: (reason?: string) => void;
+};
+
+export type CoreLinkHeartbeatOptions = {
+  /** Ping cadence. Default {@link DEFAULT_HEARTBEAT_INTERVAL_MS}. */
+  intervalMs?: number;
+  /** Declare the peer dead after this long with no frame. Default {@link DEFAULT_HEARTBEAT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+};
+
+export type CoreLinkTransportOptions = {
+  /** The URL to dial. Reported back on errors; the factory is what opens it. */
+  url: string;
+  /** How to open the socket. See {@link CoreLinkSocketFactory}. */
+  createSocket: CoreLinkSocketFactory;
+  /**
+   * The signed bearer `{coreId, exp, sig}` from the registration blob (ADR
+   * 0002), presented in the `auth` frame the instant the socket opens. Every
+   * real Core requires one — there is no trusted transport left to omit it on
+   * (ADR 0010). Omitted, the transport is writable as soon as the socket opens,
+   * which is the loopback rig and the test.
+   */
+  bearer?: string | null;
+  /**
+   * Arm the heartbeat on this connection. Off by default, and deliberately so:
+   * a one-shot client that connects, asks and exits has nothing to keep alive,
+   * and the durable entry point turns it on because a link that must survive an
+   * idle hour is the case it exists for (#129 D6).
+   *
+   * Only a socket that can actually send a ping participates — see
+   * {@link CoreLinkSocket.ping}.
+   */
+  heartbeat?: CoreLinkHeartbeatOptions | false;
+  handlers?: CoreLinkTransportHandlers;
+};
+
+/**
+ * Heartbeat cadence. A remote Core's core link runs over the open internet, so
+ * it crosses NATs and stateful firewalls that silently drop idle flows — an
+ * agent sitting at its prompt sends nothing for minutes, which is exactly the
+ * traffic pattern those boxes reap. Without a heartbeat the drop is invisible:
+ * TCP has no keepalive here, so the client keeps believing it is connected,
+ * keystrokes are written into a dead socket, and requests hang for their full
+ * timeout while the Core happily streams output nobody receives. Pinging every
+ * 15s keeps the flow alive AND detects death within one window.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
+/** Declare the peer dead after this long with no frame of any kind (3 pings). */
+export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 45_000;
+
+/** The message a request rejects with when its socket died before the answer. */
+export const CONNECTION_LOST_MESSAGE = "core-link connection lost";
+
+type Pending = {
+  resolve: (frame: CoreLinkResponseFrame) => void;
+  reject: (err: Error) => void;
+};
+
+/**
+ * One core-link connection. Constructed open-ended: the socket is dialed
+ * immediately, and the handlers passed in are the only way anything gets out of
+ * it. Not reusable — a transport is one socket, and a client that wants another
+ * builds another.
+ */
+export class CoreLinkTransport {
+  private readonly handlers: CoreLinkTransportHandlers;
+  private readonly bearer: string | null;
+  private readonly heartbeatOpts: CoreLinkHeartbeatOptions | null;
+  private socket: CoreLinkSocket | null = null;
+  private reqSeq = 0;
+  private readonly pending = new Map<string, Pending>();
+  private opened = false;
+  private authenticated = false;
+  private disposed = false;
+  /** The reason the socket died, off the `error` event, for the close report. */
+  private lastError: string | undefined;
+  private ready: CoreLinkReadyFrame | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  /** Epoch ms of the last frame received (message OR pong) on this connection. */
+  private lastInboundAt = 0;
+  /** Injectable clock so a fake-timer test can drive the heartbeat. */
+  private readonly now: () => number = () => Date.now();
+
+  constructor(opts: CoreLinkTransportOptions) {
+    this.handlers = opts.handlers ?? {};
+    this.bearer = opts.bearer ?? null;
+    this.heartbeatOpts = opts.heartbeat === false ? null : (opts.heartbeat ?? null);
+    let socket: CoreLinkSocket;
+    try {
+      socket = opts.createSocket(opts.url);
+    } catch (err) {
+      // A factory that throws — a malformed URL, a TLS material the runtime
+      // refuses — is a connection that closed before it opened, reported on the
+      // one channel an owner is already listening to.
+      this.disposed = true;
+      const reason = err instanceof Error ? err.message : String(err);
+      queueMicrotask(() => this.guard(() => this.handlers.onClose?.(reason)));
+      return;
+    }
+    this.socket = socket;
+    this.wire(socket);
+  }
+
+  private wire(socket: CoreLinkSocket): void {
+    socket.on("open", () => {
+      if (this.disposed) return;
+      this.opened = true;
+      this.authenticated = false;
+      this.startHeartbeat(socket);
+      this.guard(() => this.handlers.onOpen?.());
+      // The auth frame, first, before anything else this transport or its owner
+      // wants to say. See this module's header, trap 2.
+      if (this.bearer) {
+        this.write({ type: "auth", reqId: this.nextReqId("auth"), bearer: this.bearer });
+      } else {
+        this.guard(() => this.handlers.onWritable?.());
+      }
+    });
+
+    socket.on("message", (raw) => {
+      this.lastInboundAt = this.now();
+      this.onMessage(raw);
+    });
+
+    // Pong frames prove the peer is alive during an idle stretch. Only the Node
+    // `ws` transport surfaces them; a browser WebSocket answers pings in the
+    // engine and never tells us, which is why the heartbeat only arms where
+    // `ping` exists at all.
+    socket.on("pong", () => {
+      this.lastInboundAt = this.now();
+    });
+
+    socket.on("error", (err) => {
+      // The close handler drives everything; errors are ordinary during a Core
+      // restart. All that is kept is the reason, so the close report can say
+      // something better than "it closed" — a TLS rejection and an
+      // ECONNREFUSED both arrive here and then close silently.
+      this.lastError = err instanceof Error ? err.message : String(err);
+    });
+
+    socket.on("close", () => {
+      const wasDisposed = this.disposed;
+      this.opened = false;
+      this.authenticated = false;
+      this.stopHeartbeat();
+      // Every request written to this socket can never be answered now, so
+      // failing them here is the difference between a caller retrying at once
+      // and one waiting out its full timeout first.
+      this.rejectAll(CONNECTION_LOST_MESSAGE);
+      this.socket = null;
+      if (wasDisposed) return;
+      this.disposed = true;
+      this.guard(() => this.handlers.onClose?.(this.lastError));
+    });
+  }
+
+  /** True while this connection can carry a frame — open, and authenticated if it must be. */
+  get writable(): boolean {
+    return !this.disposed && this.opened && (this.bearer === null || this.authenticated);
+  }
+
+  /** True once the Core has accepted this connection's bearer. */
+  get isAuthenticated(): boolean {
+    return this.authenticated;
+  }
+
+  /** This connection's `ready` frame, or null before it lands. */
+  get readyFrame(): CoreLinkReadyFrame | null {
+    return this.ready;
+  }
+
+  /**
+   * Send a request frame and resolve with the Core's answer — **frames both
+   * ways**, errors included, because a router forwarding on behalf of somebody
+   * else needs the frame rather than an exception (that is the Panel's shape,
+   * and `CoreClient` is what turns a failure frame into a rejection).
+   *
+   * The `reqId` on the frame passed in is ignored: this transport owns
+   * correlation on its own socket and returns the frame carrying the id it
+   * assigned. Rejects if the socket dies before the answer arrives; never times
+   * out on its own — a deadline is the caller's policy, and the caller above
+   * this one has one.
+   */
+  request(frame: CoreLinkRequestFrame): Promise<CoreLinkResponseFrame> {
+    if (!this.writable) return Promise.reject(new Error(CONNECTION_LOST_MESSAGE));
+    const reqId = this.nextReqId("r");
+    return new Promise<CoreLinkResponseFrame>((resolve, reject) => {
+      this.pending.set(reqId, { resolve, reject });
+      if (!this.write({ ...frame, reqId } as CoreLinkRequestFrame)) {
+        this.pending.delete(reqId);
+        reject(new Error(CONNECTION_LOST_MESSAGE));
+      }
+    });
+  }
+
+  /**
+   * Send a frame and forget it. For the frames whose answer is a *stream* rather
+   * than a response — `subscribe`, whose reply is the replay tail and the
+   * `eventsReplayed` marker — and for the ones nothing waits on by design.
+   * Returns the assigned `reqId`, or null when the transport could not take it.
+   */
+  send(frame: CoreLinkRequestFrame, reqIdPrefix = "s"): string | null {
+    if (!this.writable) return null;
+    const reqId = this.nextReqId(reqIdPrefix);
+    return this.write({ ...frame, reqId } as CoreLinkRequestFrame) ? reqId : null;
+  }
+
+  /** Hang up. Idempotent; fires no `onClose`, because this is not the Core going away. */
+  close(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.stopHeartbeat();
+    this.rejectAll("core-link client closed");
+    const socket = this.socket;
+    this.socket = null;
+    this.opened = false;
+    this.authenticated = false;
+    if (socket) {
+      try {
+        socket.close();
+      } catch {
+        /* best effort — the socket is going away either way */
+      }
+    }
+  }
+
+  private nextReqId(prefix: string): string {
+    return `${prefix}${++this.reqSeq}`;
+  }
+
+  private write(frame: CoreLinkRequestFrame): boolean {
+    const socket = this.socket;
+    if (!socket || !this.opened) return false;
+    try {
+      socket.send(JSON.stringify(frame));
+      return true;
+    } catch {
+      // The close handler takes it from here — it is the one place that fails
+      // in-flight requests and tells the owner.
+      return false;
+    }
+  }
+
+  private onMessage(raw: unknown): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(typeof raw === "string" ? raw : String(raw)) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg.type !== "string") return;
+
+    switch (msg.type) {
+      // ─── The three unsolicited streams ───
+      case "ready": {
+        // Kept as the frame rather than picked apart: the version gate and the
+        // `multiConnection` capability are both read off it upstairs, and a
+        // transport that pre-digested it would have to grow a field per
+        // capability the `ready` frame ever gains.
+        this.ready = {
+          type: "ready",
+          version: typeof msg.version === "string" ? msg.version : "",
+          ...(msg.multiConnection !== undefined
+            ? { multiConnection: msg.multiConnection as CoreLinkReadyFrame["multiConnection"] }
+            : {}),
+        };
+        this.guard(() => this.handlers.onReady?.(this.ready!));
+        return;
+      }
+      case "data": {
+        const ptyId = typeof msg.ptyId === "string" ? msg.ptyId : "";
+        if (!ptyId) return;
+        const frame: CoreLinkDataFrame = {
+          type: "data",
+          ptyId,
+          data: typeof msg.data === "string" ? msg.data : "",
+          seq: typeof msg.seq === "number" ? msg.seq : 0,
+        };
+        this.guard(() => this.handlers.onData?.(frame));
+        return;
+      }
+      case "exit": {
+        const ptyId = typeof msg.ptyId === "string" ? msg.ptyId : "";
+        if (!ptyId) return;
+        const frame: CoreLinkExitFrame = {
+          type: "exit",
+          ptyId,
+          exitCode: typeof msg.exitCode === "number" ? msg.exitCode : 0,
+          ...(typeof msg.signal === "number" ? { signal: msg.signal } : {}),
+        };
+        this.guard(() => this.handlers.onExit?.(frame));
+        return;
+      }
+
+      // ─── The event log ───
+      case "event": {
+        const event = parseEvent(msg.event);
+        if (!event) return;
+        this.guard(() => this.handlers.onEvent?.(event));
+        return;
+      }
+      case "eventsReplayed": {
+        const lastEventId = typeof msg.lastEventId === "number" ? msg.lastEventId : 0;
+        this.guard(() => this.handlers.onEventsReplayed?.(lastEventId));
+        return;
+      }
+      case "subscribeAck":
+        // Informational — the event stream and its `eventsReplayed` marker
+        // follow, and they are what a subscriber is waiting for.
+        return;
+
+      // ─── Bearer auth ───
+      case "authOk": {
+        this.authenticated = true;
+        const frame: CoreLinkAuthOkFrame = {
+          type: "authOk",
+          reqId: typeof msg.reqId === "string" ? msg.reqId : "",
+          coreId: typeof msg.coreId === "string" ? msg.coreId : "",
+          exp: typeof msg.exp === "number" ? msg.exp : 0,
+        };
+        // The owner's turn first: a fresh connection owes the Core a `reclaim`
+        // and a `subscribe`, and both must precede whatever requests were
+        // waiting for this socket, so the replay tail arrives before the
+        // answers to them.
+        this.guard(() => this.handlers.onAuthOk?.(frame));
+        this.guard(() => this.handlers.onWritable?.());
+        return;
+      }
+      case "authError": {
+        const reason: CoreLinkAuthErrorReason =
+          msg.reason === "expired" || msg.reason === "bad-signature" || msg.reason === "malformed"
+            ? msg.reason
+            : "malformed";
+        this.authenticated = false;
+        this.guard(() => this.handlers.onAuthError?.(reason));
+        // The Core closes the socket right after this frame; the close handler
+        // is what reports the connection's end. An expired bearer keeps failing
+        // until a reissued blob is pasted — that is the designed "reissuing is a
+        // machine-side operation" property (ADR 0003).
+        return;
+      }
+      default:
+        break;
+    }
+
+    // ─── Everything else is an answer, correlated by reqId ───
+    const reqId = typeof msg.reqId === "string" ? msg.reqId : null;
+    if (!reqId) return;
+    const pending = this.pending.get(reqId);
+    if (!pending) return;
+    this.pending.delete(reqId);
+    pending.resolve(msg as unknown as CoreLinkResponseFrame);
+  }
+
+  private rejectAll(reason: string): void {
+    if (this.pending.size === 0) return;
+    const err = new Error(reason);
+    const pending = [...this.pending.values()];
+    this.pending.clear();
+    for (const p of pending) p.reject(err);
+  }
+
+  /**
+   * Arm the heartbeat for a freshly opened socket. Only a transport that can
+   * actually send a ping participates; a socket without one is left alone
+   * rather than being torn down for failing to answer pings nobody sent.
+   */
+  private startHeartbeat(socket: CoreLinkSocket): void {
+    this.stopHeartbeat();
+    if (!this.heartbeatOpts || !socket.ping) return;
+    const intervalMs = this.heartbeatOpts.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    const timeoutMs = this.heartbeatOpts.timeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
+    this.lastInboundAt = this.now();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket !== socket) {
+        this.stopHeartbeat();
+        return;
+      }
+      if (this.now() - this.lastInboundAt > timeoutMs) {
+        // Half-open: the peer stopped answering. A graceful close would wait for
+        // a FIN that is never coming, so destroy the socket and let the close
+        // handler run the ordinary path.
+        this.stopHeartbeat();
+        try {
+          socket.terminate ? socket.terminate() : socket.close();
+        } catch {
+          /* already gone — the close handler still fires */
+        }
+        return;
+      }
+      try {
+        socket.ping?.();
+      } catch {
+        /* the close handler will take it from here */
+      }
+    }, intervalMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Run an owner's callback. A listener that throws must not take the
+   * connection with it — half the callbacks here run inside a socket event, and
+   * an exception escaping one of those is an unhandled rejection at best and a
+   * connection stuck half-established at worst.
+   */
+  private guard(fn: () => void): void {
+    try {
+      fn();
+    } catch {
+      /* a listener's failure is not this connection's failure */
+    }
+  }
+}
+
+/**
+ * Read an `event` frame's payload into a {@link CoreLinkEvent}, or null.
+ *
+ * Field-by-field rather than a cast, because this is the one frame whose body
+ * is a nested object from another process's database: an `eventId` that is
+ * missing or zero would silently corrupt the cursor that decides what gets
+ * replayed after the next reconnect, so it is the one field whose absence
+ * rejects the frame outright.
+ */
+function parseEvent(raw: unknown): CoreLinkEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const e = raw as Record<string, unknown>;
+  const eventId = typeof e.eventId === "number" ? e.eventId : NaN;
+  if (!Number.isFinite(eventId) || eventId <= 0) return null;
+  return {
+    eventId,
+    ts: typeof e.ts === "number" ? e.ts : 0,
+    kind: typeof e.kind === "string" ? e.kind : "",
+    ptyId: typeof e.ptyId === "string" ? e.ptyId : null,
+    taskId: typeof e.taskId === "string" ? e.taskId : null,
+    payload: typeof e.payload === "string" ? e.payload : "{}",
+  };
+}

--- a/packages/sdk/src/core-registration-blob.ts
+++ b/packages/sdk/src/core-registration-blob.ts
@@ -1,0 +1,103 @@
+// The registration blob, as a Core client reads it.
+//
+// `actana setup` emits one base64 artifact per machine — `{endpoint, caCert,
+// clientCert, clientKey, bearer}` (CONTEXT.md "Registration blob"). It is the
+// whole of what a Core client needs to reach a Core: the endpoint to dial, the
+// PEM material for the mTLS handshake, and the bearer for the `auth` frame
+// (#129 D1).
+//
+// Two deliberate boundaries.
+//
+// **The SDK takes a blob object, never a file** (#129 D9). Where the blob is
+// kept — `~/.config/actana/cores/<name>.txt`, an environment variable, a
+// Panel's encrypted store — is the caller's business, and the CLI's config
+// resolution is its own ticket. Nothing here reads a path or base64-decodes a
+// paste.
+//
+// **The shape is declared here, not imported from `@actana/shared`.**
+// `packages/shared` is private and stays private ([ADR 0025][adr] D4), so an
+// SDK that imported `RegistrationBlob` from it would be a published package
+// with a dependency nobody outside this repository can resolve — the exact
+// alternative that ADR rejected. The two declarations are structurally
+// identical, so a Panel holding a `RegistrationBlob` passes it here with no
+// conversion, and the field names are the wire's rather than either side's.
+//
+// [adr]: ../../docs/adr/0025-the-protocol-ships-with-the-client.md
+
+import type { CoreLinkTlsMaterial } from "./core-link-socket";
+
+/**
+ * A decoded registration blob. `endpoint` is the Core's `wss://host:port` core
+ * link; `label` is the machine's own suggestion for an alias and is not used by
+ * anything here.
+ */
+export type CoreRegistrationBlob = {
+  endpoint: string;
+  label?: string;
+  caCert: string;
+  clientCert: string;
+  clientKey: string;
+  bearer: string;
+};
+
+/**
+ * Everything a blob says about how to reach one Core, unpacked into the parts a
+ * client dials with — and **exposed rather than merely used**.
+ *
+ * `httpsBaseUrl` is the reason this type exists instead of a private helper.
+ * A Core's file surface will mount on the same mTLS server the WebSocket
+ * already listens on (#129 F2), and the same `tls` material authenticates both,
+ * so the connection a client holds is "a Core connection" and not "a socket"
+ * (#129's phase-3 guardrail 1). Naming the base URL now costs nothing and keeps
+ * that from being a breaking change to a published surface later. Nothing in
+ * this phase reads it.
+ */
+export type CoreConnection = {
+  /** The `wss://` (or `ws://`) core-link URL to dial. */
+  url: string;
+  /**
+   * The `https://` origin of the same Core, derived by swapping the scheme —
+   * the server that terminates the WebSocket is the server that will answer
+   * `/v1/…`. No path, no trailing slash.
+   */
+  httpsBaseUrl: string;
+  /** The PEM material for the mTLS handshake, or null for a plain `ws://` dial. */
+  tls: CoreLinkTlsMaterial | null;
+  /** The signed bearer presented in the `auth` frame right after the handshake. */
+  bearer: string;
+};
+
+/**
+ * Unpack a registration blob into a {@link CoreConnection}.
+ *
+ * `ws://` is accepted here even though a blob's endpoint must be `wss://` for a
+ * real Core (ADR 0002, and the Panel's decoder refuses anything else): this
+ * function converts a shape, it does not police one, and a loopback endpoint is
+ * how the Core's own tests and a local rig dial. A `ws://` endpoint yields
+ * `tls: null` — there is no handshake to pin — and the bearer is still
+ * presented, because the `auth` frame is the app-layer session either way.
+ */
+export function coreConnectionFromBlob(blob: CoreRegistrationBlob): CoreConnection {
+  const url = blob.endpoint.trim();
+  const secure = url.startsWith("wss://");
+  return {
+    url,
+    httpsBaseUrl: httpsBaseUrlFor(url),
+    tls: secure
+      ? { ca: blob.caCert, cert: blob.clientCert, key: blob.clientKey }
+      : null,
+    bearer: blob.bearer,
+  };
+}
+
+/**
+ * `wss://host:port` → `https://host:port`, `ws://…` → `http://…`. Anything
+ * else is returned unchanged rather than guessed at — a caller that handed this
+ * a URL with no WebSocket scheme knows something about its Core that this
+ * function does not.
+ */
+function httpsBaseUrlFor(url: string): string {
+  if (url.startsWith("wss://")) return `https://${url.slice("wss://".length)}`.replace(/\/+$/, "");
+  if (url.startsWith("ws://")) return `http://${url.slice("ws://".length)}`.replace(/\/+$/, "");
+  return url;
+}

--- a/packages/sdk/src/durable-core-client.ts
+++ b/packages/sdk/src/durable-core-client.ts
@@ -1,0 +1,305 @@
+// `DurableCoreClient` — the entry point for a program that stays up.
+//
+// The second of the two entry points on one transport (#129 D6). It is
+// {@link CoreClient} plus the four things a link that must survive a night of
+// idleness needs and a one-shot dial has no use for:
+//
+//   - a **heartbeat**, because an idle core link is what a NAT reaps silently;
+//   - **reconnection with backoff**, because a Core restarts, a machine sleeps,
+//     and a laptop lid closes;
+//   - an **event cursor** in an injected {@link CoreLinkCursorStorage}, because a
+//     client that was away has to be told what it missed rather than guess;
+//   - **subscribe-then-replay**, because that is the order in which a gap is
+//     closed without a hole and without a double.
+//
+// This is what the Panel will use (#156). Nothing here is Panel-specific: there
+// is no `Fleet` type, no Core registry, and no notion of a second Core — one
+// client is one socket to one machine (#129 D5), and holding several of these is
+// the Panel's business.
+//
+// Extracted from `PtyCoreLinkClient` (issue 153), whose reconnect loop, cursor
+// handling and PTY re-subscription are the four sections below.
+
+import type { CoreLinkEvent } from "./core-link-frames";
+import { CoreClient, type CoreClientOptions } from "./core-client";
+import type { CoreRegistrationBlob } from "./core-registration-blob";
+import {
+  coreLinkCursorStorageKey,
+  InMemoryCoreLinkCursorStorage,
+  type CoreLinkCursorStorage,
+} from "./core-link-cursor-storage";
+import type { CoreLinkHeartbeatOptions } from "./core-link-transport";
+
+/** Reconnect backoff floor: the delay after the first unexpected drop. */
+export const DEFAULT_RECONNECT_INITIAL_MS = 500;
+/** Reconnect backoff ceiling. Doubling stops here and keeps trying at this rate. */
+export const DEFAULT_RECONNECT_MAX_MS = 5_000;
+
+export type DurableCoreClientOptions = CoreClientOptions & {
+  /** Reconnect backoff floor in ms. Default 500. */
+  reconnectInitialMs?: number;
+  /** Reconnect backoff ceiling in ms. Default 5000. */
+  reconnectMaxMs?: number;
+  /**
+   * Where the per-Core `lastEventId` cursor is kept. Default:
+   * {@link InMemoryCoreLinkCursorStorage} — replay across every reconnect within
+   * this process, but not across a restart. **Inject a durable store to get the
+   * restart too; never let this package import one** (see
+   * `core-link-cursor-storage.ts`).
+   */
+  storage?: CoreLinkCursorStorage;
+  /** The key the cursor is stored under. Default: derived from the Core's URL. */
+  cursorStorageKey?: string;
+  /**
+   * Arm the heartbeat. On by default here, which is the difference between this
+   * entry point and {@link CoreClient}: a link nobody is watching is exactly the
+   * one that has to notice it died.
+   */
+  heartbeat?: CoreLinkHeartbeatOptions | false;
+};
+
+/**
+ * A Core client that keeps its link up.
+ *
+ * `await connect()` resolves when the first connection is established and does
+ * not reject when a later one drops — a drop is what this class is for. From then
+ * on the link re-establishes itself: `onDisconnected` fires on every failed or
+ * lost connection, `onReady` on every one that comes back, and requests made in
+ * between are queued rather than refused.
+ */
+export class DurableCoreClient extends CoreClient {
+  private readonly reconnectInitialMs: number;
+  private readonly reconnectMaxMs: number;
+  private readonly storage: CoreLinkCursorStorage;
+  private readonly cursorStorageKey: string;
+
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** In-memory mirror of the persisted cursor; advanced by every event and marker. */
+  private lastEventId = 0;
+  /** True between this connection's `eventsReplayed` and its drop. */
+  private caughtUp = false;
+
+  /**
+   * The PTYs this client has asked the Core for (ADR 0024 D2). PTY output fans
+   * out by subscription, so this set is the difference between a pane that
+   * renders and one that sits blank — and it is connection state on the Core,
+   * which means it does not survive a reconnect. This client re-sends it on every
+   * connection; nothing above it has to know the socket ever dropped.
+   *
+   * It records what this client *wants*, not what the Core holds: every
+   * connection re-derives its frames from this set against *that* connection's
+   * announced capability. Drop the want when no frame goes out and a Core that
+   * gains the capability across a restart comes back fanning out to subscribers
+   * only, with nothing left anywhere that remembers to subscribe.
+   */
+  private readonly subscribedPtys = new Set<string>();
+
+  constructor(opts: DurableCoreClientOptions) {
+    super({ ...opts, heartbeat: opts.heartbeat ?? {} });
+    this.reconnectInitialMs = opts.reconnectInitialMs ?? DEFAULT_RECONNECT_INITIAL_MS;
+    this.reconnectMaxMs = opts.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
+    this.storage = opts.storage ?? new InMemoryCoreLinkCursorStorage();
+    this.cursorStorageKey = opts.cursorStorageKey ?? coreLinkCursorStorageKey(this.url);
+    this.lastEventId = this.readPersistedCursor();
+  }
+
+  /** Build a durable client straight off a registration blob (#129 D1). */
+  static override fromRegistrationBlob(
+    blob: CoreRegistrationBlob,
+    opts: Omit<DurableCoreClientOptions, "blob" | "url" | "tls" | "bearer"> = {},
+  ): DurableCoreClient {
+    return new DurableCoreClient({ ...opts, blob });
+  }
+
+  /**
+   * The connect promise a durable client hands back does not fail on a lost
+   * socket: the supervisor is already dialing again, so rejecting would report a
+   * connection as unrecoverable at the exact moment it is being recovered. What
+   * still rejects it is a refused bearer (retrying an expired one is futile until
+   * a fresh blob is pasted — ADR 0003) and the connect deadline.
+   */
+  protected override onConnectionClosed(): void {
+    this.caughtUp = false;
+    this.scheduleReconnect();
+  }
+
+  /**
+   * What this client owes the Core on every connection, in the one order that
+   * works.
+   *
+   * `reclaim` first (via `super`): it is the only frame on this path with a clock
+   * on it (ADR 0024 D9). Until it lands, the socket this connection replaces is
+   * still holding this client's Sessions and the Core cannot tell it from a live
+   * one. `subscribe` and the PTY re-subscription are catching up on what happened
+   * while we were away and lose nothing by going second.
+   *
+   * Then `subscribe`, carrying the cursor — the Core streams the tail past it and
+   * ends with `eventsReplayed`. Then the PTY subscriptions, which died with the
+   * previous socket.
+   *
+   * Everything here runs after `auth` has been accepted, because the Core refuses
+   * all three before authentication, and after `ready`, because all three are
+   * gated on the capability that frame announces. That ordering is load-bearing
+   * rather than incidental, and the transport is what guarantees it: it does not
+   * call this until the connection is both open and authenticated.
+   */
+  protected override onConnectionEstablished(): void {
+    this.reconnectAttempt = 0;
+    super.onConnectionEstablished();
+    this.sendSubscribe();
+    this.resendPtySubscriptions();
+  }
+
+  /**
+   * Ask the Core for the event-log tail past this client's cursor.
+   *
+   * Fire-and-forget: the answer is the `event` stream and the `eventsReplayed`
+   * marker, not a reqId-correlated response, so there is nothing here to await.
+   * A send that fails is a socket that just died, and the next connection sends
+   * this again with the same cursor.
+   */
+  private sendSubscribe(): void {
+    this.caughtUp = false;
+    this.sendNow({ type: "subscribe", reqId: "", lastEventId: this.lastEventId }, "sub");
+  }
+
+  /**
+   * Re-ask for every PTY this client had, on a connection that has just come up.
+   *
+   * `catchUp` is deliberately not set. A hold is released by a `replay` from the
+   * same client, and nothing here is going to send one — the surfaces that replay
+   * do it off their own reconnect, one layer up, and a hold nobody releases is a
+   * pane that stays blank forever. Going live immediately is also exactly what
+   * this path did before subscriptions existed.
+   */
+  private resendPtySubscriptions(): void {
+    // The same deliberate single-connection fallback `ptySubscribe` takes: a Core
+    // without the capability is already sending these PTYs to every connection.
+    if (!this.canSendMultiConnectionFrames()) return;
+    for (const ptyId of this.subscribedPtys) {
+      void this.rpc({ type: "ptySubscribe", reqId: "", ptyId, catchUp: false }).catch(() => {
+        /* the socket died again; the next connection re-sends the whole set */
+      });
+    }
+  }
+
+  /**
+   * Ask for one PTY's stream and remember the want, so a reconnect restores it.
+   *
+   * Idempotent on both sides: a second call for a PTY already held is a no-op
+   * here and an ack there. The capability fallback is
+   * {@link CoreClient.ptySubscribe}'s, unchanged — and the want is recorded
+   * either way, for the reason given on {@link subscribedPtys}.
+   */
+  override ptySubscribe(ptyId: string, opts: { catchUp?: boolean } = {}): Promise<void> {
+    if (this.subscribedPtys.has(ptyId)) return Promise.resolve();
+    this.subscribedPtys.add(ptyId);
+    return super.ptySubscribe(ptyId, opts);
+  }
+
+  /** Stop receiving one PTY's stream, and stop re-asking for it on reconnect. */
+  override ptyUnsubscribe(ptyId: string): Promise<void> {
+    if (!this.subscribedPtys.delete(ptyId)) return Promise.resolve();
+    return super.ptyUnsubscribe(ptyId);
+  }
+
+  // ─── The event cursor ──────────────────────────────────────────────────────
+
+  /**
+   * One event off the log — replayed or live, the same frame either way.
+   *
+   * Deduped against the cursor before anything above sees it: a replay overlaps
+   * by design (the Core streams everything *past* a cursor, and a re-delivery
+   * after a reconnect is ordinary), so a listener that received the same event
+   * twice would double-count a status change or paint a question menu twice. The
+   * cursor advances and is persisted on every event that gets through, which is
+   * what makes the *next* reconnect's tail start in the right place.
+   */
+  protected override deliverEvent(event: CoreLinkEvent): void {
+    if (event.eventId <= this.lastEventId) return;
+    this.lastEventId = event.eventId;
+    this.persistCursor();
+    super.deliverEvent(event);
+  }
+
+  /**
+   * End of the replay tail. The marker is authoritative for the caught-up cursor
+   * — it advances even when no `event` frame preceded it, which is the empty-tail
+   * case and the common one for a client that dropped and came straight back.
+   */
+  protected override deliverEventsReplayed(lastEventId: number): void {
+    if (lastEventId > this.lastEventId) {
+      this.lastEventId = lastEventId;
+      this.persistCursor();
+    }
+    this.caughtUp = true;
+    super.deliverEventsReplayed(this.lastEventId);
+  }
+
+  /** The highest eventId this client has seen. Mirrors the persisted cursor. */
+  getLastEventId(): number {
+    return this.lastEventId;
+  }
+
+  /** True once this connection's replay tail has been fully delivered. */
+  isCaughtUp(): boolean {
+    return this.caughtUp;
+  }
+
+  private readPersistedCursor(): number {
+    try {
+      const raw = this.storage.getItem(this.cursorStorageKey);
+      const n = raw == null ? NaN : Number(raw);
+      return Number.isFinite(n) && n >= 0 ? n : 0;
+    } catch {
+      // A store that throws on read is a store this client can still run without
+      // — it replays from 0 once, which is correct, if slower.
+      return 0;
+    }
+  }
+
+  private persistCursor(): void {
+    try {
+      this.storage.setItem(this.cursorStorageKey, String(this.lastEventId));
+    } catch {
+      /* storage unavailable — the in-memory cursor still carries the reconnect */
+    }
+  }
+
+  // ─── Reconnection ──────────────────────────────────────────────────────────
+
+  /**
+   * Exponential backoff from {@link DEFAULT_RECONNECT_INITIAL_MS} up to
+   * {@link DEFAULT_RECONNECT_MAX_MS}, reset by a connection that comes up.
+   *
+   * The ceiling is low on purpose: a Core is a machine an operator restarts, so
+   * the common case is a gap of a few seconds and the right behaviour is to keep
+   * knocking at a steady rate rather than to back off into minutes and leave a
+   * pane blank long after the Core came back.
+   */
+  private scheduleReconnect(): void {
+    if (this.closed) return;
+    if (this.reconnectTimer) return;
+    const delay = Math.min(
+      this.reconnectInitialMs * Math.pow(2, this.reconnectAttempt),
+      this.reconnectMaxMs,
+    );
+    this.reconnectAttempt++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed) return;
+      this.openTransport();
+    }, delay);
+  }
+
+  /** Hang up for good: stop the backoff, then everything {@link CoreClient.close} does. */
+  override close(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    super.close();
+  }
+}

--- a/packages/sdk/src/durable-core-client.ts
+++ b/packages/sdk/src/durable-core-client.ts
@@ -126,6 +126,15 @@ export class DurableCoreClient extends CoreClient {
   }
 
   /**
+   * The supervisor is the only thing that dials here once the first connection
+   * has been asked for, so a `connect()` made during the backoff waits for the
+   * dial that is already coming rather than racing one of its own.
+   */
+  protected override reconnectScheduled(): boolean {
+    return this.reconnectTimer !== null;
+  }
+
+  /**
    * What this client owes the Core on every connection, in the one order that
    * works.
    *

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -14,7 +14,14 @@
     "useDefineForClassFields": true,
     "ignoreDeprecations": "6.0",
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      // Test-only paths, mirroring `vitest.config.ts` — see the comment there.
+      // Nothing under `src/` outside `src/__tests__/` may import either package:
+      // the SDK's runtime dependencies are `ws` and the protocol it defines.
+      "@actana/core/*": ["../core/src/*"],
+      "@actana/shared/*": ["../shared/src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      // Test-only, and deliberately not a dependency: the Core client suites
+      // drive the real Core server rather than a hand-rolled stand-in, and the
+      // Core depends on this package (ADR 0025 D2) — a manifest entry pointing
+      // back would be a cycle in the published graph for the sake of a test.
+      // The Panel's own core-link suites resolve the Core the same way.
+      "@actana/core": path.resolve(import.meta.dirname, "../core/src"),
+      "@actana/shared": path.resolve(import.meta.dirname, "../shared/src"),
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,10 +323,17 @@ importers:
         version: 4.1.6(@types/node@25.8.0)(jsdom@30.0.1)(vite@8.1.0(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.0))
 
   packages/sdk:
+    dependencies:
+      ws:
+        specifier: '>=8.21.0'
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: 25.8.0
         version: 25.8.0
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

Extracts the Panel's `core-link/client.ts` into `@actana/sdk` as **two entry points on one
transport** (#129 D1, D2, D6, D7). `CoreClient` is the default — connect, authenticate,
request/response by `reqId`, close, one socket to one Core, mTLS plus the bearer out of a
registration blob. `DurableCoreClient` is the same client plus what a program that stays up needs:
a heartbeat, reconnection with backoff, an event cursor in an **injected**
`CoreLinkCursorStorage`, and subscribe-then-replay.

Extraction, not rewrite. **The Panel is untouched and keeps running on its own copy** — migrating
it is #156, so a regression there stays attributable. The typed method set here is the Panel
client's, frame for frame, for the same reason.

The layering: `CoreLinkTransport` owns one socket and the three traps that come with this
protocol; `CoreClient` owns the typed frames and the request queue; `DurableCoreClient` owns
reconnection. So the wire is written once, and the difference between the two entry points is
*who re-opens*.

## Related issues

Closes #153

Refs #129, #148

## Type of change

- [x] ♻️ Refactor (no functional change)
- [x] 📚 Documentation

## The traps, and where each one is answered

- **`CoreLinkCursorStorage` is browser-shaped in the Panel.** It is injected, never imported;
  the default is an in-memory store. A planted global `localStorage` is asserted untouched while
  the cursor advances, so the DOM trap is a test rather than a promise.
- **`auth` must be the first frame sent.** The transport writes it the instant the socket opens
  and reports itself unwritable until `authOk`, so a caller's request — including one issued
  before `connect()` resolved — queues behind it instead of racing it.
- **The Core speaks first, unsolicited, with `ready`.** It is surfaced as `onReady`, and the
  suite asserts it carries no `reqId` and answers nothing the client sent.
- **One socket per client, no `Fleet` type** (D5). There is none, and the Panel remains the fleet.
- `ready`, `data` and `exit` are parsed once in the transport and handed on as frames typed
  against the SDK's own schema. No caller re-parses a raw message.

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [x] Manually verified (below)

`pnpm --filter @actana/sdk test` — **88 tests, all green** (85 plus 3 live, see below). Three rigs:

1. **In-process against the real Core.** Every suite drives the Core's own `PtyCoreLinkServer`
   with its bearer gate armed, over a connected socket pair: auth-first ordering, the unsolicited
   `ready`, `reqId` correlation across concurrent requests, error frames becoming coded
   rejections, in-flight requests failing the moment a socket dies, the capability gate on a Core
   that announces nothing, the cursor closing a gap with no double and no hole, PTY subscriptions
   re-asked for on the next connection, and a half-open link destroyed rather than waited on.
2. **Real mTLS over a real port.** `wss://` with material from the Core's own
   `generateCertMaterial`; the negative control asserts on the *shape* of the refusal a Core gives
   a client with no certificate, because a control that passes on any error would pass against a
   Core that is not running.
3. **Against a live Core** (`ACTANA_CORE_BLOB`, skipped without it). Run here against this
   machine's running daemon on `wss://127.0.0.1:9444` with the blob `actana setup` wrote:

   ```
   ✓ src/__tests__/live-core.test.ts > unpacks the live blob into an endpoint, cert material and a bearer
   ✓ src/__tests__/live-core.test.ts > connects, authenticates and answers a read-only request
   ✓ src/__tests__/live-core.test.ts > replays the live event log to a durable client and lands on its cursor
   ```

   Every request in that suite is read-only — nothing spawns, writes, claims or mutates.

Repo-wide: `pnpm -r typecheck` clean, `eslint packages/sdk` clean, `pnpm scan:secrets` clean,
`pnpm install --frozen-lockfile` clean. `@actana/core` 773, `@actana/shared` 180 and `@actana/sdk`
88 all green.

**The Panel suite passes on CI** (`Unit Tests`, which runs the whole workspace). Locally it came
in at 1415/1416 with a *different* single component test timing out each run at ~5.4s against
vitest's 5s default (`terminals-in-browser`, `cores-settings-rename`,
`harness-install-from-picker`), each passing in isolation — this container is slow enough for one
of them to tip over the default timeout. No Panel file is touched: `git diff --stat
origin/refactor/sdk-extraction -- packages/panel` is empty.

## Docs

`CONTEXT.md` gains a **Core client entry points** section (D7): `CoreClient`, **Durable Core
client**, **Core connection**, **Event cursor store**. Additive — no existing entry is touched.
It rides this change rather than a docs-only PR, per #148.

## Notes for review

- `ws` joins `packages/sdk`'s manifest: dialing mTLS is the whole job, and no browser WebSocket
  can present a client certificate (ADR 0002, ADR 0012).
- The registration blob's **shape is declared in the SDK, not imported from `@actana/shared`** —
  that package is private and stays private (ADR 0025 D4), so importing it would give the package
  this effort exists to publish a dependency nobody outside this repository can resolve. A test
  pins that boundary: the shipped sources may import their own modules and `ws`, nothing else.
- A blob unpacks into a `CoreConnection` that **exposes** the HTTPS origin and the cert material
  rather than only dialing with them — #129's phase-3 guardrail met now instead of as a breaking
  change to a published surface later. Nothing in this phase reads it.
- `@actana/core` is reachable from the SDK's suites through a **test-only** alias in
  `vitest.config.ts` / `tsconfig.json`, exactly as the Panel's core-link suites reach it. It is
  deliberately not a manifest entry: the Core depends on this package (ADR 0025 D2).
- `CORE_LINK_PROTOCOL_VERSION` does not move, no version changes, no manifest count changes.

## Checklist

- [x] This PR targets the phase-1 integration branch `refactor/sdk-extraction`, not `main`
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and the branch
      name follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my change works; all suites pass locally and on CI (one local Panel
      timing flake noted above)
- [x] I updated documentation (`CONTEXT.md`) where relevant
- [x] No secrets, credentials, or personal data are included in this change
- [x] Draft: #156 migrates the Panel onto this, and is not in this PR
