### PR TITLE
feat(sdk): CoreSession — start a Session, the Core delivers the prompt, read the result

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,6 +109,14 @@ _Avoid_: session, socket wrapper, connection object, SDK consumer
 The second entry point on the same transport, for a program that stays connected — the Panel, and anything watching a Core rather than asking it one question. `CoreClient` plus a heartbeat, reconnection with backoff, an **Event cursor**, and subscribe-then-replay. On every connection it re-presents its **Core client id**, re-asks for its **PTY subscriptions**, and replays the gap it was away for, so nothing above it has to know the socket ever dropped. There is no fleet here and there must not be: one client is one Core, and holding several is the Panel's job.
 _Avoid_: manager, pool, supervisor, reconnecting socket
 
+**`CoreSession`**:
+The SDK's second level, on top of either Core client entry point: start a **Session** in a registered **Project**, let the Core deliver the starting prompt, read the result. Programmatic I/O only — `send(text)` writes exactly those bytes, `onData(…)` streams them, `screen()` returns the rendered screen — and **no TTY, ever**: it never reads `process.stdin`, never sets raw mode, and is usable from a cron job, a CI runner or a web service, which is D11. It owns none of the three things it depends on: **Prompt delivery** is the Core's, so the prompt goes over as text and the Core decides when it lands; the spawn policy is the Core's, so a working directory outside a Project root or a flag off the allow-list is surfaced as a rejection rather than pre-empted; and "the turn is over" is the Core's report on its event log rather than a guess from the byte stream falling quiet. See ADR 0025, ADR 0026.
+_Avoid_: terminal, pty wrapper, agent runner, REPL
+
+**Screen**:
+What a terminal would be showing for a **Session**, plus every line that has scrolled off the top of it. Produced by a small terminal emulator in the SDK — cursor movement, erase, insert/delete line and character, scroll, the alternate screen — because a Harness positions text with cursor moves rather than spaces, so deleting the escape sequences yields one line of concatenated spinner frames instead of a screen. The scrolled-off half is not an extra: a Harness's conversation left the visible rows long ago, so the transcript *is* the scrollback, and a reader of the viewport alone reads a status bar.
+_Avoid_: output, log, buffer, stdout (those name a stream; this is what a stream was painted into)
+
 **Core connection**:
 What a **Registration blob** unpacks into: the core-link endpoint, that machine's HTTPS origin, the mTLS material, and the bearer. One name because it is one authenticated reach into one machine — the core link and the machine's HTTPS surface are two faces of it, not two connections. A Core client is handed this rather than a URL, and the material is exposed rather than only dialed with, so a surface that needs the same credentials over HTTPS needs no new format.
 _Avoid_: socket, endpoint, credentials bundle

--- a/packages/sdk/examples/start-a-session.mjs
+++ b/packages/sdk/examples/start-a-session.mjs
@@ -1,0 +1,80 @@
+// A plain Node script that starts a Session on a Core, sends it a prompt, and
+// reads the result. No terminal is involved anywhere (#129 D11, issue 155).
+//
+// Run it:
+//
+//     ACTANA_CORE_BLOB=~/.config/actana/registration-blob.txt \
+//     ACTANA_PROJECT_ID=p-… \
+//     ACTANA_CWD=/home/op/projects/thing \
+//       node packages/sdk/examples/start-a-session.mjs "summarise this repo"
+//
+// `node`, directly — no bundler, no loader, no TypeScript step. That is the
+// point of the acceptance criterion this file answers: the SDK has to be usable
+// from a cron job, a CI runner and a web service, none of which has a terminal,
+// and two of which have no build step either.
+//
+// Note what is NOT here. Nothing reads `process.stdin`, nothing sets raw mode,
+// nothing asks whether a TTY exists. And nothing waits a fixed number of
+// milliseconds for the harness to be ready before sending the prompt: the
+// prompt is handed to the Core as text, the Core delivers it on the harness's
+// own schedule (ADR 0026), and this script waits for the Core to report the
+// turn over. The script does not know which harness it started, what that
+// harness paints while it boots, or which dialog it opens first — and it does
+// not need to.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { CoreClient } from "@actana/sdk/core-client";
+import { CoreSession } from "@actana/sdk/core-session";
+
+/** The registration blob: the base64 paste itself, or a path to the file holding it. */
+function loadBlob() {
+  const raw = process.env.ACTANA_CORE_BLOB?.trim();
+  if (!raw) throw new Error("set ACTANA_CORE_BLOB to a registration blob or a path to one");
+  const source =
+    raw.startsWith("~") || raw.startsWith("/")
+      ? readFileSync(raw.replace(/^~/, homedir()), "utf8")
+      : raw;
+  return JSON.parse(Buffer.from(source.trim(), "base64").toString("utf8"));
+}
+
+const prompt = process.argv[2] ?? "Reply with exactly: hello from the SDK";
+const projectId = process.env.ACTANA_PROJECT_ID;
+const cwd = process.env.ACTANA_CWD;
+if (!projectId || !cwd) {
+  throw new Error("set ACTANA_PROJECT_ID and ACTANA_CWD (a path inside that Project's root)");
+}
+
+const client = CoreClient.fromRegistrationBlob(loadBlob(), { connectTimeoutMs: 15_000 });
+const info = await client.connect();
+console.log(`connected to ${info.coreId} (core-link ${info.protocolVersion})`);
+
+// The Core validates the working directory against its registered Projects, the
+// command's binary against the harness's canonical one, and every flag against
+// its allow-list. A rejection arrives here as a thrown error carrying the Core's
+// own reason — this script does not second-guess any of it in advance.
+const session = await CoreSession.start(client, {
+  projectId,
+  cwd,
+  harness: process.env.ACTANA_HARNESS ?? "claude-code",
+  title: "SDK example session",
+  prompt,
+  dangerouslySkipPermissions: process.env.ACTANA_SKIP_PERMISSIONS === "1",
+});
+console.log(`session ${session.taskId} running on pty ${session.ptyId}`);
+
+session.onStatus((status) => console.log(`  status → ${status}`));
+
+// Waits on the Core's report — the harness's own lifecycle hooks moving the
+// Session's status — not on the output going quiet.
+const idle = await session.waitForIdle({ timeoutMs: Number(process.env.ACTANA_TIMEOUT_MS ?? 300_000) });
+console.log(`settled: ${idle.status}${idle.exited ? ` (process exited ${idle.exitCode})` : ""}`);
+
+// What a terminal would be showing, including everything that scrolled off the
+// top of it — which is where the harness's answer is, several screens back.
+console.log("─".repeat(60));
+console.log(session.screen());
+console.log("─".repeat(60));
+
+await session.kill();
+client.close();

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -1,0 +1,568 @@
+// The session layer against the Core's own server (issue 155).
+//
+// The rig is the one the transport suites use — a real `PtyCoreLinkServer` over
+// a fake socket — so what is asserted below is the agreement with the Core
+// rather than with a stand-in that answers whatever this file expects. What is
+// faked is the PTY manager behind it (there is no harness to run in a unit test)
+// and the Core's task store, which is where a Session's status lives.
+//
+// The properties worth reading this file for:
+//
+//   - the spawn frame carries the prompt as text and **no timing** with it;
+//   - the byte stream is wired before the spawn is answered, so a harness's
+//     banner is in the transcript rather than lost in the round trip;
+//   - `send` writes exactly its argument and appends nothing;
+//   - idleness comes from the Core's status, not from the stream going quiet;
+//   - a Core's rejection is surfaced, never pre-empted;
+//   - nothing in the shipped package touches a terminal (D11).
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type {
+  CoreMutationPort,
+  WebSocketServerLike,
+} from "@actana/core/pty-core-link-server";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "@actana/core/pty-manager";
+import type {
+  CoreLinkProjectMutation,
+  CoreLinkProjectSnapshot,
+  CoreLinkSessionSnapshot,
+  CoreLinkTaskMutation,
+  CoreLinkTaskSnapshot,
+} from "../core-link-frames.ts";
+import { CoreClient } from "../core-client.ts";
+import { CoreSession, CoreSessionStartError, HARNESS_LAUNCH_COMMANDS } from "../core-session.ts";
+import {
+  FakeEventLog,
+  FakeSocketPair,
+  FakeSocketServer,
+  makeMockPtyCore,
+} from "./fake-core-link.ts";
+
+const ESC = "\u001B";
+const CSI = `${ESC}[`;
+const PROJECT_ID = "p-1";
+
+/**
+ * The Core's task store, in memory: create a row, patch its status, list the
+ * Sessions — and append the event a patch produces, because that event is the
+ * whole of how a client learns a harness stopped. The real port
+ * (`core-task-writer.ts`) appends exactly these two kinds.
+ */
+class FakeTaskStore implements CoreMutationPort {
+  readonly tasks = new Map<string, CoreLinkTaskSnapshot>();
+  private seq = 0;
+
+  constructor(private readonly eventLog: FakeEventLog) {}
+
+  mutateProject(mutation: CoreLinkProjectMutation): CoreLinkProjectSnapshot | null {
+    void mutation;
+    return null;
+  }
+
+  mutateTask(mutation: CoreLinkTaskMutation): CoreLinkTaskSnapshot | null {
+    if (mutation.op === "create") {
+      if (mutation.projectId !== PROJECT_ID) return null;
+      const taskId = mutation.taskId ?? `t-${++this.seq}`;
+      const task: CoreLinkTaskSnapshot = {
+        taskId,
+        projectId: mutation.projectId,
+        title: mutation.title,
+        titleManuallySet: false,
+        claudeSessionId: null,
+        agent: mutation.agent,
+        status: mutation.status ?? "ready",
+        pinned: false,
+        archived: false,
+        icon: null,
+        updatedAt: 1,
+      };
+      this.tasks.set(taskId, task);
+      this.eventLog.appendEvent("task:created", JSON.stringify({ taskId }), { taskId });
+      return task;
+    }
+    if (mutation.op === "delete") {
+      this.tasks.delete(mutation.taskId);
+      return null;
+    }
+    const existing = this.tasks.get(mutation.taskId);
+    if (!existing) return null;
+    const previousStatus = existing.status;
+    const next: CoreLinkTaskSnapshot = {
+      ...existing,
+      ...(mutation.status ? { status: mutation.status } : {}),
+      ...(mutation.title ? { title: mutation.title } : {}),
+      updatedAt: existing.updatedAt + 1,
+    };
+    this.tasks.set(next.taskId, next);
+    this.eventLog.appendEvent("task:updated", JSON.stringify({ taskId: next.taskId }), {
+      taskId: next.taskId,
+    });
+    if (next.status === "finished" && previousStatus !== "finished") {
+      this.eventLog.appendEvent("session:finished", JSON.stringify({ id: next.taskId }), {
+        taskId: next.taskId,
+      });
+    }
+    return next;
+  }
+
+  listSessions(): CoreLinkSessionSnapshot[] {
+    return [...this.tasks.values()].map((t) => ({
+      taskId: t.taskId,
+      ptyId: null,
+      status: t.status,
+      updatedAt: t.updatedAt,
+    }));
+  }
+
+  /** What the Core's hook pipeline does when a harness reports its lifecycle. */
+  setStatus(taskId: string, status: string): void {
+    this.mutateTask({ op: "update", taskId, status });
+  }
+}
+
+type Rig = {
+  client: CoreClient;
+  ptyCore: PtyCore & { emitEvent: (e: PtyCoreEvent) => void };
+  tasks: FakeTaskStore;
+  eventLog: FakeEventLog;
+  close: () => void;
+};
+
+function startRig(
+  opts: {
+    announceMultiConnection?: boolean;
+    spawn?: PtyCore["spawn"];
+    /**
+     * Called after the server has written a frame, in the same synchronous
+     * turn. Node's `ws` emits several `message` events from one socket read, so
+     * this is how a test reproduces two frames reaching the client before its
+     * microtasks run — the exact window the held-bytes buffer exists for.
+     */
+    afterServerFrame?: (frame: Record<string, unknown>, rig: () => Rig) => void;
+  } = {},
+): Rig {
+  const ptyCore = makeMockPtyCore();
+  if (opts.spawn) ptyCore.spawn = opts.spawn;
+  const eventLog = new FakeEventLog();
+  const tasks = new FakeTaskStore(eventLog);
+  const wss = new FakeSocketServer();
+  const server = new PtyCoreLinkServer(ptyCore, {
+    port: 0,
+    createServer: () => wss as unknown as WebSocketServerLike,
+    eventLog,
+    mutationPort: tasks,
+    liveEventPollMs: 5,
+    ...(opts.announceMultiConnection === undefined
+      ? {}
+      : { announceMultiConnection: opts.announceMultiConnection }),
+  });
+  const client = new CoreClient({
+    url: "wss://core.test:9444",
+    createSocket: () => {
+      const pair = new FakeSocketPair();
+      if (opts.afterServerFrame) {
+        const send = pair.server.send.bind(pair.server);
+        pair.server.send = (data: string) => {
+          send(data);
+          opts.afterServerFrame!(JSON.parse(data) as Record<string, unknown>, () => built);
+        };
+      }
+      wss.accept(pair.server);
+      queueMicrotask(() => pair.open());
+      return pair.client.asClientSocket();
+    },
+  });
+  const built: Rig = { client, ptyCore, tasks, eventLog, close: () => server.close() };
+  return built;
+}
+
+let rig: Rig | null = null;
+let session: CoreSession | null = null;
+
+afterEach(() => {
+  session?.dispose();
+  session = null;
+  rig?.client.close();
+  rig?.close();
+  rig = null;
+});
+
+async function startSession(
+  r: Rig,
+  overrides: Partial<Parameters<typeof CoreSession.start>[1]> = {},
+): Promise<CoreSession> {
+  await r.client.connect();
+  return CoreSession.start(r.client, {
+    projectId: PROJECT_ID,
+    cwd: "/home/op/projects/thing",
+    harness: "claude-code",
+    prompt: "summarise this repo",
+    cols: 40,
+    rows: 6,
+    ...overrides,
+  });
+}
+
+describe("CoreSession.start", () => {
+  it("creates the Task, spawns the harness, and hands the prompt over as text", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+
+    expect(rig.tasks.tasks.size).toBe(1);
+    const spawn = vi.mocked(rig.ptyCore.spawn).mock.calls[0]?.[0];
+    expect(spawn).toMatchObject({
+      taskId: session.taskId,
+      cwd: "/home/op/projects/thing",
+      command: HARNESS_LAUNCH_COMMANDS["claude-code"],
+      agent: "claude-code",
+      cols: 40,
+      rows: 6,
+      initialInput: "summarise this repo",
+    });
+    expect(session.ptyId).toBe("pty-1");
+  });
+
+  it("sends no timing with the prompt — there is no field for one", async () => {
+    // ADR 0026: a Core client supplies text and never a delay, a ready-signal or
+    // a retry. The assertion is the *absence* of anything else, because the
+    // failure this guards against is a future option that looks helpful.
+    rig = startRig();
+    session = await startSession(rig);
+
+    const spawn = vi.mocked(rig.ptyCore.spawn).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(spawn).sort()).toEqual(
+      ["agent", "cols", "command", "cwd", "initialInput", "rows", "taskId"].sort(),
+    );
+  });
+
+  it("starts a Session with no prompt when none was given", async () => {
+    rig = startRig();
+    session = await startSession(rig, { prompt: undefined });
+
+    const spawn = vi.mocked(rig.ptyCore.spawn).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect("initialInput" in spawn).toBe(false);
+  });
+
+  it("uses an existing Task when handed one, and creates nothing", async () => {
+    rig = startRig();
+    await rig.client.connect();
+    const created = await rig.client.tasksMutate({
+      op: "create",
+      projectId: PROJECT_ID,
+      title: "mine",
+      agent: "claude-code",
+    });
+
+    session = await startSession(rig, { projectId: undefined, taskId: created!.taskId });
+
+    expect(session.taskId).toBe(created!.taskId);
+    expect(rig.tasks.tasks.size).toBe(1);
+  });
+
+  it("appends the harness's skip-permissions flag to the command it defaults to", async () => {
+    rig = startRig();
+    session = await startSession(rig, { dangerouslySkipPermissions: true });
+
+    const spawn = vi.mocked(rig.ptyCore.spawn).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(spawn.command).toBe("claude --dangerously-skip-permissions");
+    expect(spawn.dangerouslySkipPermissions).toBe(true);
+  });
+
+  it("refuses to start without a Project or a Task to start against", async () => {
+    rig = startRig();
+    await rig.client.connect();
+
+    await expect(
+      CoreSession.start(rig.client, { cwd: "/x", harness: "claude-code" }),
+    ).rejects.toBeInstanceOf(CoreSessionStartError);
+  });
+
+  it("surfaces the Core's rejection rather than pre-empting it", async () => {
+    // The working-directory check, the argv[0] check and the flag allow-list are
+    // the Core's: they read a database and a filesystem this process is not on.
+    // What this asserts is that the spawn was *attempted* and the Core's own
+    // reason came back — a client that had refused locally would never have
+    // reached the server, and would be guessing.
+    rig = startRig({
+      spawn: vi.fn(async () => {
+        throw new Error("pty:spawn rejected (cwd-outside-project-roots)");
+      }) as unknown as PtyCore["spawn"],
+    });
+
+    const start = startSession(rig, { cwd: "/etc" });
+
+    await expect(start).rejects.toThrow(/cwd-outside-project-roots/);
+    await expect(start).rejects.toBeInstanceOf(CoreSessionStartError);
+    expect(rig.ptyCore.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the bytes that arrived before the spawn was answered", async () => {
+    // A harness prints its banner immediately, and the Core subscribes the
+    // spawning connection to the PTY before it answers (issue 142) — so the
+    // first bytes can reach this side in the same read as the answer, while the
+    // promise carrying the PTY's id is still a queued microtask. Held and
+    // replayed, so the transcript starts at the beginning rather than wherever
+    // the round trip happened to end.
+    let banner = false;
+    rig = startRig({
+      afterServerFrame: (frame, rig2) => {
+        if (frame.type !== "spawned" || banner) return;
+        banner = true;
+        rig2().ptyCore.emitEvent({
+          type: "data",
+          ptyId: String(frame.ptyId),
+          data: "banner line\r\n",
+          seq: 1,
+        });
+      },
+    });
+
+    session = await startSession(rig);
+
+    expect(banner).toBe(true);
+    expect(session.screen()).toContain("banner line");
+  });
+});
+
+describe("programmatic I/O", () => {
+  it("renders what a terminal would be showing, scrolled-off lines included", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    // Six rows of viewport, ten lines of output: four of them are only in the
+    // scrollback, which is exactly where a transcript lives.
+    for (let i = 1; i <= 10; i += 1) {
+      r.ptyCore.emitEvent({ type: "data", ptyId: "pty-1", data: `answer ${i}\r\n`, seq: i });
+    }
+    await vi.waitFor(() => expect(session!.screen()).toContain("answer 10"));
+
+    expect(session.screen()).toContain("answer 1");
+    expect(session.viewport()).not.toContain("answer 1\n");
+    expect(session.lines().filter((l) => l.startsWith("answer"))).toHaveLength(10);
+  });
+
+  it("reads a screen a harness positioned with cursor moves", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    r.ptyCore.emitEvent({
+      type: "data",
+      ptyId: "pty-1",
+      data: `${CSI}2;4HDone.${CSI}1;1H${CSI}2Kheader`,
+      seq: 1,
+    });
+
+    await vi.waitFor(() => expect(session!.screen()).toContain("Done."));
+    expect(session.screen().split("\n")[0]).toBe("header");
+    expect(session.screen().split("\n")[1]).toBe("   Done.");
+  });
+
+  it("ignores another Session's PTY on the same link", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    r.ptyCore.emitEvent({ type: "data", ptyId: "pty-other", data: "not mine\r\n", seq: 1 });
+    r.ptyCore.emitEvent({ type: "data", ptyId: "pty-1", data: "mine\r\n", seq: 2 });
+
+    await vi.waitFor(() => expect(session!.screen()).toContain("mine"));
+    expect(session.screen()).not.toContain("not mine");
+  });
+
+  it("hands every chunk to a data listener, escape sequences and all", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const chunks: string[] = [];
+    session.onData((c) => chunks.push(c));
+    rig.ptyCore.emitEvent({ type: "data", ptyId: "pty-1", data: `${CSI}31mred`, seq: 1 });
+
+    await vi.waitFor(() => expect(chunks).toHaveLength(1));
+    expect(chunks[0]).toBe(`${CSI}31mred`);
+  });
+
+  it("writes exactly what it is given and appends nothing", async () => {
+    // Not even a carriage return. Deciding when to press Enter is prompt
+    // delivery, prompt delivery is the Core's (ADR 0026), and a client that did
+    // it here would do it differently from every other client.
+    rig = startRig();
+    session = await startSession(rig);
+
+    await session.send("2");
+
+    expect(rig.ptyCore.write).toHaveBeenCalledWith("pty-1", "2");
+    expect(vi.mocked(rig.ptyCore.write).mock.calls).toHaveLength(1);
+  });
+
+  it("resizes the PTY and the screen together", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+
+    await session.resize(20, 4);
+
+    expect(rig.ptyCore.resize).toHaveBeenCalledWith("pty-1", 20, 4);
+    const r = rig;
+    r.ptyCore.emitEvent({
+      type: "data",
+      ptyId: "pty-1",
+      data: "123456789012345678901234567890",
+      seq: 1,
+    });
+    // Twenty columns wide now, so thirty characters is two lines.
+    await vi.waitFor(() => expect(session!.screen().split("\n")).toHaveLength(2));
+  });
+
+  it("stops advancing once disposed and leaves the harness alone", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    r.ptyCore.emitEvent({ type: "data", ptyId: "pty-1", data: "before\r\n", seq: 1 });
+    await vi.waitFor(() => expect(session!.screen()).toContain("before"));
+
+    session.dispose();
+    r.ptyCore.emitEvent({ type: "data", ptyId: "pty-1", data: "after\r\n", seq: 2 });
+    await new Promise((r2) => setTimeout(r2, 20));
+
+    expect(session.screen()).not.toContain("after");
+    expect(r.ptyCore.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe("waiting on the Core's report", () => {
+  it("resolves when the Core says the turn finished", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    const idle = session.waitForIdle();
+
+    // What the harness's own Stop hook does on the Core.
+    r.tasks.setStatus(session.taskId, "running");
+    r.tasks.setStatus(session.taskId, "finished");
+
+    await expect(idle).resolves.toEqual({ status: "finished", exited: false });
+  });
+
+  it("resolves on a question, because a question is not something to wait out", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    const idle = session.waitForIdle();
+
+    r.tasks.setStatus(session.taskId, "needs-input");
+
+    await expect(idle).resolves.toEqual({ status: "needs-input", exited: false });
+  });
+
+  it("does not settle on the status the Task already carried", async () => {
+    // A Session started on a Task that finished yesterday is waiting for this
+    // turn, not being handed the last one's answer.
+    rig = startRig();
+    await rig.client.connect();
+    const created = await rig.client.tasksMutate({
+      op: "create",
+      projectId: PROJECT_ID,
+      title: "old",
+      agent: "claude-code",
+    });
+    rig.tasks.setStatus(created!.taskId, "finished");
+
+    session = await startSession(rig, { projectId: undefined, taskId: created!.taskId });
+    let settled = false;
+    void session.waitForIdle().then(() => {
+      settled = true;
+    });
+    await new Promise((r2) => setTimeout(r2, 50));
+
+    expect(settled).toBe(false);
+    expect(session.status()).toBeNull();
+  });
+
+  it("reports the status as it moves", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const seen: string[] = [];
+    session.onStatus((s) => seen.push(s));
+    const r = rig;
+
+    r.tasks.setStatus(session.taskId, "running");
+    await vi.waitFor(() => expect(seen).toContain("running"));
+    r.tasks.setStatus(session.taskId, "finished");
+    await vi.waitFor(() => expect(seen).toContain("finished"));
+
+    expect(seen).toEqual(["running", "finished"]);
+  });
+
+  it("resolves when the harness's process exits", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    const idle = session.waitForIdle();
+
+    r.ptyCore.emitEvent({ type: "exit", ptyId: "pty-1", exitCode: 2, signal: 9 });
+
+    await expect(idle).resolves.toMatchObject({ exited: true, exitCode: 2 });
+    expect(session.exitStatus()).toEqual({ exitCode: 2, signal: 9 });
+  });
+
+  it("answers straight away when the Session has already settled", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    r.tasks.setStatus(session.taskId, "finished");
+    await vi.waitFor(() => expect(session!.status()).toBe("finished"));
+
+    await expect(session.waitForIdle()).resolves.toEqual({
+      status: "finished",
+      exited: false,
+    });
+  });
+
+  it("gives up on a deadline the caller set, and says what it was still doing", async () => {
+    rig = startRig();
+    session = await startSession(rig);
+    rig.tasks.setStatus(session.taskId, "running");
+    await vi.waitFor(() => expect(session!.status()).toBe("running"));
+
+    await expect(session.waitForIdle({ timeoutMs: 30 })).rejects.toThrow(/still running/);
+  });
+
+  it("subscribes the client to the event log when nothing else has", async () => {
+    rig = startRig();
+    expect(rig.client.isSubscribedToEvents()).toBe(false);
+
+    session = await startSession(rig);
+
+    expect(rig.client.isSubscribedToEvents()).toBe(true);
+  });
+});
+
+describe("D11 — no terminal, anywhere", () => {
+  it("touches nothing terminal-shaped in any shipped module", () => {
+    // The rule is absolute and structural, so the check is too: terminal
+    // handling belongs to the CLI, and an SDK that read `process.stdin` or set
+    // raw mode would be unusable from the cron job, the CI runner and the web
+    // service this package exists for. A grep is a poor test of behaviour and a
+    // good test of a boundary nobody may cross by accident.
+    const src = path.resolve(import.meta.dirname, "..");
+    const forbidden = /process\.stdin|process\.stdout|setRawMode|\/dev\/tty|isTTY|readline/;
+    const offences: string[] = [];
+    const sweep = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+          sweep(path.join(dir, entry.name));
+        } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+          const file = path.join(dir, entry.name);
+          const source = readFileSync(file, "utf8")
+            .replace(/\/\*[\s\S]*?\*\//g, "")
+            .replace(/^\s*\/\/.*$/gm, "");
+          if (forbidden.test(source)) offences.push(entry.name);
+        }
+      }
+    };
+    sweep(src);
+
+    expect(offences).toEqual([]);
+  });
+});

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -33,7 +33,13 @@ import type {
   CoreLinkTaskSnapshot,
 } from "../core-link-frames.ts";
 import { CoreClient } from "../core-client.ts";
-import { CoreSession, CoreSessionStartError, HARNESS_LAUNCH_COMMANDS } from "../core-session.ts";
+import {
+  CoreSession,
+  CoreSessionStartError,
+  HARNESS_LAUNCH_COMMANDS,
+  STATUS_READ_RETRIES,
+  STATUS_READ_RETRY_MS,
+} from "../core-session.ts";
 import {
   FakeEventLog,
   FakeSocketPair,
@@ -325,6 +331,35 @@ describe("CoreSession.start", () => {
     expect(banner).toBe(true);
     expect(session.screen()).toContain("banner line");
   });
+
+  it("keeps its own exit when a co-tenant PTY exits in the same window", async () => {
+    // The exit listener hears every PTY this connection holds, and during the
+    // spawn's round trip it cannot yet filter by id — the id is what has not
+    // come back. So the frames are held like the bytes are, all of them: a
+    // Session that started while another one was dying used to lose its own
+    // exit to the co-tenant's, leaving `onExit` silent and `waitForIdle` short
+    // an exit route.
+    let spawned = 0;
+    rig = startRig({
+      spawn: vi.fn(async () => ({ ptyId: `pty-${++spawned}` })) as unknown as PtyCore["spawn"],
+      afterServerFrame: (frame, rig2) => {
+        if (frame.type !== "spawned" || frame.ptyId !== "pty-2") return;
+        // The co-tenant first, so a hold with one slot is already full when
+        // this Session's own exit arrives behind it.
+        rig2().ptyCore.emitEvent({ type: "exit", ptyId: "pty-1", exitCode: 0 });
+        rig2().ptyCore.emitEvent({ type: "exit", ptyId: "pty-2", exitCode: 7, signal: 15 });
+      },
+    });
+    const cotenant = await startSession(rig);
+
+    session = await startSession(rig);
+
+    expect(cotenant.ptyId).toBe("pty-1");
+    expect(session.ptyId).toBe("pty-2");
+    expect(session.exitStatus()).toEqual({ exitCode: 7, signal: 15 });
+    await expect(session.waitForIdle()).resolves.toMatchObject({ exited: true, exitCode: 7 });
+    cotenant.dispose();
+  });
 });
 
 describe("programmatic I/O", () => {
@@ -540,6 +575,49 @@ describe("waiting on the Core's report", () => {
     await expect(idle).resolves.toMatchObject({ exited: false });
   });
 
+  it("asks again when the status read fails, because the event will not come twice", async () => {
+    // `needs-input`, `interrupted` and `terminated` reach this layer as a bare
+    // `task:updated` — the event says a row moved and nothing more, so the
+    // status is read back off the Core, and that event is appended once. A read
+    // swallowed on the transition that mattered leaves `waitForIdle()` waiting
+    // for a report already made, and by design it has no deadline to end on.
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    const answer = r.client.sessionsList.bind(r.client);
+    let failed = 0;
+    vi.spyOn(r.client, "sessionsList").mockImplementation(async () => {
+      if (failed === 0) {
+        failed += 1;
+        throw new Error("link dropped mid-read");
+      }
+      return answer();
+    });
+    const idle = session.waitForIdle();
+
+    r.tasks.setStatus(session.taskId, "needs-input");
+
+    await expect(idle).resolves.toEqual({ status: "needs-input", exited: false });
+    expect(failed).toBe(1);
+  });
+
+  it("stops re-asking rather than polling a Core that is gone", async () => {
+    // The re-ask is bounded: a link still down after this many tries is not
+    // going to be talked round by more, and a Session that asked forever would
+    // be the busy-loop version of the timer #191 deleted.
+    rig = startRig();
+    session = await startSession(rig);
+    const r = rig;
+    vi.spyOn(r.client, "sessionsList").mockRejectedValue(new Error("link dropped"));
+
+    r.tasks.setStatus(session.taskId, "needs-input");
+
+    const attempts = () => vi.mocked(r.client.sessionsList).mock.calls.length;
+    await vi.waitFor(() => expect(attempts()).toBe(1 + STATUS_READ_RETRIES), { timeout: 3000 });
+    await new Promise((done) => setTimeout(done, STATUS_READ_RETRY_MS * 2));
+    expect(attempts()).toBe(1 + STATUS_READ_RETRIES);
+  });
+
   it("subscribes the client to the event log when nothing else has", async () => {
     rig = startRig();
     expect(rig.client.isSubscribedToEvents()).toBe(false);
@@ -557,25 +635,40 @@ describe("D11 — no terminal, anywhere", () => {
     // raw mode would be unusable from the cron job, the CI runner and the web
     // service this package exists for. A grep is a poor test of behaviour and a
     // good test of a boundary nobody may cross by accident.
-    const src = path.resolve(import.meta.dirname, "..");
+    // `examples/` is swept with `src/`, not instead of it: the one file in this
+    // package a user is *invited* to run with plain `node` is the example, so it
+    // is the last place a `process.stdin` may appear. Its extension is `.mjs`,
+    // which is why the match is on a set rather than on `.ts`.
+    const root = path.resolve(import.meta.dirname, "..", "..");
+    const roots = [path.join(root, "src"), path.join(root, "examples")];
+    const shipped = /\.(ts|mts|cts|js|mjs|cjs)$/;
     const forbidden = /process\.stdin|process\.stdout|setRawMode|\/dev\/tty|isTTY|readline/;
     const offences: string[] = [];
+    const swept: string[] = [];
     const sweep = (dir: string): void => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         if (entry.isDirectory()) {
           if (entry.name === "__tests__" || entry.name === "node_modules") continue;
           sweep(path.join(dir, entry.name));
-        } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        } else if (shipped.test(entry.name) && !/\.test\.[a-z]+$/.test(entry.name)) {
           const file = path.join(dir, entry.name);
+          swept.push(path.relative(root, file).split(path.sep).join("/"));
           const source = readFileSync(file, "utf8")
             .replace(/\/\*[\s\S]*?\*\//g, "")
             .replace(/^\s*\/\/.*$/gm, "");
-          if (forbidden.test(source)) offences.push(entry.name);
+          if (forbidden.test(source)) {
+            offences.push(path.relative(root, file).split(path.sep).join("/"));
+          }
         }
       }
     };
-    sweep(src);
+    for (const dir of roots) sweep(dir);
 
     expect(offences).toEqual([]);
+    // An empty sweep passes an empty assertion, and this one walked `src` alone
+    // until now: name a file from each tree so a narrowed walk fails here.
+    expect(swept).toEqual(
+      expect.arrayContaining(["src/core-session.ts", "examples/start-a-session.mjs"]),
+    );
   });
 });

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -527,6 +527,19 @@ describe("waiting on the Core's report", () => {
     await expect(session.waitForIdle({ timeoutMs: 30 })).rejects.toThrow(/still running/);
   });
 
+  it("settles a pending wait when the Session is disposed rather than stranding it", async () => {
+    // `await session.kill()` while a `waitForIdle()` is outstanding is an
+    // ordinary thing to write, and a disposed Session hears no more reports —
+    // so the waiter is answered on the way out instead of left pending forever.
+    rig = startRig();
+    session = await startSession(rig);
+    const idle = session.waitForIdle();
+
+    session.dispose();
+
+    await expect(idle).resolves.toMatchObject({ exited: false });
+  });
+
   it("subscribes the client to the event log when nothing else has", async () => {
     rig = startRig();
     expect(rig.client.isSubscribedToEvents()).toBe(false);

--- a/packages/sdk/src/__tests__/live-session.test.ts
+++ b/packages/sdk/src/__tests__/live-session.test.ts
@@ -1,0 +1,145 @@
+// The session layer against a Core that is actually running a harness (issue 155).
+//
+// Opt-in, and skipped unless it is given a machine to drive:
+//
+//     ACTANA_CORE_BLOB=~/.config/actana/registration-blob.txt \
+//     ACTANA_LIVE_PROJECT_ID=p-… \
+//     ACTANA_LIVE_CWD=/home/op/projects/scratch \
+//       pnpm --filter @actana/sdk test
+//
+// **Unlike `live-core.test.ts`, this one writes.** It creates a Task, spawns a
+// harness, sends it a prompt and kills it, so it wants a scratch Project rather
+// than the machine somebody is working on — hence the second and third
+// variables, which have no default. Everything it creates it kills; the Task row
+// it leaves behind is the record of the run.
+//
+// Two things only a live Core can show, and both are the ticket's acceptance
+// criteria rather than nice-to-haves:
+//
+//   1. The prompt arrives without this side timing anything. The Core waits for
+//      the harness's TUI to settle, answers whatever dialog it opened and sends
+//      the carriage return separately (ADR 0026, #191) — so what is asserted
+//      here is that the *prompt text is on the harness's screen and answered*,
+//      which no in-process rig can fake, because the thing being tested is the
+//      Core's reaction to a real TUI's real output.
+//   2. `screen()` renders that TUI. The rig's PTY manager emits whatever a test
+//      hands it; a real harness emits box drawing, cursor addressing, a spinner
+//      and a status line, and the assertion below is that a script reads its
+//      answer out of that.
+//
+// Requires a Core carrying #191 — the prompt-delivery sequence. Against an older
+// Core the prompt is written on the flat timer that release deleted, lands in
+// the harness's boot sequence, and is lost; the session then sits at `ready`
+// until this suite's deadline. That is the dependency this ticket declares, seen
+// from the outside.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { CoreClient } from "../core-client.ts";
+import { CoreSession } from "../core-session.ts";
+import type { CoreRegistrationBlob } from "../core-registration-blob.ts";
+
+function loadBlob(): CoreRegistrationBlob | null {
+  const raw = process.env.ACTANA_CORE_BLOB?.trim();
+  if (!raw) return null;
+  const source =
+    raw.startsWith("~") || raw.startsWith("/")
+      ? readFileSync(raw.replace(/^~/, homedir()), "utf8")
+      : raw;
+  const parsed = JSON.parse(
+    Buffer.from(source.trim(), "base64").toString("utf8"),
+  ) as CoreRegistrationBlob;
+  if (!parsed.endpoint || !parsed.bearer) throw new Error("ACTANA_CORE_BLOB is not a blob");
+  return parsed;
+}
+
+const blob = loadBlob();
+const projectId = process.env.ACTANA_LIVE_PROJECT_ID?.trim();
+const cwd = process.env.ACTANA_LIVE_CWD?.trim();
+const harness = (process.env.ACTANA_LIVE_HARNESS?.trim() ?? "claude-code") as "claude-code";
+const armed = blob !== null && !!projectId && !!cwd;
+/** A turn on a real harness is not fast, and this suite waits for a real one. */
+const TURN_TIMEOUT_MS = 300_000;
+
+describe.skipIf(!armed)("a Session on a live Core", () => {
+  let client: CoreClient | null = null;
+  let session: CoreSession | null = null;
+
+  afterEach(async () => {
+    if (session) await session.kill().catch(() => undefined);
+    session = null;
+    client?.close();
+    client = null;
+  });
+
+  it(
+    "starts a harness, has the Core deliver the prompt, and reads the answer off the screen",
+    async () => {
+      client = CoreClient.fromRegistrationBlob(blob!, { connectTimeoutMs: 15_000 });
+      await client.connect();
+
+      const marker = `ACTANA-SDK-LIVE-OK`;
+      session = await CoreSession.start(client, {
+        projectId,
+        cwd: cwd!,
+        harness,
+        title: "SDK live session test",
+        // Text, and no timing with it. Everything about *when* this reaches the
+        // harness is decided on the Core.
+        prompt: `Reply with exactly: ${marker} and nothing else.`,
+      });
+
+      expect(session.ptyId).toBeTruthy();
+      expect(session.taskId).toBeTruthy();
+
+      const statuses: string[] = [];
+      session.onStatus((s) => statuses.push(s));
+
+      const idle = await session.waitForIdle({ timeoutMs: TURN_TIMEOUT_MS });
+
+      // `running` is the harness's own turn-start hook firing, which happens
+      // only once it has *accepted* a prompt. Seeing it is the difference
+      // between "the text is on the input line" and "the harness was asked".
+      expect(statuses).toContain("running");
+
+      // The Core's own report of the turn, off its event log. Not a guess from
+      // the byte stream going quiet.
+      expect(["finished", "needs-input"]).toContain(idle.status);
+      expect(idle.exited).toBe(false);
+
+      // Read before the kill in `afterEach`: a full-screen harness leaves the
+      // alternate screen on the way out, and the transcript with it.
+      const screen = session.screen();
+      // The prompt reached the harness — this is #191's delivery, observed from
+      // outside the Core.
+      expect(screen).toContain(marker);
+      // And it is a rendered screen rather than a stream of escape codes: the
+      // harness's own box drawing is laid out, not stripped into one line.
+      expect(screen.split("\n").length).toBeGreaterThan(3);
+      expect(screen).not.toContain("\u001B[");
+    },
+    TURN_TIMEOUT_MS + 30_000,
+  );
+
+  it(
+    "surfaces the Core's spawn policy rather than pre-empting it",
+    async () => {
+      // A working directory outside every registered Project root. The refusal
+      // is the Core's — this side does not know that machine's Projects, and
+      // the point of the assertion is that it did not pretend to.
+      client = CoreClient.fromRegistrationBlob(blob!, { connectTimeoutMs: 15_000 });
+      await client.connect();
+
+      await expect(
+        CoreSession.start(client, {
+          projectId,
+          cwd: "/",
+          harness,
+          title: "SDK live rejection test",
+        }),
+      ).rejects.toThrow(/cwd-outside-project-roots|rejected/);
+    },
+    60_000,
+  );
+});

--- a/packages/sdk/src/__tests__/terminal-screen.test.ts
+++ b/packages/sdk/src/__tests__/terminal-screen.test.ts
@@ -1,0 +1,352 @@
+// What a terminal would be showing — including the part that scrolled away.
+//
+// The cases below are the ones that decide whether `session.screen()` returns a
+// transcript or a jumble. Several are transcribed from real harness output
+// rather than invented: the cursor-positioned menu and the erase-and-walk-up
+// clear are how Claude Code 2.1.228 actually draws, and both are unreadable to
+// anything that deletes escape sequences instead of interpreting them.
+
+import { describe, it, expect } from "vitest";
+import { TerminalScreen, charWidth } from "../terminal-screen.ts";
+
+const ESC = "\u001B";
+const CSI = `${ESC}[`;
+
+describe("TerminalScreen", () => {
+  describe("the thing stripping escape codes gets wrong", () => {
+    it("reads a menu a harness laid out with cursor moves, not spaces", () => {
+      // Claude Code's folder-trust dialog, in the shape the Core's prompt
+      // delivery had to learn to read: every column is a `CSI n G`, and there
+      // is not one space character in the payload.
+      const screen = new TerminalScreen({ cols: 40, rows: 4 });
+      screen.write(`${CSI}4G1.${CSI}7GYes,${CSI}12GI${CSI}14Gtrust`);
+
+      // Stripping the escapes yields `1.Yes,Itrust`. Interpreting them yields a
+      // line whose words are where the harness put them.
+      expect(screen.viewportLines()[0]).toBe("   1. Yes, I trust");
+    });
+
+    it("shows the last spinner frame, not every frame concatenated", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      for (const frame of ["⠋", "⠙", "⠹", "⠸"]) {
+        screen.write(`\r${CSI}2K${frame} Working…`);
+      }
+
+      expect(screen.viewportLines()[0]).toBe("⠸ Working…");
+      expect(screen.text()).toBe("⠸ Working…");
+    });
+
+    it("repaints a row in place when the cursor is addressed backwards", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      screen.write("hello world");
+      screen.write(`${CSI}1;1H`);
+      screen.write("HELLO");
+
+      expect(screen.viewportLines()[0]).toBe("HELLO world");
+    });
+  });
+
+  describe("the scrollback is the transcript", () => {
+    it("keeps every line that scrolled off the top", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      for (let i = 1; i <= 10; i += 1) screen.write(`line ${i}\r\n`);
+
+      // Ten lines each ending in a newline leaves the cursor on an eleventh,
+      // so the bottom row is blank and the top two hold the last two lines.
+      expect(screen.viewportLines().filter(Boolean)).toEqual(["line 9", "line 10"]);
+      // …and the other seven are exactly where a caller reading a transcript
+      // needs them to be.
+      expect(screen.scrollbackLines()).toEqual([
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7",
+        "line 8",
+      ]);
+      expect(screen.text().split("\n")).toEqual([
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7",
+        "line 8",
+        "line 9",
+        "line 10",
+      ]);
+    });
+
+    it("drops the oldest lines past the scrollback limit and keeps the rest", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 2, scrollback: 3 });
+      for (let i = 1; i <= 10; i += 1) screen.write(`line ${i}\r\n`);
+
+      expect(screen.scrollbackLines()).toEqual(["line 7", "line 8", "line 9"]);
+    });
+
+    it("keeps nothing when a caller asks for no scrollback", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 2, scrollback: 0 });
+      for (let i = 1; i <= 5; i += 1) screen.write(`line ${i}\r\n`);
+
+      expect(screen.scrollbackLines()).toEqual([]);
+      expect(screen.text()).toBe("line 5");
+    });
+
+    it("does not mistake a scrolled pane for history", () => {
+      // A TUI animating a three-row region in the middle of its layout is not
+      // producing a transcript, and a terminal keeps none of it either.
+      const screen = new TerminalScreen({ cols: 20, rows: 6 });
+      screen.write(`${CSI}2;4r`); // scroll region: rows 2..4
+      screen.write(`${CSI}4;1Hbottom of pane\n`);
+      screen.write("next\n");
+
+      expect(screen.scrollbackLines()).toEqual([]);
+    });
+
+    it("erases the screen without pushing it to the scrollback", () => {
+      // ED2 is an erase, not a scroll. A terminal loses that content too.
+      const screen = new TerminalScreen({ cols: 20, rows: 4 });
+      screen.write("keep me\r\n");
+      screen.write(`${CSI}2J${CSI}1;1H`);
+      screen.write("fresh");
+
+      expect(screen.scrollbackLines()).toEqual([]);
+      expect(screen.text()).toBe("fresh");
+    });
+
+    it("discards the scrollback only when asked to, with ED3", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 2 });
+      for (let i = 1; i <= 5; i += 1) screen.write(`line ${i}\r\n`);
+      expect(screen.scrollbackLines().length).toBeGreaterThan(0);
+
+      screen.write(`${CSI}3J`);
+
+      expect(screen.scrollbackLines()).toEqual([]);
+    });
+
+    it("survives the clear Claude Code actually emits — erase-line and walk up", () => {
+      // The harness never sends ED2; it erases each line and moves up, five or
+      // more times, then paints the new frame. Nothing scrolls, so the
+      // transcript that scrolled off earlier is still there afterwards.
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      for (let i = 1; i <= 6; i += 1) screen.write(`line ${i}\r\n`);
+      const before = screen.scrollbackLines();
+
+      let clear = "";
+      for (let i = 0; i < 5; i += 1) clear += `${CSI}2K${CSI}1G${CSI}1A`;
+      screen.write(clear);
+      screen.write(`${CSI}1;1H${CSI}Jrepainted`);
+
+      expect(screen.scrollbackLines()).toEqual(before);
+      expect(screen.viewportText()).toBe("repainted");
+    });
+  });
+
+  describe("the alternate screen", () => {
+    it("shows the alternate buffer and keeps the main one intact underneath", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      screen.write("shell line 1\r\nshell line 2\r\n");
+
+      screen.write(`${CSI}?1049h`);
+      screen.write("full screen app");
+      expect(screen.alternateScreen).toBe(true);
+      expect(screen.viewportText()).toBe("full screen app");
+      // The alternate screen starts blank: the main buffer's history is not
+      // visible through it.
+      expect(screen.scrollbackLines()).toEqual([]);
+
+      screen.write(`${CSI}?1049l`);
+      expect(screen.alternateScreen).toBe(false);
+      expect(screen.viewportText()).toBe("shell line 1\nshell line 2");
+    });
+
+    it("keeps what scrolls off the alternate screen, which a terminal does not", () => {
+      // Deliberate, and the reason is in the header: a human scrolls a
+      // full-screen app with the app's own keys, a script cannot, and those
+      // lines are the transcript it was asked to read.
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      screen.write("main screen\r\n");
+      screen.write(`${CSI}?1049h`);
+      for (let i = 1; i <= 6; i += 1) screen.write(`tui ${i}\r\n`);
+
+      expect(screen.scrollbackLines()).toEqual(["tui 1", "tui 2", "tui 3", "tui 4"]);
+      expect(screen.text()).toContain("tui 1");
+      // Each buffer keeps its own, so the app's output never lands in the
+      // shell's history.
+      screen.write(`${CSI}?1049l`);
+      expect(screen.scrollbackLines()).toEqual([]);
+      expect(screen.text()).toBe("main screen");
+    });
+  });
+
+  describe("editing the grid", () => {
+    it("inserts and deletes lines within the scroll region", () => {
+      const screen = new TerminalScreen({ cols: 10, rows: 4 });
+      screen.write("a\r\nb\r\nc\r\nd");
+
+      screen.write(`${CSI}2;1H${CSI}L`); // insert a blank line at row 2
+      expect(screen.viewportLines()).toEqual(["a", "", "b", "c"]);
+
+      screen.write(`${CSI}2;1H${CSI}M`); // and take it back out
+      expect(screen.viewportLines()).toEqual(["a", "b", "c", ""]);
+    });
+
+    it("inserts, deletes and erases characters", () => {
+      const screen = new TerminalScreen({ cols: 12, rows: 1 });
+      screen.write("abcdef");
+
+      screen.write(`${CSI}3G${CSI}2@`); // two blanks in front of `c`
+      expect(screen.viewportLines()[0]).toBe("ab  cdef");
+
+      screen.write(`${CSI}3G${CSI}2P`); // take them out again
+      expect(screen.viewportLines()[0]).toBe("abcdef");
+
+      screen.write(`${CSI}2G${CSI}3X`); // blank three cells in place
+      expect(screen.viewportLines()[0]).toBe("a   ef");
+    });
+
+    it("erases to the end of a line, to its start, and all of it", () => {
+      const screen = new TerminalScreen({ cols: 12, rows: 1 });
+
+      screen.write("abcdef");
+      screen.write(`${CSI}4G${CSI}0K`);
+      expect(screen.viewportLines()[0]).toBe("abc");
+
+      screen.write(`${CSI}1Gabcdef${CSI}3G${CSI}1K`);
+      expect(screen.viewportLines()[0]).toBe("   def");
+
+      screen.write(`${CSI}2K`);
+      expect(screen.viewportLines()[0]).toBe("");
+    });
+
+    it("scrolls up and down on request, and the scroll feeds the transcript", () => {
+      const screen = new TerminalScreen({ cols: 10, rows: 3 });
+      screen.write("a\r\nb\r\nc");
+
+      screen.write(`${CSI}1S`);
+      expect(screen.viewportLines()).toEqual(["b", "c", ""]);
+      expect(screen.scrollbackLines()).toEqual(["a"]);
+
+      screen.write(`${CSI}1T`);
+      expect(screen.viewportLines()).toEqual(["", "b", "c"]);
+    });
+  });
+
+  describe("the parser", () => {
+    it("carries an escape sequence split across chunks", () => {
+      // Chunk boundaries land wherever the PTY's read did. A parser that
+      // re-scanned each chunk on its own would print `[3;5H` as text.
+      const screen = new TerminalScreen({ cols: 20, rows: 5 });
+      screen.write(`hello${ESC}`);
+      screen.write("[3");
+      screen.write(";5");
+      screen.write("Hthere");
+
+      expect(screen.viewportLines()[0]).toBe("hello");
+      expect(screen.viewportLines()[2]).toBe("    there");
+    });
+
+    it("swallows an OSC title and prints nothing of it", () => {
+      const screen = new TerminalScreen({ cols: 30, rows: 2 });
+      screen.write(`${ESC}]0;a window title\u0007visible`);
+
+      expect(screen.viewportLines()[0]).toBe("visible");
+    });
+
+    it("swallows an OSC terminated by ST rather than BEL", () => {
+      const screen = new TerminalScreen({ cols: 30, rows: 2 });
+      screen.write(`${ESC}]8;;https://example.test${ESC}\\link`);
+
+      expect(screen.viewportLines()[0]).toBe("link");
+    });
+
+    it("drops colour without dropping the text it was colouring", () => {
+      const screen = new TerminalScreen({ cols: 30, rows: 2 });
+      screen.write(`${CSI}1;31mred${CSI}0m plain`);
+
+      expect(screen.viewportLines()[0]).toBe("red plain");
+    });
+
+    it("prints no character for a bell, a backspace or a stray control byte", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 2 });
+      screen.write("ab\u0007c");
+      expect(screen.viewportLines()[0]).toBe("abc");
+
+      screen.write("\b\bXY");
+      expect(screen.viewportLines()[0]).toBe("aXY");
+    });
+
+    it("moves to the next tab stop rather than printing a tab", () => {
+      const screen = new TerminalScreen({ cols: 24, rows: 2 });
+      screen.write("ab\tcd");
+
+      expect(screen.viewportLines()[0]).toBe("ab      cd");
+    });
+
+    it("saves and restores the cursor both ways it is spelled", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 3 });
+      screen.write(`${CSI}2;3H${ESC}7`);
+      screen.write(`${CSI}1;1Htop${ESC}8here`);
+      expect(screen.viewportLines()[1]).toBe("  here");
+
+      screen.write(`${CSI}3;1H${CSI}s${CSI}1;1H${CSI}u`);
+      expect(screen.cursor).toEqual({ row: 2, col: 0 });
+    });
+  });
+
+  describe("the grid's geometry", () => {
+    it("wraps at the last column and not one character early", () => {
+      // Deferred wrap: a line exactly `cols` wide fills its row and the *next*
+      // character starts the row below. Getting this wrong shifts every line
+      // after the first full one.
+      const screen = new TerminalScreen({ cols: 5, rows: 3 });
+      screen.write("abcde");
+      expect(screen.viewportLines()).toEqual(["abcde", "", ""]);
+
+      screen.write("f");
+      expect(screen.viewportLines()).toEqual(["abcde", "f", ""]);
+    });
+
+    it("gives a wide character two columns and a combining mark none", () => {
+      expect(charWidth("漢")).toBe(2);
+      expect(charWidth("a")).toBe(1);
+      expect(charWidth("́")).toBe(0);
+
+      const screen = new TerminalScreen({ cols: 6, rows: 2 });
+      screen.write("漢字ab");
+      expect(screen.viewportLines()[0]).toBe("漢字ab");
+      expect(screen.cursor.col).toBe(5);
+
+      const accented = new TerminalScreen({ cols: 6, rows: 1 });
+      // `e` plus a combining acute: two code points, one cell, one column.
+      accented.write("e\u0301x");
+      expect(accented.viewportLines()[0]).toBe("e\u0301x");
+    });
+
+    it("resizes, keeping what a shrink pushes off the top", () => {
+      const screen = new TerminalScreen({ cols: 20, rows: 4 });
+      screen.write("a\r\nb\r\nc\r\nd");
+
+      screen.resize(20, 2);
+
+      expect(screen.rows).toBe(2);
+      expect(screen.scrollbackLines()).toEqual(["a", "b"]);
+      expect(screen.viewportLines()).toEqual(["c", "d"]);
+    });
+
+    it("resets everything on RIS", () => {
+      const screen = new TerminalScreen({ cols: 10, rows: 2 });
+      screen.write("a\r\nb\r\nc");
+      expect(screen.scrollbackLines().length).toBeGreaterThan(0);
+
+      screen.write(`${ESC}c`);
+
+      expect(screen.text()).toBe("");
+      expect(screen.scrollbackLines()).toEqual([]);
+      expect(screen.cursor).toEqual({ row: 0, col: 0 });
+    });
+  });
+});

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -261,6 +261,13 @@ export class CoreClient {
 
   protected transport: CoreLinkTransport | null = null;
   protected closed = false;
+  /**
+   * True once a `subscribe` has gone out for this client — see
+   * {@link subscribeEvents}. Per client rather than per connection: it records
+   * that this client *wants* the event stream, which is what a reconnecting
+   * subclass re-asks for, and what stops a second caller asking twice.
+   */
+  private eventsSubscribed = false;
   /** True once this connection has been established — reset per connection. */
   private established = false;
 
@@ -787,6 +794,46 @@ export class CoreClient {
   onEvent(cb: (msg: { event: CoreLinkEvent }) => void): Unsubscribe {
     this.eventListeners.add(cb);
     return () => this.eventListeners.delete(cb);
+  }
+
+  /**
+   * Ask this Core for its event log: the tail past `lastEventId`, then live
+   * push for as long as this connection lasts.
+   *
+   * Fire-and-forget, because the answer is a *stream* — the replay tail as
+   * `event` frames and the {@link onEventsReplayed} marker behind them — rather
+   * than a reqId-correlated response. Returns false when there was no writable
+   * connection to put the frame on.
+   *
+   * A one-shot client sends this only if it is asked to. That is the difference
+   * between the two entry points here: {@link DurableCoreClient} owes the Core a
+   * subscribe on every connection and sends one through this method, whereas a
+   * program that connects to ask one question wants no event stream at all.
+   * What made it public is the session layer (issue 155): a script that starts a
+   * Session and waits for the harness to finish is reading the Core's own
+   * report of that, and the report is an event.
+   *
+   * `lastEventId` defaults to 0, which asks for the whole tail the Core will
+   * serve. That is the honest default for a caller with no cursor — the
+   * alternative is inventing a high-water mark, and a cursor that runs ahead of
+   * the log stops live push entirely. A caller that keeps a cursor passes it.
+   */
+  subscribeEvents(lastEventId = 0): boolean {
+    if (this.closed) return false;
+    this.eventsSubscribed = true;
+    return this.sendNow({ type: "subscribe", reqId: "", lastEventId }, "sub");
+  }
+
+  /**
+   * Has a `subscribe` gone out on this client's behalf?
+   *
+   * For a caller that needs the event stream but does not know whether the
+   * client it was handed is already receiving one — a durable client subscribes
+   * itself, a one-shot client does not, and a second subscribe would replay the
+   * tail a second time.
+   */
+  isSubscribedToEvents(): boolean {
+    return this.eventsSubscribed;
   }
 
   /** Notified when a `subscribe` replay tail has been fully streamed. */

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -38,7 +38,7 @@ import {
   type CoreLinkSessionTakenFrom,
   type CoreLinkTaskMutation,
   type CoreLinkTaskSnapshot,
-} from "./core-link-frames";
+} from "./core-link-frames.ts";
 import {
   CoreLinkTransport,
   type CoreLinkAuthErrorReason,
@@ -47,13 +47,13 @@ import {
   type CoreLinkExitFrame,
   type CoreLinkHeartbeatOptions,
   type CoreLinkReadyFrame,
-} from "./core-link-transport";
+} from "./core-link-transport.ts";
 import {
   createNodeCoreLinkSocket,
   type CoreLinkSocketFactory,
   type CoreLinkTlsMaterial,
-} from "./core-link-socket";
-import { coreConnectionFromBlob, type CoreRegistrationBlob } from "./core-registration-blob";
+} from "./core-link-socket.ts";
+import { coreConnectionFromBlob, type CoreRegistrationBlob } from "./core-registration-blob.ts";
 
 /**
  * Request frames that only mean anything against a Core announcing

--- a/packages/sdk/src/core-link-transport.ts
+++ b/packages/sdk/src/core-link-transport.ts
@@ -34,8 +34,8 @@ import type {
   CoreLinkRequestFrame,
   CoreLinkResponseFrame,
   CoreLinkStreamFrame,
-} from "./core-link-frames";
-import type { CoreLinkSocket, CoreLinkSocketFactory } from "./core-link-socket";
+} from "./core-link-frames.ts";
+import type { CoreLinkSocket, CoreLinkSocketFactory } from "./core-link-socket.ts";
 
 /** The Core's opening frame on every connection — protocol version, capability. */
 export type CoreLinkReadyFrame = Extract<CoreLinkResponseFrame, { type: "ready" }>;

--- a/packages/sdk/src/core-registration-blob.ts
+++ b/packages/sdk/src/core-registration-blob.ts
@@ -24,7 +24,7 @@
 //
 // [adr]: ../../docs/adr/0025-the-protocol-ships-with-the-client.md
 
-import type { CoreLinkTlsMaterial } from "./core-link-socket";
+import type { CoreLinkTlsMaterial } from "./core-link-socket.ts";
 
 /**
  * A decoded registration blob. `endpoint` is the Core's `wss://host:port` core

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -44,7 +44,9 @@
 //   3. **It does not decide what "done" means from the bytes.** Idleness is the
 //      Core's report — the harness's own lifecycle hooks moving the Session's
 //      status — read off the event log. Watching the stream go quiet is the
-//      450 ms timer that #191 deleted, in a new place.
+//      450 ms timer that #191 deleted, in a new place. (A status read the link
+//      lost is asked again, which is a retry of a *question*: it can only ever
+//      report what the Core already decided, never decide it here.)
 
 import type {
   CoreLinkEvent,
@@ -125,6 +127,26 @@ const STATUS_BEARING_EVENT_KINDS: ReadonlySet<string> = new Set([
   "task:statusChanged",
   "session:finished",
 ]);
+
+/**
+ * How a failed status read is re-asked: this many further attempts, this long
+ * apart.
+ *
+ * A retry of a *read*, and only of a read. It re-asks the Core a question whose
+ * answer the Core already settled on — it does not retry a prompt, a keystroke
+ * or a spawn, and it cannot make a Session look idle sooner than the Core says
+ * it is. The reason it has to exist: `needs-input`, `interrupted` and
+ * `terminated` reach this layer only as `task:updated`, and that event is
+ * appended once. Swallowing the read that failed on it leaves
+ * {@link CoreSession.waitForIdle} waiting for a report that will not be made
+ * again, and by design there is no deadline to end that wait.
+ *
+ * Bounded rather than indefinite: a link that is still down after three tries a
+ * quarter-second apart is not going to be talked round by a fourth, and a
+ * Session that polls forever is the busy-loop version of the timer #191 deleted.
+ */
+export const STATUS_READ_RETRIES = 3;
+export const STATUS_READ_RETRY_MS = 250;
 
 export type CoreSessionStartOptions = {
   /**
@@ -258,6 +280,9 @@ export class CoreSession {
   /** A status read is in flight; another event arrived while it was. */
   private statusReadInFlight = false;
   private statusReadAgain = false;
+  /** Re-asks left for the read that failed, and the timer carrying the next. */
+  private statusReadRetriesLeft = STATUS_READ_RETRIES;
+  private statusRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor(opts: {
     client: CoreClient;
@@ -320,7 +345,7 @@ export class CoreSession {
     // by anything but the id, and the id is what has not come back yet.
     const held: CoreLinkDataFrame[] = [];
     const heldEvents: CoreLinkEvent[] = [];
-    let heldExit: CoreLinkExitFrame | null = null;
+    const heldExits: CoreLinkExitFrame[] = [];
     let ptyId: string | null = null;
     const terminal = new TerminalScreen({ cols, rows, scrollback: opts.scrollback });
     let session: CoreSession | null = null;
@@ -335,7 +360,12 @@ export class CoreSession {
     });
     const stopExit = client.onExit((frame) => {
       if (ptyId === null) {
-        if (!heldExit) heldExit = frame;
+        // Every exit, not the first: this listener hears the whole Core, so a
+        // co-tenant PTY exiting inside the spawn's round trip would otherwise
+        // take the one slot and this Session's own exit frame would be dropped
+        // — `onExit` silent, and `waitForIdle` short an exit route. Held like
+        // the bytes above and filtered by id for the same reason.
+        heldExits.push(frame);
         return;
       }
       if (frame.ptyId !== ptyId) return;
@@ -397,9 +427,8 @@ export class CoreSession {
     for (const frame of held) {
       if (frame.ptyId === ptyId) session.ingest(frame.data);
     }
-    if (heldExit !== null && (heldExit as CoreLinkExitFrame).ptyId === ptyId) {
-      session.ingestExit(heldExit as CoreLinkExitFrame);
-    }
+    const mineExit = heldExits.find((frame) => frame.ptyId === ptyId);
+    if (mineExit) session.ingestExit(mineExit);
 
     return session;
   }
@@ -510,6 +539,12 @@ export class CoreSession {
    *
    * Resolves as soon as it can: if the Session has already settled by the time
    * this is called, it answers from what it saw.
+   *
+   * With no {@link CoreSessionWaitOptions.timeoutMs} this waits indefinitely, on
+   * purpose. A status read that fails is re-asked, so a link that blinks does
+   * not cost the report; a link that stays down does, and nothing here invents a
+   * status the Core never sent. A caller that must not hang on a broken Core
+   * passes a deadline it chose itself.
    */
   waitForIdle(opts: CoreSessionWaitOptions = {}): Promise<CoreSessionIdle> {
     const settled = this.settledNow();
@@ -562,6 +597,10 @@ export class CoreSession {
     this.disposed = true;
     for (const off of this.unsubscribes) off();
     this.unsubscribes.length = 0;
+    if (this.statusRetryTimer) {
+      clearTimeout(this.statusRetryTimer);
+      this.statusRetryTimer = null;
+    }
     // Anyone still waiting is waiting on a report this Session will no longer
     // hear, so they are settled on the way out rather than left pending
     // forever. `kill()` disposes, and `await session.kill()` after starting a
@@ -625,6 +664,10 @@ export class CoreSession {
    * hook events arrives in a burst and each one would otherwise be its own round
    * trip: a read already in flight is re-run once at the end rather than queued
    * behind itself.
+   *
+   * A read that fails is re-asked ({@link STATUS_READ_RETRIES}), because on
+   * `needs-input`, `interrupted` and `terminated` there is no second event to
+   * carry the news.
    */
   private async readStatus(): Promise<void> {
     if (this.disposed) return;
@@ -633,20 +676,42 @@ export class CoreSession {
       return;
     }
     this.statusReadInFlight = true;
+    let failed = false;
     try {
       const sessions = await this.client.sessionsList();
       const mine = sessions.find((s: CoreLinkSessionSnapshot) => s.taskId === this.taskId);
       if (mine) this.noteStatus(mine.status);
+      this.statusReadRetriesLeft = STATUS_READ_RETRIES;
     } catch {
-      // A read that failed is a link that dropped or a Core that is busy. The
-      // next event asks again, and an exit resolves the wait regardless.
+      // A read that failed is a link that dropped or a Core that is busy. It is
+      // re-asked below rather than swallowed: on the transitions that reach this
+      // layer as a bare `task:updated` there is no later event to ask on, so a
+      // dropped read is the difference between a caller learning the harness is
+      // waiting for an answer and a caller waiting forever for one.
+      failed = true;
     } finally {
       this.statusReadInFlight = false;
       if (this.statusReadAgain && !this.disposed) {
+        // An event that arrived mid-read is the re-ask, and a fresher one.
         this.statusReadAgain = false;
         void this.readStatus();
+      } else if (failed && !this.disposed && this.statusReadRetriesLeft > 0) {
+        this.statusReadRetriesLeft -= 1;
+        this.scheduleStatusRetry();
       }
     }
+  }
+
+  /** The next re-ask of a read that failed. Cleared by {@link dispose}. */
+  private scheduleStatusRetry(): void {
+    if (this.statusRetryTimer) return;
+    this.statusRetryTimer = setTimeout(() => {
+      this.statusRetryTimer = null;
+      if (!this.disposed) void this.readStatus();
+    }, STATUS_READ_RETRY_MS);
+    // A pending re-ask is not a reason for a script that is otherwise done to
+    // stay alive.
+    this.statusRetryTimer.unref?.();
   }
 
   private noteStatus(status: string): void {

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -319,6 +319,7 @@ export class CoreSession {
     // single-connection Core arrives on this listener, so nothing can be routed
     // by anything but the id, and the id is what has not come back yet.
     const held: CoreLinkDataFrame[] = [];
+    const heldEvents: CoreLinkEvent[] = [];
     let heldExit: CoreLinkExitFrame | null = null;
     let ptyId: string | null = null;
     const terminal = new TerminalScreen({ cols, rows, scrollback: opts.scrollback });
@@ -340,6 +341,18 @@ export class CoreSession {
       if (frame.ptyId !== ptyId) return;
       session?.ingestExit(frame);
     });
+    // Held for the same reason the bytes are, and with a sharper consequence:
+    // a status change is not a stream, and the one event saying the harness
+    // finished is the only one that will ever say it. Dropped in the window
+    // between the spawn going out and its answer landing, `waitForIdle` waits
+    // for a report that has already been made.
+    const stopEvents = client.onEvent(({ event }) => {
+      if (session === null) {
+        heldEvents.push(event);
+        return;
+      }
+      session.onCoreEvent(event);
+    });
 
     let spawned: { ptyId: string };
     try {
@@ -360,6 +373,7 @@ export class CoreSession {
     } catch (err) {
       stopData();
       stopExit();
+      stopEvents();
       throw new CoreSessionStartError(
         `the Core refused to start a ${opts.harness} Session in ${opts.cwd}: ${
           err instanceof Error ? err.message : String(err)
@@ -377,9 +391,9 @@ export class CoreSession {
       command,
       terminal,
     });
-    session.unsubscribes.push(stopData, stopExit);
-    session.unsubscribes.push(client.onEvent(({ event }) => session?.onCoreEvent(event)));
+    session.unsubscribes.push(stopData, stopExit, stopEvents);
 
+    for (const event of heldEvents) session.onCoreEvent(event);
     for (const frame of held) {
       if (frame.ptyId === ptyId) session.ingest(frame.data);
     }
@@ -548,6 +562,13 @@ export class CoreSession {
     this.disposed = true;
     for (const off of this.unsubscribes) off();
     this.unsubscribes.length = 0;
+    // Anyone still waiting is waiting on a report this Session will no longer
+    // hear, so they are settled on the way out rather than left pending
+    // forever. `kill()` disposes, and `await session.kill()` after starting a
+    // `waitForIdle()` is an ordinary thing to write.
+    for (const waiter of [...this.idleWaiters]) {
+      waiter(this.settledNow() ?? { status: this.lastStatus ?? "disposed", exited: false });
+    }
     this.dataListeners.clear();
     this.exitListeners.clear();
     this.statusListeners.clear();
@@ -583,6 +604,7 @@ export class CoreSession {
     this.releaseWaiters();
   }
 
+  /** @internal — called by {@link start} for events held during the spawn. */
   private onCoreEvent(event: CoreLinkEvent): void {
     if (event.taskId !== this.taskId) return;
     if (!STATUS_BEARING_EVENT_KINDS.has(event.kind)) return;

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -1,0 +1,710 @@
+// `CoreSession` — the second level of the SDK: start a Session, let the Core
+// deliver the prompt, read the result (#129 D2, D11; issue 155).
+//
+// The transport level below this one (`CoreLinkTransport` → `CoreClient`) knows
+// frames. It will spawn a PTY and hand you `data` frames, and that is as far as
+// it goes: a caller wanting a *Session* has to correlate the spawn with its
+// byte stream, filter that stream out of every other PTY on the machine, know
+// that a harness's output is a screen rather than a log, and know how a Core
+// reports that a harness has finished. This is that, once, so a script is four
+// calls:
+//
+//     const client = CoreClient.fromRegistrationBlob(blob);
+//     await client.connect();
+//     const session = await CoreSession.start(client, {
+//       projectId, cwd, harness: "claude-code", prompt: "…",
+//     });
+//     await session.waitForIdle();
+//     console.log(session.screen());
+//
+// **No TTY, ever (D11).** Nothing here reads `process.stdin`, sets raw mode,
+// opens `/dev/tty` or asks whether one exists. Terminal handling belongs to the
+// `actana` CLI, which is a different program with a human in front of it; an SDK
+// that touched the process's terminal would be unusable from the cron job, the
+// CI runner and the web service that are the reason this package exists.
+// `send` takes a string and `screen` returns one.
+//
+// Three things this layer deliberately does NOT do:
+//
+//   1. **It does not time the prompt.** The starting prompt is handed to the
+//      Core as `initialInput` and the Core delivers it on the harness's own
+//      schedule — wait for the TUI to stop painting, answer the blocking dialog
+//      by its own numbered option, write the text, send the carriage return as a
+//      separate keystroke (ADR 0026, #191). There is no delay, no ready-signal
+//      and no retry here to disagree with it, which is what makes a Panel, the
+//      CLI and this behave identically on a machine none of them is on.
+//   2. **It does not pre-empt the Core's spawn policy.** A Session is spawned
+//      against a registered Project: the Core checks that the working directory
+//      resolves inside a known Project root, that the command's first token is
+//      that harness's canonical binary, and that every flag is allow-listed.
+//      Those checks read a database and a filesystem on another machine, so a
+//      copy of them here would be a guess — and a guess that says no to a spawn
+//      the Core would have accepted is worse than the round trip. {@link start}
+//      surfaces the rejection.
+//   3. **It does not decide what "done" means from the bytes.** Idleness is the
+//      Core's report — the harness's own lifecycle hooks moving the Session's
+//      status — read off the event log. Watching the stream go quiet is the
+//      450 ms timer that #191 deleted, in a new place.
+
+import type {
+  CoreLinkEvent,
+  CoreLinkPtySpawnHarness,
+  CoreLinkSessionSnapshot,
+} from "./core-link-frames.ts";
+import type { CoreClient } from "./core-client.ts";
+import type { CoreLinkDataFrame, CoreLinkExitFrame } from "./core-link-transport.ts";
+import { DEFAULT_COLS, DEFAULT_ROWS, TerminalScreen } from "./terminal-screen.ts";
+
+type Unsubscribe = () => void;
+
+/**
+ * The command a fresh Session starts with, per harness, when the caller names
+ * none.
+ *
+ * The first token has to be that harness's canonical binary or the Core refuses
+ * the spawn — that is the allow-list, and it is enforced there, not here. What
+ * this table adds beyond the binary is the one flag a harness needs for the
+ * Core to hear about it at all: `codex` reports its lifecycle through hooks only
+ * when started with `--enable hooks`, and a Session that never reports is a
+ * Session {@link CoreSession.waitForIdle} waits on forever.
+ *
+ * A caller wanting anything else — a model, a resumed session id — passes
+ * `command` and takes the Core's answer on it.
+ */
+export const HARNESS_LAUNCH_COMMANDS: Readonly<Record<CoreLinkPtySpawnHarness, string>> = {
+  "claude-code": "claude",
+  codex: "codex --enable hooks",
+  "cursor-cli": "cursor-agent",
+  opencode: "opencode",
+};
+
+/**
+ * Each harness's spelling of "do not stop to ask me", appended to the default
+ * command when {@link CoreSessionOptions.dangerouslySkipPermissions} is set.
+ *
+ * The option and the flag are two halves of one gesture and the Core checks
+ * both: the flag is allow-listed only for a spawn that also set the option, so
+ * setting one without the other is a rejected spawn rather than a quiet
+ * downgrade. OpenCode has no such flag, and gets none.
+ */
+const HARNESS_SKIP_PERMISSION_FLAGS: Readonly<Record<CoreLinkPtySpawnHarness, string | null>> = {
+  "claude-code": "--dangerously-skip-permissions",
+  codex: "--yolo",
+  "cursor-cli": "--force",
+  opencode: null,
+};
+
+/**
+ * The statuses that mean the harness has stopped and is waiting on a human.
+ *
+ * `finished` is a completed turn, `needs-input` a permission prompt or a
+ * question, `interrupted` an escape, `terminated` a dead process, and
+ * `disconnected` a Core that restarted underneath the Session. Every one of them
+ * is a state that does not leave on its own, which is the property
+ * {@link CoreSession.waitForIdle} is waiting for — not "finished", which would
+ * hang on the question a caller could have answered.
+ */
+export const SETTLED_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "finished",
+  "needs-input",
+  "interrupted",
+  "terminated",
+  "disconnected",
+]);
+
+/**
+ * Event kinds that may carry a status change for a Session.
+ *
+ * `task:updated` is the general one and says only that the row moved; the status
+ * itself is read back off the Core, which owns it. `session:finished` is
+ * appended on the transition into `finished` and nowhere else (see the Core's
+ * task writer), so it is the one kind whose meaning needs no round trip.
+ */
+const STATUS_BEARING_EVENT_KINDS: ReadonlySet<string> = new Set([
+  "task:updated",
+  "task:statusChanged",
+  "session:finished",
+]);
+
+export type CoreSessionStartOptions = {
+  /**
+   * The Project to start this Session in. Either this or {@link taskId}: with a
+   * `projectId` a Task row is created on the Core first, because a Session's
+   * status lives on that row and a spawn naming a row that does not exist
+   * reports nothing back.
+   */
+  projectId?: string;
+  /** An existing Task to start a Session for. Either this or {@link projectId}. */
+  taskId?: string;
+  /** Title for the Task created from {@link projectId}. Ignored with a `taskId`. */
+  title?: string;
+  /**
+   * The working directory on the **Core's** machine.
+   *
+   * A machine path, validatable only there: the Core resolves it through
+   * `realpath` and refuses it unless it lands inside a registered Project root.
+   * Nothing here checks it — this process may not even be on that machine — so a
+   * bad path comes back as a rejected {@link start}, which is the design.
+   */
+  cwd: string;
+  /** Which harness to run. */
+  harness: CoreLinkPtySpawnHarness;
+  /**
+   * The starting prompt, handed to the Core as `initialInput`.
+   *
+   * Text, and no timing with it. The Core waits for the harness's TUI to settle,
+   * answers whatever dialog it opened, writes this, and sends the carriage
+   * return separately (ADR 0026). Omit it to start a Session with no prompt and
+   * drive it with {@link CoreSession.send}.
+   */
+  prompt?: string;
+  /**
+   * Override the launch command. Defaults to {@link HARNESS_LAUNCH_COMMANDS}.
+   * The Core allow-lists the binary and every flag; a command it does not accept
+   * rejects the spawn rather than being trimmed here.
+   */
+  command?: string;
+  /** PTY width. The screen is built at the same size, or the two disagree about wrapping. */
+  cols?: number;
+  /** PTY height. Same. */
+  rows?: number;
+  /** How many scrolled-off lines {@link CoreSession.screen} keeps. */
+  scrollback?: number;
+  /** Start the harness with permission prompts disabled. See {@link HARNESS_SKIP_PERMISSION_FLAGS}. */
+  dangerouslySkipPermissions?: boolean;
+  /** The Core's theme hint for the harness, so its output matches a Panel's. */
+  theme?: "dark" | "light";
+  /**
+   * Subscribe this client to the Core's event log if nothing has yet, so
+   * {@link CoreSession.waitForIdle} and {@link CoreSession.onStatus} have
+   * something to work from. Default true.
+   *
+   * Set it false when the events are already arriving by another route and the
+   * replay tail is not wanted — a {@link DurableCoreClient} subscribes itself,
+   * and this checks before sending anything, so the flag is for the case where a
+   * caller is doing something the check cannot see.
+   */
+  subscribeToEvents?: boolean;
+};
+
+/** What a Session settled on. */
+export type CoreSessionIdle = {
+  /** The Core's status for this Session — one of {@link SETTLED_SESSION_STATUSES}. */
+  status: string;
+  /** True when the harness's process exited rather than settling on a status. */
+  exited: boolean;
+  /** The process's exit code, when it exited. */
+  exitCode?: number;
+};
+
+export type CoreSessionWaitOptions = {
+  /**
+   * Give up after this long, in ms. **No deadline by default**, and that is not
+   * an oversight: a turn takes as long as the work takes, and a default that
+   * fires would report a healthy Session as broken — the same lie the flat
+   * timer #191 deleted used to tell. A caller that needs a deadline knows what
+   * its own is.
+   */
+  timeoutMs?: number;
+};
+
+/** The Core refused to start this Session. Carries the Core's own reason. */
+export class CoreSessionStartError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "CoreSessionStartError";
+  }
+}
+
+/**
+ * One Session on one Core, driven programmatically.
+ *
+ * Built by {@link start}. Holds a screen fed from the Session's PTY, the Core's
+ * last reported status for it, and the listeners that keep both current — so
+ * it must be released with {@link dispose} (or {@link kill}, which disposes)
+ * when the caller is done, or those listeners outlive it on the client.
+ */
+export class CoreSession {
+  /** The Task this Session belongs to. Its status is the Session's status. */
+  readonly taskId: string;
+  /** The Core's id for this Session's PTY. */
+  readonly ptyId: string;
+  /** The harness running in it. */
+  readonly harness: CoreLinkPtySpawnHarness;
+  /** The command the Core was asked to start, after defaulting. */
+  readonly command: string;
+
+  private readonly client: CoreClient;
+  private readonly terminal: TerminalScreen;
+  private readonly unsubscribes: Unsubscribe[] = [];
+
+  private readonly dataListeners = new Set<(chunk: string) => void>();
+  private readonly exitListeners = new Set<(exit: { exitCode: number; signal?: number }) => void>();
+  private readonly statusListeners = new Set<(status: string) => void>();
+  private readonly idleWaiters = new Set<(idle: CoreSessionIdle) => void>();
+
+  /**
+   * The Core's last reported status, or null before one has been *observed*.
+   *
+   * Null rather than the status the Task carried when this Session started, and
+   * the distinction is what makes {@link waitForIdle} correct: a caller starting
+   * a Session on a Task that was already `finished` is waiting for the next turn
+   * to end, not being told about the last one. Only a status learned from an
+   * event after {@link start} lands here.
+   */
+  private lastStatus: string | null = null;
+  private exit: { exitCode: number; signal?: number } | null = null;
+  private disposed = false;
+  /** A status read is in flight; another event arrived while it was. */
+  private statusReadInFlight = false;
+  private statusReadAgain = false;
+
+  private constructor(opts: {
+    client: CoreClient;
+    taskId: string;
+    ptyId: string;
+    harness: CoreLinkPtySpawnHarness;
+    command: string;
+    terminal: TerminalScreen;
+  }) {
+    this.client = opts.client;
+    this.taskId = opts.taskId;
+    this.ptyId = opts.ptyId;
+    this.harness = opts.harness;
+    this.command = opts.command;
+    this.terminal = opts.terminal;
+  }
+
+  /**
+   * Start a Session and return once the Core has one running.
+   *
+   * What happens, in order: a Task row is created when the caller named a
+   * Project rather than a Task; the client is subscribed to the Core's event log
+   * if nothing has done that yet; the PTY's byte stream is wired up *before* the
+   * spawn goes out; and the spawn carries the prompt as `initialInput` for the
+   * Core to deliver.
+   *
+   * The stream is wired first on purpose. A harness starts printing its banner
+   * immediately, and on a Core that fans output out by subscription the
+   * connection that spawned a PTY is subscribed to it before the answer is even
+   * written — so the first bytes can be on the wire before this side knows the
+   * PTY's id. They are held and replayed into the screen once it is known, which
+   * is the difference between a transcript that starts at the beginning and one
+   * that starts wherever the round trip happened to end.
+   *
+   * Rejects with the Core's own message when the Core refuses: a working
+   * directory outside every registered Project root, a command whose binary is
+   * not that harness's, a flag that is not allow-listed, a harness that is not
+   * installed on that machine.
+   */
+  static async start(client: CoreClient, opts: CoreSessionStartOptions): Promise<CoreSession> {
+    if (!opts.taskId && !opts.projectId) {
+      throw new CoreSessionStartError(
+        "CoreSession.start needs a taskId or a projectId to start a Session against",
+      );
+    }
+    const cols = opts.cols ?? DEFAULT_COLS;
+    const rows = opts.rows ?? DEFAULT_ROWS;
+    const command = opts.command ?? defaultLaunchCommand(opts.harness, opts.dangerouslySkipPermissions === true);
+
+    // The event log first: a subscribe sent after the spawn could miss the
+    // status change of a harness that answered before this side asked.
+    if (opts.subscribeToEvents !== false && !client.isSubscribedToEvents()) {
+      client.subscribeEvents();
+    }
+
+    const taskId = opts.taskId ?? (await createTask(client, opts));
+
+    // Held until the spawn answers with the id these belong to. Every PTY on a
+    // single-connection Core arrives on this listener, so nothing can be routed
+    // by anything but the id, and the id is what has not come back yet.
+    const held: CoreLinkDataFrame[] = [];
+    let heldExit: CoreLinkExitFrame | null = null;
+    let ptyId: string | null = null;
+    const terminal = new TerminalScreen({ cols, rows, scrollback: opts.scrollback });
+    let session: CoreSession | null = null;
+
+    const stopData = client.onData((frame) => {
+      if (ptyId === null) {
+        held.push(frame);
+        return;
+      }
+      if (frame.ptyId !== ptyId) return;
+      session?.ingest(frame.data);
+    });
+    const stopExit = client.onExit((frame) => {
+      if (ptyId === null) {
+        if (!heldExit) heldExit = frame;
+        return;
+      }
+      if (frame.ptyId !== ptyId) return;
+      session?.ingestExit(frame);
+    });
+
+    let spawned: { ptyId: string };
+    try {
+      spawned = await client.spawn({
+        taskId,
+        cwd: opts.cwd,
+        command,
+        agent: opts.harness,
+        cols,
+        rows,
+        ...(opts.dangerouslySkipPermissions === true
+          ? { dangerouslySkipPermissions: true }
+          : {}),
+        ...(opts.theme ? { missionControlTheme: opts.theme } : {}),
+        // Text, and no timing with it. See this module's header.
+        ...(opts.prompt === undefined ? {} : { initialInput: opts.prompt }),
+      });
+    } catch (err) {
+      stopData();
+      stopExit();
+      throw new CoreSessionStartError(
+        `the Core refused to start a ${opts.harness} Session in ${opts.cwd}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
+      );
+    }
+
+    ptyId = spawned.ptyId;
+    session = new CoreSession({
+      client,
+      taskId,
+      ptyId: spawned.ptyId,
+      harness: opts.harness,
+      command,
+      terminal,
+    });
+    session.unsubscribes.push(stopData, stopExit);
+    session.unsubscribes.push(client.onEvent(({ event }) => session?.onCoreEvent(event)));
+
+    for (const frame of held) {
+      if (frame.ptyId === ptyId) session.ingest(frame.data);
+    }
+    if (heldExit !== null && (heldExit as CoreLinkExitFrame).ptyId === ptyId) {
+      session.ingestExit(heldExit as CoreLinkExitFrame);
+    }
+
+    return session;
+  }
+
+  // ─── Programmatic I/O ──────────────────────────────────────────────────────
+
+  /**
+   * Write to the Session, exactly these bytes and nothing else.
+   *
+   * The equivalent of typing, not of prompting. Nothing is appended: no carriage
+   * return, no delay, no waiting for the harness to look ready. That restraint
+   * is the rule rather than a gap — a client that decided when to press Enter
+   * would be doing prompt delivery, which is the Core's (ADR 0026), and would do
+   * it differently from every other client. A *starting* prompt goes through
+   * {@link CoreSessionStartOptions.prompt}, where the Core owns the schedule.
+   *
+   * What this is for is everything after: answering the numbered option of a
+   * question the harness asked (`send("2")` then `send("\r")`), an escape
+   * (`send("\u001B")`), a follow-up typed into a harness already at its prompt.
+   *
+   * Resolves false when the Core did not accept the write — a PTY that has
+   * exited. Rejects when another Core client holds this Session's lock.
+   */
+  send(text: string): Promise<boolean> {
+    return this.client.write(this.ptyId, text);
+  }
+
+  /**
+   * Every chunk of this Session's output, as it arrives.
+   *
+   * Raw PTY bytes, escape sequences included — the same stream the screen is
+   * built from. A caller wanting the rendered text wants {@link screen}; this is
+   * for one that is streaming somewhere else.
+   */
+  onData(cb: (chunk: string) => void): Unsubscribe {
+    this.dataListeners.add(cb);
+    return () => this.dataListeners.delete(cb);
+  }
+
+  /** The harness's process exited. Fires once. */
+  onExit(cb: (exit: { exitCode: number; signal?: number }) => void): Unsubscribe {
+    this.exitListeners.add(cb);
+    return () => this.exitListeners.delete(cb);
+  }
+
+  /** The Core reported a new status for this Session. */
+  onStatus(cb: (status: string) => void): Unsubscribe {
+    this.statusListeners.add(cb);
+    return () => this.statusListeners.delete(cb);
+  }
+
+  /**
+   * What a terminal would be showing for this Session, **including the lines
+   * that have scrolled off the top of it**.
+   *
+   * The scrolled-off part is not a bonus: a harness's conversation left the
+   * screen long ago, so the transcript is the scrollback and a caller reading
+   * only the visible rows reads a status bar. See `terminal-screen.ts` for what
+   * is emulated and what an erase costs.
+   *
+   * **Read it while the Session is alive.** A harness that runs full-screen
+   * leaves the alternate screen when it quits, and what a terminal shows after
+   * that is the main buffer — which is where nothing was ever printed. Reading
+   * before {@link kill}, not after, is the difference between the transcript and
+   * an empty string. (Claude Code 2.1.228 runs full-screen, so this is the
+   * ordinary case rather than an exotic one.)
+   */
+  screen(): string {
+    return this.terminal.text();
+  }
+
+  /** Only the rows on screen right now — for reading a dialog rather than a transcript. */
+  viewport(): string {
+    return this.terminal.viewportText();
+  }
+
+  /** The screen as an array of lines, scrollback first. */
+  lines(): string[] {
+    return this.terminal.lines();
+  }
+
+  /** The Core's last reported status, or null before one has been observed. */
+  status(): string | null {
+    return this.lastStatus;
+  }
+
+  /** How the harness's process ended, or null while it is running. */
+  exitStatus(): { exitCode: number; signal?: number } | null {
+    return this.exit;
+  }
+
+  // ─── Waiting ───────────────────────────────────────────────────────────────
+
+  /**
+   * Wait until the Core reports this Session settled — the harness finished its
+   * turn, asked a question, was interrupted, or died.
+   *
+   * **The Core's report, not a guess from the byte stream.** The harness's own
+   * lifecycle hooks move the Session's status on the Core, the change lands in
+   * the event log, and this is watching for it. Nothing here inspects output for
+   * quietness: that is a timing decision, it belongs to the Core, and the flat
+   * timer that used to make it here is what #191 deleted.
+   *
+   * Only statuses observed *after* this Session started count, so starting one
+   * on a Task that was already `finished` waits for this turn rather than
+   * returning last turn's answer. An exit resolves it too — a harness that died
+   * is not going to report anything else.
+   *
+   * Resolves as soon as it can: if the Session has already settled by the time
+   * this is called, it answers from what it saw.
+   */
+  waitForIdle(opts: CoreSessionWaitOptions = {}): Promise<CoreSessionIdle> {
+    const settled = this.settledNow();
+    if (settled) return Promise.resolve(settled);
+    return new Promise<CoreSessionIdle>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const waiter = (idle: CoreSessionIdle): void => {
+        this.idleWaiters.delete(waiter);
+        if (timer) clearTimeout(timer);
+        resolve(idle);
+      };
+      this.idleWaiters.add(waiter);
+      if (opts.timeoutMs && opts.timeoutMs > 0) {
+        timer = setTimeout(() => {
+          this.idleWaiters.delete(waiter);
+          reject(
+            new Error(
+              `session ${this.taskId} was still ${this.lastStatus ?? "unreported"} after ${opts.timeoutMs}ms`,
+            ),
+          );
+        }, opts.timeoutMs);
+      }
+    });
+  }
+
+  // ─── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /** Resize the PTY and the screen together, so both agree about wrapping. */
+  async resize(cols: number, rows: number): Promise<boolean> {
+    const ok = await this.client.resize(this.ptyId, cols, rows);
+    this.terminal.resize(cols, rows);
+    return ok;
+  }
+
+  /** Kill the harness's process, then release this Session's listeners. */
+  async kill(): Promise<boolean> {
+    try {
+      return await this.client.kill(this.ptyId);
+    } finally {
+      this.dispose();
+    }
+  }
+
+  /**
+   * Release the listeners this Session holds on the client, leaving the harness
+   * running. The screen stops advancing; the Core carries on.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const off of this.unsubscribes) off();
+    this.unsubscribes.length = 0;
+    this.dataListeners.clear();
+    this.exitListeners.clear();
+    this.statusListeners.clear();
+    this.idleWaiters.clear();
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────────
+
+  private ingest(chunk: string): void {
+    this.terminal.write(chunk);
+    for (const cb of this.dataListeners) {
+      try {
+        cb(chunk);
+      } catch {
+        /* a listener's failure is not this Session's failure */
+      }
+    }
+  }
+
+  private ingestExit(frame: CoreLinkExitFrame): void {
+    if (this.exit) return;
+    this.exit = {
+      exitCode: frame.exitCode,
+      ...(frame.signal === undefined ? {} : { signal: frame.signal }),
+    };
+    for (const cb of this.exitListeners) {
+      try {
+        cb(this.exit);
+      } catch {
+        /* same */
+      }
+    }
+    this.releaseWaiters();
+  }
+
+  private onCoreEvent(event: CoreLinkEvent): void {
+    if (event.taskId !== this.taskId) return;
+    if (!STATUS_BEARING_EVENT_KINDS.has(event.kind)) return;
+    // `session:finished` is appended on the transition into `finished` and on
+    // nothing else, so it is the one kind that already says what happened.
+    if (event.kind === "session:finished") {
+      this.noteStatus("finished");
+      return;
+    }
+    void this.readStatus();
+  }
+
+  /**
+   * Read this Session's status back off the Core.
+   *
+   * The `task:updated` event says a row moved, not what it moved to, and the
+   * Core owns the answer — so it is asked. Coalesced, because a turn's worth of
+   * hook events arrives in a burst and each one would otherwise be its own round
+   * trip: a read already in flight is re-run once at the end rather than queued
+   * behind itself.
+   */
+  private async readStatus(): Promise<void> {
+    if (this.disposed) return;
+    if (this.statusReadInFlight) {
+      this.statusReadAgain = true;
+      return;
+    }
+    this.statusReadInFlight = true;
+    try {
+      const sessions = await this.client.sessionsList();
+      const mine = sessions.find((s: CoreLinkSessionSnapshot) => s.taskId === this.taskId);
+      if (mine) this.noteStatus(mine.status);
+    } catch {
+      // A read that failed is a link that dropped or a Core that is busy. The
+      // next event asks again, and an exit resolves the wait regardless.
+    } finally {
+      this.statusReadInFlight = false;
+      if (this.statusReadAgain && !this.disposed) {
+        this.statusReadAgain = false;
+        void this.readStatus();
+      }
+    }
+  }
+
+  private noteStatus(status: string): void {
+    if (status === this.lastStatus) return;
+    this.lastStatus = status;
+    for (const cb of this.statusListeners) {
+      try {
+        cb(status);
+      } catch {
+        /* same */
+      }
+    }
+    this.releaseWaiters();
+  }
+
+  /** What {@link waitForIdle} would answer right now, or null if it must wait. */
+  private settledNow(): CoreSessionIdle | null {
+    if (this.exit) {
+      return {
+        status: this.lastStatus ?? "terminated",
+        exited: true,
+        ...(this.exit.exitCode === undefined ? {} : { exitCode: this.exit.exitCode }),
+      };
+    }
+    if (this.lastStatus && SETTLED_SESSION_STATUSES.has(this.lastStatus)) {
+      return { status: this.lastStatus, exited: false };
+    }
+    return null;
+  }
+
+  private releaseWaiters(): void {
+    const settled = this.settledNow();
+    if (!settled) return;
+    for (const waiter of [...this.idleWaiters]) waiter(settled);
+  }
+}
+
+/** The launch command for a harness nobody named one for. */
+function defaultLaunchCommand(
+  harness: CoreLinkPtySpawnHarness,
+  skipPermissions: boolean,
+): string {
+  const base = HARNESS_LAUNCH_COMMANDS[harness];
+  if (!skipPermissions) return base;
+  const flag = HARNESS_SKIP_PERMISSION_FLAGS[harness];
+  return flag ? `${base} ${flag}` : base;
+}
+
+/**
+ * Create the Task a Session hangs off, in the Project the caller named.
+ *
+ * A Session's status is a column on this row: the Core's hook pipeline patches
+ * it, the patch appends the event, and the event is what {@link
+ * CoreSession.waitForIdle} is waiting for. A spawn naming a row that does not
+ * exist runs a harness that reports to nowhere — so the row comes first, and a
+ * Core that will not create it (an unknown Project) fails the start here rather
+ * than producing a Session nothing can observe.
+ */
+async function createTask(client: CoreClient, opts: CoreSessionStartOptions): Promise<string> {
+  const projectId = opts.projectId!;
+  let created;
+  try {
+    created = await client.tasksMutate({
+      op: "create",
+      projectId,
+      title: opts.title ?? "SDK session",
+      agent: opts.harness,
+    });
+  } catch (err) {
+    throw new CoreSessionStartError(
+      `the Core refused to create a Session in project ${projectId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err },
+    );
+  }
+  if (!created) {
+    throw new CoreSessionStartError(
+      `the Core has no project ${projectId} to start a Session in`,
+    );
+  }
+  return created.taskId;
+}

--- a/packages/sdk/src/durable-core-client.ts
+++ b/packages/sdk/src/durable-core-client.ts
@@ -171,7 +171,7 @@ export class DurableCoreClient extends CoreClient {
    */
   private sendSubscribe(): void {
     this.caughtUp = false;
-    this.sendNow({ type: "subscribe", reqId: "", lastEventId: this.lastEventId }, "sub");
+    this.subscribeEvents(this.lastEventId);
   }
 
   /**

--- a/packages/sdk/src/durable-core-client.ts
+++ b/packages/sdk/src/durable-core-client.ts
@@ -20,15 +20,15 @@
 // Extracted from `PtyCoreLinkClient` (issue 153), whose reconnect loop, cursor
 // handling and PTY re-subscription are the four sections below.
 
-import type { CoreLinkEvent } from "./core-link-frames";
-import { CoreClient, type CoreClientOptions } from "./core-client";
-import type { CoreRegistrationBlob } from "./core-registration-blob";
+import type { CoreLinkEvent } from "./core-link-frames.ts";
+import { CoreClient, type CoreClientOptions } from "./core-client.ts";
+import type { CoreRegistrationBlob } from "./core-registration-blob.ts";
 import {
   coreLinkCursorStorageKey,
   InMemoryCoreLinkCursorStorage,
   type CoreLinkCursorStorage,
-} from "./core-link-cursor-storage";
-import type { CoreLinkHeartbeatOptions } from "./core-link-transport";
+} from "./core-link-cursor-storage.ts";
+import type { CoreLinkHeartbeatOptions } from "./core-link-transport.ts";
 
 /** Reconnect backoff floor: the delay after the first unexpected drop. */
 export const DEFAULT_RECONNECT_INITIAL_MS = 500;

--- a/packages/sdk/src/terminal-screen.ts
+++ b/packages/sdk/src/terminal-screen.ts
@@ -203,7 +203,9 @@ export class TerminalScreen {
       }
       while (buffer.grid.length < nextRows) buffer.grid.push(this.blankLine(nextCols));
       // The cursor lives on the active buffer, so only that one's shrink moves
-      // it — and only the main buffer's keeps what it loses.
+      // it. What each buffer loses off the top it keeps, in its own scrollback —
+      // the alternate screen included, which is this module's deliberate
+      // departure from a real terminal (see the header).
       const active = buffer === this.buffer;
       while (buffer.grid.length > nextRows) {
         // Take the blank rows below the cursor first. A terminal shrinking a

--- a/packages/sdk/src/terminal-screen.ts
+++ b/packages/sdk/src/terminal-screen.ts
@@ -1,0 +1,804 @@
+// A terminal, small enough to live in an SDK and faithful enough to read a
+// harness with (#129 D2, issue 155).
+//
+// The reason this file exists rather than a call to `stripAnsi`: a harness does
+// not lay text out with spaces and newlines, it lays it out with cursor moves.
+// Claude Code draws its folder-trust dialog as
+// `ESC[4G1.ESC[7GYes,ESC[12GIESC[14Gtrust`, repaints its spinner by walking the
+// cursor back up and erasing lines, and rewrites the same row eighty times a
+// second. Delete the escapes from that stream and you get one very long line of
+// concatenated spinner frames with the words jammed together — not a screen, and
+// nothing a caller can read an answer out of. The only way to know what a
+// terminal would be showing is to be one.
+//
+// So: a grid, a cursor, a scroll region, two buffers, and the subset of the
+// escape vocabulary a TUI actually uses to position and erase — cursor movement,
+// erase display/line/characters, insert and delete lines and characters, scroll
+// up and down, the alternate screen. Colour is parsed and dropped, because the
+// answer this returns is text.
+//
+// **Scrolled-off lines are kept, and that is the point.** A harness's
+// conversation is not on the screen — it went past the top of it minutes ago.
+// The transcript *is* the scrollback, so a line that leaves the top of the grid
+// is joined, trimmed and pushed onto {@link TerminalScreen.scrollbackLines}
+// rather than dropped. `experiment/action.md` §4 is where that was learned the
+// hard way.
+//
+// Two rules about what is kept, and they are not the same rule:
+//
+//   - **An erased screen is erased.** `ESC[2J` wipes the grid in place and adds
+//     nothing to the scrollback, because that is what a terminal does with it —
+//     erasing is not scrolling. Content reaches the scrollback by scrolling off
+//     the top, which is how a harness that prints a conversation produces one.
+//     (Claude Code 2.1.228 never emits `ED2` at all; it clears by walking
+//     line-erases up the screen, and that path scrolls nothing either.)
+//   - **The alternate screen keeps its scrolled-off lines too**, which a real
+//     terminal does not, and the difference is deliberate. A terminal drops them
+//     because a human can scroll a full-screen app with the app's own keys; a
+//     script cannot, and the lines are the transcript it was asked to read. Each
+//     buffer keeps its own history, so switching back to the main screen does not
+//     mix a full-screen app's output into the shell's. Everything else about the
+//     alternate screen is ordinary: it starts blank and the main buffer is
+//     untouched underneath it.
+//
+// One consequence worth knowing before reading `screen()`: a harness that
+// switches to the alternate screen and then *exits* it (`ESC[?1049l`, which
+// Claude Code sends on quit) puts the main buffer back, and the main buffer is
+// whatever was on it before the harness started — near enough empty. Read the
+// screen while the Session is alive, not after killing it.
+//
+// Nothing here reads or writes a file descriptor. It is fed strings and hands
+// back strings; the process it runs in may have no terminal at all, which is
+// D11 and the whole reason the session layer can be used from a script.
+
+/** How many scrolled-off lines are kept by default. */
+export const DEFAULT_SCROLLBACK_LINES = 5_000;
+/** Grid width used when a caller names none — the Core's own PTY default. */
+export const DEFAULT_COLS = 100;
+/** Grid height used when a caller names none — the Core's own PTY default. */
+export const DEFAULT_ROWS = 30;
+
+export type TerminalScreenOptions = {
+  /** Grid width. Must match the PTY's, or wrapping here disagrees with there. */
+  cols?: number;
+  /** Grid height. Same. */
+  rows?: number;
+  /**
+   * How many scrolled-off lines to keep. The oldest are dropped past this.
+   * Zero keeps none — a caller that only ever reads the viewport.
+   */
+  scrollback?: number;
+};
+
+/** A cell's contents: one character, `" "` for blank, `""` for a wide char's second column. */
+type Cell = string;
+
+type Buffer = {
+  grid: Cell[][];
+  /** This buffer's own scrolled-off lines. Both buffers keep theirs — see the header. */
+  scrollback: string[];
+  savedRow: number;
+  savedCol: number;
+};
+
+type ParserState = "ground" | "esc" | "csi" | "osc" | "string" | "consume-one";
+
+/**
+ * A terminal screen fed one PTY's bytes.
+ *
+ * Feed it every chunk in order with {@link write} and read {@link lines},
+ * {@link text} or {@link viewportText}. Chunk boundaries are not respected by
+ * the stream — an escape sequence is routinely split across two `data` frames —
+ * so the parser is a state machine that carries its position between calls
+ * rather than anything that re-scans a buffer.
+ */
+export class TerminalScreen {
+  private colsValue: number;
+  private rowsValue: number;
+  private readonly scrollbackLimit: number;
+
+  private main: Buffer;
+  private alt: Buffer;
+  private buffer: Buffer;
+  private onAlt = false;
+
+  private row = 0;
+  private col = 0;
+  /**
+   * The cursor is parked on the last column with a character already written
+   * there, and the *next* printable wraps before it lands (DEC's deferred wrap).
+   * Without this, a line exactly `cols` wide scrolls one line too early and
+   * every subsequent row is off by one.
+   */
+  private pendingWrap = false;
+
+  /** Scroll region, inclusive, 0-based. Set by DECSTBM; full screen by default. */
+  private scrollTop = 0;
+  private scrollBottom: number;
+
+  private state: ParserState = "ground";
+  private csiBuf = "";
+
+  constructor(opts: TerminalScreenOptions = {}) {
+    this.colsValue = Math.max(1, Math.floor(opts.cols ?? DEFAULT_COLS));
+    this.rowsValue = Math.max(1, Math.floor(opts.rows ?? DEFAULT_ROWS));
+    this.scrollbackLimit = Math.max(0, Math.floor(opts.scrollback ?? DEFAULT_SCROLLBACK_LINES));
+    this.main = this.freshBuffer();
+    this.alt = this.freshBuffer();
+    this.buffer = this.main;
+    this.scrollBottom = this.rowsValue - 1;
+  }
+
+  get cols(): number {
+    return this.colsValue;
+  }
+
+  get rows(): number {
+    return this.rowsValue;
+  }
+
+  /** Where the cursor is, 0-based, for a caller that needs to know. */
+  get cursor(): { row: number; col: number } {
+    return { row: this.row, col: this.col };
+  }
+
+  /** True while a full-screen TUI has switched to the alternate buffer. */
+  get alternateScreen(): boolean {
+    return this.onAlt;
+  }
+
+  // ─── Feeding it ────────────────────────────────────────────────────────────
+
+  /**
+   * Write one chunk of PTY output. Call it with every chunk, in order.
+   *
+   * Iterated by code point rather than by UTF-16 unit, so an astral character
+   * (an emoji, and harnesses print plenty) occupies one cell rather than two
+   * halves of a surrogate pair in two.
+   */
+  write(data: string): void {
+    for (const ch of data) {
+      switch (this.state) {
+        case "ground":
+          this.ground(ch);
+          break;
+        case "esc":
+          this.escape(ch);
+          break;
+        case "csi":
+          this.csi(ch);
+          break;
+        case "osc":
+          this.osc(ch);
+          break;
+        case "string":
+          this.stringSequence(ch);
+          break;
+        case "consume-one":
+          // A charset designator's payload (`ESC ( B`) or a DEC private
+          // sequence's (`ESC # 8`). One character, dropped.
+          this.state = "ground";
+          break;
+      }
+    }
+  }
+
+  /**
+   * Change the grid's size. A caller that resizes the PTY resizes this too, or
+   * the two disagree about where every line wraps.
+   *
+   * Rows are added at the bottom and removed from the bottom; lines that a
+   * shrink pushes off the top go to the scrollback, exactly as scrolling would.
+   * Reflowing the existing text to a new width is deliberately not attempted —
+   * a real terminal's reflow is its own subsystem, and a harness repaints on
+   * `SIGWINCH` anyway, so the next frame is correct either way.
+   */
+  resize(cols: number, rows: number): void {
+    const nextCols = Math.max(1, Math.floor(cols));
+    const nextRows = Math.max(1, Math.floor(rows));
+    for (const buffer of [this.main, this.alt]) {
+      for (const line of buffer.grid) {
+        while (line.length < nextCols) line.push(" ");
+        line.length = nextCols;
+      }
+      while (buffer.grid.length < nextRows) buffer.grid.push(this.blankLine(nextCols));
+      // The cursor lives on the active buffer, so only that one's shrink moves
+      // it — and only the main buffer's keeps what it loses.
+      const active = buffer === this.buffer;
+      while (buffer.grid.length > nextRows) {
+        // Take the blank rows below the cursor first. A terminal shrinking a
+        // half-empty screen loses the padding, not the text — pushing those
+        // blanks onto the scrollback instead would put empty lines in the middle
+        // of a transcript, which is the one place they are read as content.
+        const last = buffer.grid.length - 1;
+        if ((!active || last > this.row) && isBlank(buffer.grid[last])) {
+          buffer.grid.pop();
+          continue;
+        }
+        const dropped = buffer.grid.shift();
+        if (dropped) this.pushScrollback(buffer, dropped);
+        if (active && this.row > 0) this.row -= 1;
+      }
+    }
+    this.colsValue = nextCols;
+    this.rowsValue = nextRows;
+    this.scrollTop = 0;
+    this.scrollBottom = nextRows - 1;
+    this.row = Math.min(this.row, nextRows - 1);
+    this.col = Math.min(this.col, nextCols - 1);
+    this.pendingWrap = false;
+  }
+
+  // ─── Reading it ────────────────────────────────────────────────────────────
+
+  /** The rows a terminal would be displaying now, top to bottom, right-trimmed. */
+  viewportLines(): string[] {
+    return this.buffer.grid.map((line) => trimEnd(line.join("")));
+  }
+
+  /** Every line that has scrolled off the top, oldest first. The transcript. */
+  scrollbackLines(): string[] {
+    return [...this.buffer.scrollback];
+  }
+
+  /** Scrollback then viewport: everything this terminal has been shown. */
+  lines(): string[] {
+    return [...this.buffer.scrollback, ...this.viewportLines()];
+  }
+
+  /**
+   * {@link lines} as one string, with the blank rows below the last written one
+   * trimmed off — a viewport is 30 rows whether or not a harness filled them,
+   * and a caller reading a screen wants what is on it, not the padding.
+   */
+  text(): string {
+    return joinTrimmed(this.lines());
+  }
+
+  /** The visible rows only, as one string. Same trailing-blank trim. */
+  viewportText(): string {
+    return joinTrimmed(this.viewportLines());
+  }
+
+  // ─── The parser ────────────────────────────────────────────────────────────
+
+  private ground(ch: string): void {
+    switch (ch) {
+      case "\u001B":
+        this.state = "esc";
+        return;
+      case "\r":
+        this.col = 0;
+        this.pendingWrap = false;
+        return;
+      case "\n":
+      case "\u000B": // vertical tab
+      case "\u000C": // form feed
+        this.lineFeed();
+        this.pendingWrap = false;
+        return;
+      case "\b":
+        this.col = Math.max(0, this.col - 1);
+        this.pendingWrap = false;
+        return;
+      case "\t":
+        this.col = Math.min(this.colsValue - 1, (Math.floor(this.col / 8) + 1) * 8);
+        this.pendingWrap = false;
+        return;
+      default:
+        break;
+    }
+    const code = ch.codePointAt(0) ?? 0;
+    // Remaining C0 controls and DEL paint nothing. A bell in the middle of a
+    // word must not become a character, or every alert shifts the line.
+    if (code < 0x20 || code === 0x7f) return;
+    this.putChar(ch);
+  }
+
+  private escape(ch: string): void {
+    switch (ch) {
+      case "[":
+        this.state = "csi";
+        this.csiBuf = "";
+        return;
+      case "]":
+        this.state = "osc";
+        return;
+      // DCS / SOS / PM / APC — a string until its terminator, none of which is
+      // screen content. Consumed so its payload is not printed as text.
+      case "P":
+      case "X":
+      case "^":
+      case "_":
+        this.state = "string";
+        return;
+      case "7":
+        this.saveCursor();
+        this.state = "ground";
+        return;
+      case "8":
+        this.restoreCursor();
+        this.state = "ground";
+        return;
+      case "D": // IND — down one line, scrolling at the bottom
+        this.lineFeed();
+        this.state = "ground";
+        return;
+      case "E": // NEL — carriage return and down one
+        this.col = 0;
+        this.lineFeed();
+        this.state = "ground";
+        return;
+      case "M": // RI — up one line, scrolling at the top
+        this.reverseIndex();
+        this.state = "ground";
+        return;
+      case "c": // RIS — full reset
+        this.reset();
+        this.state = "ground";
+        return;
+      // Charset designators and DEC private sequences take one more byte.
+      case "(":
+      case ")":
+      case "*":
+      case "+":
+      case "-":
+      case ".":
+      case "/":
+      case "#":
+        this.state = "consume-one";
+        return;
+      default:
+        // Keypad modes and everything else with no payload.
+        this.state = "ground";
+        return;
+    }
+  }
+
+  private csi(ch: string): void {
+    const code = ch.codePointAt(0) ?? 0;
+    // Parameter and intermediate bytes accumulate; the first byte in the final
+    // range ends the sequence.
+    if (code >= 0x30 && code <= 0x3f) {
+      this.csiBuf += ch;
+      return;
+    }
+    if (code >= 0x20 && code <= 0x2f) {
+      this.csiBuf += ch;
+      return;
+    }
+    this.state = "ground";
+    if (code >= 0x40 && code <= 0x7e) this.dispatchCsi(ch, this.csiBuf);
+    this.csiBuf = "";
+  }
+
+  private osc(ch: string): void {
+    // BEL-terminated, or ST (`ESC \`). The ESC is enough to end it here: no OSC
+    // payload this cares about contains one, and treating it as the terminator
+    // means a truncated sequence cannot swallow the rest of the stream.
+    // Consumed and dropped either way: a window title, a hyperlink target and a
+    // colour query are not screen content.
+    if (ch === "\u0007") {
+      this.state = "ground";
+      return;
+    }
+    if (ch === "\u001B") this.state = "consume-one";
+  }
+
+  private stringSequence(ch: string): void {
+    if (ch === "\u0007") {
+      this.state = "ground";
+      return;
+    }
+    if (ch === "\u001B") this.state = "consume-one";
+  }
+
+  private dispatchCsi(final: string, raw: string): void {
+    const isPrivate = raw.startsWith("?");
+    const body = isPrivate ? raw.slice(1) : raw;
+    const params = body
+      .split(";")
+      .map((p) => (p === "" ? NaN : Number.parseInt(p, 10)))
+      .map((n) => (Number.isFinite(n) ? n : NaN));
+    const p = (index: number, fallback: number): number => {
+      const value = params[index];
+      return value === undefined || Number.isNaN(value) ? fallback : value;
+    };
+
+    if (isPrivate) {
+      // The alternate screen, in and out. 1049 also saves/restores the cursor;
+      // 47 and 1047 are the older spellings and swap the buffer alone.
+      if (final === "h" || final === "l") {
+        const mode = p(0, 0);
+        if (mode === 47 || mode === 1047 || mode === 1049) {
+          this.setAlternateScreen(final === "h", mode === 1049);
+        }
+      }
+      // Cursor visibility, bracketed paste, mouse reporting: nothing that
+      // changes what the screen says.
+      return;
+    }
+
+    switch (final) {
+      case "A":
+        this.row = Math.max(this.scrollTop, this.row - Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "B":
+        this.row = Math.min(this.scrollBottom, this.row + Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "C":
+        this.col = Math.min(this.colsValue - 1, this.col + Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "D":
+        this.col = Math.max(0, this.col - Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "E":
+        this.col = 0;
+        this.row = Math.min(this.scrollBottom, this.row + Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "F":
+        this.col = 0;
+        this.row = Math.max(this.scrollTop, this.row - Math.max(1, p(0, 1)));
+        this.pendingWrap = false;
+        return;
+      case "G":
+      case "`": // HPA, the same move under another name
+        this.col = clamp(p(0, 1) - 1, 0, this.colsValue - 1);
+        this.pendingWrap = false;
+        return;
+      case "d": // VPA
+        this.row = clamp(p(0, 1) - 1, 0, this.rowsValue - 1);
+        this.pendingWrap = false;
+        return;
+      case "H":
+      case "f":
+        this.row = clamp(p(0, 1) - 1, 0, this.rowsValue - 1);
+        this.col = clamp(p(1, 1) - 1, 0, this.colsValue - 1);
+        this.pendingWrap = false;
+        return;
+      case "J":
+        this.eraseInDisplay(p(0, 0));
+        return;
+      case "K":
+        this.eraseInLine(p(0, 0));
+        return;
+      case "L":
+        this.insertLines(Math.max(1, p(0, 1)));
+        return;
+      case "M":
+        this.deleteLines(Math.max(1, p(0, 1)));
+        return;
+      case "@":
+        this.insertChars(Math.max(1, p(0, 1)));
+        return;
+      case "P":
+        this.deleteChars(Math.max(1, p(0, 1)));
+        return;
+      case "X":
+        this.eraseChars(Math.max(1, p(0, 1)));
+        return;
+      case "S":
+        this.scrollUp(Math.max(1, p(0, 1)));
+        return;
+      case "T":
+        this.scrollDown(Math.max(1, p(0, 1)));
+        return;
+      case "r": {
+        // DECSTBM. An out-of-order or out-of-range region is ignored rather
+        // than clamped into something the TUI did not ask for.
+        const top = clamp(p(0, 1) - 1, 0, this.rowsValue - 1);
+        const bottom = clamp(p(1, this.rowsValue) - 1, 0, this.rowsValue - 1);
+        if (top >= bottom) return;
+        this.scrollTop = top;
+        this.scrollBottom = bottom;
+        this.row = 0;
+        this.col = 0;
+        this.pendingWrap = false;
+        return;
+      }
+      case "s":
+        this.saveCursor();
+        return;
+      case "u":
+        this.restoreCursor();
+        return;
+      default:
+        // SGR (`m`), device reports, mode sets: colour and protocol, not layout.
+        return;
+    }
+  }
+
+  // ─── The grid ──────────────────────────────────────────────────────────────
+
+  private putChar(ch: string): void {
+    const width = charWidth(ch);
+    if (width === 0) {
+      // A combining mark belongs to the character before it, not to a cell of
+      // its own — otherwise an accent shifts the rest of the line one column.
+      const prev = this.col - 1;
+      if (prev >= 0) {
+        const line = this.buffer.grid[this.row];
+        if (line) line[prev] = (line[prev] ?? " ") + ch;
+      }
+      return;
+    }
+    if (this.pendingWrap) {
+      this.col = 0;
+      this.lineFeed();
+      this.pendingWrap = false;
+    }
+    if (this.col + width > this.colsValue) {
+      this.col = 0;
+      this.lineFeed();
+    }
+    const line = this.buffer.grid[this.row];
+    if (!line) return;
+    line[this.col] = ch;
+    // A wide character owns two columns; the second holds nothing so that
+    // joining the row reproduces the glyph once and the width still lines up.
+    if (width === 2 && this.col + 1 < this.colsValue) line[this.col + 1] = "";
+    this.col += width;
+    if (this.col >= this.colsValue) {
+      this.col = this.colsValue - 1;
+      this.pendingWrap = true;
+    }
+  }
+
+  private lineFeed(): void {
+    if (this.row === this.scrollBottom) {
+      this.scrollUp(1);
+      return;
+    }
+    if (this.row < this.rowsValue - 1) this.row += 1;
+  }
+
+  private reverseIndex(): void {
+    if (this.row === this.scrollTop) {
+      this.scrollDown(1);
+      return;
+    }
+    if (this.row > 0) this.row -= 1;
+  }
+
+  /**
+   * Scroll the region up by `n`, which is where the scrollback comes from.
+   *
+   * A line only reaches the scrollback when the *whole screen* scrolls: a TUI
+   * scrolling a three-row region in the middle of its layout is animating a
+   * pane, not producing history, and a terminal keeps none of it either. Which
+   * buffer it scrolled on does not matter — see the header on why the alternate
+   * screen keeps its history here when a terminal would not.
+   */
+  private scrollUp(n: number): void {
+    const keepsHistory = this.scrollTop === 0 && this.scrollBottom === this.rowsValue - 1;
+    for (let i = 0; i < n; i += 1) {
+      const dropped = this.buffer.grid.splice(this.scrollTop, 1)[0];
+      if (dropped && keepsHistory) this.pushScrollback(this.buffer, dropped);
+      this.buffer.grid.splice(this.scrollBottom, 0, this.blankLine(this.colsValue));
+    }
+  }
+
+  private scrollDown(n: number): void {
+    for (let i = 0; i < n; i += 1) {
+      this.buffer.grid.splice(this.scrollBottom, 1);
+      this.buffer.grid.splice(this.scrollTop, 0, this.blankLine(this.colsValue));
+    }
+  }
+
+  private insertLines(n: number): void {
+    if (this.row < this.scrollTop || this.row > this.scrollBottom) return;
+    for (let i = 0; i < n; i += 1) {
+      this.buffer.grid.splice(this.scrollBottom, 1);
+      this.buffer.grid.splice(this.row, 0, this.blankLine(this.colsValue));
+    }
+    this.col = 0;
+    this.pendingWrap = false;
+  }
+
+  private deleteLines(n: number): void {
+    if (this.row < this.scrollTop || this.row > this.scrollBottom) return;
+    for (let i = 0; i < n; i += 1) {
+      this.buffer.grid.splice(this.row, 1);
+      this.buffer.grid.splice(this.scrollBottom, 0, this.blankLine(this.colsValue));
+    }
+    this.col = 0;
+    this.pendingWrap = false;
+  }
+
+  private insertChars(n: number): void {
+    const line = this.buffer.grid[this.row];
+    if (!line) return;
+    for (let i = 0; i < n; i += 1) {
+      line.splice(this.col, 0, " ");
+      line.length = this.colsValue;
+    }
+    this.pendingWrap = false;
+  }
+
+  private deleteChars(n: number): void {
+    const line = this.buffer.grid[this.row];
+    if (!line) return;
+    for (let i = 0; i < n; i += 1) {
+      line.splice(this.col, 1);
+      line.push(" ");
+    }
+    this.pendingWrap = false;
+  }
+
+  private eraseChars(n: number): void {
+    const line = this.buffer.grid[this.row];
+    if (!line) return;
+    for (let i = 0; i < n && this.col + i < this.colsValue; i += 1) line[this.col + i] = " ";
+    this.pendingWrap = false;
+  }
+
+  private eraseInLine(mode: number): void {
+    const line = this.buffer.grid[this.row];
+    if (!line) return;
+    if (mode === 1) {
+      for (let i = 0; i <= this.col && i < this.colsValue; i += 1) line[i] = " ";
+    } else if (mode === 2) {
+      for (let i = 0; i < this.colsValue; i += 1) line[i] = " ";
+    } else {
+      for (let i = this.col; i < this.colsValue; i += 1) line[i] = " ";
+    }
+    this.pendingWrap = false;
+  }
+
+  private eraseInDisplay(mode: number): void {
+    if (mode === 1) {
+      for (let r = 0; r < this.row; r += 1) this.buffer.grid[r] = this.blankLine(this.colsValue);
+      const line = this.buffer.grid[this.row];
+      if (line) for (let i = 0; i <= this.col && i < this.colsValue; i += 1) line[i] = " ";
+      this.pendingWrap = false;
+      return;
+    }
+    if (mode === 2) {
+      // Erased, not scrolled: nothing goes to the scrollback. See the header.
+      for (let r = 0; r < this.rowsValue; r += 1) this.buffer.grid[r] = this.blankLine(this.colsValue);
+      this.pendingWrap = false;
+      return;
+    }
+    if (mode === 3) {
+      // ED3 is the one sequence whose whole job is to discard the scrollback.
+      this.buffer.scrollback.length = 0;
+      return;
+    }
+    const line = this.buffer.grid[this.row];
+    if (line) for (let i = this.col; i < this.colsValue; i += 1) line[i] = " ";
+    for (let r = this.row + 1; r < this.rowsValue; r += 1) {
+      this.buffer.grid[r] = this.blankLine(this.colsValue);
+    }
+    this.pendingWrap = false;
+  }
+
+  private setAlternateScreen(on: boolean, withCursor: boolean): void {
+    if (on === this.onAlt) return;
+    if (on) {
+      if (withCursor) this.saveCursor();
+      this.alt = this.freshBuffer();
+      this.buffer = this.alt;
+      this.onAlt = true;
+      this.row = 0;
+      this.col = 0;
+    } else {
+      this.buffer = this.main;
+      this.onAlt = false;
+      if (withCursor) this.restoreCursor();
+    }
+    this.scrollTop = 0;
+    this.scrollBottom = this.rowsValue - 1;
+    this.pendingWrap = false;
+  }
+
+  private saveCursor(): void {
+    this.buffer.savedRow = this.row;
+    this.buffer.savedCol = this.col;
+  }
+
+  private restoreCursor(): void {
+    this.row = clamp(this.buffer.savedRow, 0, this.rowsValue - 1);
+    this.col = clamp(this.buffer.savedCol, 0, this.colsValue - 1);
+    this.pendingWrap = false;
+  }
+
+  private reset(): void {
+    this.main = this.freshBuffer();
+    this.alt = this.freshBuffer();
+    this.buffer = this.main;
+    this.onAlt = false;
+    this.row = 0;
+    this.col = 0;
+    this.scrollTop = 0;
+    this.scrollBottom = this.rowsValue - 1;
+    this.pendingWrap = false;
+  }
+
+  private pushScrollback(buffer: Buffer, line: Cell[]): void {
+    if (this.scrollbackLimit === 0) return;
+    buffer.scrollback.push(trimEnd(line.join("")));
+    const overflow = buffer.scrollback.length - this.scrollbackLimit;
+    if (overflow > 0) buffer.scrollback.splice(0, overflow);
+  }
+
+  private blankLine(cols: number): Cell[] {
+    return new Array<Cell>(cols).fill(" ");
+  }
+
+  private freshBuffer(): Buffer {
+    return {
+      grid: Array.from({ length: this.rowsValue }, () => this.blankLine(this.colsValue)),
+      scrollback: [],
+      savedRow: 0,
+      savedCol: 0,
+    };
+  }
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+function isBlank(line: Cell[] | undefined): boolean {
+  return line === undefined || line.every((cell) => cell === " " || cell === "");
+}
+
+function trimEnd(line: string): string {
+  return line.replace(/\s+$/u, "");
+}
+
+/** Join lines, dropping the run of blank ones at the end. */
+function joinTrimmed(lines: string[]): string {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === "") end -= 1;
+  return lines.slice(0, end).join("\n");
+}
+
+/**
+ * How many columns one character occupies: 0, 1 or 2.
+ *
+ * Not a full Unicode width table — that is a data file, and this is an SDK. It
+ * is the three cases a harness's output actually contains: combining marks and
+ * the zero-width joiners that build emoji sequences take no column, the East
+ * Asian wide blocks and the emoji planes take two, and everything else takes
+ * one. Getting this wrong does not corrupt the text, it shifts a line by a
+ * column — which is why a box-drawing character (narrow, and everywhere in a
+ * TUI) matters more here than a rare script does.
+ */
+export function charWidth(ch: string): 0 | 1 | 2 {
+  const code = ch.codePointAt(0) ?? 0;
+  if (code === 0x200b || code === 0x200d || code === 0xfeff) return 0;
+  if (
+    (code >= 0x0300 && code <= 0x036f) || // combining diacriticals
+    (code >= 0x1ab0 && code <= 0x1aff) ||
+    (code >= 0x20d0 && code <= 0x20ff) || // combining marks for symbols
+    (code >= 0xfe00 && code <= 0xfe0f) || // variation selectors
+    (code >= 0xfe20 && code <= 0xfe2f)
+  ) {
+    return 0;
+  }
+  if (
+    (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+    (code >= 0x2e80 && code <= 0x303e) || // CJK radicals, Kangxi, punctuation
+    (code >= 0x3041 && code <= 0x33ff) || // kana through CJK compatibility
+    (code >= 0x3400 && code <= 0x4dbf) ||
+    (code >= 0x4e00 && code <= 0x9fff) || // CJK unified ideographs
+    (code >= 0xa000 && code <= 0xa4cf) ||
+    (code >= 0xac00 && code <= 0xd7a3) || // Hangul syllables
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe30 && code <= 0xfe6f) ||
+    (code >= 0xff00 && code <= 0xff60) || // fullwidth forms
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0x1f300 && code <= 0x1f64f) || // emoji
+    (code >= 0x1f900 && code <= 0x1f9ff) ||
+    (code >= 0x20000 && code <= 0x3fffd)
+  ) {
+    return 2;
+  }
+  return 1;
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,6 +4,13 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    // Relative imports inside this package carry their `.ts` extension so Node
+    // can resolve them directly — `node script.mjs` importing `@actana/sdk/…`
+    // works with no bundler and no loader, which is what makes the session
+    // layer's "a plain Node script" (issue 155) literally that. Safe with
+    // `noEmit`: nothing here is compiled, and every consumer resolves through a
+    // bundler that reads the same specifiers.
+    "allowImportingTsExtensions": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

The SDK's second level, on top of the transport from #192: **start a Session, let the
Core deliver the prompt, read the result** (#129 D2, D11). Programmatic I/O only —
`session.send(text)`, `session.onData(…)`, `session.screen()`.

Two new modules and one runnable proof:

- **`packages/sdk/src/core-session.ts`** — `CoreSession.start(client, {projectId, cwd,
  harness, prompt})` creates the Task, spawns the harness, wires the byte stream and
  waits on the Core's report of the turn.
- **`packages/sdk/src/terminal-screen.ts`** — a small terminal, because `screen()`
  cannot strip escape codes.
- **`packages/sdk/examples/start-a-session.mjs`** — plain `node`, no terminal anywhere.

## Related issues

Closes #155

Refs #129, #148

<!-- `Closes` because this ticket's own acceptance criteria are met and demonstrated
     below. The phase-1 parent (#148) closes on its own merge. -->

## Type of change

- [x] ✨ New feature (non-breaking change adding functionality)
- [x] 📚 Documentation

## What it does, and what it deliberately refuses to do

The level below this one knows frames. A caller wanting a *Session* had to correlate a
spawn with its byte stream, filter that stream out of every other PTY on the machine,
know that a harness's output is a screen rather than a log, and know how a Core reports
that a harness has finished. This is that, once, so a script is four calls:

```js
const client = CoreClient.fromRegistrationBlob(blob);
await client.connect();
const session = await CoreSession.start(client, { projectId, cwd, harness: "claude-code", prompt });
await session.waitForIdle();
console.log(session.screen());
```

Three things this layer does **not** do, each because the Core does it:

- **It does not time the prompt.** The starting prompt goes over as `initialInput` and
  the Core delivers it on the harness's own schedule — wait for the TUI to stop
  painting, answer the blocking dialog by its own numbered option, write the text, send
  the carriage return separately (ADR 0026, #191). There is no delay, no ready-signal
  and no retry here to disagree with it. A test asserts the spawn frame's *whole key
  set*, so a future `readyDelayMs` that looks helpful fails it rather than shipping.
- **It does not pre-empt the Core's spawn policy.** A Session is spawned against a
  registered Project: the Core checks the working directory resolves inside a known
  Project root, that argv[0] is that harness's canonical binary, and that every flag is
  allow-listed. Those checks read a database and a filesystem on another machine, so a
  copy here would be a guess. `start()` surfaces the rejection — asserted in the unit
  suite and again live against a real Core.
- **It does not decide what "done" means from the bytes.** Idleness is the Core's
  report: the harness's own lifecycle hooks move the Session's status, the change lands
  in the event log, and `waitForIdle()` watches for it. Watching output go quiet is the
  450 ms timer #191 deleted, in a new place.

**D11 is absolute.** Nothing reads `process.stdin`, sets raw mode, opens `/dev/tty` or
asks whether one exists — and a test sweeps every shipped module for all of those, so
the boundary is a red build rather than a promise.

## `screen()` is a terminal, not a `stripAnsi`

A harness positions text with cursor moves, not spaces. Claude Code draws its
folder-trust dialog as `ESC[4G1.ESC[7GYes,ESC[12GI…` and repaints its spinner by walking
the cursor up the screen; deleting the escapes yields `1.Yes,Itrust` on one line of
concatenated spinner frames. So `terminal-screen.ts` is a grid, a cursor, a scroll
region, two buffers and the escape vocabulary a TUI uses to position and erase — cursor
movement, erase display/line/characters, insert/delete lines and characters, scroll, the
alternate screen. The parser carries state between chunks, because an escape split
across two `data` frames is routine.

**Scrolled-off lines are kept**, which is where the transcript lives. Two rules, and
they differ on purpose:

- *An erased screen is erased.* `ED2` wipes in place and adds nothing to the scrollback,
  because erasing is not scrolling. (Claude Code 2.1.228 never emits `ED2`; it clears by
  walking line-erases up the screen, which scrolls nothing either.)
- *The alternate screen keeps its scrolled-off lines*, which a real terminal does not.
  A human scrolls a full-screen app with the app's own keys; a script cannot, and those
  lines are the transcript it was asked to read. Each buffer keeps its own, so a
  full-screen app's output never lands in the shell's history.

One consequence is documented on `screen()` rather than hidden: a full-screen harness
leaves the alternate screen when it quits, so read the screen **before** killing the
Session.

## Tested against a real Core

The daemon installed on the test machine predates #191 — no `HarnessPromptDelivery` in
its bundle — and against it the prompt is lost exactly as that PR describes: the session
sits at `ready` and `screen()` shows an empty input line. So the live run was done
against a Core **built from this branch**, which is the dependency this ticket declares.

A plain `node packages/sdk/examples/start-a-session.mjs`, no terminal involved:

```
connected to core_186064a659d68c6e (core-link 0.15.0)
session t-msq37v00-0a6e5a running on pty pty-msq37v05-7f6s2i
  status → ready
  status → running
  status → finished
settled: finished
────────────────────────────────────────────────────────────
❯ Reply with exactly: ACTANA-SDK-LIVE-OK and nothing else.
● ACTANA-SDK-LIVE-OK
```

`src/__tests__/live-session.test.ts` is that run as an opt-in suite
(`ACTANA_CORE_BLOB` + `ACTANA_LIVE_PROJECT_ID` + `ACTANA_LIVE_CWD`), asserting the
Session was observed `running` — the harness's own turn-start hook, which fires only
once it has *accepted* a prompt — and that the marker is on a rendered screen with no
escape sequences left in it. Unlike `live-core.test.ts` this one writes, so it takes a
scratch Project rather than defaulting to anything.

## Two changes outside the new modules

- **`CoreClient.subscribeEvents()` / `isSubscribedToEvents()`** (additive). A one-shot
  client sends no `subscribe`, and a script waiting for a harness to finish is reading
  an event. `DurableCoreClient` now writes its own subscribe through the same method, so
  the frame has one home.
- **Relative imports carry their `.ts` extension** (`build(sdk)` commit). Node's ESM
  resolver adds no extensions, so `node script.mjs` importing `@actana/sdk/…` failed on
  the first internal import. This is what makes "a plain Node script" literally that.
  `noEmit` is unchanged and every consumer resolves these specifiers through a bundler.

## The two known sharp edges in the merged transport

Left alone on purpose, both earmarked for #156, and neither is tripped here:

- A `request()` issued between writability and ready on the no-bearer path is never
  queued (pre-existing). This layer only issues requests after `await connect()`, which
  resolves after both.
- `onClose` fires disconnect listeners before the backoff arms, so a listener calling
  `connect()` synchronously can double-dial. `CoreSession` registers no disconnect
  listener at all.

## How was this tested?

- [x] Unit tests added/updated — 27 for the terminal, 28 for the session layer
- [x] Manual testing against a live Core (above)
- [x] `pnpm -r typecheck` clean; `pnpm lint` reports 0 errors and nothing in `packages/sdk`
- [x] CI green

One local-only note: `scripts/__tests__/core-launcher.test.mjs` fails in this dev
container over an install-root path, **identically on the base commit** (`9c02185`), and
passes in CI. Environment, not this branch.

