### PR TITLE
feat(cli): actana session — start, ls, logs, resume, kill and send, with the Core owning prompt delivery

### DIFF
--- a/packages/cli/src/__tests__/actana-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-cli.test.ts
@@ -25,7 +25,8 @@ afterEach(() => {
 
 /** Every noun reserved in the tree, and the ticket each names. */
 const RESERVED = [
-  ["session", "#160"],
+  // `session` left this list when #160 built it — the row moving out is what a
+  // noun landing looks like from here.
   ["project", "#161"],
   ["harness", "#161"],
   ["events", "#161"],
@@ -43,7 +44,7 @@ describe("a reserved noun is `not built yet`, not `you typed it wrong`", () => {
   });
 
   it("agrees with `core shell`, which is the same fact about the same build", async () => {
-    const noun = await cli().run(["session"]);
+    const noun = await cli().run(["project"]);
     const verb = await cli().run(["core", "shell"]);
     expect(noun.code).toBe(verb.code);
   });

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -12,6 +12,11 @@ import path from "node:path";
 import { runActanaCli } from "../actana-cli.ts";
 import { registryPaths, type RegistryPaths } from "../blob-registry.ts";
 import type { CoreProbe, CoreProbeFn } from "../core-probe.ts";
+import type {
+  OpenSessionGateway,
+  SessionGateway,
+  StartedSession,
+} from "../session-gateway.ts";
 
 /** One run's captured output, plus the exit code. */
 export type CliRun = {
@@ -44,8 +49,54 @@ export type RunOptions = {
   stdinIsTty?: boolean;
   /** What `core status` gets back, or a throw. */
   probe?: CoreProbeFn;
+  /** What the `session` noun's verbs get back, or a throw. */
+  sessions?: OpenSessionGateway;
   now?: number;
 };
+
+/**
+ * A Session that started, for a fake gateway to hand back.
+ *
+ * `wait` resolves with whatever the test says the Core reported — the CLI never
+ * decides idleness, so a fake has to be the one holding the answer.
+ */
+export function fakeStartedSession(overrides: Partial<StartedSession> = {}): StartedSession {
+  return {
+    taskId: "task_1",
+    ptyId: "pty_1",
+    harness: "claude-code",
+    command: "claude",
+    projectId: "proj_1",
+    project: "web",
+    wait: async () => ({ status: "finished", exited: false }),
+    screen: () => "the transcript",
+    dispose: () => {},
+    ...overrides,
+  };
+}
+
+/**
+ * A gateway that answers without a Core.
+ *
+ * Every verb throws by default and a test overrides the one it is about: a
+ * suite that reaches a verb it did not mean to exercise should fail loudly
+ * rather than pass against a stub that said yes.
+ */
+export function fakeSessionGateway(overrides: Partial<SessionGateway> = {}): OpenSessionGateway {
+  const refuse = (verb: string) => async () => {
+    throw new Error(`this test did not expect session ${verb}`);
+  };
+  return async () => ({
+    list: refuse("ls"),
+    start: refuse("start"),
+    resume: refuse("resume"),
+    logs: refuse("logs"),
+    send: refuse("send"),
+    kill: refuse("kill"),
+    close: () => {},
+    ...overrides,
+  });
+}
 
 /** A probe that answers like a healthy Core on the current protocol. */
 export function healthyProbe(overrides: Partial<CoreProbe> = {}): CoreProbeFn {
@@ -87,6 +138,11 @@ export function makeCliFixture(): CliFixture {
           opts.probe ??
           (async () => {
             throw new Error("this test did not expect to dial a Core");
+          }),
+        openSessions:
+          opts.sessions ??
+          (async () => {
+            throw new Error("this test did not expect to open a session gateway");
           }),
         now: () => opts.now ?? Date.UTC(2026, 7, 12),
       });

--- a/packages/cli/src/__tests__/harness-resume.test.ts
+++ b/packages/cli/src/__tests__/harness-resume.test.ts
@@ -1,0 +1,115 @@
+// The resume commands, checked against the machine that has to accept them.
+//
+// `harnessResumeCommand` builds a launch command per harness, and the Core's
+// spawn policy is what decides whether that command may run. A table that
+// drifts from the allow-list produces a `session resume` that always fails, and
+// it fails on the *Core*, where a CLI unit test would never see it — so this
+// suite runs every command it builds through `resolveSpawnPlan`, the same
+// function `packages/core` calls before spawning anything.
+//
+// Importing `@actana/shared` from a test is the arrangement `tsconfig.json` and
+// `vitest.config.ts` already describe and `no-local-escape.test.ts` enforces:
+// test-only, never from a shipped module.
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveSpawnPlan,
+  type SpawnPolicyDeps,
+  type SpawnRequest,
+} from "@actana/shared/pty-spawn-policy";
+import { harnessResumeCommand } from "../harness-resume.ts";
+import { KNOWN_HARNESSES } from "../session-gateway.ts";
+import type { CoreLinkPtySpawnHarness } from "@actana/sdk/core-link-frames.ts";
+
+const PROJECT_ROOT = "/home/core/projects/web";
+
+/** Session ids in the shape each harness actually reports one. */
+const SESSION_IDS: Record<CoreLinkPtySpawnHarness, string> = {
+  "claude-code": "00000000-0000-4000-8000-000000000000",
+  // The Core validates a codex resume id against its model-id pattern, which a
+  // UUID satisfies; a spelling it rejects is rejected there, not trimmed here.
+  codex: "019d7a0f-432a-7fa1-a821-b7841f983967",
+  "cursor-cli": "00000000-0000-4000-8000-000000000000",
+  // OpenCode ids carry a `ses` prefix and the Core insists on it.
+  opencode: "ses_01H8Z0MEXAMPLE",
+};
+
+function policyDeps(): SpawnPolicyDeps {
+  return {
+    cwdExists: () => true,
+    realpath: (p) => p,
+    projectRoots: () => [PROJECT_ROOT],
+    resolveCommand: (name) => `/usr/local/bin/${name}`,
+    resolveShell: () => ({ shell: "/bin/zsh", shellArgs: (cmd) => (cmd ? ["-l", "-c", cmd] : ["-l"]) }),
+  };
+}
+
+function planFor(harness: CoreLinkPtySpawnHarness, command: string, skip: boolean) {
+  return resolveSpawnPlan(
+    {
+      taskId: "t1",
+      cwd: PROJECT_ROOT,
+      command,
+      agent: harness,
+      ...(skip ? { dangerouslySkipPermissions: true } : {}),
+    } as SpawnRequest,
+    policyDeps(),
+  );
+}
+
+describe("harnessResumeCommand", () => {
+  it("spells resumption the way each harness spells it", () => {
+    expect(harnessResumeCommand("claude-code", "abc")).toBe("claude --resume abc");
+    // A subcommand, so it comes first — and the hooks flag stays on, or the
+    // resumed Session never reports its lifecycle and every wait on it hangs.
+    expect(harnessResumeCommand("codex", "abc")).toBe("codex resume abc --enable hooks");
+    expect(harnessResumeCommand("cursor-cli", "abc")).toBe("cursor-agent --resume abc");
+    expect(harnessResumeCommand("opencode", "ses_abc")).toBe("opencode --session ses_abc");
+  });
+
+  it("appends each harness's own skip-permissions flag, and none for OpenCode", () => {
+    const skip = { dangerouslySkipPermissions: true };
+    expect(harnessResumeCommand("claude-code", "abc", skip)).toContain("--dangerously-skip-permissions");
+    expect(harnessResumeCommand("codex", "abc", skip)).toContain("--yolo");
+    expect(harnessResumeCommand("cursor-cli", "abc", skip)).toContain("--force");
+    // OpenCode has no such flag. Inventing one would be a rejected spawn.
+    expect(harnessResumeCommand("opencode", "ses_abc", skip)).toBe("opencode --session ses_abc");
+  });
+
+  it("builds a command for every harness this build knows", () => {
+    // The guard on the guard: a harness added to the SDK with no entry here
+    // would otherwise be a `resume` that throws at run time.
+    for (const harness of KNOWN_HARNESSES) {
+      expect(harnessResumeCommand(harness, SESSION_IDS[harness]).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("the Core's spawn policy accepts what this builds", () => {
+  it("resolves a plan for every harness", () => {
+    for (const harness of KNOWN_HARNESSES) {
+      const plan = planFor(harness, harnessResumeCommand(harness, SESSION_IDS[harness]), false);
+      expect(plan.mode, `${harness} resume was not accepted as an agent spawn`).toBe("agent");
+    }
+  });
+
+  it("resolves a plan with skip-permissions on, which the policy gates on the option", () => {
+    for (const harness of KNOWN_HARNESSES) {
+      const command = harnessResumeCommand(harness, SESSION_IDS[harness], {
+        dangerouslySkipPermissions: true,
+      });
+      const plan = planFor(harness, command, true);
+      expect(plan.mode, `${harness} resume with --dangerously-skip-permissions was refused`).toBe("agent");
+    }
+  });
+
+  it("refuses the same command when the option did not travel with the flag", () => {
+    // Both halves of the gesture or neither — the gateway sends the option
+    // whenever it appends the flag, and this is what would catch it if it
+    // stopped doing so.
+    const command = harnessResumeCommand("claude-code", SESSION_IDS["claude-code"], {
+      dangerouslySkipPermissions: true,
+    });
+    expect(() => planFor("claude-code", command, false)).toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/in-process-core-harness.ts
+++ b/packages/cli/src/__tests__/in-process-core-harness.ts
@@ -1,0 +1,188 @@
+// A real Core, in this process, on a real `wss://` port.
+//
+// Extracted from `in-process-core.test.ts` when #160 wanted the same Core for
+// the `session` noun: `packages/core`'s real `PtyCoreLinkServer`, mTLS material
+// from the Core's own `generateCertMaterial`, and a bearer its own verifier
+// accepts. Two suites building that twice would be two chances to build it
+// slightly differently, and the difference would look like a CLI bug.
+//
+// The ports are arguments because that is what the two suites differ in:
+// `core status` reaches a Core that answers no request frames at all, and the
+// `session` verbs reach one holding tasks, projects and a live PTY. Everything
+// else — the handshake, the certificates, the blob an operator would be handed
+// — is identical, which is the point.
+
+import { Server } from "node:net";
+import https from "node:https";
+import { WebSocketServer } from "ws";
+import {
+  PtyCoreLinkServer,
+  type CoreMutationPort,
+  type CoreQueryPort,
+  type WebSocketLike as ServerSocketLike,
+  type WebSocketServerLike,
+} from "@actana/core/pty-core-link-server";
+import { generateCertMaterial } from "@actana/core/core-cert-material";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+
+export const SECRET = "cli-in-process-core-secret-at-least-32-bytes";
+export const CORE_ID = "core_in_process";
+
+/**
+ * A PTY manager that is never asked for anything.
+ *
+ * Every method throws rather than returning an empty: a verb that starts
+ * reaching the PTY manager when it was not meant to should fail loudly instead
+ * of quietly proving less. Suites that *do* mean to reach it pass their own.
+ */
+export function unusedPtyCore(): never[] & Record<string, unknown> {
+  const unreachable = (name: string) => () => {
+    throw new Error(`this suite reached the PTY manager (${name}) — it is meant to be read-only`);
+  };
+  return {
+    setEmitTarget: () => {},
+    spawn: unreachable("spawn"),
+    write: unreachable("write"),
+    resize: unreachable("resize"),
+    kill: unreachable("kill"),
+    killAll: unreachable("killAll"),
+    killLaunchProcesses: unreachable("killLaunchProcesses"),
+    killPtysUnderPath: unreachable("killPtysUnderPath"),
+    findByTask: unreachable("findByTask"),
+    taskIdForPty: () => null,
+    replay: unreachable("replay"),
+  } as unknown as never[] & Record<string, unknown>;
+}
+
+/** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
+export function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = new Server();
+    s.on("error", reject);
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      if (addr && typeof addr === "object") {
+        const { port } = addr;
+        s.close(() => resolve(port));
+      } else {
+        s.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+/**
+ * The real `wss://` server the Core builds, with the bound port recorded.
+ * `requestCert` plus `rejectUnauthorized` are what make this a mutual
+ * handshake — without them the blob's client cert would be decoration.
+ */
+function recordingCreateServer(
+  bound: { port: number },
+): (opts: { port: number; host: string; tls?: unknown }) => WebSocketServerLike {
+  return (opts) => {
+    const tls = opts.tls as { caCert: string; serverCert: string; serverKey: string };
+    const tlsServer = https.createServer({
+      cert: tls.serverCert,
+      key: tls.serverKey,
+      ca: tls.caCert,
+      requestCert: true,
+      rejectUnauthorized: true,
+    });
+    tlsServer.listen(opts.port, opts.host, () => {
+      const addr = tlsServer.address();
+      if (addr && typeof addr === "object") bound.port = addr.port;
+    });
+    const wss = new WebSocketServer({ server: tlsServer });
+    return {
+      close: (cb?: () => void) => wss.close(() => tlsServer.close(cb)),
+      on: (event: string, cb: unknown) => {
+        if (event === "connection") {
+          wss.on("connection", (ws) => (cb as (s: ServerSocketLike) => void)(adapt(ws)));
+        } else if (event === "error") {
+          wss.on("error", (err: Error) => (cb as (e: Error) => void)(err));
+        }
+      },
+    } as WebSocketServerLike;
+  };
+}
+
+function adapt(ws: import("ws").WebSocket): ServerSocketLike {
+  return {
+    get readyState() {
+      return ws.readyState;
+    },
+    send: (data: string) => ws.send(data),
+    close: () => ws.close(),
+    on: (event: string, cb: unknown) => {
+      if (event === "message") ws.on("message", (d: unknown) => (cb as (d: unknown) => void)(d));
+      else if (event === "close") ws.on("close", () => (cb as () => void)());
+      else if (event === "error") ws.on("error", (e: Error) => (cb as (e: Error) => void)(e));
+    },
+    removeAllListeners: () => ws.removeAllListeners(),
+  } as ServerSocketLike;
+}
+
+export type InProcessCore = {
+  server: PtyCoreLinkServer;
+  /** The base64 blob an operator would be handed for this Core. */
+  blobText: string;
+  endpoint: string;
+};
+
+/** Start a Core on a real port, and build the blob that reaches it. */
+export async function startInProcessCore(
+  opts: {
+    protocolVersion?: string;
+    bearerExpiresInMs?: number;
+    ptyCore?: unknown;
+    queryPort?: CoreQueryPort;
+    mutationPort?: CoreMutationPort;
+  } = {},
+): Promise<InProcessCore> {
+  const material = await generateCertMaterial({ host: "127.0.0.1" });
+  const port = await freePort();
+  const bound = { port: 0 };
+  const server = new PtyCoreLinkServer((opts.ptyCore ?? unusedPtyCore()) as never, {
+    port,
+    host: "127.0.0.1",
+    createServer: recordingCreateServer(bound),
+    tls: {
+      caCert: material.ca.cert,
+      serverCert: material.server.cert,
+      serverKey: material.server.key,
+    },
+    authVerifier: (bearer: string) => verifyBearer(bearer, SECRET),
+    ...(opts.protocolVersion === undefined ? {} : { protocolVersion: opts.protocolVersion }),
+    ...(opts.queryPort === undefined ? {} : { queryPort: opts.queryPort }),
+    ...(opts.mutationPort === undefined ? {} : { mutationPort: opts.mutationPort }),
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const deadline = Date.now() + 10_000;
+    const tick = () => {
+      if (bound.port > 0) return resolve();
+      if (Date.now() > deadline) return reject(new Error("TLS server never bound"));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+
+  const endpoint = `wss://127.0.0.1:${bound.port}`;
+  const blobText = Buffer.from(
+    JSON.stringify({
+      endpoint,
+      label: "in-process",
+      caCert: material.ca.cert,
+      clientCert: material.client.cert,
+      clientKey: material.client.key,
+      bearer: signBearer(
+        { coreId: CORE_ID, exp: Date.now() + (opts.bearerExpiresInMs ?? 3_600_000) },
+        SECRET,
+      ),
+    }),
+    "utf8",
+  ).toString("base64");
+
+  return { server, blobText, endpoint };
+}

--- a/packages/cli/src/__tests__/in-process-core-session.test.ts
+++ b/packages/cli/src/__tests__/in-process-core-session.test.ts
@@ -1,0 +1,274 @@
+// The `session` noun against a Core that is actually running (#160).
+//
+// `session-command.test.ts` injects the gateway, which is what makes the flags,
+// the tables, the `--json` shapes and the exit codes testable without a Core —
+// and is exactly why it cannot say whether the frames this noun sends are the
+// ones a Core answers. This suite closes that gap the way
+// `in-process-core.test.ts` closed it for `core status`: the real
+// `PtyCoreLinkServer` on a real `wss://` port, the real `openSessionGateway`,
+// and nothing faked between them except the machine they would otherwise be on.
+//
+// The Core here holds **Sessions this CLI did not start** — a task list, a
+// project list, and a PTY that was already running when the command was typed.
+// That is not scene-setting: it is the ticket's criterion. Nothing about having
+// started a Session is remembered locally, so `ls`, `logs`, `send` and `kill`
+// have nothing to recognise and work on any Session on the Core.
+//
+// Starting a Session is deliberately not exercised here. A spawn needs a real
+// harness binary on this machine's PATH and a real PTY, which is
+// `packages/sdk`'s `live-session.test.ts` — an opt-in suite against an
+// operator's own Core. What is provable without one is proved here.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
+import type {
+  CoreLinkProjectSnapshot,
+  CoreLinkSessionSnapshot,
+  CoreLinkTaskSnapshot,
+} from "@actana/sdk/core-link-frames.ts";
+import { openSessionGateway } from "../session-gateway.ts";
+import { EXIT_FAILURE, EXIT_OK } from "../exit-codes.ts";
+import { makeCliFixture, type CliFixture } from "./cli-harness.ts";
+import { startInProcessCore } from "./in-process-core-harness.ts";
+
+const PROJECT: CoreLinkProjectSnapshot = {
+  projectId: "proj_web",
+  name: "web",
+  path: "/home/core/projects/web",
+  icon: "WE",
+  iconColor: "#123456",
+  pinned: false,
+  rememberHarnessSettings: false,
+  savedHarness: null,
+  savedSkipPermissions: false,
+  savedBareSession: false,
+  defaultGridView: false,
+  updatedAt: 1_700_000_000_000,
+};
+
+function task(overrides: Partial<CoreLinkTaskSnapshot> = {}): CoreLinkTaskSnapshot {
+  return {
+    taskId: "task_live",
+    projectId: PROJECT.projectId,
+    title: "rebuild the flaky auth test",
+    titleManuallySet: false,
+    claudeSessionId: "00000000-0000-4000-8000-000000000000",
+    agent: "claude-code",
+    status: "running",
+    pinned: false,
+    archived: false,
+    icon: null,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+/**
+ * The transcript a harness actually produces: a repainted line, not a log.
+ *
+ * `ESC[1G` walks the cursor back to column one and the next write lands on top
+ * of what was there. Concatenated raw, this reads `Scanning…Scanning… 2
+ * filesdone: 3 files changed`; rendered, it reads what a terminal would be
+ * showing. That difference is the ticket's `logs` trap, and it is asserted in
+ * both directions below.
+ */
+const REPAINTED =
+  "\u001B[2J\u001B[H\u001B[1GScanning…\u001B[1GScanning… 2 files\u001B[1Gdone: 3 files changed\r\n";
+
+/** A PTY manager holding one live PTY, and a record of what was done to it. */
+function livePtyCore(): {
+  core: unknown;
+  writes: string[];
+  killed: string[];
+} {
+  const writes: string[] = [];
+  const killed: string[] = [];
+  const ptys = new Map<string, string>([["task_live", "pty_live"]]);
+  const core = {
+    setEmitTarget: () => {},
+    findByTask: (taskId: string) => ({ ptyId: ptys.get(taskId) ?? null }),
+    taskIdForPty: (ptyId: string) =>
+      [...ptys.entries()].find(([, id]) => id === ptyId)?.[0] ?? null,
+    replay: (ptyId: string) =>
+      ptyId === "pty_live"
+        ? { data: REPAINTED, nextSeq: 1 }
+        : { data: "", nextSeq: 0 },
+    write: (ptyId: string, data: string) => {
+      if (ptyId !== "pty_live") return false;
+      writes.push(data);
+      return true;
+    },
+    kill: (ptyId: string) => {
+      if (ptyId !== "pty_live") return false;
+      killed.push(ptyId);
+      for (const [taskId, id] of ptys) if (id === ptyId) ptys.delete(taskId);
+      return true;
+    },
+    resize: () => true,
+    spawn: () => {
+      throw new Error("this suite does not spawn — see the header");
+    },
+    killAll: () => {},
+    killLaunchProcesses: () => ({ ptyCount: 0, ports: [] }),
+    killPtysUnderPath: () => {},
+  };
+  return { core, writes, killed };
+}
+
+/** Task and project reads, answered from memory. */
+function ports(tasks: CoreLinkTaskSnapshot[], live: (taskId: string) => string | null) {
+  const sessions = (): CoreLinkSessionSnapshot[] =>
+    tasks
+      .filter((row) => !row.archived)
+      .map((row) => ({
+        taskId: row.taskId,
+        ptyId: live(row.taskId),
+        status: row.status,
+        updatedAt: row.updatedAt,
+      }));
+  return {
+    queryPort: {
+      listProjects: () => [PROJECT],
+      listTasks: () => tasks.filter((row) => !row.archived),
+      listArchivedTasks: () => tasks.filter((row) => row.archived),
+      countArchivedTasks: () => tasks.filter((row) => row.archived).length,
+      getTask: (taskId: string) => tasks.find((row) => row.taskId === taskId) ?? null,
+    },
+    mutationPort: {
+      mutateProject: () => null,
+      mutateTask: () => null,
+      listSessions: sessions,
+    },
+  };
+}
+
+let server: PtyCoreLinkServer | null = null;
+let fixture: CliFixture | null = null;
+
+afterEach(() => {
+  server?.close();
+  server = null;
+  fixture?.cleanup();
+  fixture = null;
+});
+
+/** A Core holding one live Session and one that has already stopped. */
+async function coreWithSessions(): Promise<{ writes: string[]; killed: string[] }> {
+  const pty = livePtyCore();
+  const tasks = [
+    task(),
+    task({ taskId: "task_done", title: "ship the changelog", status: "finished" }),
+  ];
+  const { queryPort, mutationPort } = ports(tasks, (taskId) =>
+    (pty.core as { findByTask(id: string): { ptyId: string | null } }).findByTask(taskId).ptyId,
+  );
+  const core = await startInProcessCore({ ptyCore: pty.core, queryPort, mutationPort });
+  server = core.server;
+  fixture = makeCliFixture();
+  await fixture.run(["core", "add", "inproc"], { stdin: core.blobText });
+  return { writes: pty.writes, killed: pty.killed };
+}
+
+/** Every session verb dials the Core for real in this suite. */
+function withCore() {
+  return { sessions: openSessionGateway };
+}
+
+describe("actana session, against a Core in this process", () => {
+  it("lists the Sessions the Core holds, with the live one marked", async () => {
+    await coreWithSessions();
+
+    const run = await fixture!.run(["session", "ls", "--json"], withCore());
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+
+    const rows = JSON.parse(run.out.join("\n")) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    const live = rows.find((row) => row.taskId === "task_live")!;
+    expect(live.live).toBe(true);
+    expect(live.ptyId).toBe("pty_live");
+    // Joined off the Task rows: `sessionsList` carries neither, and a listing
+    // that showed only ids would be unreadable.
+    expect(live.title).toBe("rebuild the flaky auth test");
+    expect(live.project).toBe("web");
+    expect(live.harness).toBe("claude-code");
+    expect(rows.find((row) => row.taskId === "task_done")!.live).toBe(false);
+  }, 30_000);
+
+  it("renders the transcript rather than concatenating the bytes", async () => {
+    await coreWithSessions();
+
+    const rendered = await fixture!.run(["session", "logs", "task_live"], withCore());
+    expect(rendered.code, rendered.err.join("\n")).toBe(EXIT_OK);
+    const screen = rendered.out.join("\n");
+    expect(screen).toContain("done: 3 files changed");
+    // The repaints are gone, which is the whole difference between a screen and
+    // a byte log — and they are gone because the SDK's terminal drew them, not
+    // because an escape stripper deleted them.
+    expect(screen).not.toContain("Scanning…");
+    expect(screen).not.toContain("\u001B");
+
+    const raw = await fixture!.run(["session", "logs", "task_live", "--raw"], withCore());
+    expect(raw.code).toBe(EXIT_OK);
+    expect(raw.out.join("\n")).toContain("\u001B[1G");
+  }, 30_000);
+
+  it("sends exactly the bytes it was given, and adds a return only when asked", async () => {
+    const { writes } = await coreWithSessions();
+
+    const sent = await fixture!.run(["session", "send", "task_live", "2"], withCore());
+    expect(sent.code, sent.err.join("\n")).toBe(EXIT_OK);
+    // No carriage return, no second write, no timer: prompt delivery is the
+    // Core's (ADR 0026) and `send` is the equivalent of typing.
+    expect(writes).toEqual(["2"]);
+
+    const withEnter = await fixture!.run(["session", "send", "task_live", "2", "--enter"], withCore());
+    expect(withEnter.code).toBe(EXIT_OK);
+    expect(writes).toEqual(["2", "2", "\r"]);
+  }, 30_000);
+
+  it("kills a Session this CLI did not start", async () => {
+    // The ticket's criterion, stated as a test: the PTY below was running
+    // before this process existed, and the only thing naming it is a Task id.
+    const { killed } = await coreWithSessions();
+
+    const run = await fixture!.run(["session", "kill", "task_live", "--json"], withCore());
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    expect(killed).toEqual(["pty_live"]);
+    expect(JSON.parse(run.out.join("\n"))).toEqual({
+      taskId: "task_live",
+      ptyId: "pty_live",
+      killed: true,
+    });
+
+    // And it is gone: the second kill finds no PTY and says so rather than
+    // reporting a success the Core did not perform.
+    const again = await fixture!.run(["session", "kill", "task_live", "--json"], withCore());
+    expect(again.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(again.out.join("\n")).error).toContain("no harness running");
+  }, 30_000);
+
+  it("says a stopped Session has no transcript rather than printing an empty one", async () => {
+    await coreWithSessions();
+
+    const run = await fixture!.run(["session", "logs", "task_done", "--json"], withCore());
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(run.out.join("\n")).error).toContain("no harness running");
+    expect(run.err.join("\n")).toContain("actana session logs");
+  }, 30_000);
+
+  it("puts nothing but JSON on stdout, on the failing path as well as the happy one", async () => {
+    await coreWithSessions();
+
+    for (const argv of [
+      ["session", "ls", "--json", "--verbose"],
+      ["session", "logs", "task_live", "--json", "--verbose"],
+      ["session", "logs", "task_missing", "--json", "--verbose"],
+      ["session", "kill", "task_missing", "--json", "--verbose"],
+    ]) {
+      const run = await fixture!.run(argv, withCore());
+      // One document, parsed whole. A single stray progress line would throw.
+      expect(() => JSON.parse(run.out.join("\n")), `${argv.join(" ")} put prose on stdout`).not.toThrow();
+      expect(run.err.length, `${argv.join(" ")} sent nothing to stderr`).toBeGreaterThan(0);
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/__tests__/in-process-core.test.ts
+++ b/packages/cli/src/__tests__/in-process-core.test.ts
@@ -25,119 +25,16 @@
 // A test-only module alias buys the coverage without the graph.
 
 import { describe, it, expect, afterEach } from "vitest";
-import { Server } from "node:net";
-import https from "node:https";
-import { WebSocketServer } from "ws";
-import {
-  PtyCoreLinkServer,
-  type WebSocketLike as ServerSocketLike,
-  type WebSocketServerLike,
-} from "@actana/core/pty-core-link-server";
-import { generateCertMaterial } from "@actana/core/core-cert-material";
-import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
 import { probeCore } from "../core-probe.ts";
 import { EXIT_FAILURE, EXIT_OK } from "../exit-codes.ts";
 import { makeCliFixture, type CliFixture } from "./cli-harness.ts";
+import { CORE_ID, startInProcessCore } from "./in-process-core-harness.ts";
 
-const SECRET = "cli-in-process-core-secret-at-least-32-bytes";
-const CORE_ID = "core_in_process";
-
-/**
- * A PTY manager that is never asked for anything.
- *
- * `core status` sends no request frames at all — it reads the `ready` and
- * `authOk` frames the Core opens every connection with, and hangs up — so every
- * method here is unreachable by design rather than by stubbing. They throw
- * rather than returning empties: if a later change to the probe starts spawning
- * something, this suite should fail loudly instead of quietly proving less.
- */
-function unusedPtyCore(): never[] & Record<string, unknown> {
-  const unreachable = (name: string) => () => {
-    throw new Error(`core status reached the PTY manager (${name}) — it is meant to be read-only`);
-  };
-  return {
-    setEmitTarget: () => {},
-    spawn: unreachable("spawn"),
-    write: unreachable("write"),
-    resize: unreachable("resize"),
-    kill: unreachable("kill"),
-    killAll: unreachable("killAll"),
-    killLaunchProcesses: unreachable("killLaunchProcesses"),
-    killPtysUnderPath: unreachable("killPtysUnderPath"),
-    findByTask: unreachable("findByTask"),
-    taskIdForPty: () => null,
-    replay: unreachable("replay"),
-  } as unknown as never[] & Record<string, unknown>;
-}
-
-/** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
-function freePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const s = new Server();
-    s.on("error", reject);
-    s.listen(0, "127.0.0.1", () => {
-      const addr = s.address();
-      if (addr && typeof addr === "object") {
-        const { port } = addr;
-        s.close(() => resolve(port));
-      } else {
-        s.close();
-        reject(new Error("no port"));
-      }
-    });
-  });
-}
-
-/**
- * The real `wss://` server the Core builds, with the bound port recorded.
- * `requestCert` plus `rejectUnauthorized` are what make this a mutual
- * handshake — without them the blob's client cert would be decoration.
- */
-function recordingCreateServer(
-  bound: { port: number },
-): (opts: { port: number; host: string; tls?: unknown }) => WebSocketServerLike {
-  return (opts) => {
-    const tls = opts.tls as { caCert: string; serverCert: string; serverKey: string };
-    const tlsServer = https.createServer({
-      cert: tls.serverCert,
-      key: tls.serverKey,
-      ca: tls.caCert,
-      requestCert: true,
-      rejectUnauthorized: true,
-    });
-    tlsServer.listen(opts.port, opts.host, () => {
-      const addr = tlsServer.address();
-      if (addr && typeof addr === "object") bound.port = addr.port;
-    });
-    const wss = new WebSocketServer({ server: tlsServer });
-    return {
-      close: (cb?: () => void) => wss.close(() => tlsServer.close(cb)),
-      on: (event: string, cb: unknown) => {
-        if (event === "connection") {
-          wss.on("connection", (ws) => (cb as (s: ServerSocketLike) => void)(adapt(ws)));
-        } else if (event === "error") {
-          wss.on("error", (err: Error) => (cb as (e: Error) => void)(err));
-        }
-      },
-    } as WebSocketServerLike;
-  };
-}
-
-function adapt(ws: import("ws").WebSocket): ServerSocketLike {
-  return {
-    get readyState() {
-      return ws.readyState;
-    },
-    send: (data: string) => ws.send(data),
-    close: () => ws.close(),
-    on: (event: string, cb: unknown) => {
-      if (event === "message") ws.on("message", (d: unknown) => (cb as (d: unknown) => void)(d));
-      else if (event === "close") ws.on("close", () => (cb as () => void)());
-      else if (event === "error") ws.on("error", (e: Error) => (cb as (e: Error) => void)(e));
-    },
-    removeAllListeners: () => ws.removeAllListeners(),
-  } as ServerSocketLike;
-}
+// The Core itself, the certificates and the blob live in
+// `in-process-core-harness.ts` — #160 needed the same Core for the `session`
+// verbs, and two suites standing one up separately would be two chances to
+// build it slightly differently.
 
 let server: PtyCoreLinkServer | null = null;
 let fixture: CliFixture | null = null;
@@ -153,49 +50,9 @@ afterEach(() => {
 async function startCore(
   opts: { protocolVersion?: string; bearerExpiresInMs?: number } = {},
 ): Promise<{ blobText: string; endpoint: string }> {
-  const material = await generateCertMaterial({ host: "127.0.0.1" });
-  const port = await freePort();
-  const bound = { port: 0 };
-  server = new PtyCoreLinkServer(unusedPtyCore() as never, {
-    port,
-    host: "127.0.0.1",
-    createServer: recordingCreateServer(bound),
-    tls: {
-      caCert: material.ca.cert,
-      serverCert: material.server.cert,
-      serverKey: material.server.key,
-    },
-    authVerifier: (bearer: string) => verifyBearer(bearer, SECRET),
-    ...(opts.protocolVersion === undefined ? {} : { protocolVersion: opts.protocolVersion }),
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    const deadline = Date.now() + 10_000;
-    const tick = () => {
-      if (bound.port > 0) return resolve();
-      if (Date.now() > deadline) return reject(new Error("TLS server never bound"));
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
-
-  const endpoint = `wss://127.0.0.1:${bound.port}`;
-  const blobText = Buffer.from(
-    JSON.stringify({
-      endpoint,
-      label: "in-process",
-      caCert: material.ca.cert,
-      clientCert: material.client.cert,
-      clientKey: material.client.key,
-      bearer: signBearer(
-        { coreId: CORE_ID, exp: Date.now() + (opts.bearerExpiresInMs ?? 3_600_000) },
-        SECRET,
-      ),
-    }),
-    "utf8",
-  ).toString("base64");
-
-  return { blobText, endpoint };
+  const core = await startInProcessCore(opts);
+  server = core.server;
+  return { blobText: core.blobText, endpoint: core.endpoint };
 }
 
 describe("actana core status, against a Core in this process", () => {

--- a/packages/cli/src/__tests__/never-logs-a-blob.test.ts
+++ b/packages/cli/src/__tests__/never-logs-a-blob.test.ts
@@ -16,6 +16,8 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
+  fakeSessionGateway,
+  fakeStartedSession,
   healthyProbe,
   makeCliFixture,
   sentinelBlobText,
@@ -71,6 +73,47 @@ describe("no verb prints a blob, with --verbose on", () => {
 
     for (const [what, argv] of runs) {
       const run = await cli().run(argv, { probe: healthyProbe() });
+      expectNoSecrets(what, run.all);
+    }
+  });
+
+  it("sweeps every session verb, which dials with the same credential (#160)", async () => {
+    // The `session` noun resolves a blob on every verb and hands it to a
+    // gateway, so it has the credential in scope everywhere — including on the
+    // failure path, which is where a diagnostic would quote what it dialled
+    // with. The gateway refuses so that path is the one swept; the successes
+    // are covered by the verbs above it.
+    await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() });
+
+    const refusing = fakeSessionGateway({
+      list: async () => {
+        throw new Error("the Core refused");
+      },
+      kill: async () => {
+        throw new Error("the Core refused");
+      },
+    });
+    const starting = fakeSessionGateway({
+      start: async () => fakeStartedSession(),
+      resume: async () => fakeStartedSession(),
+      logs: async () => ({ taskId: "task_1", ptyId: "pty_1", screen: "a screen", raw: "raw" }),
+      send: async () => true,
+    });
+
+    const runs: Array<[string, string[], typeof refusing]> = [
+      ["session ls", ["session", "ls", "--verbose"], refusing],
+      ["session ls --json", ["session", "ls", "--json", "--verbose"], refusing],
+      ["session kill", ["session", "kill", "task_1", "--verbose"], refusing],
+      ["session start", ["session", "start", "web", "go", "--verbose"], starting],
+      ["session start --json", ["session", "start", "web", "go", "--json", "--verbose"], starting],
+      ["session resume", ["session", "resume", "task_1", "--verbose"], starting],
+      ["session logs", ["session", "logs", "task_1", "--verbose"], starting],
+      ["session send", ["session", "send", "task_1", "hi", "--verbose"], starting],
+      ["session --help", ["session", "--help", "--verbose"], refusing],
+    ];
+
+    for (const [what, argv, sessions] of runs) {
+      const run = await cli().run(argv, { sessions });
       expectNoSecrets(what, run.all);
     }
   });

--- a/packages/cli/src/__tests__/no-prompt-timing.test.ts
+++ b/packages/cli/src/__tests__/no-prompt-timing.test.ts
@@ -1,0 +1,115 @@
+// Prompt delivery is the Core's job, and this is what keeps it that way (#160,
+// #129 D3, ADR 0026).
+//
+// The trap this suite exists for is not hypothetical — it is the 450 ms
+// `initialInput` timer #191 deleted from the Core, and the shape it takes in a
+// client is always the same: a harness misses a prompt, somebody adds "wait a
+// moment, then press Enter again" to whichever program is closest to the
+// complaint, and the bug moves from one machine that could fix it to every
+// client that could not. So the rule is a property of the package rather than a
+// paragraph in a header:
+//
+//   **Nothing shipped in `packages/cli` schedules anything.** No timer, no
+//   sleep, no delay, no retry loop, and no carriage return appended to text on
+//   its way to a Session. A prompt that does not arrive is a Core bug, and it
+//   must stay visible as one.
+//
+// The one deadline the CLI does have — `session start --wait --wait-timeout` —
+// is a number handed to the SDK's `waitForIdle`, which is watching the Core's
+// event log. It cannot make a Session look ready sooner, it cannot re-send
+// anything, and its expiry is reported as this side giving up rather than as a
+// status. Passing a number is not scheduling; that is why the sweep below looks
+// for the scheduling primitives themselves.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const SRC = path.resolve(import.meta.dirname, "..");
+
+/** Every shipped module — this package's own source at any depth, tests excluded. */
+function shippedSources(dir: string = SRC): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  )) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      files.push(...shippedSources(full));
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Source with its comments removed.
+ *
+ * Every file in this package explains the rule it obeys, and those headers name
+ * the very things swept for — `setTimeout`, the 450 ms timer, the carriage
+ * return the Core sends. Scanning the prose would make documenting a rule
+ * indistinguishable from breaking it.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[^\n"'`]*\/\/[^\n]*$/gm, "");
+}
+
+/** The ways a program schedules something for later. */
+const SCHEDULERS = [
+  /\bsetTimeout\s*\(/,
+  /\bsetInterval\s*\(/,
+  /\bsetImmediate\s*\(/,
+  /\bqueueMicrotask\s*\(/,
+  /\bnew\s+Promise\s*\([^)]*\)\s*=>\s*setTimeout/,
+];
+
+describe("the CLI schedules nothing (#129 D3, ADR 0026)", () => {
+  it("has sources to sweep", () => {
+    // The guard on the guard: a sweep over an empty list proves nothing.
+    expect(shippedSources().length).toBeGreaterThan(5);
+  });
+
+  it("contains no timer, anywhere", () => {
+    for (const file of shippedSources()) {
+      const source = withoutComments(readFileSync(file, "utf8"));
+      for (const scheduler of SCHEDULERS) {
+        expect(
+          scheduler.test(source),
+          `${path.relative(SRC, file)} schedules something — prompt delivery is the Core's (ADR 0026)`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("reads the clock in exactly one place, and only to print an age", () => {
+    // `Date.now()` is bound once, in the entry file, and reaches the command
+    // tree as an injected `now()` that two lines of formatting call: the
+    // bearer-expiry line and `session ls`'s age column. A second reader would
+    // be the beginning of something measuring elapsed time, which is what a
+    // timing decision looks like before it grows a `setTimeout`.
+    const readers = shippedSources().filter((file) =>
+      /\bDate\s*\.\s*now\s*\(/.test(withoutComments(readFileSync(file, "utf8"))),
+    );
+    expect(readers.map((file) => path.relative(SRC, file))).toEqual(["actana-cli-entry.ts"]);
+  });
+
+  it("never appends a carriage return to text on its way to a Session", () => {
+    // `session send --enter` writes one, as a **separate** write, because the
+    // operator asked for it in that invocation. What must not exist is a return
+    // glued onto somebody's text — that is the CLI deciding when a prompt is
+    // submitted, which is the decision ADR 0026 moved to the Core.
+    for (const file of shippedSources()) {
+      const source = withoutComments(readFileSync(file, "utf8"));
+      expect(source, `${path.relative(SRC, file)} appends a carriage return to text`).not.toMatch(
+        /(text|prompt|data|input)\s*\+\s*["'`]\\r/,
+      );
+      expect(source, `${path.relative(SRC, file)} interpolates a carriage return after text`).not.toMatch(
+        /\$\{\s*(text|prompt|data|input)\s*\}\\r/,
+      );
+    }
+  });
+});

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -410,20 +410,52 @@ describe("actana session send", () => {
     expect(run.out).toEqual([]);
   });
 
-  it("sends a carriage return as a separate write, and only with --enter", async () => {
+  it("asks for the return in the same call, so the PTY is resolved once", async () => {
     await withRegisteredCore();
-    const writes: string[] = [];
+    const calls: Array<{ text: string; enter: boolean | undefined }> = [];
     const run = await cli().run(["session", "send", "task_1", "2", "--enter", "--json"], {
       sessions: fakeSessionGateway({
-        send: async (_taskId, text) => {
-          writes.push(text);
+        send: async (_taskId, text, opts) => {
+          calls.push({ text, enter: opts?.enter });
           return true;
         },
       }),
     });
     expect(run.code).toBe(EXIT_OK);
-    expect(writes).toEqual(["2", "\r"]);
+    // One call, not two: the gateway resolves the PTY once and writes both, so
+    // there is no window in which the text lands and the return goes nowhere.
+    // That the return is a *separate write* to that PTY is asserted against a
+    // real Core in `in-process-core-session.test.ts`.
+    expect(calls).toEqual([{ text: "2", enter: true }]);
     expect(JSON.parse(run.out.join("\n"))).toMatchObject({ enter: true, delivered: true });
+  });
+
+  it("refuses empty stdin rather than reporting a delivery it never made", async () => {
+    await withRegisteredCore();
+    // The Core is never reached, so the fixture's gateway would throw if it
+    // were — which is the assertion: nothing claimed a write it did not do.
+    const run = await cli().run(["session", "send", "task_1", "-"], {
+      sessions: fakeSessionGateway(),
+      stdin: "",
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("stdin was empty");
+  });
+
+  it("still sends a bare carriage return when stdin is empty and --enter was asked for", async () => {
+    await withRegisteredCore();
+    const calls: Array<{ text: string; enter: boolean | undefined }> = [];
+    const run = await cli().run(["session", "send", "task_1", "-", "--enter"], {
+      sessions: fakeSessionGateway({
+        send: async (_taskId, text, opts) => {
+          calls.push({ text, enter: opts?.enter });
+          return true;
+        },
+      }),
+      stdin: "",
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    expect(calls).toEqual([{ text: "", enter: true }]);
   });
 
   it("fails when the Core declined the write", async () => {

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -1,0 +1,510 @@
+// The `session` noun's surface: flags, output, exit codes (#160).
+//
+// The gateway is injected (`session-gateway.ts` is the only module that dials),
+// so everything here runs with no Core and no socket — which is what makes it
+// possible to assert the things a Core would otherwise hide: that `start`
+// returns without waiting, that stdout carries the id and nothing else, that
+// `--json` never shares stdout with prose, and that a flag a verb does not take
+// is refused rather than ignored.
+//
+// `in-process-core-session.test.ts` is the other half: the same verbs against a
+// real `PtyCoreLinkServer`, proving the frames are the ones a Core answers.
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  fakeSessionGateway,
+  fakeStartedSession,
+  makeCliFixture,
+  sentinelBlobText,
+  type CliFixture,
+} from "./cli-harness.ts";
+import { SessionGatewayError, type SessionRow } from "../session-gateway.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "../exit-codes.ts";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+});
+
+/** A registered Core, so resolution finds one and the verbs get as far as the gateway. */
+async function withRegisteredCore(): Promise<void> {
+  await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() });
+}
+
+function row(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    taskId: "task_1",
+    title: "fix the flaky test",
+    harness: "claude-code",
+    status: "running",
+    projectId: "proj_1",
+    project: "web",
+    ptyId: "pty_1",
+    live: true,
+    writable: null,
+    lock: null,
+    updatedAt: Date.UTC(2026, 7, 12) - 3_600_000,
+    ...overrides,
+  };
+}
+
+describe("actana session — the command tree", () => {
+  it("prints its help, and a bare `session` is a usage error", async () => {
+    const help = await cli().run(["session", "--help"]);
+    expect(help.code).toBe(EXIT_OK);
+    expect(help.out.join("\n")).toContain("actana session start <project> [prompt]");
+
+    const bare = await cli().run(["session"]);
+    expect(bare.code).toBe(EXIT_USAGE);
+  });
+
+  it("names #163 for `attach` rather than failing as an unknown verb", async () => {
+    const run = await cli().run(["session", "attach", "task_1"]);
+    // The distinction `exit-codes.ts` exists to draw: reserved, not mistyped.
+    expect(run.code).toBe(EXIT_UNIMPLEMENTED);
+    expect(run.err.join("\n")).toContain("#163");
+  });
+
+  it("rejects an unknown verb without dialling anything", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "detach", "task_1"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain('unknown verb "detach"');
+  });
+
+  it("refuses a flag the verb does not take rather than ignoring it", async () => {
+    await withRegisteredCore();
+    // `--wait` on `kill` is an instruction that would otherwise be silently
+    // dropped, and the operator would believe they had waited.
+    const run = await cli().run(["session", "kill", "task_1", "--wait"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--wait does not apply here");
+  });
+
+  it("says which Core it could not find when none is selected", async () => {
+    const run = await cli().run(["session", "ls"], { sessions: fakeSessionGateway() });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("no Core selected");
+  });
+});
+
+describe("actana session ls", () => {
+  it("renders a table, and the lock column only when the Core publishes one", async () => {
+    await withRegisteredCore();
+    const plain = await cli().run(["session", "ls"], {
+      sessions: fakeSessionGateway({ list: async () => [row()] }),
+    });
+    expect(plain.code, plain.err.join("\n")).toBe(EXIT_OK);
+    expect(plain.out[0]).toContain("SESSION");
+    expect(plain.out[0]).not.toContain("LOCK");
+    expect(plain.out[1]).toContain("task_1");
+    expect(plain.out[1]).toContain("fix the flaky test");
+    // Relative age, from the injected clock rather than the wall clock.
+    expect(plain.out[1]).toContain("1h");
+
+    const locked = await cli().run(["session", "ls"], {
+      sessions: fakeSessionGateway({
+        list: async () => [row({ lock: "held-by-another", writable: false })],
+      }),
+    });
+    expect(locked.out[0]).toContain("LOCK");
+    expect(locked.out[1]).toContain("other");
+  });
+
+  it("says so when there are none, in both output modes", async () => {
+    await withRegisteredCore();
+    const human = await cli().run(["session", "ls"], {
+      sessions: fakeSessionGateway({ list: async () => [] }),
+    });
+    expect(human.code).toBe(EXIT_OK);
+    expect(human.out.join("\n")).toContain("No sessions");
+
+    const json = await cli().run(["session", "ls", "--json"], {
+      sessions: fakeSessionGateway({ list: async () => [] }),
+    });
+    expect(JSON.parse(json.out.join("\n"))).toEqual([]);
+  });
+
+  it("passes a project filter through as typed", async () => {
+    await withRegisteredCore();
+    let asked: string | null | undefined;
+    const run = await cli().run(["session", "ls", "web"], {
+      sessions: fakeSessionGateway({
+        list: async (project) => {
+          asked = project;
+          return [];
+        },
+      }),
+    });
+    expect(run.code).toBe(EXIT_OK);
+    expect(asked).toBe("web");
+  });
+});
+
+describe("actana session start", () => {
+  it("exits without waiting, printing the id and nothing else on stdout", async () => {
+    await withRegisteredCore();
+    let waited = false;
+    const run = await cli().run(["session", "start", "web", "fix", "the", "tests"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              waited = true;
+              return { status: "finished", exited: false };
+            },
+          }),
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    // The one-shot default (#129 D6): the Session outlives the command.
+    expect(waited).toBe(false);
+    // `TASK=$(actana session start …)` is the shape of every script that will
+    // use this, so stdout is the id and the progress line went to stderr.
+    expect(run.out).toEqual(["task_1"]);
+    expect(run.err.join("\n")).toContain("Started claude-code in web");
+  });
+
+  it("hands the prompt over as typed, and never a carriage return with it", async () => {
+    await withRegisteredCore();
+    let seen: Record<string, unknown> | null = null;
+    await cli().run(["session", "start", "web", "fix the tests"], {
+      sessions: fakeSessionGateway({
+        start: async (request) => {
+          seen = request as unknown as Record<string, unknown>;
+          return fakeStartedSession();
+        },
+      }),
+    });
+    // Prompt delivery is the Core's (ADR 0026, #129 D3). What leaves this
+    // process is text — no return, no timing, nothing appended.
+    expect(seen!.prompt).toBe("fix the tests");
+  });
+
+  it("reads a prompt from stdin when it is `-`", async () => {
+    await withRegisteredCore();
+    let seen = "";
+    await cli().run(["session", "start", "web", "-"], {
+      stdin: "a prompt too long for a command line\n",
+      sessions: fakeSessionGateway({
+        start: async (request) => {
+          seen = request.prompt ?? "";
+          return fakeStartedSession();
+        },
+      }),
+    });
+    expect(seen).toBe("a prompt too long for a command line\n");
+  });
+
+  it("emits one object under --json, with no prose beside it", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--json", "--verbose"], {
+      sessions: fakeSessionGateway({ start: async () => fakeStartedSession() }),
+    });
+    expect(run.code).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload).toMatchObject({ taskId: "task_1", ptyId: "pty_1", waited: false });
+    // `--verbose` is the flag most likely to break the rule, so it is on here.
+    expect(run.err.length).toBeGreaterThan(0);
+  });
+
+  it("blocks with --wait and reports the state the Core settled on", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--wait", "--json"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async () => ({ status: "finished", exited: true, exitCode: 0 }),
+            screen: () => "the rendered transcript",
+          }),
+      }),
+    });
+    expect(run.code).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload).toMatchObject({ waited: true, status: "finished", exited: true, exitCode: 0 });
+    // The transcript rides along: the Core's replay ring dies with the PTY, so
+    // a `--json` caller has no second chance at it.
+    expect(payload.screen).toBe("the rendered transcript");
+  });
+
+  it("exits non-zero when the harness died, and zero when it stopped to ask", async () => {
+    await withRegisteredCore();
+    const died = await cli().run(["session", "start", "web", "go", "--wait"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({ wait: async () => ({ status: "terminated", exited: true, exitCode: 137 }) }),
+      }),
+    });
+    expect(died.code).toBe(EXIT_FAILURE);
+
+    // A question is not a failure — a script that treated it as one could not
+    // then answer it with `session send`.
+    const asked = await cli().run(["session", "start", "web", "go", "--wait"], {
+      sessions: fakeSessionGateway({
+        start: async () => fakeStartedSession({ wait: async () => ({ status: "needs-input", exited: false }) }),
+      }),
+    });
+    expect(asked.code).toBe(EXIT_OK);
+    expect(asked.err.join("\n")).toContain("needs-input");
+  });
+
+  it("passes --wait-timeout through as the SDK's deadline, and refuses it alone", async () => {
+    await withRegisteredCore();
+    let timeoutMs: number | undefined;
+    const run = await cli().run(["session", "start", "web", "go", "--wait", "--wait-timeout", "90"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async (opts) => {
+              timeoutMs = opts.timeoutMs;
+              return { status: "finished", exited: false };
+            },
+          }),
+      }),
+    });
+    expect(run.code).toBe(EXIT_OK);
+    expect(timeoutMs).toBe(90_000);
+
+    const alone = await cli().run(["session", "start", "web", "go", "--wait-timeout", "90"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(alone.code).toBe(EXIT_USAGE);
+    expect(alone.err.join("\n")).toContain("only means something with --wait");
+  });
+
+  it("reports a wait that ran out as this side giving up, not as a status", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--wait", "--wait-timeout", "1", "--json"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              throw new Error("session task_1 was still running after 1000ms");
+            },
+          }),
+      }),
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.error).toContain("still running after");
+    expect(payload.status).toBeUndefined();
+  });
+
+  it("checks the harness name before dialling", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "--harness", "emacs"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("claude-code");
+  });
+
+  it("needs a project", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start"], { sessions: fakeSessionGateway() });
+    expect(run.code).toBe(EXIT_USAGE);
+  });
+});
+
+describe("actana session resume", () => {
+  it("starts a Session on an existing conversation and reports it like `start`", async () => {
+    await withRegisteredCore();
+    let asked = "";
+    const run = await cli().run(["session", "resume", "task_1", "carry on"], {
+      sessions: fakeSessionGateway({
+        resume: async (request) => {
+          asked = request.taskId;
+          expect(request.prompt).toBe("carry on");
+          return fakeStartedSession({ command: "claude --resume abc" });
+        },
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    expect(asked).toBe("task_1");
+    expect(run.out).toEqual(["task_1"]);
+  });
+
+  it("passes the gateway's reason through when there is nothing to resume", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "resume", "task_1", "--json"], {
+      sessions: fakeSessionGateway({
+        resume: async () => {
+          throw new SessionGatewayError("nothing-to-resume", "session task_1 has no harness session id on it");
+        },
+      }),
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(run.out.join("\n")).error).toContain("no harness session id");
+    expect(run.err.join("\n")).toContain("actana session resume:");
+  });
+
+  it("does not take --harness: the harness is a fact about the conversation", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "resume", "task_1", "--harness", "codex"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+  });
+});
+
+describe("actana session logs", () => {
+  it("prints the rendered screen, and the raw bytes only when asked", async () => {
+    await withRegisteredCore();
+    const logs = {
+      taskId: "task_1",
+      ptyId: "pty_1",
+      screen: "done: 3 files changed",
+      raw: "[1GScanning…[1Gdone: 3 files changed",
+    };
+    const rendered = await cli().run(["session", "logs", "task_1"], {
+      sessions: fakeSessionGateway({ logs: async () => logs }),
+    });
+    expect(rendered.code, rendered.err.join("\n")).toBe(EXIT_OK);
+    expect(rendered.out.join("\n")).toBe("done: 3 files changed");
+
+    const raw = await cli().run(["session", "logs", "task_1", "--raw"], {
+      sessions: fakeSessionGateway({ logs: async () => logs }),
+    });
+    expect(raw.out.join("\n")).toContain("[1G");
+  });
+
+  it("puts the transcript in one JSON object, saying which form it is", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "logs", "task_1", "--json"], {
+      sessions: fakeSessionGateway({
+        logs: async () => ({ taskId: "task_1", ptyId: "pty_1", screen: "a screen", raw: "raw" }),
+      }),
+    });
+    expect(JSON.parse(run.out.join("\n"))).toEqual({
+      taskId: "task_1",
+      ptyId: "pty_1",
+      rendered: true,
+      screen: "a screen",
+    });
+  });
+});
+
+describe("actana session send", () => {
+  it("writes exactly what it was given, once", async () => {
+    await withRegisteredCore();
+    const writes: string[] = [];
+    const run = await cli().run(["session", "send", "task_1", "yes", "please"], {
+      sessions: fakeSessionGateway({
+        send: async (_taskId, text) => {
+          writes.push(text);
+          return true;
+        },
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    // Joined the way a shell already joined them, and nothing appended: no
+    // carriage return, no second write, no timer (ADR 0026).
+    expect(writes).toEqual(["yes please"]);
+    expect(run.out).toEqual([]);
+  });
+
+  it("sends a carriage return as a separate write, and only with --enter", async () => {
+    await withRegisteredCore();
+    const writes: string[] = [];
+    const run = await cli().run(["session", "send", "task_1", "2", "--enter", "--json"], {
+      sessions: fakeSessionGateway({
+        send: async (_taskId, text) => {
+          writes.push(text);
+          return true;
+        },
+      }),
+    });
+    expect(run.code).toBe(EXIT_OK);
+    expect(writes).toEqual(["2", "\r"]);
+    expect(JSON.parse(run.out.join("\n"))).toMatchObject({ enter: true, delivered: true });
+  });
+
+  it("fails when the Core declined the write", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "send", "task_1", "hello"], {
+      sessions: fakeSessionGateway({ send: async () => false }),
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("did not accept the write");
+  });
+
+  it("needs something to send", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "send", "task_1"], { sessions: fakeSessionGateway() });
+    expect(run.code).toBe(EXIT_USAGE);
+  });
+});
+
+describe("actana session kill", () => {
+  it("kills by session id, which is all it ever knew about the Session", async () => {
+    await withRegisteredCore();
+    // Nothing local is consulted: this fixture has never started a Session, and
+    // the verb still works — the ticket's "killing a session the CLI did not
+    // start" criterion, at the surface level.
+    let asked = "";
+    const run = await cli().run(["session", "kill", "task_from_the_panel"], {
+      sessions: fakeSessionGateway({
+        kill: async (taskId) => {
+          asked = taskId;
+          return { ptyId: "pty_9", killed: true };
+        },
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    expect(asked).toBe("task_from_the_panel");
+    expect(run.err.join("\n")).toContain("Killed session task_from_the_panel");
+  });
+
+  it("reports a Session with nothing running as such", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "kill", "task_1", "--json"], {
+      sessions: fakeSessionGateway({
+        kill: async () => {
+          throw new SessionGatewayError("not-running", "session task_1 has no harness running");
+        },
+      }),
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(run.out.join("\n")).error).toContain("no harness running");
+  });
+});
+
+describe("--json means only JSON on stdout", () => {
+  it("holds for every verb, on the failing path too", async () => {
+    await withRegisteredCore();
+    const boom = () => async () => {
+      throw new SessionGatewayError("refused", "the Core refused");
+    };
+    const gateway = fakeSessionGateway({
+      list: boom(),
+      start: boom(),
+      resume: boom(),
+      logs: boom(),
+      send: boom(),
+      kill: boom(),
+    });
+
+    for (const argv of [
+      ["session", "ls", "--json", "--verbose"],
+      ["session", "start", "web", "go", "--json", "--verbose"],
+      ["session", "resume", "task_1", "--json", "--verbose"],
+      ["session", "logs", "task_1", "--json", "--verbose"],
+      ["session", "send", "task_1", "hi", "--json", "--verbose"],
+      ["session", "kill", "task_1", "--json", "--verbose"],
+    ]) {
+      const run = await cli().run(argv, { sessions: gateway });
+      expect(run.code, argv.join(" ")).toBe(EXIT_FAILURE);
+      const parsed = JSON.parse(run.out.join("\n"));
+      expect(parsed.error, argv.join(" ")).toBe("the Core refused");
+      // And the human half went where it belongs.
+      expect(run.err.join("\n"), argv.join(" ")).toContain("the Core refused");
+    }
+  });
+});

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -10,6 +10,7 @@
 
 import { runActanaCli } from "./actana-cli.ts";
 import { probeCore } from "./core-probe.ts";
+import { openSessionGateway } from "./session-gateway.ts";
 import { EXIT_FAILURE } from "./exit-codes.ts";
 import { homedir } from "node:os";
 
@@ -38,6 +39,7 @@ const code = await runActanaCli({
   readStdin,
   stdinIsTty: Boolean(process.stdin.isTTY),
   probe: probeCore,
+  openSessions: openSessionGateway,
   now: () => Date.now(),
 }).catch((err: unknown) => {
   // A throw that reached here is a defect, not an operator error: every

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -27,6 +27,7 @@
 import { parseArgs } from "./cli-args.ts";
 import { registryPaths } from "./blob-registry.ts";
 import { runCoreCommand } from "./core-command.ts";
+import { runSessionCommand } from "./session-command.ts";
 import { CORE_BLOB_ENV } from "./core-resolution.ts";
 import { EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -48,7 +49,6 @@ export const CLI_VERSION: string = manifest.version;
  * English off stderr to find it.
  */
 const RESERVED_NOUNS: Record<string, string> = {
-  session: "start, ls, logs, resume, kill, send, attach — #160 and #163",
   project: "ls, add, browse, and later `cp` / `files` — #161 and #168",
   harness: "ls, install — #161",
   events: "tail — #161",
@@ -61,9 +61,9 @@ Usage
 
 Nouns
   core      register, select and inspect the Cores this machine can reach
+  session   start, ls, logs, resume, kill and send to Sessions on one
 
 Reserved, landing later in this phase
-  session   ${RESERVED_NOUNS.session}
   project   ${RESERVED_NOUNS.project}
   harness   ${RESERVED_NOUNS.harness}
   events    ${RESERVED_NOUNS.events}
@@ -117,6 +117,8 @@ export async function runActanaCli(deps: ActanaCliDeps): Promise<number> {
   switch (noun) {
     case "core":
       return runCoreCommand(deps, args, paths);
+    case "session":
+      return runSessionCommand(deps, args, paths);
     case "help":
       deps.out(ROOT_HELP);
       return EXIT_OK;

--- a/packages/cli/src/cli-args.ts
+++ b/packages/cli/src/cli-args.ts
@@ -25,6 +25,23 @@ export type ParsedArgs = {
   version: boolean;
   /** `--core <name>`, or null when the flag was absent. */
   core: string | null;
+  // ─── The `session` noun's flags (#160) ───
+  /** `--wait`: block until the Core reports a started Session settled. */
+  wait: boolean;
+  /** `--wait-timeout <seconds>`, unparsed — the verb decides what a bad value means. */
+  waitTimeout: string | null;
+  /** `--harness <name>`, or null to take the Project's remembered one. */
+  harness: string | null;
+  /** `--cwd <path>`: a directory on the **Core's** machine. */
+  cwd: string | null;
+  /** `--title <text>`: what a started Session is called in a listing. */
+  title: string | null;
+  /** `--raw`: hand over bytes rather than a rendered screen. */
+  raw: boolean;
+  /** `--enter`: follow sent text with a carriage return, because the operator asked. */
+  enter: boolean;
+  /** `--dangerously-skip-permissions`: start the harness without permission prompts. */
+  skipPermissions: boolean;
   /** Flags this build does not know, in the order they appeared. */
   unknown: string[];
   /** A flag that takes a value and was given none, or null. */
@@ -32,7 +49,7 @@ export type ParsedArgs = {
 };
 
 /** Flags that take a value. */
-const VALUE_FLAGS = new Set(["--core"]);
+const VALUE_FLAGS = new Set(["--core", "--wait-timeout", "--harness", "--cwd", "--title"]);
 
 /** Parse `process.argv.slice(2)`. Never throws; malformed input is reported in the result. */
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -43,6 +60,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
     help: false,
     version: false,
     core: null,
+    wait: false,
+    waitTimeout: null,
+    harness: null,
+    cwd: null,
+    title: null,
+    raw: false,
+    enter: false,
+    skipPermissions: false,
     unknown: [],
     missingValue: null,
   };
@@ -74,6 +99,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
         continue;
       }
       if (name === "--core") parsed.core = value;
+      else if (name === "--wait-timeout") parsed.waitTimeout = value;
+      else if (name === "--harness") parsed.harness = value;
+      else if (name === "--cwd") parsed.cwd = value;
+      else if (name === "--title") parsed.title = value;
       continue;
     }
 
@@ -83,6 +112,18 @@ export function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--verbose":
         parsed.verbose = true;
+        break;
+      case "--wait":
+        parsed.wait = true;
+        break;
+      case "--raw":
+        parsed.raw = true;
+        break;
+      case "--enter":
+        parsed.enter = true;
+        break;
+      case "--dangerously-skip-permissions":
+        parsed.skipPermissions = true;
         break;
       case "-h":
       case "--help":

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -8,6 +8,7 @@
 // `process`.
 
 import type { CoreProbeFn } from "./core-probe.ts";
+import type { OpenSessionGateway } from "./session-gateway.ts";
 
 export type ActanaCliDeps = {
   /** `process.argv.slice(2)`. */
@@ -37,6 +38,8 @@ export type ActanaCliDeps = {
   stdinIsTty: boolean;
   /** How `core status` reaches a Core. See `core-probe.ts`. */
   probe: CoreProbeFn;
+  /** How the `session` noun reaches a Core. See `session-gateway.ts`. */
+  openSessions: OpenSessionGateway;
   /** Epoch ms. Only the bearer-expiry line reads it. */
   now: () => number;
 };

--- a/packages/cli/src/harness-resume.ts
+++ b/packages/cli/src/harness-resume.ts
@@ -1,0 +1,62 @@
+// How each harness is asked to pick a conversation back up (#129 D10, #160).
+//
+// `actana session resume <task>` starts a **new** PTY for a Task that already
+// has one behind it, and the only thing that makes it a resumption rather than
+// a fresh Session is the launch command: the harness's own session id, spelled
+// the way that harness spells it. The Core stores that id on the Task row
+// (`claudeSessionId`, written by the hook pipeline), so the CLI never invents
+// one — it reads the Task and asks for what is already there.
+//
+// A pure function, in its own module, for one reason: **the Core's allow-list
+// is the authority on what may be spawned** (`pty-spawn-policy.ts`), and the
+// only honest way to keep this table in step with it is to have a unit test
+// read both. A command this builds that the Core would refuse is a rejected
+// spawn with the Core's own message on it — not a command trimmed here on a
+// guess about a machine this process is not on.
+
+import type { CoreLinkPtySpawnHarness } from "@actana/sdk/core-link-frames.ts";
+
+/**
+ * The launch command that resumes `sessionId` under `harness`.
+ *
+ * The four spellings are not stylistic variation, and they are not this file's
+ * invention — each is what that harness's own CLI accepts and what the Core's
+ * spawn policy allow-lists:
+ *
+ *   - `claude --resume <id>`         a flag with a value
+ *   - `codex resume <id>`            a **subcommand**, so it comes first, and
+ *                                    `--enable hooks` still has to be there or
+ *                                    the Session never reports its lifecycle
+ *                                    and every wait on it hangs
+ *   - `cursor-agent --resume <id>`   a flag again, different binary
+ *   - `opencode --session <id>`      a different flag entirely, and the Core
+ *                                    additionally requires the value to start
+ *                                    `ses`
+ *
+ * `dangerouslySkipPermissions` appends that harness's spelling of "do not stop
+ * to ask me", which the Core accepts **only** on a spawn that also set the
+ * matching option — the CLI sends both or neither (see `session-gateway.ts`).
+ * OpenCode has no such flag and gets none, which is not an omission: a flag
+ * invented here would be rejected by the allow-list rather than honoured.
+ */
+export function harnessResumeCommand(
+  harness: CoreLinkPtySpawnHarness,
+  sessionId: string,
+  opts: { dangerouslySkipPermissions?: boolean } = {},
+): string {
+  const skip = opts.dangerouslySkipPermissions === true;
+  switch (harness) {
+    case "claude-code":
+      return join(["claude", "--resume", sessionId], skip ? "--dangerously-skip-permissions" : null);
+    case "codex":
+      return join(["codex", "resume", sessionId, "--enable", "hooks"], skip ? "--yolo" : null);
+    case "cursor-cli":
+      return join(["cursor-agent", "--resume", sessionId], skip ? "--force" : null);
+    case "opencode":
+      return join(["opencode", "--session", sessionId], null);
+  }
+}
+
+function join(parts: string[], trailing: string | null): string {
+  return (trailing === null ? parts : [...parts, trailing]).join(" ");
+}

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -419,8 +419,9 @@ async function sessionLogs(
  * Verbatim, and nothing appended (ADR 0026, and the module header). `--enter`
  * adds a second write of a carriage return **because the operator asked for
  * one** — no pause between them, no waiting for the harness to look ready, and
- * nothing that decides on its own that Enter is due. A *starting* prompt goes
- * through `session start`, where the Core owns the schedule.
+ * nothing that decides on its own that Enter is due. Both writes go to one PTY
+ * resolved once, so the harness cannot move between them. A *starting* prompt
+ * goes through `session start`, where the Core owns the schedule.
  */
 async function sessionSend(
   deps: ActanaCliDeps,
@@ -444,11 +445,22 @@ async function sessionSend(
       "nothing to send — pass text, `-` to read stdin, or --enter for a bare carriage return",
     );
   }
+  if (read.text === "" && !args.enter) {
+    // Empty stdin, and nothing else asked for. Reporting a delivery here would
+    // be a lie in the one direction that matters: no Core was contacted, no
+    // Session was proved to exist, and nothing was written.
+    return usage(
+      deps,
+      "send",
+      "nothing to send — stdin was empty; pass --enter to send a bare carriage return",
+    );
+  }
 
   return withGateway(deps, args, paths, "send", async (gateway) => {
     const text = read.text ?? "";
-    let delivered = text.length === 0 ? true : await gateway.send(taskId, text);
-    if (delivered && args.enter) delivered = await gateway.send(taskId, "\r");
+    // One call, one PTY resolution, both writes (#204 review). The command no
+    // longer decides anything about the return beyond passing on the flag.
+    const delivered = await gateway.send(taskId, text, { enter: args.enter });
 
     if (args.json) {
       deps.out(formatJson({ taskId, characters: text.length, enter: args.enter, delivered }));

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -1,0 +1,698 @@
+// `actana session` — the Sessions running on a Core (#129 D10, #160).
+//
+//   actana session start <project> [prompt]  start one; prints its id and exits
+//   actana session ls [project]              what is running, and what settled
+//   actana session logs <session>            the transcript, rendered
+//   actana session resume <session> [prompt] pick a conversation back up
+//   actana session send <session> <text>     type into a running Session
+//   actana session kill <session>            stop the harness, whoever started it
+//   actana session attach                    scaffolded here, built in #163
+//
+// Three rules this noun is built around. The first two are the ticket's, the
+// third is what makes the other two usable from a script.
+//
+// **The Core delivers prompts (ADR 0026, #129 D3).** `start` hands its prompt to
+// the SDK, which hands it to the Core, which waits for the harness's TUI to
+// settle, answers whatever dialog it opened, and writes the prompt and the
+// carriage return. Nothing in this package waits, retries, or presses Enter on
+// a timer — `send` writes exactly the bytes it was given and appends nothing.
+// A prompt that goes missing is a Core bug and must be fixed there, where every
+// client benefits; a client that compensated would hide it and would behave
+// differently from the Panel doing the same thing.
+//
+// **A transcript is a screen.** `logs` renders the Core's replay ring through
+// the SDK's terminal emulator, because a harness paints with cursor moves and
+// repaints one row eighty times a second: the raw stream concatenates into
+// spinner soup with the words jammed together. `--raw` hands over the bytes for
+// a caller piping into a terminal that will render them itself.
+//
+// **`--json` means only JSON on stdout.** Every verb here writes exactly one
+// JSON document to stdout under `--json` — including when it fails, where the
+// document is `{"error": …}` — and every human line, every progress note and
+// every warning goes to stderr. Without that rule each consumer has to strip
+// prose out of a stream it is trying to parse.
+//
+// One more, which falls out of the last: **without `--json`, stdout carries the
+// Session id and nothing else.** `TASK=$(actana session start web "fix it")` is
+// the shape of every script that will ever use this, and it works with `--wait`
+// as well as without it because the settled status goes to stderr too.
+
+import { resolveCore } from "./core-resolution.ts";
+import { formatJson, formatTable } from "./cli-output.ts";
+import { isKnownHarness, KNOWN_HARNESSES } from "./session-gateway.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "./exit-codes.ts";
+import type { RegistryPaths } from "./blob-registry.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+import type { ParsedArgs } from "./cli-args.ts";
+import type {
+  SessionGateway,
+  SessionLogs,
+  SessionOutcome,
+  SessionRow,
+  StartedSession,
+} from "./session-gateway.ts";
+
+/** How long a `session` verb waits for a Core to answer one request. */
+const SESSION_TIMEOUT_MS = 30_000;
+
+/**
+ * The statuses that mean the Session did not end well.
+ *
+ * `--wait` exits non-zero on these and on a harness that exited non-zero, and
+ * zero on everything else — `finished` obviously, but `needs-input` too: a
+ * harness that stopped to ask a question did not fail, and a script that treats
+ * a question as a failure cannot then answer it with `session send`.
+ */
+const UNHAPPY_STATUSES: ReadonlySet<string> = new Set(["terminated", "disconnected"]);
+
+export const SESSION_HELP = `actana session — the Sessions running on a Core
+
+Usage
+  actana session start <project> [prompt]   start a Session; prints its id
+  actana session ls [project]               list Sessions on this Core
+  actana session logs <session>             print the transcript, rendered
+  actana session resume <session> [prompt]  start a Session that continues one
+  actana session send <session> <text>      write text into a running Session
+  actana session kill <session>             stop the harness running for it
+  actana session attach <session>           take the terminal (not built — #163)
+
+Flags
+  --core <name>       which registered Core to talk to
+  --json              machine-readable output. Only JSON reaches stdout.
+  --wait              start/resume: block until the Core reports it settled
+  --wait-timeout <s>  give up waiting after this many seconds, and say so
+  --harness <name>    start: ${KNOWN_HARNESSES.join(", ")}
+  --cwd <path>        start: a directory on the Core, inside the Project
+  --title <text>      start: what the Session is called in \`ls\`
+  --raw               logs: the bytes, escape codes and all, unrendered
+  --enter             send: follow the text with a carriage return
+  --dangerously-skip-permissions
+                      start/resume: run the harness without permission prompts
+  --verbose           explain the steps, on stderr. Never prints a blob.
+
+A prompt or a text argument of \`-\` is read from stdin, so a long prompt can be
+piped in:  cat brief.md | actana session start web -
+
+Sessions are the Core's, not this command's
+  \`start\` exits as soon as the Core has the Session running, printing its id —
+  the harness keeps going without this process (#129 D6). \`kill\`, \`send\` and
+  \`logs\` name a Session by that id and work on any Session on the Core,
+  including ones a Panel or another terminal started.
+
+Who delivers the prompt
+  The Core does (ADR 0026). It waits for the harness to settle, answers the
+  dialog it opened, and writes the prompt. This CLI adds no timing of its own,
+  and \`send\` writes exactly what it is given — a lost prompt is a Core bug.`;
+
+/** Dispatch a `session` verb. `args.positionals` still has the noun on the front. */
+export async function runSessionCommand(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+): Promise<number> {
+  const [verb, ...rest] = args.positionals.slice(1);
+
+  if (args.help || verb === undefined) {
+    deps.out(SESSION_HELP);
+    return verb === undefined && !args.help ? EXIT_USAGE : EXIT_OK;
+  }
+
+  switch (verb) {
+    case "start":
+      return sessionStart(deps, args, paths, rest);
+    case "ls":
+    case "list":
+      return sessionLs(deps, args, paths, rest);
+    case "logs":
+      return sessionLogs(deps, args, paths, rest);
+    case "resume":
+      return sessionResume(deps, args, paths, rest);
+    case "send":
+      return sessionSend(deps, args, paths, rest);
+    case "kill":
+      return sessionKill(deps, args, paths, rest);
+    case "attach":
+      return sessionAttach(deps);
+    default:
+      deps.err(`actana session: unknown verb "${verb}".`);
+      deps.err("Verbs: start, ls, logs, resume, kill, send, attach. `actana session --help` lists them.");
+      return EXIT_USAGE;
+  }
+}
+
+// ─── The verbs ───────────────────────────────────────────────────────────────
+
+/**
+ * `actana session start <project> [prompt]`.
+ *
+ * **Exits once the Core has the Session running** (#129 D6): the id goes to
+ * stdout, the harness carries on without this process, and the socket closes.
+ * `--wait` keeps the connection open until the Core reports the Session settled
+ * — which is the Core's report off its event log, never a guess made here from
+ * how quiet the output went.
+ */
+async function sessionStart(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, [
+    "--wait",
+    "--wait-timeout",
+    "--harness",
+    "--cwd",
+    "--title",
+    "--dangerously-skip-permissions",
+  ]);
+  if (misused) return usage(deps, "start", misused);
+
+  const [project, ...promptWords] = rest;
+  if (project === undefined) {
+    return usage(deps, "start", "a project is required — `actana session start <project> [prompt]`");
+  }
+
+  const timeout = waitTimeoutMs(args);
+  if (timeout.error) return usage(deps, "start", timeout.error);
+
+  const harness = args.harness;
+  if (harness !== null && !isKnownHarness(harness)) {
+    return usage(
+      deps,
+      "start",
+      `unknown harness "${harness}". This build knows: ${KNOWN_HARNESSES.join(", ")}`,
+    );
+  }
+
+  const prompt = await readText(deps, promptWords);
+  if (prompt.error) return usage(deps, "start", prompt.error);
+
+  return withGateway(deps, args, paths, "start", async (gateway) => {
+    deps.verbose(`starting a session in ${project}`);
+    const session = await gateway.start({
+      project,
+      ...(prompt.text === null ? {} : { prompt: prompt.text }),
+      ...(args.title === null ? {} : { title: args.title }),
+      harness,
+      cwd: args.cwd,
+      dangerouslySkipPermissions: args.skipPermissions,
+    });
+    return reportStartedSession(deps, args, session, timeout.ms);
+  });
+}
+
+/** `actana session resume <session> [prompt]` — a new harness on an old conversation. */
+async function sessionResume(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, ["--wait", "--wait-timeout", "--dangerously-skip-permissions"]);
+  if (misused) return usage(deps, "resume", misused);
+
+  const [taskId, ...promptWords] = rest;
+  if (taskId === undefined) {
+    return usage(deps, "resume", "a session id is required — `actana session resume <session> [prompt]`");
+  }
+
+  const timeout = waitTimeoutMs(args);
+  if (timeout.error) return usage(deps, "resume", timeout.error);
+
+  const prompt = await readText(deps, promptWords);
+  if (prompt.error) return usage(deps, "resume", prompt.error);
+
+  return withGateway(deps, args, paths, "resume", async (gateway) => {
+    deps.verbose(`resuming session ${taskId}`);
+    const session = await gateway.resume({
+      taskId,
+      ...(prompt.text === null ? {} : { prompt: prompt.text }),
+      dangerouslySkipPermissions: args.skipPermissions,
+    });
+    return reportStartedSession(deps, args, session, timeout.ms);
+  });
+}
+
+/**
+ * What `start` and `resume` print, which is the same thing because they produce
+ * the same thing: a running Session, and a decision about whether to wait for it.
+ */
+async function reportStartedSession(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  session: StartedSession,
+  timeoutMs: number | null,
+): Promise<number> {
+  try {
+    const where = session.project ?? session.projectId;
+    deps.err(`Started ${session.harness} in ${where} — session ${session.taskId}, pty ${session.ptyId}.`);
+    deps.verbose(`command: ${session.command}`);
+
+    if (!args.wait) {
+      // The one-shot default (#129 D6). The id is the whole of stdout, so it can
+      // be captured; everything a person reads went to stderr above.
+      //
+      // The socket closes on the way out of `withGateway`, and the prompt has
+      // almost certainly not been delivered yet — the Core waits for the
+      // harness's screen to settle first. That is not a race this side has to
+      // win: `initialInput` travelled with the spawn and delivery runs inside
+      // the Core (ADR 0026 D2), which is exactly why a client can hang up.
+      if (args.json) {
+        deps.out(formatJson({ ...startedFields(session), waited: false }));
+      } else {
+        deps.out(session.taskId);
+      }
+      return EXIT_OK;
+    }
+
+    deps.err("Waiting for the Core to report this session settled…");
+    let outcome: SessionOutcome;
+    try {
+      outcome = await session.wait(timeoutMs === null ? {} : { timeoutMs });
+    } catch (err) {
+      // The only thing that reaches here is the deadline the operator asked for.
+      // It is reported as what it is — this side gave up — rather than as a
+      // status, because the Core never said one.
+      const message = messageOf(err);
+      if (args.json) deps.out(formatJson({ ...startedFields(session), waited: true, error: message }));
+      deps.err(`actana session: ${message}`);
+      return EXIT_FAILURE;
+    }
+
+    // Read while the Session is alive: a full-screen harness restores the main
+    // buffer when it quits, and the main buffer is where nothing was printed.
+    const screen = session.screen();
+
+    if (args.json) {
+      deps.out(
+        formatJson({
+          ...startedFields(session),
+          waited: true,
+          status: outcome.status,
+          exited: outcome.exited,
+          ...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
+          // The transcript rides along because a `--json` caller has no second
+          // chance at it: the Core's replay ring lives with the PTY, so a
+          // harness that exited takes its output with it and a later
+          // `session logs` has nothing to answer with.
+          screen,
+        }),
+      );
+    } else {
+      deps.out(session.taskId);
+      deps.err(settledLine(outcome));
+      deps.err(`\`actana session logs ${session.taskId}\` prints the transcript while the harness is running.`);
+    }
+    return settledWell(outcome) ? EXIT_OK : EXIT_FAILURE;
+  } finally {
+    // Listeners on the client, released. The harness on the Core is untouched —
+    // that is `session kill`.
+    session.dispose();
+  }
+}
+
+/** `actana session ls [project]` — every Session on the Core, newest first. */
+async function sessionLs(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, []);
+  if (misused) return usage(deps, "ls", misused);
+
+  const [project, ...extra] = rest;
+  if (extra.length > 0) return usage(deps, "ls", `unexpected argument "${extra[0]}"`);
+
+  return withGateway(deps, args, paths, "ls", async (gateway) => {
+    const rows = await gateway.list(project ?? null);
+
+    if (args.json) {
+      deps.out(formatJson(rows));
+      return EXIT_OK;
+    }
+    if (rows.length === 0) {
+      deps.out(project === undefined ? "No sessions on this Core." : `No sessions in ${project}.`);
+      return EXIT_OK;
+    }
+
+    // The lock column appears only when the Core publishes lock state (ADR
+    // 0024). A Core that predates it has no lock table, and a column of dashes
+    // would read as "nobody may write" rather than "this Core does not answer
+    // that question".
+    const locks = rows.some((row) => row.lock !== null);
+    const header = [
+      ...["SESSION", "STATUS", "LIVE", "HARNESS", "PROJECT"],
+      ...(locks ? ["LOCK"] : []),
+      ...["AGE", "TITLE"],
+    ];
+    const table = formatTable(
+      header,
+      rows.map((row) => [
+        row.taskId,
+        row.status,
+        row.live ? "yes" : "",
+        row.harness,
+        row.project ?? row.projectId,
+        ...(locks ? [lockCell(row)] : []),
+        age(deps.now(), row.updatedAt),
+        row.title,
+      ]),
+    );
+    for (const line of table) deps.out(line);
+    return EXIT_OK;
+  });
+}
+
+/**
+ * `actana session logs <session>` — the transcript, as a terminal would show it.
+ *
+ * Rendered, not raw: see the module header. What it can print is what the Core
+ * still holds, and the Core holds a Session's output in a ring that belongs to
+ * the PTY — so a harness that has already exited has no logs to give, which is
+ * what `not-running` says.
+ */
+async function sessionLogs(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, ["--raw"]);
+  if (misused) return usage(deps, "logs", misused);
+
+  const [taskId, ...extra] = rest;
+  if (taskId === undefined) {
+    return usage(deps, "logs", "a session id is required — `actana session logs <session>`");
+  }
+  if (extra.length > 0) return usage(deps, "logs", `unexpected argument "${extra[0]}"`);
+
+  return withGateway(deps, args, paths, "logs", async (gateway) => {
+    const logs: SessionLogs = await gateway.logs(taskId);
+    deps.verbose(`read the replay ring of pty ${logs.ptyId}`);
+
+    if (args.json) {
+      deps.out(
+        formatJson({
+          taskId: logs.taskId,
+          ptyId: logs.ptyId,
+          rendered: !args.raw,
+          screen: args.raw ? logs.raw : logs.screen,
+        }),
+      );
+      return EXIT_OK;
+    }
+    const body = args.raw ? logs.raw : logs.screen;
+    for (const line of body.split("\n")) deps.out(line);
+    return EXIT_OK;
+  });
+}
+
+/**
+ * `actana session send <session> <text>` — the equivalent of typing.
+ *
+ * Verbatim, and nothing appended (ADR 0026, and the module header). `--enter`
+ * adds a second write of a carriage return **because the operator asked for
+ * one** — no pause between them, no waiting for the harness to look ready, and
+ * nothing that decides on its own that Enter is due. A *starting* prompt goes
+ * through `session start`, where the Core owns the schedule.
+ */
+async function sessionSend(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, ["--enter"]);
+  if (misused) return usage(deps, "send", misused);
+
+  const [taskId, ...words] = rest;
+  if (taskId === undefined) {
+    return usage(deps, "send", "a session id is required — `actana session send <session> <text>`");
+  }
+  const read = await readText(deps, words);
+  if (read.error) return usage(deps, "send", read.error);
+  if (read.text === null && !args.enter) {
+    return usage(
+      deps,
+      "send",
+      "nothing to send — pass text, `-` to read stdin, or --enter for a bare carriage return",
+    );
+  }
+
+  return withGateway(deps, args, paths, "send", async (gateway) => {
+    const text = read.text ?? "";
+    let delivered = text.length === 0 ? true : await gateway.send(taskId, text);
+    if (delivered && args.enter) delivered = await gateway.send(taskId, "\r");
+
+    if (args.json) {
+      deps.out(formatJson({ taskId, characters: text.length, enter: args.enter, delivered }));
+    } else if (delivered) {
+      const andReturn = args.enter ? " and a carriage return" : "";
+      deps.err(`Sent ${text.length} characters to session ${taskId}${andReturn}.`);
+    }
+    if (!delivered) {
+      deps.err(`actana session send: the Core did not accept the write to session ${taskId}.`);
+      return EXIT_FAILURE;
+    }
+    return EXIT_OK;
+  });
+}
+
+/**
+ * `actana session kill <session>`.
+ *
+ * **Works on a Session this CLI did not start**, which is the point of naming
+ * Sessions by Task id: the PTY belongs to the Core, and a Panel, a cron job and
+ * this command all name it the same way. Nothing about having started a Session
+ * is remembered locally, so there is nothing here that could fail to recognise
+ * one.
+ */
+async function sessionKill(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, []);
+  if (misused) return usage(deps, "kill", misused);
+
+  const [taskId, ...extra] = rest;
+  if (taskId === undefined) {
+    return usage(deps, "kill", "a session id is required — `actana session kill <session>`");
+  }
+  if (extra.length > 0) return usage(deps, "kill", `unexpected argument "${extra[0]}"`);
+
+  return withGateway(deps, args, paths, "kill", async (gateway) => {
+    const { ptyId, killed } = await gateway.kill(taskId);
+    if (args.json) {
+      deps.out(formatJson({ taskId, ptyId, killed }));
+    } else if (killed) {
+      deps.err(`Killed session ${taskId} (pty ${ptyId}).`);
+    }
+    if (!killed) {
+      deps.err(`actana session kill: the Core did not kill session ${taskId}.`);
+      return EXIT_FAILURE;
+    }
+    return EXIT_OK;
+  });
+}
+
+/**
+ * `actana session attach` — scaffolded, not built.
+ *
+ * Deliberately a separate ticket: attaching is raw mode, resize forwarding and
+ * signal handling on *this* terminal, and none of the rest of this noun needs a
+ * terminal at all. It is in the tree and in the help for the reason `core shell`
+ * is — the noun's shape is decided in one place — and it exits
+ * {@link EXIT_UNIMPLEMENTED} rather than pretending.
+ */
+function sessionAttach(deps: ActanaCliDeps): number {
+  deps.err("actana session attach: not built yet — it is #163, in this phase.");
+  deps.err("Until then: `actana session logs <session>` reads the transcript and `session send` types into it.");
+  return EXIT_UNIMPLEMENTED;
+}
+
+// ─── The plumbing every verb shares ──────────────────────────────────────────
+
+/**
+ * Resolve the Core, open one connection, run the verb, and always hang up.
+ *
+ * Also the single place a {@link SessionGatewayError} becomes a message and an
+ * exit code, so no verb writes its own version of "the Core refused" and every
+ * one of them obeys the `--json` rule on the failure path as well as the happy
+ * one — which is the path that usually forgets.
+ */
+async function withGateway(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  verb: string,
+  run: (gateway: SessionGateway) => Promise<number>,
+): Promise<number> {
+  const resolved = resolveCore({ paths, env: deps.env, home: deps.home, coreFlag: args.core });
+  if (!resolved.ok) return failed(deps, args, verb, resolved.error);
+
+  deps.verbose(`dialling ${resolved.core.blob.endpoint}`);
+  let gateway: SessionGateway;
+  try {
+    gateway = await deps.openSessions(resolved.core.blob, { timeoutMs: SESSION_TIMEOUT_MS });
+  } catch (err) {
+    return failed(deps, args, verb, `${resolved.core.blob.endpoint} did not answer — ${messageOf(err)}`);
+  }
+
+  try {
+    return await run(gateway);
+  } catch (err) {
+    // Every failure here, not only the gateway's own kinds: a Core that answers
+    // a frame with an error, or a link that drops mid-command, arrives as the
+    // SDK's plain `Error`. Letting those through would exit on the entry file's
+    // last-resort handler — which prints a message, but after `--json` has
+    // already promised a document and produced none.
+    return failed(deps, args, verb, messageOf(err));
+  } finally {
+    gateway.close();
+  }
+}
+
+/** One failure, reported the same way every time: JSON on stdout, prose on stderr. */
+function failed(deps: ActanaCliDeps, args: ParsedArgs, verb: string, message: string): number {
+  if (args.json) deps.out(formatJson({ error: message }));
+  deps.err(`actana session ${verb}: ${message}`);
+  return EXIT_FAILURE;
+}
+
+/** A command line this verb cannot act on. Never dials, so `--json` gets no document. */
+function usage(deps: ActanaCliDeps, verb: string, message: string): number {
+  deps.err(`actana session ${verb}: ${message}.`);
+  return EXIT_USAGE;
+}
+
+/** The session flags, and how to tell whether one was used. */
+const SESSION_FLAGS: ReadonlyArray<{ name: string; used: (args: ParsedArgs) => boolean }> = [
+  { name: "--wait", used: (args) => args.wait },
+  { name: "--wait-timeout", used: (args) => args.waitTimeout !== null },
+  { name: "--harness", used: (args) => args.harness !== null },
+  { name: "--cwd", used: (args) => args.cwd !== null },
+  { name: "--title", used: (args) => args.title !== null },
+  { name: "--raw", used: (args) => args.raw },
+  { name: "--enter", used: (args) => args.enter },
+  { name: "--dangerously-skip-permissions", used: (args) => args.skipPermissions },
+];
+
+/**
+ * The first flag that was passed to a verb that does not take it, or null.
+ *
+ * Rejected rather than ignored, because every one of these flags changes what
+ * the operator expects to happen: `--wait` on `kill`, or `--harness` on
+ * `resume` (whose harness is a fact about the conversation being resumed, not a
+ * choice), read as instructions that were silently dropped.
+ */
+function misusedFlag(args: ParsedArgs, accepted: readonly string[]): string | null {
+  for (const flag of SESSION_FLAGS) {
+    if (flag.used(args) && !accepted.includes(flag.name)) {
+      return `${flag.name} does not apply here`;
+    }
+  }
+  return null;
+}
+
+/**
+ * `--wait-timeout <seconds>`, in milliseconds.
+ *
+ * Only with `--wait`, because on its own it is an instruction that cannot be
+ * carried out — and a deadline somebody believes they set is worse than no
+ * deadline at all. The wait it bounds is the SDK's; nothing here counts time.
+ */
+function waitTimeoutMs(args: ParsedArgs): { ms: number | null; error?: string } {
+  if (args.waitTimeout === null) return { ms: null };
+  if (!args.wait) return { ms: null, error: "--wait-timeout only means something with --wait" };
+  const seconds = Number(args.waitTimeout);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return { ms: null, error: `--wait-timeout wants a number of seconds, not "${args.waitTimeout}"` };
+  }
+  return { ms: Math.round(seconds * 1000) };
+}
+
+/**
+ * A prompt or a `send` text: the words as typed, or stdin when it is `-`.
+ *
+ * Words are joined with single spaces, which is what a shell has already done
+ * to anything unquoted — so `session send s1 yes please` sends `yes please`
+ * rather than failing over an argument the operator did not think of as a
+ * second one. `-` is the same stdin convention `core add` uses, and it is what
+ * a prompt longer than a command line arrives by.
+ */
+async function readText(
+  deps: ActanaCliDeps,
+  words: string[],
+): Promise<{ text: string | null; error?: string }> {
+  if (words.length === 0) return { text: null };
+  if (words.length === 1 && words[0] === "-") {
+    if (deps.stdinIsTty) {
+      return { text: null, error: "`-` reads stdin, and nothing is piped in" };
+    }
+    deps.verbose("reading the text from stdin");
+    return { text: await deps.readStdin() };
+  }
+  return { text: words.join(" ") };
+}
+
+/** The identity fields `start` and `resume` report, in both output modes. */
+function startedFields(session: StartedSession): Record<string, unknown> {
+  return {
+    taskId: session.taskId,
+    ptyId: session.ptyId,
+    harness: session.harness,
+    command: session.command,
+    projectId: session.projectId,
+    project: session.project,
+  };
+}
+
+/** Did the Session settle in a way a script should call success? */
+function settledWell(outcome: SessionOutcome): boolean {
+  if (UNHAPPY_STATUSES.has(outcome.status)) return false;
+  return !outcome.exited || (outcome.exitCode ?? 0) === 0;
+}
+
+function settledLine(outcome: SessionOutcome): string {
+  if (outcome.exited) {
+    return `The harness exited with code ${outcome.exitCode ?? 0} (status: ${outcome.status}).`;
+  }
+  return `The Core reports this session ${outcome.status}.`;
+}
+
+/** How a Session's lock reads in a table cell. */
+function lockCell(row: SessionRow): string {
+  switch (row.lock) {
+    case "held-by-you":
+      return "you";
+    case "held-by-another":
+      return "other";
+    case "unlocked":
+      return "free";
+    default:
+      return "";
+  }
+}
+
+/**
+ * How long ago, in the shortest unit that still says something.
+ *
+ * A table is read by eye and `2h` is what the eye wants; the exact epoch stays
+ * on the `--json` row for anything that is going to compute with it.
+ */
+function age(now: number, updatedAt: number): string {
+  const seconds = Math.max(0, Math.round((now - updatedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -99,6 +99,11 @@ Sessions are the Core's, not this command's
   \`logs\` name a Session by that id and work on any Session on the Core,
   including ones a Panel or another terminal started.
 
+What \`logs\` can show you
+  The Core's replay ring, which belongs to the harness's PTY — so a Session that
+  has already exited has no transcript left to print, and the way to keep one is
+  \`start --wait --json\`, whose object carries the screen as it settled.
+
 Who delivers the prompt
   The Core does (ADR 0026). It waits for the harness to settle, answers the
   dialog it opened, and writes the prompt. This CLI adds no timing of its own,

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -181,8 +181,13 @@ export type SessionGateway = {
   start(request: SessionStartRequest): Promise<StartedSession>;
   resume(request: SessionResumeRequest): Promise<StartedSession>;
   logs(taskId: string): Promise<SessionLogs>;
-  /** Write text to a running Session, verbatim. Resolves false if the Core declined. */
-  send(taskId: string, text: string): Promise<boolean>;
+  /**
+   * Write text to a running Session, verbatim. Resolves false if the Core
+   * declined. `enter` adds a carriage return as a **separate write to the same
+   * PTY**, resolved once for both, so there is no window between them in which
+   * the text lands and the return is sent somewhere else — or nowhere.
+   */
+  send(taskId: string, text: string, opts?: { enter?: boolean }): Promise<boolean>;
   /** Kill the harness running for this Task, whoever started it. */
   kill(taskId: string): Promise<{ ptyId: string; killed: boolean }>;
   close(): void;
@@ -323,11 +328,18 @@ class CoreLinkSessionGateway implements SessionGateway {
     return { taskId, ptyId, screen: terminal.text(), raw: replay.data };
   }
 
-  async send(taskId: string, text: string): Promise<boolean> {
+  async send(taskId: string, text: string, opts: { enter?: boolean } = {}): Promise<boolean> {
+    // One resolution for the whole verb. Resolving again for the return would
+    // open a window — the harness exits between the two round trips, the text
+    // has landed, and the command reports a failure after a partial delivery.
     const ptyId = await this.livePty(taskId);
+
     // Verbatim, and that is the whole verb. See rule 1: nothing is appended,
-    // nothing is timed, nothing is retried.
-    return this.client.write(ptyId, text);
+    // nothing is timed, nothing is retried. The return, when it was asked for,
+    // is its own write of its own byte — never glued to the text.
+    if (text.length > 0 && !(await this.client.write(ptyId, text))) return false;
+    if (!opts.enter) return true;
+    return this.client.write(ptyId, "\r");
   }
 
   async kill(taskId: string): Promise<{ ptyId: string; killed: boolean }> {

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -1,0 +1,499 @@
+// Reaching a Core for the `session` noun (#129 D10, #160).
+//
+// The same seam `core-probe.ts` opened for `core status`, widened exactly as
+// its header said it would be: one module that dials, so the noun above it —
+// flags, tables, `--json` shapes, exit codes — is exercised by unit tests with
+// no Core anywhere near them. Everything in this file is behind
+// {@link OpenSessionGateway}, which `actana-cli-entry.ts` binds to the real
+// implementation and the test harness binds to a fake.
+//
+// **This file is where the SDK is used, and it is used and not re-implemented.**
+// Three rules that live here rather than in the command module, because they
+// are properties of talking to a Core rather than of printing:
+//
+//   1. **The Core delivers prompts (ADR 0026, #129 D3).** A starting prompt is
+//      handed to `CoreSession.start` as `prompt` and that is the whole of the
+//      CLI's involvement. Nothing here waits for a harness to look ready,
+//      re-sends anything, or presses Enter after a pause — no timer of any kind
+//      appears in this package, and `src/__tests__/no-prompt-timing.test.ts` is
+//      what keeps that true. A prompt that does not arrive is a Core bug, and a
+//      client that papered over it would hide the bug from the one machine that
+//      can fix it and would behave differently from every other client.
+//   2. **A transcript is a screen, not a byte log.** `logs` renders the Core's
+//      replay ring through the SDK's `TerminalScreen` — the same emulator the
+//      session layer builds `screen()` from. A harness paints with cursor moves
+//      and repaints one row eighty times a second; concatenating that stream
+//      raw produces spinner soup, not a transcript. `--raw` still exists for a
+//      caller piping into a terminal that will do the rendering itself.
+//   3. **Idleness is the Core's report.** `--wait` is `CoreSession.waitForIdle`,
+//      which watches the Core's event log for a status the Core decided on.
+//      Nothing here inspects output for quietness.
+//
+// Everything this module hands back is plain data or a small object with
+// methods — no `CoreClient`, no `CoreSession`, no frames escape it. That is
+// what keeps `session-command.ts` free of the SDK and free of a socket.
+
+import { CoreClient } from "@actana/sdk/core-client.ts";
+import { CoreSession, HARNESS_LAUNCH_COMMANDS } from "@actana/sdk/core-session.ts";
+import { TerminalScreen, DEFAULT_COLS, DEFAULT_ROWS } from "@actana/sdk/terminal-screen.ts";
+import { harnessResumeCommand } from "./harness-resume.ts";
+import type {
+  CoreLinkProjectSnapshot,
+  CoreLinkPtySpawnHarness,
+  CoreLinkSessionLockState,
+  CoreLinkTaskSnapshot,
+} from "@actana/sdk/core-link-frames.ts";
+import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
+
+/** The harnesses this build knows, in the order `--help` lists them. */
+export const KNOWN_HARNESSES: readonly CoreLinkPtySpawnHarness[] = Object.keys(
+  HARNESS_LAUNCH_COMMANDS,
+) as CoreLinkPtySpawnHarness[];
+
+/** The harness a `session start` gets when neither the flag nor the Project names one. */
+export const DEFAULT_HARNESS: CoreLinkPtySpawnHarness = "claude-code";
+
+/** Is this string one of the harnesses the Core can be asked for? */
+export function isKnownHarness(value: string): value is CoreLinkPtySpawnHarness {
+  return (KNOWN_HARNESSES as readonly string[]).includes(value);
+}
+
+/**
+ * What went wrong, in a vocabulary the command module can turn into a message
+ * and an exit code without parsing English out of an SDK error.
+ *
+ * The kinds are the situations a person actually lands in, and each is a
+ * different next step: a Task id that does not exist is a typo, a Session with
+ * no live PTY is a harness that has already exited, a Task the harness never
+ * reported a session id for has nothing to resume *from*, and a Session that is
+ * already running is one to `send` to rather than start again. Anything the
+ * Core refused for its own reasons arrives as `refused` carrying the Core's own
+ * message — this side does not paraphrase a machine it is not on.
+ */
+export type SessionGatewayErrorKind =
+  | "no-such-session"
+  | "no-such-project"
+  | "not-running"
+  | "already-running"
+  | "nothing-to-resume"
+  | "refused";
+
+export class SessionGatewayError extends Error {
+  readonly kind: SessionGatewayErrorKind;
+  constructor(kind: SessionGatewayErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "SessionGatewayError";
+    this.kind = kind;
+  }
+}
+
+/** One row of `actana session ls`. */
+export type SessionRow = {
+  taskId: string;
+  title: string;
+  /** The harness on the Task row, as the Core spells it. */
+  harness: string;
+  /** The Core's status for the Session — `running`, `finished`, `needs-input`, … */
+  status: string;
+  projectId: string;
+  /** The Project's name, or null when the Task points at a Project the Core did not list. */
+  project: string | null;
+  /** The live PTY, or null when nothing is running for this Task right now. */
+  ptyId: string | null;
+  /** Whether a harness process is running for this Task — `ptyId !== null`, named. */
+  live: boolean;
+  /**
+   * Whether *this* client may write to the Session, and which of the three lock
+   * states it is in — both null on a Core that does not publish lock state (ADR
+   * 0024). Null is "this Core has no lock table", not "you may not write".
+   */
+  writable: boolean | null;
+  lock: CoreLinkSessionLockState | null;
+  updatedAt: number;
+};
+
+export type SessionStartRequest = {
+  /** A Project id, or a Project name, exactly as it was typed. */
+  project: string;
+  /** The starting prompt. Handed to the Core to deliver; never timed here. */
+  prompt?: string;
+  title?: string;
+  /** `--harness`, or null to take the Project's remembered one (ADR 0017). */
+  harness: CoreLinkPtySpawnHarness | null;
+  /** `--cwd` on the **Core's** machine, or null for the Project root. */
+  cwd: string | null;
+  dangerouslySkipPermissions: boolean;
+};
+
+export type SessionResumeRequest = {
+  taskId: string;
+  prompt?: string;
+  dangerouslySkipPermissions: boolean;
+};
+
+/** How a Session ended up, once the Core reported it settled. */
+export type SessionOutcome = {
+  /** One of the settled statuses — `finished`, `needs-input`, `interrupted`, … */
+  status: string;
+  /** True when the harness's process exited rather than settling on a status. */
+  exited: boolean;
+  exitCode?: number;
+};
+
+/** A Session this invocation started, still connected. */
+export type StartedSession = {
+  taskId: string;
+  ptyId: string;
+  harness: CoreLinkPtySpawnHarness;
+  /** The command the Core was asked to run, after defaulting. */
+  command: string;
+  projectId: string;
+  /** The Project's name, when the start resolved one. */
+  project: string | null;
+  /**
+   * Block until the Core reports this Session settled.
+   *
+   * The SDK's wait, which is the Core's event log — see rule 3 in the header.
+   * `timeoutMs` is a deadline the *operator* asked for (`--wait-timeout`) and
+   * its expiry is an error, never a status invented here.
+   */
+  wait(opts: { timeoutMs?: number }): Promise<SessionOutcome>;
+  /** The rendered transcript, read while the Session is alive. */
+  screen(): string;
+  /** Release the listeners this Session holds. The harness keeps running. */
+  dispose(): void;
+};
+
+/** What `actana session logs` reads back. */
+export type SessionLogs = {
+  taskId: string;
+  ptyId: string;
+  /** The replay ring rendered as a terminal would show it, scrollback included. */
+  screen: string;
+  /** The same bytes unrendered, for a caller piping into a real terminal. */
+  raw: string;
+};
+
+/** Everything the `session` noun asks of a Core, and nothing else. */
+export type SessionGateway = {
+  /** `null` lists every Project's Sessions; a string filters by Project name or id. */
+  list(project: string | null): Promise<SessionRow[]>;
+  start(request: SessionStartRequest): Promise<StartedSession>;
+  resume(request: SessionResumeRequest): Promise<StartedSession>;
+  logs(taskId: string): Promise<SessionLogs>;
+  /** Write text to a running Session, verbatim. Resolves false if the Core declined. */
+  send(taskId: string, text: string): Promise<boolean>;
+  /** Kill the harness running for this Task, whoever started it. */
+  kill(taskId: string): Promise<{ ptyId: string; killed: boolean }>;
+  close(): void;
+};
+
+/** How the `session` noun reaches a Core. Injected, so every verb is testable. */
+export type OpenSessionGateway = (
+  blob: CoreRegistrationBlob,
+  opts: { timeoutMs: number },
+) => Promise<SessionGateway>;
+
+/**
+ * The real gateway: connect, and hand back the verbs bound to that connection.
+ *
+ * Connecting here rather than per verb is deliberate — every `session` verb
+ * needs a live socket, and a command that dialled twice would double the
+ * latency of the fast path (`ls`) for no gain.
+ */
+export const openSessionGateway: OpenSessionGateway = async (blob, opts) => {
+  const client = CoreClient.fromRegistrationBlob(blob, {
+    connectTimeoutMs: opts.timeoutMs,
+    requestTimeoutMs: opts.timeoutMs,
+  });
+  await client.connect();
+  return new CoreLinkSessionGateway(client);
+};
+
+class CoreLinkSessionGateway implements SessionGateway {
+  constructor(private readonly client: CoreClient) {}
+
+  async list(project: string | null): Promise<SessionRow[]> {
+    const projects = await this.client.projectsList();
+    const projectId = project === null ? undefined : this.resolveProject(projects, project).projectId;
+
+    // Two reads because they answer two questions: `sessionsList` is the
+    // Session view (status, the live PTY, this client's lock) and the Task rows
+    // carry what a person reads a list by — the title, the harness, the Project.
+    // Neither frame carries the other's fields, and joining here costs one round
+    // trip against a list nobody paginates.
+    const [sessions, tasks] = await Promise.all([
+      this.client.sessionsList(projectId),
+      this.client.tasksList(projectId),
+    ]);
+    const byTask = new Map(tasks.tasks.map((task) => [task.taskId, task]));
+    const projectNames = new Map(projects.map((p) => [p.projectId, p.name]));
+
+    return sessions.map((session) => {
+      const task = byTask.get(session.taskId);
+      return {
+        taskId: session.taskId,
+        title: task?.title ?? "(untitled)",
+        harness: task?.agent ?? "(unknown)",
+        status: session.status,
+        projectId: task?.projectId ?? "",
+        project: task ? (projectNames.get(task.projectId) ?? null) : null,
+        ptyId: session.ptyId,
+        live: session.ptyId !== null,
+        writable: session.lock?.writable ?? null,
+        lock: session.lock?.state ?? null,
+        updatedAt: session.updatedAt,
+      };
+    });
+  }
+
+  async start(request: SessionStartRequest): Promise<StartedSession> {
+    const projects = await this.client.projectsList();
+    const project = this.resolveProject(projects, request.project);
+    const harness = request.harness ?? rememberedHarness(project) ?? DEFAULT_HARNESS;
+
+    const session = await this.begin({
+      projectId: project.projectId,
+      cwd: request.cwd ?? project.path,
+      harness,
+      title: request.title ?? titleFor(request.prompt),
+      prompt: request.prompt,
+      dangerouslySkipPermissions: request.dangerouslySkipPermissions,
+    });
+    return wrap(session, project.projectId, project.name);
+  }
+
+  async resume(request: SessionResumeRequest): Promise<StartedSession> {
+    const task = await this.findTask(request.taskId);
+
+    // A Task with a live PTY is a Session that never stopped. Starting a second
+    // harness on the same row would leave two processes writing one transcript
+    // and one of them unreachable — `session send` and `session logs` resolve a
+    // Task to *the* PTY, and there would be two.
+    const live = await this.client.findByTask(task.taskId);
+    if (live.ptyId !== null) {
+      throw new SessionGatewayError(
+        "already-running",
+        `session ${task.taskId} is already running (pty ${live.ptyId})`,
+      );
+    }
+
+    // The harness's own id for the conversation, written on the Task row by the
+    // Core's hook pipeline. Absent means no harness ever reported one — there is
+    // nothing to resume, and inventing an id would start a fresh Session while
+    // claiming to have continued one.
+    if (!task.claudeSessionId) {
+      throw new SessionGatewayError(
+        "nothing-to-resume",
+        `session ${task.taskId} has no harness session id on it — nothing was recorded to resume from`,
+      );
+    }
+    if (!isKnownHarness(task.agent)) {
+      throw new SessionGatewayError(
+        "refused",
+        `session ${task.taskId} ran under "${task.agent}", which this build cannot start`,
+      );
+    }
+
+    const project = await this.projectFor(task.projectId);
+    const session = await this.begin({
+      taskId: task.taskId,
+      cwd: project.path,
+      harness: task.agent,
+      command: harnessResumeCommand(task.agent, task.claudeSessionId, {
+        dangerouslySkipPermissions: request.dangerouslySkipPermissions,
+      }),
+      prompt: request.prompt,
+      dangerouslySkipPermissions: request.dangerouslySkipPermissions,
+    });
+    return wrap(session, project.projectId, project.name);
+  }
+
+  async logs(taskId: string): Promise<SessionLogs> {
+    const ptyId = await this.livePty(taskId);
+    const replay = await this.client.replay(ptyId);
+
+    // Rule 2 in the header, in four lines. The screen is built at the Core's own
+    // default PTY size because the protocol carries no way to ask what size this
+    // PTY actually is; a Session started at another size wraps differently here
+    // than it does there, which is the one inaccuracy this verb has and the
+    // reason `--raw` exists beside it.
+    const terminal = new TerminalScreen({ cols: DEFAULT_COLS, rows: DEFAULT_ROWS });
+    terminal.write(replay.data);
+    return { taskId, ptyId, screen: terminal.text(), raw: replay.data };
+  }
+
+  async send(taskId: string, text: string): Promise<boolean> {
+    const ptyId = await this.livePty(taskId);
+    // Verbatim, and that is the whole verb. See rule 1: nothing is appended,
+    // nothing is timed, nothing is retried.
+    return this.client.write(ptyId, text);
+  }
+
+  async kill(taskId: string): Promise<{ ptyId: string; killed: boolean }> {
+    // Resolved through the Core by Task id, which is what makes killing a
+    // Session this CLI did not start ordinary rather than special: the PTY
+    // belongs to the Core, and every client names it the same way. The only
+    // Session this refuses is one another client holds the write lock on, and
+    // that refusal is the Core's (ADR 0024).
+    const ptyId = await this.livePty(taskId);
+    const killed = await this.client.kill(ptyId);
+    return { ptyId, killed };
+  }
+
+  close(): void {
+    this.client.close();
+  }
+
+  // ─── Shared resolution ─────────────────────────────────────────────────────
+
+  /** Start a Session, translating the SDK's refusal into a gateway error. */
+  private async begin(opts: {
+    projectId?: string;
+    taskId?: string;
+    cwd: string;
+    harness: CoreLinkPtySpawnHarness;
+    title?: string;
+    command?: string;
+    prompt?: string;
+    dangerouslySkipPermissions: boolean;
+  }): Promise<CoreSession> {
+    try {
+      return await CoreSession.start(this.client, {
+        ...(opts.projectId ? { projectId: opts.projectId } : {}),
+        ...(opts.taskId ? { taskId: opts.taskId } : {}),
+        ...(opts.title ? { title: opts.title } : {}),
+        ...(opts.command ? { command: opts.command } : {}),
+        ...(opts.prompt ? { prompt: opts.prompt } : {}),
+        // Sent only when it is true: the Core allow-lists a harness's
+        // skip-permissions flag *only* on a spawn that also set this option, so
+        // the two travel together or not at all.
+        ...(opts.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
+        cwd: opts.cwd,
+        harness: opts.harness,
+      });
+    } catch (err) {
+      throw new SessionGatewayError("refused", messageOf(err), { cause: err });
+    }
+  }
+
+  /** The PTY running for this Task, or the reason there is none to act on. */
+  private async livePty(taskId: string): Promise<string> {
+    const { ptyId } = await this.client.findByTask(taskId);
+    if (ptyId === null) {
+      throw new SessionGatewayError(
+        "not-running",
+        `session ${taskId} has no harness running — nothing to read from or write to`,
+      );
+    }
+    return ptyId;
+  }
+
+  private async findTask(taskId: string): Promise<CoreLinkTaskSnapshot> {
+    const { tasks } = await this.client.tasksList();
+    const task = tasks.find((row) => row.taskId === taskId);
+    if (!task) {
+      throw new SessionGatewayError("no-such-session", `this Core has no session ${taskId}`);
+    }
+    return task;
+  }
+
+  private async projectFor(projectId: string): Promise<CoreLinkProjectSnapshot> {
+    const projects = await this.client.projectsList();
+    const project = projects.find((row) => row.projectId === projectId);
+    if (!project) {
+      throw new SessionGatewayError(
+        "no-such-project",
+        `this Core no longer has the project ${projectId} that session belongs to`,
+      );
+    }
+    return project;
+  }
+
+  /**
+   * A Project by id, or by name.
+   *
+   * By id first, because an id is unambiguous and a name is what somebody types.
+   * A name matching two Projects is an error rather than a coin toss: starting a
+   * Session in the wrong repository is not a mistake a person notices quickly.
+   */
+  private resolveProject(
+    projects: CoreLinkProjectSnapshot[],
+    wanted: string,
+  ): CoreLinkProjectSnapshot {
+    const byId = projects.find((project) => project.projectId === wanted);
+    if (byId) return byId;
+
+    const byName = projects.filter((project) => project.name === wanted);
+    if (byName.length === 1) return byName[0]!;
+    if (byName.length > 1) {
+      throw new SessionGatewayError(
+        "no-such-project",
+        `"${wanted}" names ${byName.length} projects on this Core — use the project id: ${byName
+          .map((project) => project.projectId)
+          .join(", ")}`,
+      );
+    }
+    const known = projects.map((project) => project.name).join(", ");
+    throw new SessionGatewayError(
+      "no-such-project",
+      known.length > 0
+        ? `this Core has no project "${wanted}". It has: ${known}`
+        : `this Core has no projects registered`,
+    );
+  }
+}
+
+/** Present one `CoreSession` as a {@link StartedSession}. */
+function wrap(session: CoreSession, projectId: string, project: string | null): StartedSession {
+  return {
+    taskId: session.taskId,
+    ptyId: session.ptyId,
+    harness: session.harness,
+    command: session.command,
+    projectId,
+    project,
+    wait: async (opts) => {
+      const idle = await session.waitForIdle(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {});
+      return {
+        status: idle.status,
+        exited: idle.exited,
+        ...(idle.exitCode === undefined ? {} : { exitCode: idle.exitCode }),
+      };
+    },
+    screen: () => session.screen(),
+    dispose: () => session.dispose(),
+  };
+}
+
+/**
+ * The Project's remembered harness, when it names one this build knows.
+ *
+ * A Core fact (ADR 0017), so the CLI reads it rather than keeping its own
+ * default per Project. An unrecognised value falls through to
+ * {@link DEFAULT_HARNESS} rather than being sent — a Core that remembers a
+ * harness this build has never heard of is a Core to update, not a spawn to
+ * fail.
+ */
+function rememberedHarness(project: CoreLinkProjectSnapshot): CoreLinkPtySpawnHarness | null {
+  if (!project.rememberHarnessSettings) return null;
+  const saved = project.savedHarness;
+  return saved !== null && isKnownHarness(saved) ? saved : null;
+}
+
+/**
+ * A Task title from the prompt, because "SDK session" — the SDK's own default —
+ * is not a title anybody can pick out of `session ls`.
+ *
+ * First line, trimmed, and short enough to sit in a table column. A Session
+ * started with no prompt gets a neutral name rather than an empty cell.
+ */
+function titleFor(prompt: string | undefined): string {
+  const firstLine = (prompt ?? "").split("\n").map((line) => line.trim()).find(Boolean);
+  if (firstLine === undefined) return "actana session";
+  return firstLine.length > 72 ? `${firstLine.slice(0, 71)}…` : firstLine;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
Implements the `session` noun of #129 D10, minus `attach` (#163). Base is
`feat/cli-and-publishing`, train `beta/0.2.2`.

    actana session start <project> [prompt]   start a Session; prints its id
    actana session ls [project]               list Sessions on this Core
    actana session logs <session>             the transcript, rendered
    actana session resume <session> [prompt]  continue a conversation
    actana session send <session> <text>      write text into a running Session
    actana session kill <session>             stop the harness running for it
    actana session attach <session>           in the tree, exits 3, names #163

## What it does

**`start` exits by default** (#129 D6), printing a Session id; the harness
carries on without the process that asked for it. `--wait` blocks until the Core
reports the Session settled, and `--wait --json` emits that final state as one
object with the transcript in it — the Core's replay ring lives with the PTY, so
a `--json` caller has no second chance to read it.

**`--json` means only JSON on stdout**, on the failing path as much as the happy
one: one document per verb, `{"error": …}` when it could not do what it was
asked, and every progress line on stderr. Without `--json`, stdout carries the
Session id and nothing else, so `TASK=$(actana session start web "fix it")`
works with `--wait` as well as without it.

**`kill`, `send` and `logs` work on any Session on the Core**, including ones a
Panel or another terminal started. Nothing about having started a Session is
remembered locally — a Session is named by Task id and resolved through the
Core — so "a Session this CLI did not start" is not a case the code has.

## The traps, and what holds them

**Prompt delivery is the Core's** (ADR 0026, #129 D3). A starting prompt is
handed to the SDK and that is the whole of this CLI's involvement: no timing, no
retry, no Enter after a pause. `send` writes exactly the bytes it was given;
`--enter` writes a carriage return as a *separate* write because the operator
asked for one in that invocation. `no-prompt-timing.test.ts` makes this a
property of the package rather than a paragraph in a header — nothing shipped
here schedules anything, and the clock is read in one file to print an age.

**`logs` renders a screen**, through the SDK's `TerminalScreen`, because a
harness paints with cursor moves. The in-process-Core suite asserts both
directions on a repainted line: rendered it reads `done: 3 files changed`, raw it
reads `Scanning…Scanning… 2 filesdone: 3 files changed`.

**`--wait` is the Core's report**, `waitForIdle` watching the event log — never a
guess from how quiet the output went. `--wait-timeout` is a deadline the operator
chose, handed to the SDK, and its expiry is reported as this side giving up
rather than as a status the Core never sent.

## Tests

`pnpm --filter @actana/cli test` — 149 passing, 3 skipped (the opt-in live-Core
suites). Typecheck and lint are clean across the workspace.

- `session-command.test.ts` — 30 cases over the flags, tables, `--json` shapes
  and exit codes, with the gateway injected and no socket anywhere.
- `in-process-core-session.test.ts` — the same verbs against `packages/core`'s
  real `PtyCoreLinkServer` on a real wss:// port, holding a PTY that was already
  running: `ls`, `logs` (rendered and `--raw`), `send` (exact bytes, no return),
  and `kill` on a Session this CLI did not start.
- `harness-resume.test.ts` — every resume command run through the Core's own
  `resolveSpawnPlan`, so a table that drifts from the allow-list fails here
  rather than on a Core.
- `never-logs-a-blob.test.ts` — extended to sweep every session verb with
  `--verbose`, since each one resolves a credential.

## Boundaries

Touches `packages/cli` only. The shared router and root help take the single
registration for the noun; `packages/sdk`, `release.yml` and `docs/reference` are
untouched, and no file belonging to #161 or #162 is created or edited.

Refs #160
