### PR TITLE
chore(ci): commitlint body limits must fit concatenated squash titles

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -109,7 +109,14 @@ export default {
     // project's own history fails is a limit people learn to bypass. This one
     // catches a runaway subject without arguing with the house style.
     'header-max-length': [2, 'always', 120],
-    'body-max-line-length': [2, 'always', 100],
+    // 132, not 100, and the same for the footer: this repo squashes with
+    // COMMIT_MESSAGES, so a train squash carries every ticket PR title
+    // concatenated into its body. Those titles are capped at 112 plus a
+    // ` (#NNN)` suffix, and the parser may land the tail of that block in the
+    // footer, so both limits must clear the 120 `header-max-length` above —
+    // otherwise a title that was legal as a header is illegal once quoted.
+    'body-max-line-length': [2, 'always', 132],
+    'footer-max-line-length': [2, 'always', 132],
     'body-leading-blank': [2, 'always'],
     // Off in favour of `trailer-leading-blank` above it — same intent, without
     // mistaking a wrapped body sentence for a footer.


### PR DESCRIPTION
## Why

The repo squash-merges with `COMMIT_MESSAGES`, so a train squash carries every ticket PR title concatenated into its message body. Those titles are capped at 112 characters plus a ` (#NNN)` suffix, which clears the 120-character `header-max-length` but not the 100-character body and footer limits — a title that is legal as a header becomes illegal the moment a squash quotes it.

The promotion PR for `beta/0.2.1` (#198) fails its Conventions check deterministically on `5eb2b3a`, whose body embeds PR #190's 105-character title:

```
* refactor(sdk): the core-link protocol moves into packages/sdk, and the cut writes five manifests (#190)
```

The parser reads that block as **footer**, so the rule that actually fires is `footer-max-line-length` — which had been inheriting `config-conventional`'s default of 100 rather than being set explicitly in this repo's config.

## What

`commitlint.config.mjs` only. `body-max-line-length` raised 100 → 132, and `footer-max-line-length` set explicitly to 132, with a comment recording the reasoning. Nothing else is touched.

## Verification

commitlint run locally over the promotion range `520cd22..5eb2b3a` with each config:

| config | result |
| --- | --- |
| current (`origin/beta/0.2.1`) | `✖ found 1 problems` — `footer-max-line-length` |
| this branch | `✔ found 0 problems, 0 warnings` |

This commit's own message was linted against the new config before it was written — subject 69 characters, longest body line 72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)