### PR TITLE
test(sdk): the multiConnection gate's dead detectors, rebuilt on the SDK's durable client

### DIFF
--- a/packages/sdk/src/__tests__/client-id-reclaim.test.ts
+++ b/packages/sdk/src/__tests__/client-id-reclaim.test.ts
@@ -1,0 +1,113 @@
+// The stable Core client id, across the connections it exists to span (ADR 0024
+// D9, issue 146).
+//
+// The two detectors the Panel's `client-id-reclaim.test.ts` held and #156's
+// deletion did not replace — section 2 of #195's review names both. The rest of
+// that file came across with the migration: the id on the wire once the link is
+// up (`core-client.test.ts`), ahead of the replay tail and the PTY resend and
+// withheld until the bearer is accepted (`durable-core-client.test.ts`), the
+// caller-supplied id, and one id per client. What had no home is the property
+// the whole feature rests on and the one failure it has to survive:
+//
+//  1. **The id does not move.** It is the same string on every reconnect,
+//     because a reconnect is exactly what it spans. An id that changed with the
+//     socket would reclaim nothing, every time, and the defect would be
+//     invisible — the Core would answer politely and the ghost connection would
+//     hold this client's Sessions for the full 45-second heartbeat timeout.
+//     Safe by construction today (`readonly clientId`, assigned once, read at
+//     one send site), which is an argument for keeping it that way and not one
+//     for leaving it unpinned.
+//  2. **A refused reclaim is survivable.** It is fire-and-forget by design: the
+//     answer costs the heartbeat timeout it was shortening, never correctness,
+//     so a Core that refuses it must not take anything else down with it.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import { DurableCoreClient } from "../durable-core-client";
+import { handDrivenDialer, startCoreRig, type CoreRig } from "./fake-core-link";
+
+const SECRET = "client-id-suite-secret-32-bytes-xx";
+const URL_A = "wss://core-a.test:9444";
+
+function bearerFor(coreId = "core_test"): string {
+  return signBearer({ coreId, exp: Date.now() + 60_000 }, SECRET);
+}
+
+describe("the SDK client's Core client id (ADR 0024 D9)", () => {
+  let rig: CoreRig | null = null;
+  let client: DurableCoreClient | null = null;
+
+  afterEach(() => {
+    client?.close();
+    client = null;
+    rig?.close();
+    rig = null;
+  });
+
+  it("is the same string on every reconnect — the property the feature rests on", async () => {
+    rig = startCoreRig({ authVerifier: (bearer) => verifyBearer(bearer, SECRET) });
+    const dial = rig.dialer();
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+      reconnectInitialMs: 5,
+      reconnectMaxMs: 5,
+      heartbeat: false,
+    });
+    const durable = client;
+
+    await durable.connect();
+    // Three connections, each a genuinely new socket the Core accepted and each
+    // presenting this client's id for the reaping of the one before it.
+    for (let connection = 1; connection <= 3; connection++) {
+      await vi.waitFor(() => expect(dial.pairs).toHaveLength(connection));
+      await vi.waitFor(() =>
+        expect(dial.last().client.framesOfType("reclaim")).toHaveLength(1),
+      );
+      if (connection < 3) dial.last().server.close();
+    }
+
+    const presented = dial.pairs.flatMap((pair) =>
+      pair.client.framesOfType("reclaim").map((frame) => frame.clientId),
+    );
+    expect(presented).toEqual([durable.clientId, durable.clientId, durable.clientId]);
+    expect(durable.clientId).toMatch(/^sdk-/);
+  });
+
+  it("carries on when the Core refuses the reclaim", async () => {
+    // Hand-driven, because the Core's reclaim handler cannot fail: there is no
+    // server path that answers this frame with an `error`, and the client's
+    // tolerance of one is otherwise asserted by nothing.
+    const dial = handDrivenDialer();
+    client = new DurableCoreClient({
+      url: URL_A,
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+      reconnectInitialMs: 10_000,
+      reconnectMaxMs: 10_000,
+      heartbeat: false,
+    });
+    const durable = client;
+    const reclaimed = vi.fn();
+    durable.onReclaimed(reclaimed);
+
+    const connecting = durable.connect();
+    await vi.waitFor(() => expect(dial.last().framesOfType("auth")).toHaveLength(1));
+    dial.ready({ multiConnection: { version: 1 } });
+    dial.authOk();
+    await connecting;
+
+    expect(dial.last().framesOfType("reclaim")).toHaveLength(1);
+    dial.answerLast("reclaim", { type: "error", message: "nope" });
+
+    // The link is still a link: the next request goes out and is answered.
+    const found = durable.findByTask("task_1");
+    await vi.waitFor(() => expect(dial.last().framesOfType("findByTask")).toHaveLength(1));
+    dial.answerLast("findByTask", { type: "findByTaskResult", ptyId: "pty_1" });
+
+    await expect(found).resolves.toEqual({ ptyId: "pty_1" });
+    // And nothing was reported as reclaimed, because nothing was.
+    expect(reclaimed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/__tests__/fake-core-link.ts
+++ b/packages/sdk/src/__tests__/fake-core-link.ts
@@ -18,7 +18,7 @@ import type {
 } from "@actana/core/pty-core-link-server";
 import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
 import type { PtyCore, PtyCoreEvent } from "@actana/core/pty-manager";
-import type { CoreLinkEvent } from "../core-link-frames";
+import { CORE_LINK_PROTOCOL_VERSION, type CoreLinkEvent } from "../core-link-frames";
 import type { CoreLinkSocket, CoreLinkSocketFactory } from "../core-link-socket";
 
 type Listener = (...args: unknown[]) => void;
@@ -226,6 +226,77 @@ export class FakeEventLog implements EventLogPort {
   getLastEventId(): number {
     return this.seq;
   }
+}
+
+/**
+ * A dialer with no Core behind it: every dial hands back a socket whose inbound
+ * frames the test writes itself.
+ *
+ * Everything else in this file exists so a suite does not have to fake a Core,
+ * and that is the right default — a hand-rolled server answers whatever the
+ * client expects, which is the agreement worth testing. This is the exception,
+ * for the frames a real `PtyCoreLinkServer` cannot be made to produce:
+ *
+ *   - **`authOk` before `ready`.** The Core sends `ready` as frame one on every
+ *     connection, which is exactly why nothing in the client enforces the order
+ *     — so the only way to pin what that order buys is to invert it here.
+ *   - **an `error` answer to a `reclaim`.** The server's reclaim handler cannot
+ *     fail, and the client's tolerance of one that does is a `.catch()` no
+ *     reachable server path exercises.
+ *
+ * Reach for it only for those; a test a real Core can drive belongs on one.
+ */
+export type HandDrivenDialer = {
+  createSocket: CoreLinkSocketFactory;
+  /** Every socket handed out, in dial order — a reconnect is the next entry. */
+  sockets: FakeSocket[];
+  last(): FakeSocket;
+  /** Frame one on the current connection, with or without the capability. */
+  ready(opts?: { multiConnection?: unknown }): void;
+  /** The Core accepting this connection's bearer. */
+  authOk(opts?: { coreId?: string }): void;
+  /** Answer the last frame of `type` this client sent, correlated by its reqId. */
+  answerLast(type: string, frame: Record<string, unknown>): void;
+  /** The socket dies, as a Core restart or a reaped NAT flow does. */
+  drop(): void;
+};
+
+export function handDrivenDialer(): HandDrivenDialer {
+  const sockets: FakeSocket[] = [];
+  const last = (): FakeSocket => {
+    const socket = sockets[sockets.length - 1];
+    if (!socket) throw new Error("nothing dialed yet");
+    return socket;
+  };
+  return {
+    sockets,
+    last,
+    createSocket: () => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      // A tick later, so the transport is fully wired before `open` fires and
+      // its `auth` frame goes out — the same order the real dialer gives it.
+      queueMicrotask(() => {
+        socket.readyState = 1;
+        socket.emit("open");
+      });
+      return socket.asClientSocket();
+    },
+    ready: ({ multiConnection }: { multiConnection?: unknown } = {}) =>
+      last().receive({
+        type: "ready",
+        version: CORE_LINK_PROTOCOL_VERSION,
+        ...(multiConnection === undefined ? {} : { multiConnection }),
+      }),
+    authOk: ({ coreId = "core_hand_driven" }: { coreId?: string } = {}) =>
+      last().receive({ type: "authOk", reqId: "auth-1", coreId, exp: 1_700_000_000_000 }),
+    answerLast: (type, frame) => {
+      const asked = last().framesOfType(type).at(-1);
+      if (!asked) throw new Error(`no ${type} frame on the wire to answer`);
+      last().receive({ ...frame, reqId: asked.reqId });
+    },
+    drop: () => last().close(),
+  };
 }
 
 export type CoreRig = {

--- a/packages/sdk/src/__tests__/multiconnection-gate.test.ts
+++ b/packages/sdk/src/__tests__/multiconnection-gate.test.ts
@@ -1,0 +1,480 @@
+// The multiConnection gate, from the client's side (ADR 0024 D11, issue 143).
+//
+// These are the detectors the Panel's `multiconnection-capability.test.ts` held
+// until #156 deleted the class they drove. The code they guard came across to
+// this package in #153 and is correct — #195's review read it line by line and
+// approved it — so nothing here is a bug report. What went missing is the
+// pinning: the capability's lifecycle on a client, and the contents of the
+// registry the gate consults, were asserted by nothing in this repo, which made
+// a regression in either of them green. Restored against the client the Panel
+// actually runs now, per section 2 of that review (issue 153, #156).
+//
+// Two properties, and the second is the one with teeth:
+//
+//  1. The capability is read off every `ready`, per connection, and never
+//     remembered across one — a Core can be downgraded while a client is away.
+//  2. Against a Core that does not announce it, a multi-connection-only frame is
+//     not sent AT ALL. Not sent-and-tolerate-the-error: nothing reaches the
+//     socket, so the Core never has to answer for a frame it does not know.
+//
+// Property 2's sharp edge is the *drop window*. A stale `true` would let a
+// gated frame past the check and onto the outbound queue, which the next
+// established connection drains unconditionally — so the frame would land on a
+// Core that never said it could answer it. The deleted client's own comment
+// called that edge load-bearing; the two tests that pinned it are below.
+//
+// Every reconnect here is a real second connection to a real
+// `PtyCoreLinkServer`, and a Core that "comes back downgraded" is a second
+// server that announces nothing — the one shape that cannot be built that way
+// is `authOk` arriving before `ready`, which is hand-driven and says so.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import type { CoreLinkRequestFrame } from "../core-link-frames";
+import {
+  CoreLinkRequestError,
+  MULTI_CONNECTION_ONLY_FRAME_TYPES,
+} from "../core-client";
+import type { CoreLinkSocketFactory } from "../core-link-socket";
+import { DurableCoreClient } from "../durable-core-client";
+import {
+  FakeSocketPair,
+  handDrivenDialer,
+  startCoreRig,
+  type CoreRig,
+} from "./fake-core-link";
+
+const SECRET = "gate-suite-secret-32-bytes-long-xx";
+const URL_A = "wss://core-a.test:9444";
+
+/** The gated frame these tests put on the wire. `release` had no call site under test. */
+const RELEASE: CoreLinkRequestFrame = { type: "release", reqId: "", taskId: "task_1" };
+
+/**
+ * One real frame per entry in the registry, so the gate is exercised for every
+ * type it lists rather than for the two with a degrading call site. The set this
+ * covers is asserted against the registry itself in the test that uses it.
+ */
+const GATED_FRAMES: CoreLinkRequestFrame[] = [
+  { type: "ptySubscribe", reqId: "", ptyId: "pty_1", catchUp: false },
+  { type: "ptyUnsubscribe", reqId: "", ptyId: "pty_1" },
+  { type: "claim", reqId: "", taskId: "task_1" },
+  { type: "release", reqId: "", taskId: "task_1" },
+  { type: "forceTakeover", reqId: "", taskId: "task_1" },
+  { type: "reclaim", reqId: "", clientId: "sdk-some-client" },
+];
+
+function bearerFor(coreId = "core_test"): string {
+  return signBearer({ coreId, exp: Date.now() + 60_000 }, SECRET);
+}
+
+/**
+ * Fire a request and swallow its settlement. These tests assert on what reached
+ * the socket, never on the answer — and a frame still in flight when the
+ * connection drops rejects by design.
+ */
+function fireAndForget(promise: Promise<unknown>): void {
+  void promise.catch(() => {});
+}
+
+describe("the multiConnection gate on a durable Core client", () => {
+  const rigs: CoreRig[] = [];
+  const clients: DurableCoreClient[] = [];
+
+  afterEach(() => {
+    for (const client of clients.splice(0)) client.close();
+    for (const rig of rigs.splice(0)) rig.close();
+  });
+
+  /** A Core that announces the capability, with the remote shape's auth gate. */
+  function coreThatAnnounces(): CoreRig {
+    const rig = startCoreRig({ authVerifier: (bearer) => verifyBearer(bearer, SECRET) });
+    rigs.push(rig);
+    return rig;
+  }
+
+  /** The same Core, one release older: it answers `ready` and announces nothing. */
+  function coreThatDoesNot(): CoreRig {
+    const rig = startCoreRig({
+      authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+      announceMultiConnection: false,
+    });
+    rigs.push(rig);
+    return rig;
+  }
+
+  /**
+   * Dial a sequence of Cores: the first connection reaches `cores[0]`, the
+   * reconnect after it `cores[1]`, and every later one the last entry.
+   *
+   * That is what "the Core came back downgraded" is here — a second real server
+   * on the same endpoint, announcing what that build announces — rather than a
+   * `ready` frame written by the test.
+   */
+  function dialInTurn(cores: CoreRig[]): {
+    createSocket: CoreLinkSocketFactory;
+    pairs: FakeSocketPair[];
+    last(): FakeSocketPair;
+  } {
+    const pairs: FakeSocketPair[] = [];
+    const createSocket: CoreLinkSocketFactory = () => {
+      const pair = new FakeSocketPair();
+      pairs.push(pair);
+      const core = cores[Math.min(pairs.length - 1, cores.length - 1)]!;
+      core.wss.accept(pair.server);
+      queueMicrotask(() => pair.open());
+      return pair.client.asClientSocket();
+    };
+    return {
+      createSocket,
+      pairs,
+      last: () => {
+        const pair = pairs[pairs.length - 1];
+        if (!pair) throw new Error("nothing dialed yet");
+        return pair;
+      },
+    };
+  }
+
+  function clientOver(
+    createSocket: CoreLinkSocketFactory,
+    opts: { reconnectMs?: number } = {},
+  ): DurableCoreClient {
+    const client = new DurableCoreClient({
+      url: URL_A,
+      bearer: bearerFor(),
+      createSocket,
+      reconnectInitialMs: opts.reconnectMs ?? 5,
+      reconnectMaxMs: opts.reconnectMs ?? 5,
+      heartbeat: false,
+    });
+    clients.push(client);
+    return client;
+  }
+
+  /** Wait until connection number `n` is up and has been served its replay tail. */
+  async function connectionUp(
+    client: DurableCoreClient,
+    pairs: FakeSocketPair[],
+    n: number,
+  ): Promise<void> {
+    await vi.waitFor(() => expect(pairs).toHaveLength(n));
+    await vi.waitFor(() => expect(client.isCaughtUp()).toBe(true));
+  }
+
+  /** Every frame of one type this client wrote, across every connection it opened. */
+  function sentAcross(pairs: FakeSocketPair[], type: string): Array<Record<string, unknown>> {
+    return pairs.flatMap((pair) => pair.client.framesOfType(type));
+  }
+
+  describe("the capability's lifecycle on one client", () => {
+    it("is closed before ready lands — the answer is unknown, not yes", async () => {
+      const core = coreThatAnnounces();
+      const pair = new FakeSocketPair();
+      const createSocket: CoreLinkSocketFactory = () => {
+        queueMicrotask(() => pair.open());
+        // Long enough that the window below is the test's, not a race with it.
+        setTimeout(() => core.wss.accept(pair.server), 50);
+        return pair.client.asClientSocket();
+      };
+      const client = clientOver(createSocket);
+
+      const connecting = client.connect();
+      // One tick: the socket is open and its `auth` frame is out. The Core has
+      // not been handed this connection yet, so no `ready` exists — and the gate
+      // over an unknown answer is closed, not open.
+      await Promise.resolve();
+      expect(pair.client.framesOfType("auth")).toHaveLength(1);
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBeNull();
+
+      await connecting;
+    });
+
+    it("records the capability the Core announced on ready", async () => {
+      const client = clientOver(coreThatAnnounces().dialer().createSocket);
+
+      await client.connect();
+
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+      expect(client.multiConnectionCapability()).toEqual({ version: 1 });
+    });
+
+    it("does not carry it across a reconnect — it is re-read on the new ready", async () => {
+      const dial = dialInTurn([coreThatAnnounces(), coreThatDoesNot()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+
+      // The Core comes back downgraded: rolled back, or a different build on the
+      // same endpoint. A remembered `true` here would send frames it cannot
+      // answer, on a link that reports itself perfectly healthy.
+      dial.last().server.close();
+      await connectionUp(client, dial.pairs, 2);
+
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBeNull();
+    });
+
+    it("closes the moment the link drops, not when the next one opens", async () => {
+      const dial = coreThatAnnounces().dialer();
+      // A backoff longer than this test, so the drop window is the whole of it:
+      // what the gate says here is what it says with no Core on the other end.
+      const client = clientOver(dial.createSocket, { reconnectMs: 10_000 });
+      await client.connect();
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+
+      dial.last().server.close();
+
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+      expect(client.multiConnectionCapability()).toBeNull();
+      expect(dial.pairs).toHaveLength(1);
+    });
+
+    it("picks it back up when an upgraded Core reconnects", async () => {
+      const dial = dialInTurn([coreThatDoesNot(), coreThatAnnounces()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+      expect(client.canSendMultiConnectionFrames()).toBe(false);
+
+      dial.last().server.close();
+      await connectionUp(client, dial.pairs, 2);
+
+      expect(client.canSendMultiConnectionFrames()).toBe(true);
+      expect(client.multiConnectionCapability()).toEqual({ version: 1 });
+    });
+  });
+
+  describe("a refused frame is gone, not deferred", () => {
+    it("does not queue it for a later flush", async () => {
+      const dial = dialInTurn([coreThatDoesNot(), coreThatAnnounces()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+
+      await expect(client.request(RELEASE)).rejects.toThrow(/multiConnection capability/);
+
+      // A queued frame goes out when the socket next opens. Reconnect to a Core
+      // that DOES announce the capability — which is the connection that would
+      // carry it — and confirm nothing flushed.
+      dial.last().server.close();
+      await connectionUp(client, dial.pairs, 2);
+
+      expect(sentAcross(dial.pairs, "release")).toEqual([]);
+    });
+
+    it("refuses it in the drop window, and nothing flushes when the socket reopens", async () => {
+      const dial = dialInTurn([coreThatAnnounces()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+
+      // The link drops. Nothing has re-announced anything yet, so a frame asked
+      // for now must be refused outright — if a stale `true` let it past the
+      // gate it would land on the queue, and the next established connection
+      // drains that queue before it knows what this Core can answer.
+      dial.last().server.close();
+      const refused = client.request(RELEASE);
+      fireAndForget(refused);
+
+      // The Core that comes back DOES announce the capability, so the frame
+      // would be allowed if it were asked for now: nothing about this connection
+      // can explain a `release` on the wire, and only a flush of the queue
+      // could. Which is why this assertion comes before the rejection one — a
+      // frame that slipped past the gate is still pending rather than rejected,
+      // so asserting the rejection first would fail as a timeout and say nothing
+      // about the wire.
+      await connectionUp(client, dial.pairs, 2);
+      expect(sentAcross(dial.pairs, "release")).toEqual([]);
+
+      await expect(refused).rejects.toThrow(/multiConnection capability/);
+    });
+
+    it("stops sending it again if the Core comes back downgraded", async () => {
+      const dial = dialInTurn([coreThatAnnounces(), coreThatDoesNot()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+
+      await expect(client.request(RELEASE)).resolves.toMatchObject({ type: "releaseResult" });
+      expect(sentAcross(dial.pairs, "release")).toHaveLength(1);
+
+      dial.last().server.close();
+      await connectionUp(client, dial.pairs, 2);
+
+      await expect(client.request(RELEASE)).rejects.toThrow(/multiConnection capability/);
+      expect(sentAcross(dial.pairs, "release")).toHaveLength(1);
+    });
+  });
+
+  describe("the gate's frame registry", () => {
+    it("holds exactly the PTY subscription frames, the Session lock's three, and reclaim", () => {
+      // Exact membership, not a superset check: this set is the whole statement
+      // of what this build refuses to send to a single-connection Core, so a
+      // type appearing here without the ticket that owns it, or one quietly
+      // dropping out, is the thing to notice. `claim` / `release` /
+      // `forceTakeover` (D3–D7) joined when the Session lock landed (issue 144)
+      // — a Core that evicts every client but one has nothing for a lock to
+      // arbitrate between, and no table to put a claim in. `reclaim` (issue 146,
+      // D9) joined last: against such a Core the frame asks for the eviction
+      // that Core has already performed, out of a lock table it does not have.
+      expect([...MULTI_CONNECTION_ONLY_FRAME_TYPES].sort()).toEqual([
+        "claim",
+        "forceTakeover",
+        "ptySubscribe",
+        "ptyUnsubscribe",
+        "reclaim",
+        "release",
+      ]);
+    });
+
+    it("puts every one of them through the gate, not only the ones with a call site", async () => {
+      // `release`, `ptyUnsubscribe` and `reclaim` reach the gate from nowhere
+      // else in this suite — their call sites either degrade first or are the
+      // client's own — so without this they are in the registry untested.
+      expect(new Set(GATED_FRAMES.map((frame) => frame.type))).toEqual(
+        new Set(MULTI_CONNECTION_ONLY_FRAME_TYPES),
+      );
+
+      const dial = coreThatDoesNot().dialer();
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+
+      for (const frame of GATED_FRAMES) {
+        await expect(client.request(frame)).rejects.toThrow(/multiConnection capability/);
+        // The property that matters: nothing was written. The Core is never
+        // asked to answer for a frame it does not know.
+        expect(dial.last().client.framesOfType(frame.type)).toEqual([]);
+      }
+    });
+  });
+
+  describe("the single-connection fallback for PTY subscriptions", () => {
+    it("asks for real once that Core comes back announcing the capability", async () => {
+      const dial = dialInTurn([coreThatDoesNot(), coreThatAnnounces()]);
+      const client = clientOver(dial.createSocket);
+      await client.connect();
+
+      // Nothing on the wire and nothing swallowed: such a Core fans that PTY out
+      // to every connection already, so silence is the answer, not a failure.
+      await expect(client.ptySubscribe("pty_1")).resolves.toBeUndefined();
+      expect(sentAcross(dial.pairs, "ptySubscribe")).toEqual([]);
+
+      dial.last().server.close();
+      await connectionUp(client, dial.pairs, 2);
+
+      // Why the want is remembered even when no frame went out. Nothing above
+      // this client remembers the pane — a router binds a Core once, not once
+      // per reconnect — so a want dropped here is a pane that goes dark against
+      // the upgraded Core, which fans out to subscribers and nobody else.
+      expect(sentAcross(dial.pairs, "ptySubscribe")).toMatchObject([
+        { ptyId: "pty_1", catchUp: false },
+      ]);
+    });
+  });
+
+  describe("the reconnect resend and the ready/authOk ordering", () => {
+    it("self-refuses if authOk ever arrives first — the ordering is the guard", async () => {
+      // Not a wish for this order, a demonstration of what the order buys. The
+      // capability is recorded by `ready` and the connection's opening frames go
+      // out when the link becomes writable, which on a bearer link is `authOk`.
+      // A Core that answered `auth` before it said `ready` would leave the
+      // resend with no capability to read — and reading "unknown" as "absent"
+      // would silently unsubscribe every held pane. Establishment waits for both
+      // instead, so such a connection sends nothing at all.
+      const dial = handDrivenDialer();
+      const client = clientOver(dial.createSocket);
+
+      const connecting = client.connect();
+      await vi.waitFor(() => expect(dial.last().framesOfType("auth")).toHaveLength(1));
+      dial.ready({ multiConnection: { version: 1 } });
+      dial.authOk();
+      await connecting;
+
+      // Nothing answers this Core's RPCs, so the subscription is asserted on the
+      // wire rather than awaited.
+      fireAndForget(client.ptySubscribe("pty_1"));
+      expect(dial.last().framesOfType("ptySubscribe")).toHaveLength(1);
+
+      // Connection two accepts the bearer and never says who it is.
+      dial.drop();
+      await vi.waitFor(() => expect(dial.sockets).toHaveLength(2));
+      await vi.waitFor(() => expect(dial.last().framesOfType("auth")).toHaveLength(1));
+      dial.authOk();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Not one frame of what a connection owes — including the `subscribe`
+      // that is not gated on the capability at all, which is what makes this an
+      // assertion about establishment rather than about the gate.
+      expect(dial.last().framesOfType("subscribe")).toEqual([]);
+      expect(dial.last().framesOfType("reclaim")).toEqual([]);
+      expect(dial.last().framesOfType("ptySubscribe")).toEqual([]);
+
+      // And it recovers on the next connection that observes the real order,
+      // because the want outlived the connection that could not express it.
+      dial.drop();
+      await vi.waitFor(() => expect(dial.sockets).toHaveLength(3));
+      await vi.waitFor(() => expect(dial.last().framesOfType("auth")).toHaveLength(1));
+      dial.ready({ multiConnection: { version: 1 } });
+      dial.authOk();
+
+      expect(dial.last().framesOfType("subscribe")).toHaveLength(1);
+      expect(dial.last().framesOfType("ptySubscribe")).toMatchObject([
+        { ptyId: "pty_1", catchUp: false },
+      ]);
+    });
+  });
+
+  describe("the Session lock over the gate", () => {
+    it("distinguishes 'no lock on this Core' from 'someone else holds it'", async () => {
+      // The one confusion that would matter downstream: `supported: false` and
+      // `granted: false` both carry a false, and reading them the same way
+      // renders a single-connection Core permanently read-only to the operator
+      // who is in fact its only client.
+      const announcing = coreThatAnnounces();
+      const holder = clientOver(announcing.dialer().createSocket);
+      await holder.connect();
+      await expect(holder.claim("task_1")).resolves.toEqual({ supported: true, granted: true });
+
+      // A second client on the same Core, asking for a Session that is held.
+      const contender = clientOver(announcing.dialer().createSocket);
+      await contender.connect();
+      await expect(contender.claim("task_1")).resolves.toEqual({
+        supported: true,
+        granted: false,
+      });
+
+      // And a Core with no lock table at all, which is a different answer to a
+      // different question — reached without asking it anything.
+      const singleDial = coreThatDoesNot().dialer();
+      const single = clientOver(singleDial.createSocket);
+      await single.connect();
+      await expect(single.claim("task_1")).resolves.toEqual({
+        supported: false,
+        granted: false,
+      });
+      expect(singleDial.last().client.framesOfType("claim")).toEqual([]);
+    });
+
+    it("leaves the code undefined on an error that carries none", async () => {
+      // The field is additive and optional: every error that shipped before it
+      // arrives without one, so a reader falls back to the message rather than
+      // treating an absent code as a code. The coded sibling — a mutation
+      // refused because another client holds the Session — is pinned in
+      // `core-client.test.ts`.
+      const core = coreThatAnnounces();
+      // A Core whose kill throws. The server turns any handler failure into an
+      // `error` frame carrying its message and nothing else.
+      core.ptyCore.kill = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const client = clientOver(core.dialer().createSocket);
+      await client.connect();
+
+      const err = await client.kill("pty-1").then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(CoreLinkRequestError);
+      expect((err as Error).message).toBe("boom");
+      expect((err as CoreLinkRequestError).code).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
The follow-up section 2 of [qcentic-adm's review on #195](https://github.com/actana/control/pull/195#pullrequestreview-4917520207)
asked for, on the base that review named: **"port the capability-lifecycle block and a registry-contents
test into `packages/sdk`"**. That review's section 2 *is* the porting spec, and the checklist at the
bottom maps every assertion it enumerates to its home, checked or explicitly not.

The suite the originals belonged to was written in #153 and the originals were deleted in #156 —
`client-id-reclaim.test.ts`, `multiconnection-capability.test.ts` and `mtls-integration.test.ts` drove
`PtyCoreLinkClient`, which no longer exists. **The code they guarded is correct**; the review read it
at `core-client.ts:402`, `:413` and `:448` and approved the PR. This is a detector gap and is treated
as one.

### Scope

- **Tests only. No production code changes** — the diff is three files under `packages/sdk/src/__tests__/`.
  Nothing under `src/` outside `__tests__` is touched, in this package or any other.
- Two new suites, `multiconnection-gate.test.ts` (14 tests) and `client-id-reclaim.test.ts` (2), plus a
  hand-driven dialer added to the shared rig.
- Base `refactor/sdk-extraction`, draft, and staying draft.

### Rebuilt against the client the Panel runs

Every test drives `DurableCoreClient` against the Core's own `PtyCoreLinkServer`. A Core that "comes
back downgraded" is a **second real server** that announces nothing, dialed on the reconnect — not a
`ready` frame written by the test — and every reconnect is a genuinely new socket with its own `auth`,
its own `ready` and its own subscription state.

Two shapes a real Core cannot produce, and the one place this suite hand-feeds frames:

- **`authOk` before `ready`.** The Core sends `ready` as frame one on every connection, which is
  exactly why nothing in the client enforces the order — so the only way to pin what that order buys is
  to invert it.
- **an `error` answer to a `reclaim`.** The server's reclaim handler cannot fail, and the client's
  tolerance of one that does is a `.catch()` no reachable server path exercises.

Both are documented at `handDrivenDialer` in `fake-core-link.ts`, along with the instruction to reach
for a real Core otherwise.

### Each one fails when the behaviour it guards is broken

Not asserted — run. Each mutation was applied to `packages/sdk/src/` on its own, the two suites run, and
the mutation reverted; the tree carries none of them.

| Mutation | Tests it kills |
| --- | --- |
| Gate open before `ready` (capability defaults to `{version: 1}`, no per-connection reset) | closed before ready lands |
| Capability never recorded off `ready` | 10 of the 16, incl. records-on-announce and picks-it-back-up |
| Capability remembered across connections (sticky read + neither clear) | does not carry it across a reconnect · closes on drop · drop window · downgraded |
| No clear on `onClose` | closes the moment the link drops · drop window |
| Gate removed from `request()` | does not queue it · drop window · downgraded · every type through the gate |
| `release` dropped from the registry | those three, plus both registry tests |
| A seventh type added to the registry | both registry tests |
| Establishment without `ready` | self-refuses if authOk arrives first |
| PTY want dropped when the gate is closed | asks for real once that Core comes back |
| `claim` answering `supported: true` with no capability | distinguishes no-lock from held |
| `CoreLinkRequestError` defaulting its `code` | leaves the code undefined |
| Fresh client id minted per connection | same string on every reconnect |
| `.catch()` removed from `sendReclaim` | carries on when the Core refuses the reclaim — as an unhandled rejection that **fails the run** with every assertion in the file still passing |

Two findings worth recording rather than burying:

1. **`openTransport`'s `multiConnection = null` is redundant on its own** — removing it alone kills no
   test, because `onClose` has already cleared it on every path that reaches a second connection. It is
   belt-and-braces, not dead: the composite mutation above needs *both* gone plus a sticky read before
   the lifecycle assertion moves. Recorded so the next reader does not mistake a passing suite for a
   claim that either line is individually load-bearing.
2. **The refused-reclaim detector fails the run, not an assertion.** A swallowed rejection has no
   observable consequence to assert on — that is what swallowing it means — so what the mutation
   produces is an unhandled rejection attributed to the file. CI goes red; no `it()` reports it.

### Verification

`@actana/sdk` **167 ✓ / 5 skipped** (was 151 ✓ / 5 skipped at `1e0b0b8`; +16, all additions — no existing
test's assertions were changed, and the only edit to an existing file is the additive dialer in
`fake-core-link.ts`). `pnpm -r typecheck` clean. `pnpm lint` **0 errors**, and none of the 51 pre-existing
warnings is in a file this PR touches.

---

## Checklist — every assertion section 2 enumerates

### `multiconnection-capability.test.ts` — "the real gap"

**The capability's lifecycle on a client** (review's first bullet):

- [x] closed before `ready` lands → `multiconnection-gate.test.ts:171` *"is closed before ready lands — the answer is unknown, not yes"*
- [x] recorded on announce → `:194` *"records the capability the Core announced on ready"*
- [x] not carried across a reconnect → `:203` *"does not carry it across a reconnect — it is re-read on the new ready"*
- [x] cleared the moment the link drops rather than when the next opens → `:219` *"closes the moment the link drops, not when the next one opens"*
- [x] picked back up when an upgraded Core reconnects → `:234` *"picks it back up when an upgraded Core reconnects"*
- [x] the load-bearing hazard, "does not queue it for a later flush" → `:249` *"does not queue it for a later flush"*
- [x] the load-bearing hazard, "refuses it in the drop window, and nothing flushes when the socket reopens" → `:265`, same name

**The frame registry's contents** (second bullet):

- [x] `MULTI_CONNECTION_ONLY_FRAME_TYPES` asserted — removing one or adding a seventh is no longer green → `:308` *"holds exactly the PTY subscription frames, the Session lock's three, and reclaim"*
- [x] `release`, `ptyUnsubscribe` and `reclaim` go through the gate under test → `:328` *"puts every one of them through the gate, not only the ones with a call site"* (the frame table is asserted to equal the registry, so a seventh type added without an entry fails here too)

**The rest** (third bullet):

- [x] "stops sending it again if the Core comes back downgraded" → `:291`, same name
- [x] "asks for real once that Core comes back announcing the capability" → `:350`, same name
- [x] "self-refuses if authOk ever arrives first — the ordering is the guard" → `:374`, same name
- [x] "distinguishes 'no lock on this Core' from 'someone else holds it'" → `:426`, same name
- [x] "leaves the code undefined on an error that carries none" → `:456`, same name. Worth a note: this
  one was **not** wholly unpinned — `core-client.test.ts:189` already asserts an absent code on the
  Core's thrown-mutation path. Restored anyway, on the surface the original used (a `kill` the Core
  refuses with an uncoded `error`), because the review listed it and the two paths reach the field
  differently.

### `client-id-reclaim.test.ts` — "two assertions died"

- [x] "is the same string on every reconnect — the property the feature rests on" → `client-id-reclaim.test.ts:47`, same name
- [x] "carries on when the Core refuses the reclaim" → `:78`, same name

The nine the review found already re-covered are **not restored**, because a second copy of a passing
detector is not coverage. Each was re-read on this branch and is where the review says it is:

- [ ] on the wire once up — `core-client.test.ts:245`. Unchanged, still asserts the `clientId` on the reclaim frame.
- [ ] ahead of the replay tail and the PTY resend — `durable-core-client.test.ts:66`, `:328`.
- [ ] withheld until the bearer is accepted — `durable-core-client.test.ts:66` (`["auth", "reclaim", "subscribe"]`).
- [ ] caller-supplied id — `core-client.test.ts:252`.
- [ ] distinct per client — `packages/panel/src/server/services/__tests__/core-link-client-id.test.ts:18`.
- [ ] presented on `ready` when no bearer is configured — `core-client.test.ts:417` (the loopback path, `["reclaim", "replay"]`).
- [ ] withheld from a Core that announces nothing — `core-client.test.ts:315` for the degrade shape, and
  `multiconnection-gate.test.ts:328` now also pins that **no `reclaim` frame reaches such a Core at all**,
  which was the deleted file's "sends nothing, because that Core has already done it".

### `mtls-integration.test.ts` — "fully re-covered, and improved"

- [ ] wss:// with mTLS, then a round trip — `core-link-mtls.test.ts:164`. Nothing to restore.
- [ ] the pinned-cert refusal — `:178`. Nothing to restore.
- [ ] (net gain, no original) a refused handshake told apart from a Core that is not running — `:210`.

### Out of scope, deliberately

- [ ] The gate's *Panel-side* use — `panel-link/router.test.ts`, `panel-link/session-write-access.test.ts`,
  `shared/session-write-access.test.ts`, `services/core-link-manager.test.ts:250`. The review confirms
  these are covered and untouched, and this PR does not touch `packages/panel`.
- [ ] Sections 1, 3, 4 and 5 of the review. Approved as they stand; section 2 is the only one that
  asked for a follow-up.

Refs #153, #156, #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
