### PR TITLE
feat(cli): actana session attach — a terminal on a Session, holding its write lock

### DIFF
--- a/packages/cli/src/__tests__/actana-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-cli.test.ts
@@ -7,8 +7,10 @@
 // whole of `exit-codes.ts`'s argument, and until now nothing asserted it at the
 // root — the reserved nouns exited `2` and `core shell` exited `3` for the same
 // underlying fact, which the review of #201 caught. #162 built `core shell` and
-// #160/#161/#163 built the nouns, so what is reserved here is verbs inside a
-// built noun: `project cp`, `project files`, `session attach`.
+// #160/#161 built the nouns, so what is reserved here is verbs inside a built
+// noun: `project cp` and `project files`. `session attach` was the third until
+// #163 built it, and it is the counter-example below — the thing a reservation
+// is supposed to stop being.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "../exit-codes.ts";
@@ -30,14 +32,14 @@ afterEach(() => {
  *
  * No *noun* is reserved any more: `session` left the list when #160 built it
  * and `project`, `harness` and `events` left when #161 did, which is the shape
- * a reservation is supposed to end in. What is still reserved is a verb — and
+ * a reservation is supposed to end in. `session attach` left it the same way
+ * when #163 built it. What is still reserved is a verb waiting on phase 3 — and
  * the distinction the exit code draws is the same one either way, so these are
  * what assert it.
  */
 const RESERVED = [
   [["project", "cp"], "#168"],
   [["project", "files"], "#168"],
-  [["session", "attach"], "#163"],
 ] as const;
 
 /** The nouns that are built, so the help below cannot go quiet about them. */
@@ -56,22 +58,28 @@ describe("a reservation is `not built yet`, not `you typed it wrong`", () => {
 
   it("is the answer for a name that is reserved, and not for one that is built", async () => {
     // `core shell` was the reserved *verb* and shared this code until #162
-    // built it. Now it is a command like any other, and a build that answered
-    // `3` for it would be telling a script to come back on a later train for
-    // something already shipped.
-    const reserved = await cli().run(["session", "attach"]);
+    // built it; `session attach` was the last one and #163 built it. Now they
+    // are commands like any other, and a build that answered `3` for either
+    // would be telling a script to come back on a later train for something
+    // already shipped.
+    const reserved = await cli().run(["project", "cp"]);
     expect(reserved.code).toBe(EXIT_UNIMPLEMENTED);
-    const built = await cli().run(["core", "shell"]);
-    expect(built.code).not.toBe(EXIT_UNIMPLEMENTED);
+    for (const built of [["core", "shell"], ["session", "attach"]]) {
+      const run = await cli().run(built);
+      expect(run.code, built.join(" ")).not.toBe(EXIT_UNIMPLEMENTED);
+    }
   });
 
-  it("answers the same for a reserved verb wherever it sits in the tree", async () => {
-    // `project cp` is reserved in `project-command.ts` and `session attach` in
-    // `session-command.ts`, and a script cannot be asked to know which file it
-    // landed in. One fact about this build, one exit code.
-    const project = await cli().run(["project", "cp"]);
-    const session = await cli().run(["session", "attach"]);
-    expect(project.code).toBe(session.code);
+  it("answers the same for every reserved verb, and not for a built one beside it", async () => {
+    // One fact about this build, one exit code — and it has to stay a *fact
+    // about the build* rather than about a file. `project cp` and `project ls`
+    // sit in the same module and differ only in whether they are built, which
+    // is the difference the code is supposed to carry.
+    const cp = await cli().run(["project", "cp"]);
+    const files = await cli().run(["project", "files"]);
+    expect(cp.code).toBe(files.code);
+    const built = await cli().run(["project", "ls"]);
+    expect(built.code).not.toBe(cp.code);
   });
 
   it("dials nothing to say it — a reservation is answered before a Core is", async () => {

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -14,6 +14,13 @@ import { registryPaths, type RegistryPaths } from "../blob-registry.ts";
 import type { CoreProbe, CoreProbeFn } from "../core-probe.ts";
 import { nonInteractiveTerminal, type CliTerminal, type TerminalSignal } from "../cli-terminal.ts";
 import type { OpenCoreShellFn } from "../core-shell-channel.ts";
+import { SessionWriteRefused } from "../session-attach-channel.ts";
+import type {
+  AttachAuthority,
+  OpenSessionAttachFn,
+  SessionAttachExit,
+  SessionAttachment,
+} from "../session-attach-channel.ts";
 import type { CoreConnectFn, CoreConnectOptions, CoreLinkClient } from "../core-connection.ts";
 import type { OpenSessionGateway, SessionGateway, StartedSession } from "../session-gateway.ts";
 import type {
@@ -88,6 +95,8 @@ export type RunOptions = {
   terminal?: CliTerminal;
   /** What `core shell` gets back, or a throw. */
   openShell?: OpenCoreShellFn;
+  /** What `session attach` gets back, or a throw. */
+  openAttach?: OpenSessionAttachFn;
 };
 
 /**
@@ -205,6 +214,11 @@ export function makeCliFixture(): CliFixture {
           opts.openShell ??
           (async () => {
             throw new Error("this test did not expect to open a shell");
+          }),
+        openAttach:
+          opts.openAttach ??
+          (async () => {
+            throw new Error("this test did not expect to attach to a session");
           }),
       });
       return { code, out, err, all: [...out, ...err].join("\n") };
@@ -459,6 +473,112 @@ export function fakeTerminal(opts: { isTty?: boolean; cols?: number; rows?: numb
     },
     raise: (signal) => {
       for (const cb of [...(signalled.get(signal) ?? [])]) cb();
+    },
+  };
+}
+
+/**
+ * An attached Session, under the test's control.
+ *
+ * The counterpart to {@link fakeTerminal} for `session attach`: the lock is a
+ * value the test sets rather than a race it has to stage, and every ending —
+ * the harness exiting, the link dropping, a write refused because the lock
+ * moved — is a method. `session-attach-live.test.ts` is where those same
+ * endings are produced by a real Core instead.
+ */
+export type FakeAttachment = SessionAttachment & {
+  /** Everything the CLI forwarded, joined — keystrokes, in order. */
+  typed: () => string;
+  resizes: Array<{ cols: number; rows: number }>;
+  /** How many times the lock was handed back. Never more than once. */
+  releaseCount: () => number;
+  closeCount: () => number;
+  /** The harness prints. */
+  emit: (data: string) => void;
+  /** The harness's process exits. */
+  exit: (exit: SessionAttachExit) => void;
+  /** The link goes away underneath. */
+  drop: (error?: string) => void;
+  /** Somebody force-took the lock: every write from here is refused (ADR 0024 D7). */
+  takeLock: () => void;
+  /** Make every write fail for a reason that is *not* the lock. */
+  breakWrites: (err: Error) => void;
+};
+
+export function fakeAttachment(
+  opts: { authority?: AttachAuthority; backlog?: string; taskId?: string } = {},
+): FakeAttachment {
+  const authority = opts.authority ?? "held";
+  const sent: string[] = [];
+  const resizes: Array<{ cols: number; rows: number }> = [];
+  const data = new Set<(d: string) => void>();
+  const exits = new Set<(e: SessionAttachExit) => void>();
+  const drops = new Set<(i: { error?: string }) => void>();
+  let releases = 0;
+  let closes = 0;
+  let held = authority === "held";
+  let taken = false;
+  let writeError: Error | null = null;
+
+  return {
+    taskId: opts.taskId ?? "task_1",
+    ptyId: "pty_1",
+    authority,
+    backlog: opts.backlog ?? "",
+    typed: () => sent.join(""),
+    resizes,
+    releaseCount: () => releases,
+    closeCount: () => closes,
+    takeLock: () => {
+      taken = true;
+      held = false;
+    },
+    breakWrites: (err) => {
+      writeError = err;
+    },
+    write: async (d) => {
+      // The real channel refuses before the wire when it holds no authority and
+      // after the Core's refusal when the lock moved. One error for both, so a
+      // test that drives either path drives the command's one handler.
+      if (taken) throw new SessionWriteRefused("another Core client has taken this Session's write lock");
+      if (authority === "held-by-another" || authority === "not-claimed") {
+        throw new SessionWriteRefused("this attachment does not hold this Session's write lock");
+      }
+      if (writeError) throw writeError;
+      sent.push(d);
+    },
+    resize: async (cols, rows) => {
+      resizes.push({ cols, rows });
+    },
+    onData: (cb) => {
+      data.add(cb);
+      return () => data.delete(cb);
+    },
+    onExit: (cb) => {
+      exits.add(cb);
+      return () => exits.delete(cb);
+    },
+    onDisconnected: (cb) => {
+      drops.add(cb);
+      return () => drops.delete(cb);
+    },
+    release: async () => {
+      releases += 1;
+      const wasHeld = held;
+      held = false;
+      return wasHeld;
+    },
+    close: () => {
+      closes += 1;
+    },
+    emit: (d) => {
+      for (const cb of [...data]) cb(d);
+    },
+    exit: (e) => {
+      for (const cb of [...exits]) cb(e);
+    },
+    drop: (error) => {
+      for (const cb of [...drops]) cb(error === undefined ? {} : { error });
     },
   };
 }

--- a/packages/cli/src/__tests__/in-process-core.ts
+++ b/packages/cli/src/__tests__/in-process-core.ts
@@ -29,6 +29,15 @@
 //     {@link recordingCreateServer}. Without it the restart above is an
 //     `EADDRINUSE` rather than the reconnect the suite meant to stage.
 //
+//   • **Killing a live connection while the Core keeps running**
+//     ({@link InProcessCore.dropConnections}). `session attach` claims a Session
+//     write lock and the Core releases it when the holding connection goes (ADR
+//     0024 D7) — the case #163 calls the one that gets missed and the one that
+//     strands a Session unwritable. A client cannot stage that from its own side:
+//     hanging up politely is not the same event, and stopping the whole Core
+//     proves nothing about a lock table that died with it. This destroys the
+//     socket the way a network does.
+//
 // **`@actana/core` and `@actana/shared` stay out of `package.json`** (ADR 0025
 // D4) — both are private, one is a daemon, and a manifest entry would put them
 // in the published CLI's dependency graph for the sake of a test. The module
@@ -113,7 +122,7 @@ export function freePort(): Promise<number> {
  * handshake — without them the blob's client cert would be decoration.
  */
 function recordingCreateServer(
-  bound: { port: number },
+  bound: { port: number; dropAll: () => void },
 ): (opts: { port: number; host: string; tls?: unknown }) => WebSocketServerLike {
   return (opts) => {
     const tls = opts.tls as { caCert: string; serverCert: string; serverKey: string };
@@ -129,6 +138,18 @@ function recordingCreateServer(
       if (addr && typeof addr === "object") bound.port = addr.port;
     });
     const wss = new WebSocketServer({ server: tlsServer });
+    // `terminate`, not `close`: the socket is destroyed with no close frame and
+    // no handshake, which is what a network drop looks like to the Core — and
+    // the only way the release-on-drop path (D7) can be reached from a test.
+    bound.dropAll = () => {
+      for (const client of wss.clients) {
+        try {
+          client.terminate();
+        } catch {
+          /* already gone */
+        }
+      }
+    };
     return {
       // Torn down the way a Core process being killed tears down, and in an
       // order that actually releases the port. `wss.close()` stops the upgrade
@@ -214,6 +235,14 @@ export type InProcessCore = {
   material: CertMaterial;
   close: () => void;
   /**
+   * Destroy every live core-link connection, leaving the Core running.
+   *
+   * The abrupt disconnect: no close frame, no `release`, nothing the client
+   * chose. What the Core does next — drop that connection's Session locks (ADR
+   * 0024 D7) — is the claim `session-attach-live.test.ts` exists to check.
+   */
+  dropConnections: () => void;
+  /**
    * Close, and resolve once the port is genuinely free again.
    *
    * `close()` is enough for teardown and not enough for a restart: the
@@ -229,7 +258,7 @@ export type InProcessCore = {
 export async function startInProcessCore(opts: InProcessCoreOptions = {}): Promise<InProcessCore> {
   const material = opts.material ?? (await generateCertMaterial({ host: "127.0.0.1" }));
   const port = opts.port ?? (await freePort());
-  const bound = { port: 0 };
+  const bound = { port: 0, dropAll: () => {} };
   const server = new PtyCoreLinkServer((opts.ptyCore ?? unusedPtyCore()) as never, {
     port,
     host: "127.0.0.1",
@@ -275,6 +304,7 @@ export async function startInProcessCore(opts: InProcessCoreOptions = {}): Promi
     blobText,
     material,
     close: () => server.close(),
+    dropConnections: () => bound.dropAll(),
     stop: async () => {
       server.close();
       await waitForPortFree(bound.port);

--- a/packages/cli/src/__tests__/never-logs-a-blob.test.ts
+++ b/packages/cli/src/__tests__/never-logs-a-blob.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
+  fakeAttachment,
   fakeTerminal,
   fakeCore,
   fakeSessionGateway,
@@ -234,6 +235,37 @@ describe("no verb prints a blob, with --verbose on", () => {
     });
     expect(run.code).not.toBe(0);
     expectNoSecrets("core shell (refused)", run.all);
+  });
+
+  it("sweeps `session attach`, the other verb that holds the credential for a whole session", async () => {
+    // Two lines are worth the sweep here. The one that reports an attach that
+    // would not open has the resolved blob in hand and is explaining a failure
+    // to reach the Core the blob names; and the one that says *why* an attach is
+    // read-only names another Core client, at a moment when the only identity
+    // this process holds is a credential. Everything else is bytes the harness
+    // chose, which never touch one.
+    await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() });
+
+    const refused = await cli().run(["session", "attach", "task_1", "--verbose"], {
+      terminal: fakeTerminal(),
+      openAttach: async () => {
+        throw new Error("connect ECONNREFUSED");
+      },
+    });
+    expect(refused.code).not.toBe(0);
+    expectNoSecrets("session attach (refused)", refused.all);
+
+    const readOnly = fakeAttachment({ authority: "held-by-another" });
+    const terminal = fakeTerminal();
+    const attached = cli().run(["session", "attach", "task_1", "--verbose"], {
+      terminal,
+      openAttach: async () => readOnly,
+    });
+    // Wired first: a drop delivered before the command is listening is a drop
+    // nobody hears, and the run would sit there until the suite timed out.
+    await terminal.wired;
+    readOnly.drop("socket hang up");
+    expectNoSecrets("session attach (read-only, dropped)", (await attached).all);
   });
 
   it("prints the endpoint and label, which are the non-secret half", async () => {

--- a/packages/cli/src/__tests__/session-attach-live.test.ts
+++ b/packages/cli/src/__tests__/session-attach-live.test.ts
@@ -1,0 +1,284 @@
+// `actana session attach` against a Core that is actually running (#163).
+//
+// `session-attach.test.ts` injects the attachment, which is what makes raw mode,
+// the detach key and every teardown path testable without a Core — and is
+// exactly why it cannot say whether the *lock* behaves. A lock is a fact about
+// two connections to one Core, and there is no way to fake one honestly: the
+// interesting states are the ones the Core decides.
+//
+// So this suite runs the real `openSessionAttach` against the real
+// `PtyCoreLinkServer` on a real `wss://` port, twice at a time, and checks the
+// three claims the ticket makes about contention:
+//
+//   1. **Two attaches on one Session: one writes, one reads.** Both see the
+//      output; only the first can type, and the second is told why.
+//   2. **Detaching releases the lock** — the next attach is granted it.
+//   3. **So does the connection dropping.** The connection is destroyed with no
+//      close frame and no `release` (`dropConnections`), and the Session is
+//      claimable again afterwards. This is the case the ticket calls the one
+//      that gets missed and the one that strands a Session unwritable, and it is
+//      the reason a fake cannot stand in here: nothing this CLI does produces
+//      it, which is precisely why it is worth a test.
+//
+// The Core comes from `in-process-core.ts` — the rig #205 unified — with the
+// live PTY this suite drives, the same shape `in-process-core-session.test.ts`
+// contributed for `logs`, `send` and `kill`.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { EXIT_FAILURE, EXIT_OK } from "../exit-codes.ts";
+import { openSessionAttach } from "../session-attach-channel.ts";
+import { fakeTerminal, makeCliFixture, type CliFixture, type FakeTerminal } from "./cli-harness.ts";
+import { startInProcessCore, waitFor, type InProcessCore } from "./in-process-core.ts";
+import type {
+  CoreLinkProjectSnapshot,
+  CoreLinkSessionSnapshot,
+  CoreLinkTaskSnapshot,
+} from "@actana/sdk/core-link-frames.ts";
+
+/** `Ctrl-]`, the detach key. */
+const DETACH = "\u001D";
+
+const PROJECT: CoreLinkProjectSnapshot = {
+  projectId: "proj_web",
+  name: "web",
+  path: "/home/core/projects/web",
+  icon: "WE",
+  iconColor: "#123456",
+  pinned: false,
+  rememberHarnessSettings: false,
+  savedHarness: null,
+  savedSkipPermissions: false,
+  savedBareSession: false,
+  defaultGridView: false,
+  updatedAt: 1_700_000_000_000,
+};
+
+const TASK: CoreLinkTaskSnapshot = {
+  taskId: "task_live",
+  projectId: PROJECT.projectId,
+  title: "rebuild the flaky auth test",
+  titleManuallySet: false,
+  claudeSessionId: "00000000-0000-4000-8000-000000000000",
+  agent: "claude-code",
+  status: "running",
+  pinned: false,
+  archived: false,
+  icon: null,
+  updatedAt: 1_700_000_000_000,
+};
+
+/** What the harness had already printed before anybody attached. */
+const SCROLLBACK = "the harness was already running\r\n";
+
+/**
+ * A PTY manager holding one live PTY, with the Core's fan-out callback captured
+ * so the test can make the harness print.
+ *
+ * `setEmitTarget` is the Core's one hook into a PTY's output, and it is the only
+ * way to prove a Reader is really reading: the Core fans a PTY's bytes out to
+ * the connections that subscribed to it and to no others (ADR 0024 D2), so an
+ * attach that never sent `ptySubscribe` would paint the scrollback and then sit
+ * there silently.
+ */
+function livePtyCore() {
+  const writes: string[] = [];
+  let emit: ((event: unknown) => void) | null = null;
+  let seq = 0;
+  const ptys = new Map<string, string>([["task_live", "pty_live"]]);
+
+  const core = {
+    setEmitTarget: (cb: ((event: unknown) => void) | null) => {
+      emit = cb;
+    },
+    findByTask: (taskId: string) => ({ ptyId: ptys.get(taskId) ?? null }),
+    taskIdForPty: (ptyId: string) =>
+      [...ptys.entries()].find(([, id]) => id === ptyId)?.[0] ?? null,
+    replay: (ptyId: string) =>
+      ptyId === "pty_live" ? { data: SCROLLBACK, nextSeq: 1 } : { data: "", nextSeq: 0 },
+    write: (ptyId: string, data: string) => {
+      if (ptyId !== "pty_live") return false;
+      writes.push(data);
+      return true;
+    },
+    kill: () => true,
+    resize: () => true,
+    spawn: () => {
+      throw new Error("this suite attaches to a Session that is already running");
+    },
+    killAll: () => {},
+    killLaunchProcesses: () => ({ ptyCount: 0, ports: [] }),
+    killPtysUnderPath: () => {},
+  };
+
+  return {
+    core,
+    writes,
+    /** The harness prints a line, as the Core's PTY would. */
+    print: (data: string) => {
+      seq += 1;
+      emit?.({ type: "data", ptyId: "pty_live", data, seq });
+    },
+  };
+}
+
+/** Task and project reads, answered from memory. */
+function ports() {
+  const sessions = (): CoreLinkSessionSnapshot[] => [
+    { taskId: TASK.taskId, ptyId: "pty_live", status: TASK.status, updatedAt: TASK.updatedAt },
+  ];
+  return {
+    queryPort: {
+      listProjects: () => [PROJECT],
+      listTasks: () => [TASK],
+      listArchivedTasks: () => [],
+      countArchivedTasks: () => 0,
+      getTask: (taskId: string) => (taskId === TASK.taskId ? TASK : null),
+    },
+    mutationPort: {
+      mutateProject: () => null,
+      mutateTask: () => null,
+      listSessions: sessions,
+    },
+  };
+}
+
+let core: InProcessCore | null = null;
+let fixture: CliFixture | null = null;
+
+afterEach(() => {
+  core?.close();
+  core = null;
+  fixture?.cleanup();
+  fixture = null;
+});
+
+/** A Core holding one live Session, with the CLI pointed at it. */
+async function coreWithLiveSession(): Promise<ReturnType<typeof livePtyCore>> {
+  const pty = livePtyCore();
+  core = await startInProcessCore({ ptyCore: pty.core, ...ports() });
+  fixture = makeCliFixture();
+  await fixture.run(["core", "add", "inproc"], { stdin: core.blobText });
+  return pty;
+}
+
+/** One `actana session attach`, dialling the Core for real, fully wired. */
+async function attach(argv: string[] = ["session", "attach", "task_live"]): Promise<{
+  run: Promise<{ code: number; err: string[] }>;
+  terminal: FakeTerminal;
+}> {
+  const terminal = fakeTerminal();
+  const run = fixture!.run(argv, { terminal, openAttach: openSessionAttach });
+  await terminal.wired;
+  return { run, terminal };
+}
+
+describe("two attaches on one Session, against a Core in this process", () => {
+  it("gives the first the write lock and the second a read-only view that says why", async () => {
+    const pty = await coreWithLiveSession();
+
+    const first = await attach();
+    const second = await attach();
+
+    // Both are reading — the Core fans this PTY out to every connection that
+    // subscribed to it, and both did.
+    pty.print("a line from the harness\r\n");
+    await waitFor(
+      () => first.terminal.painted().includes("a line") && second.terminal.painted().includes("a line"),
+      "one of the two attaches never received the live stream",
+    );
+    expect(first.terminal.painted()).toContain(SCROLLBACK.trim());
+    expect(second.terminal.painted()).toContain(SCROLLBACK.trim());
+
+    // Only one is writing. The second's keystrokes are never put on the wire —
+    // and if they were, this Core would refuse them.
+    first.terminal.type("typed by the holder");
+    second.terminal.type("typed by the reader");
+    await waitFor(() => pty.writes.length > 0, "the holder's keystrokes never reached the PTY");
+
+    second.terminal.type(DETACH);
+    first.terminal.type(DETACH);
+    const [a, b] = await Promise.all([first.run, second.run]);
+
+    expect(pty.writes.join("")).toBe("typed by the holder");
+    expect(a.code).toBe(EXIT_OK);
+    expect(b.code).toBe(EXIT_OK);
+    expect(a.err.join("\n")).toContain("You hold the write lock");
+    expect(b.err.join("\n")).toContain("READ-ONLY");
+    expect(b.err.join("\n")).toContain("another Core client holds this Session's write lock");
+  }, 30_000);
+
+  it("hands the lock to the next attach once the first detaches", async () => {
+    const pty = await coreWithLiveSession();
+
+    const first = await attach();
+    first.terminal.type(DETACH);
+    expect((await first.run).err.join("\n")).toContain("You hold the write lock");
+
+    // Same Session, new connection, and it is claimable — which is only true
+    // because the detach above sent a `release` (ADR 0024 D7).
+    const second = await attach();
+    second.terminal.type("typed after the handover");
+    await waitFor(() => pty.writes.length > 0, "the second attach never got the lock");
+    second.terminal.type(DETACH);
+
+    const result = await second.run;
+    expect(result.err.join("\n")).toContain("You hold the write lock");
+    expect(pty.writes.join("")).toBe("typed after the handover");
+  }, 30_000);
+
+  it("does not leave the Session locked when the connection drops abruptly", async () => {
+    // **The case that strands a Session.** No detach, no release frame, no close
+    // handshake: the socket is destroyed under a live attach that holds the
+    // lock. Everything below is what must still be true afterwards.
+    const pty = await coreWithLiveSession();
+
+    const holder = await attach();
+    holder.terminal.type("typed before the drop");
+    await waitFor(() => pty.writes.length > 0, "the first attach never got the lock");
+
+    core!.dropConnections();
+
+    const dropped = await holder.run;
+    // This side: the terminal is back, the exit code says it did not end well,
+    // and the operator is told the Session is not stuck.
+    expect(holder.terminal.isRaw()).toBe(false);
+    expect(dropped.code).toBe(EXIT_FAILURE);
+    expect(dropped.err.join("\n")).toContain("dropped");
+    expect(dropped.err.join("\n")).toContain("claimable again");
+
+    // The Core's side, which is the half that matters: the lock went with the
+    // connection, so the next attach is granted it and can type.
+    const next = await attach();
+    next.terminal.type("typed after the drop");
+    await waitFor(
+      () => pty.writes.length > 1,
+      "the Session was left locked by a connection that no longer exists",
+    );
+    next.terminal.type(DETACH);
+
+    const result = await next.run;
+    expect(result.err.join("\n")).toContain("You hold the write lock");
+    expect(pty.writes.join("|")).toBe("typed before the drop|typed after the drop");
+  }, 30_000);
+
+  it("attaches read-only without taking a lock nobody else holds", async () => {
+    // `--read-only` on an unclaimed Session. The point is what happens *next*:
+    // the Session is still free, so an attach that meant to drive it gets the
+    // lock rather than finding a watcher holding it.
+    const pty = await coreWithLiveSession();
+
+    const watcher = await attach(["session", "attach", "task_live", "--read-only"]);
+    const driver = await attach();
+
+    driver.terminal.type("typed by the driver");
+    await waitFor(() => pty.writes.length > 0, "the driver never got the lock");
+
+    watcher.terminal.type(DETACH);
+    driver.terminal.type(DETACH);
+    const [w, d] = await Promise.all([watcher.run, driver.run]);
+
+    expect(w.err.join("\n")).toContain("--read-only");
+    expect(d.err.join("\n")).toContain("You hold the write lock");
+    expect(pty.writes.join("")).toBe("typed by the driver");
+  }, 30_000);
+});

--- a/packages/cli/src/__tests__/session-attach.test.ts
+++ b/packages/cli/src/__tests__/session-attach.test.ts
@@ -214,6 +214,44 @@ describe("the write lock is the first thing this command settles (ADR 0024 D3–
     expect(result.err.join("\n")).toContain("claimable again");
   });
 
+  it("does not tell an attach that held nothing that the Session is claimable again", async () => {
+    // D7 releases the locks the dropped connection *held*, and a read-only
+    // attach held none. The unconditional line was wrong twice over in the
+    // operator's favour: this connection freed nothing, and the Session is still
+    // held by the client that has it.
+    const { run, attachment } = await attach({ authority: "held-by-another" });
+    attachment.drop("socket hang up");
+    const said = (await run).err.join("\n");
+
+    expect(said).not.toContain("claimable again");
+    expect(said).toContain("stays held by the client that does");
+  });
+
+  it("says a `--read-only` drop left the Session's lock exactly as it was", async () => {
+    const { run, attachment } = await attach({
+      authority: "not-claimed",
+      argv: ["session", "attach", "task_1", "--read-only"],
+    });
+    attachment.drop("socket hang up");
+    const said = (await run).err.join("\n");
+
+    expect(said).not.toContain("claimable again");
+    expect(said).toContain("leaves the Session's lock as it was");
+  });
+
+  it("does not claim a drop freed a lock this attach had already lost", async () => {
+    const { run, terminal, attachment } = await attach();
+
+    attachment.takeLock();
+    terminal.type("x");
+    await Promise.resolve();
+    attachment.drop("socket hang up");
+    const said = (await run).err.join("\n");
+
+    expect(said).not.toContain("claimable again");
+    expect(said).toContain("stays held by the client that took it");
+  });
+
   it("gives the terminal back before the release goes out, not after", async () => {
     // Ordering, not politeness. A release is a round trip to a Core that may
     // have stopped answering, and every millisecond of it would be a millisecond
@@ -382,6 +420,52 @@ describe("the keyboard", () => {
     expect(result.err.join("\n")).toContain("Detached from session task_1");
   });
 
+  it("makes Ctrl-C a detach once the lock has been taken away", async () => {
+    // The honest reading of a demoted attach: it is a Reader now, so `Ctrl-C`
+    // means what it means for every other Reader. Gating it on the authority
+    // this attach *opened* with left the key doing nothing at all — not
+    // forwarded, because there is no lock, and not a detach, because the
+    // read-only affordance never activated — which is the one outcome the
+    // operator cannot act on. They are told, on the terminal, at the moment it
+    // changes.
+    const { run, terminal, attachment } = await attach();
+
+    attachment.takeLock();
+    terminal.type("into the void\r");
+    await Promise.resolve();
+    expect(terminal.painted()).toContain("Ctrl-C now detaches");
+
+    terminal.type(CTRL_C);
+    const result = await run;
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.err.join("\n")).toContain("Detached from session task_1");
+    // And it is still a detach rather than a stray keystroke on the new holder's
+    // harness: nothing after the takeover reached the far side.
+    expect(attachment.typed()).toBe("");
+  });
+
+  it("says the lock was lost rather than that the attach was read-only", async () => {
+    // An attach that opened holding the lock and had it taken was not read-only;
+    // it was demoted. Telling the operator they had been read-only all along
+    // describes a session they did not have.
+    const { run, terminal, attachment } = await attach();
+
+    attachment.takeLock();
+    // The chunk that discovers the takeover is refused on the wire and answered
+    // on the terminal there and then; the tally is for the ones typed after,
+    // when this attach already knew it could not write.
+    terminal.type("x");
+    await Promise.resolve();
+    terminal.type("abc");
+    terminal.type(DETACH);
+    const said = (await run).err.join("\n");
+
+    expect(said).toContain("3 keystrokes were not forwarded");
+    expect(said).toContain("lost the write lock partway through");
+    expect(said).not.toContain("this attach was read-only");
+  });
+
   it("forwards what was typed before the detach key and nothing after it", async () => {
     // A chunk can carry both — a fast typist, or a paste. The bytes before the
     // key are keystrokes the operator meant; the ones after it were typed at a
@@ -439,6 +523,26 @@ describe("the screen", () => {
     await run;
 
     expect(attachment.resizes).toEqual([]);
+  });
+
+  it("stops resizing the PTY the moment the lock is taken away", async () => {
+    // The same restraint as the read-only case, but for the attach that used to
+    // be allowed — and the one that actually does damage. The Core does not gate
+    // `resize` on the lock, so a demoted attach that kept sending them reflows
+    // the *new* holder's PTY: somebody else's full-screen harness redrawn
+    // because this window changed size, from the one client whose frames the
+    // lock cannot see coming.
+    const { run, terminal, attachment } = await attach();
+
+    terminal.resizeTo(120, 40);
+    attachment.takeLock();
+    terminal.type("x");
+    await Promise.resolve();
+    terminal.resizeTo(200, 60);
+    terminal.type(DETACH);
+    await run;
+
+    expect(attachment.resizes).toEqual([{ cols: 120, rows: 40 }]);
   });
 
   it("tells the Core the terminal's size when it attaches", async () => {

--- a/packages/cli/src/__tests__/session-attach.test.ts
+++ b/packages/cli/src/__tests__/session-attach.test.ts
@@ -1,0 +1,494 @@
+// `actana session attach`, against a fake terminal and a fake Session (#163).
+//
+// The suite is organised around the ticket's "done when" rather than around the
+// command's code, because those four lines are the reason this command is hard:
+//
+//   - **attaching to a Session somebody else is writing gives a read-only view
+//     with a visible reason** — not an error, and not a silent steal.
+//   - **detaching releases the lock, and so does the connection dropping.** The
+//     second is the one that gets missed, and the asymmetry is the assertion:
+//     a detach sends a `release`, a dropped link deliberately does not, because
+//     the Core has already done it (ADR 0024 D7) and asking a socket that is
+//     gone is how a teardown hangs.
+//   - **two attaches on one Session: one writes, one reads.** Here as the two
+//     halves separately — a granted claim types, a refused one does not — and in
+//     `session-attach-live.test.ts` as two clients contending for real.
+//   - **the terminal is restored on every exit path.** One test per path, and
+//     the list of paths is the point.
+//
+// Every one of those is a failure nobody can stage against a real Core on
+// demand, which is why `deps.terminal` and `deps.openAttach` are injected at
+// all. The fake terminal records raw-mode calls instead of performing them, so
+// "did it restore?" is an assertion rather than an operator noticing their shell
+// has stopped echoing.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
+import { SessionGatewayError } from "../session-gateway.ts";
+import {
+  fakeAttachment,
+  fakeTerminal,
+  makeCliFixture,
+  sentinelBlobText,
+  type CliFixture,
+  type FakeAttachment,
+  type FakeTerminal,
+} from "./cli-harness.ts";
+import type { AttachAuthority } from "../session-attach-channel.ts";
+
+/** `Ctrl-]`, the detach key, and `Ctrl-C`, which is the harness's. */
+const DETACH = "\u001D";
+const CTRL_C = "\u0003";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+});
+
+/** A registered Core, so resolution has something to find. */
+async function withRegisteredCore(): Promise<void> {
+  await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() });
+}
+
+type AttachOpts = {
+  authority?: AttachAuthority;
+  backlog?: string;
+  terminal?: FakeTerminal;
+  attachment?: FakeAttachment;
+  argv?: string[];
+};
+
+/**
+ * Attach, and hand back the pieces with the session guaranteed to be fully
+ * wired — every listener registered — before the test acts on it.
+ */
+async function attach(opts: AttachOpts = {}) {
+  await withRegisteredCore();
+  const terminal = opts.terminal ?? fakeTerminal();
+  const attachment =
+    opts.attachment ??
+    fakeAttachment({
+      ...(opts.authority === undefined ? {} : { authority: opts.authority }),
+      ...(opts.backlog === undefined ? {} : { backlog: opts.backlog }),
+    });
+  const asked: Array<{ taskId: string; claimWrite: boolean; cols: number; rows: number }> = [];
+
+  const run = cli().run(opts.argv ?? ["session", "attach", "task_1"], {
+    terminal,
+    openAttach: async (_blob, o) => {
+      asked.push({ taskId: o.taskId, claimWrite: o.claimWrite, cols: o.cols, rows: o.rows });
+      return attachment;
+    },
+  });
+  await terminal.wired;
+  return { run, terminal, attachment, asked };
+}
+
+describe("the write lock is the first thing this command settles (ADR 0024 D3–D7)", () => {
+  it("claims it, says so, and forwards what is typed", async () => {
+    const { run, terminal, attachment } = await attach({ authority: "held" });
+
+    terminal.type("ls -la\r");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(attachment.typed()).toBe("ls -la\r");
+    // The reason is on the line before the screen fills, not discovered later by
+    // having a keystroke refused.
+    expect(result.err.join("\n")).toContain("You hold the write lock");
+  });
+
+  it("gives a read-only view with the reason on it, rather than an error or a steal", async () => {
+    // The ticket's first criterion, whole. Another Core client holds this
+    // Session: the attach opens, says why it cannot type, forwards nothing, and
+    // ends successfully — an attach that exited non-zero here would make
+    // "somebody else is driving" indistinguishable from "the Core is down".
+    const { run, terminal, attachment } = await attach({ authority: "held-by-another" });
+
+    terminal.type("rm -rf /\r");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(attachment.typed()).toBe("");
+    const said = result.err.join("\n");
+    expect(said).toContain("READ-ONLY");
+    expect(said).toContain("another Core client holds this Session's write lock");
+    // And it says how many keystrokes went nowhere, once, at the end — rather
+    // than repainting the Session's screen with a warning per key.
+    expect(said).toContain("keystrokes were not forwarded");
+  });
+
+  it("still reads the Session it may not write — a Reader is not a refusal", async () => {
+    const { run, terminal, attachment } = await attach({
+      authority: "held-by-another",
+      backlog: "the scrollback\r\n",
+    });
+
+    attachment.emit("a line the other client's harness printed\r\n");
+    terminal.type(DETACH);
+    await run;
+
+    expect(terminal.painted()).toContain("the scrollback");
+    expect(terminal.painted()).toContain("a line the other client's harness printed");
+  });
+
+  it("`--read-only` sends no claim at all", async () => {
+    // Not the same thing as being refused one. A Session starts unlocked (D5),
+    // so an ordinary attach on an unclaimed Session takes the lock — and an
+    // operator who only meant to watch an automation would take it from the
+    // automation that was about to claim.
+    const { run, terminal, asked, attachment } = await attach({
+      authority: "not-claimed",
+      argv: ["session", "attach", "task_1", "--read-only"],
+    });
+
+    terminal.type("hello");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(asked[0]!.claimWrite).toBe(false);
+    expect(attachment.typed()).toBe("");
+    expect(result.err.join("\n")).toContain("--read-only");
+    expect(result.code).toBe(EXIT_OK);
+  });
+
+  it("writes to a Core that has no lock table, and never calls that read-only", async () => {
+    // `supported: false` is not `granted: false`. Such a Core serves every
+    // mutation this client makes (D11), and rendering it read-only would tell an
+    // operator who is its only client that somebody else is typing.
+    const { run, terminal, attachment } = await attach({ authority: "no-lock-table" });
+
+    terminal.type("echo hi\r");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(attachment.typed()).toBe("echo hi\r");
+    expect(result.err.join("\n")).not.toContain("READ-ONLY");
+    expect(result.err.join("\n")).toContain("no Session lock");
+  });
+
+  it("hands the lock back when the operator detaches", async () => {
+    const { run, terminal, attachment } = await attach();
+
+    terminal.type(DETACH);
+    await run;
+
+    expect(attachment.releaseCount()).toBe(1);
+    expect(attachment.closeCount()).toBe(1);
+  });
+
+  it.each(["SIGINT", "SIGTERM"] as const)("hands it back on %s too", async (signal) => {
+    // A signal is a detach somebody else asked for. The lock has to come back on
+    // it for the same reason the terminal does: this process is going away and
+    // the Session must not go with it.
+    const { run, terminal, attachment } = await attach();
+    terminal.raise(signal);
+
+    const result = await run;
+    expect(attachment.releaseCount()).toBe(1);
+    expect(result.code).toBe(signal === "SIGINT" ? 130 : 143);
+  });
+
+  it("does not try to release over a link that has dropped — the Core already did", async () => {
+    // **The case the ticket says gets missed**, from this side. A dropped
+    // connection releases its locks at the Core (D7), so there is nothing to
+    // send; sending anyway means a teardown waiting on a socket that is gone,
+    // with the operator's terminal still raw behind it. The other half of this
+    // claim — that the Session really is claimable again afterwards — is proved
+    // against a real Core in `session-attach-live.test.ts`.
+    const { run, attachment } = await attach();
+    attachment.drop("socket hang up");
+
+    const result = await run;
+    expect(attachment.releaseCount()).toBe(0);
+    expect(result.code).toBe(EXIT_FAILURE);
+    // And the operator is told, because otherwise they would reasonably assume
+    // the Session they were driving is now stuck.
+    expect(result.err.join("\n")).toContain("claimable again");
+  });
+
+  it("gives the terminal back before the release goes out, not after", async () => {
+    // Ordering, not politeness. A release is a round trip to a Core that may
+    // have stopped answering, and every millisecond of it would be a millisecond
+    // the operator's terminal was still raw.
+    const terminal = fakeTerminal();
+    const attachment = fakeAttachment();
+    let rawAtRelease: boolean | null = null;
+    const release = attachment.release.bind(attachment);
+    attachment.release = async () => {
+      rawAtRelease = terminal.isRaw();
+      return release();
+    };
+
+    const { run } = await attach({ terminal, attachment });
+    terminal.type(DETACH);
+    await run;
+
+    expect(rawAtRelease).toBe(false);
+  });
+
+  it("keeps reading after the lock is taken away, and says it happened", async () => {
+    // D7's force takeover, from the losing end: the previous holder learns of it
+    // on its next mutation and no sooner. An attach that quit on that would take
+    // the operator's *view* away as well as their keyboard — and the Session is
+    // still worth watching.
+    const { run, terminal, attachment } = await attach();
+
+    terminal.type("before\r");
+    attachment.takeLock();
+    terminal.type("after\r");
+    await Promise.resolve();
+    attachment.emit("output that arrived after the takeover\r\n");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(attachment.typed()).toBe("before\r");
+    expect(terminal.painted()).toContain("taken this Session's write lock");
+    expect(terminal.painted()).toContain("output that arrived after the takeover");
+    expect(result.code).toBe(EXIT_OK);
+    // Nothing left to give back: the lock moved, and a release frame for it
+    // would be this client talking about a lock it no longer has.
+    expect(attachment.releaseCount()).toBe(1);
+  });
+});
+
+describe("the terminal is restored on every exit path", () => {
+  it("restores it on a detach", async () => {
+    const { run, terminal } = await attach();
+    expect(terminal.isRaw()).toBe(true);
+
+    terminal.type(DETACH);
+    await run;
+
+    expect(terminal.rawModeCalls).toEqual([true, false]);
+    expect(terminal.isRaw()).toBe(false);
+  });
+
+  it("restores it when the harness exits underneath", async () => {
+    const { run, terminal, attachment } = await attach();
+    attachment.exit({ exitCode: 0 });
+
+    const result = await run;
+    expect(terminal.isRaw()).toBe(false);
+    // Not this command's failure: an attach is a terminal onto somebody else's
+    // Session, and a script that could not tell "the attach failed" from "the
+    // harness you were watching exited 1" would be worse off than one that reads
+    // the line.
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.err.join("\n")).toContain("exited with code 0");
+  });
+
+  it("restores it when the connection drops", async () => {
+    const { run, terminal, attachment } = await attach();
+    attachment.drop("socket hang up");
+
+    const result = await run;
+    expect(terminal.isRaw()).toBe(false);
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(result.err.join("\n")).toContain("socket hang up");
+  });
+
+  it.each(["SIGINT", "SIGTERM"] as const)("restores it on %s", async (signal) => {
+    const { run, terminal } = await attach();
+    terminal.raise(signal);
+
+    const result = await run;
+    expect(terminal.isRaw()).toBe(false);
+    expect(result.code).toBe(signal === "SIGINT" ? 130 : 143);
+  });
+
+  it("restores it when the Session stops accepting input for a reason that is not the lock", async () => {
+    const { run, terminal, attachment } = await attach();
+    attachment.breakWrites(new Error("write after end"));
+
+    terminal.type("x");
+    const result = await run;
+    expect(terminal.isRaw()).toBe(false);
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(result.err.join("\n")).toContain("stopped accepting input");
+  });
+
+  it("never enters raw mode when the terminal refuses it — and releases the lock anyway", async () => {
+    await withRegisteredCore();
+    const terminal = fakeTerminal();
+    terminal.breakRawMode(new Error("not a tty after all"));
+    const attachment = fakeAttachment();
+
+    const result = await cli().run(["session", "attach", "task_1"], {
+      terminal,
+      openAttach: async () => attachment,
+    });
+
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(terminal.rawModeCalls).toEqual([]);
+    // The lock was taken by the claim that opened this attachment, and a Session
+    // left locked by an attach that never opened is the stranding this ticket is
+    // about.
+    expect(attachment.releaseCount()).toBe(1);
+    expect(attachment.closeCount()).toBe(1);
+  });
+
+  it("touches the terminal at all only after the Session is open", async () => {
+    // A Core that is down, a Session that is not running and a session id that
+    // does not exist are the ordinary failures of this command. None of them has
+    // any business happening while the operator's terminal is in raw mode.
+    await withRegisteredCore();
+    const terminal = fakeTerminal();
+
+    const result = await cli().run(["session", "attach", "task_gone"], {
+      terminal,
+      openAttach: async () => {
+        throw new SessionGatewayError("no-such-session", "this Core has no session task_gone");
+      },
+    });
+
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(terminal.rawModeCalls).toEqual([]);
+    expect(result.err.join("\n")).toContain("this Core has no session task_gone");
+  });
+});
+
+describe("the keyboard", () => {
+  it("forwards Ctrl-C to the harness rather than dying on it", async () => {
+    // The whole reason a person attaches instead of reading `session logs`. Raw
+    // mode turns off `ISIG`, so this is the byte 0x03 and it belongs to whatever
+    // the harness is running.
+    const { run, terminal, attachment } = await attach();
+
+    terminal.type(CTRL_C);
+    expect(attachment.typed()).toBe(CTRL_C);
+
+    terminal.type(DETACH);
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+  });
+
+  it("treats Ctrl-C as a detach when there is nothing to interrupt", async () => {
+    // Read-only: nothing is forwarded, so a `Ctrl-C` that did nothing at all
+    // would be a key that appears broken. Here it means the only thing left it
+    // can mean.
+    const { run, terminal } = await attach({ authority: "held-by-another" });
+
+    terminal.type(CTRL_C);
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.err.join("\n")).toContain("Detached from session task_1");
+  });
+
+  it("forwards what was typed before the detach key and nothing after it", async () => {
+    // A chunk can carry both — a fast typist, or a paste. The bytes before the
+    // key are keystrokes the operator meant; the ones after it were typed at a
+    // terminal that is no longer attached to anything.
+    const { run, terminal, attachment } = await attach();
+
+    terminal.type(`hello${DETACH}goodbye`);
+    await run;
+
+    expect(attachment.typed()).toBe("hello");
+  });
+
+  it("counts what a read-only attach did not forward, and reports it once", async () => {
+    const { run, terminal } = await attach({ authority: "held-by-another" });
+
+    terminal.type("abc");
+    terminal.type("de");
+    terminal.type(DETACH);
+    const result = await run;
+
+    expect(result.err.join("\n")).toContain("5 keystrokes were not forwarded");
+  });
+});
+
+describe("the screen", () => {
+  it("paints the scrollback before the live stream, in that order", async () => {
+    const { run, terminal, attachment } = await attach({ backlog: "history\r\n" });
+
+    attachment.emit("present\r\n");
+    terminal.type(DETACH);
+    await run;
+
+    expect(terminal.painted().indexOf("history")).toBeLessThan(terminal.painted().indexOf("present"));
+  });
+
+  it("propagates a resize while it holds the lock", async () => {
+    const { run, terminal, attachment } = await attach();
+
+    terminal.resizeTo(120, 40);
+    terminal.type(DETACH);
+    await run;
+
+    expect(attachment.resizes).toEqual([{ cols: 120, rows: 40 }]);
+  });
+
+  it("does not resize the PTY from a read-only attach", async () => {
+    // The Core would accept it — `resize` is not gated on the lock (D4 covers
+    // `write`, `kill` and task mutations). This is the CLI's own restraint:
+    // reflowing the terminal of the person actually typing because an observer
+    // widened a window is interference in the one direction the lock cannot see.
+    const { run, terminal, attachment } = await attach({ authority: "held-by-another" });
+
+    terminal.resizeTo(200, 60);
+    terminal.type(DETACH);
+    await run;
+
+    expect(attachment.resizes).toEqual([]);
+  });
+
+  it("tells the Core the terminal's size when it attaches", async () => {
+    const { run, terminal, asked } = await attach({ terminal: fakeTerminal({ cols: 132, rows: 43 }) });
+
+    terminal.type(DETACH);
+    await run;
+
+    expect(asked[0]).toMatchObject({ taskId: "task_1", cols: 132, rows: 43 });
+  });
+});
+
+describe("the command line", () => {
+  it("refuses --json, because there is no document to emit", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "attach", "task_1", "--json"], {
+      terminal: fakeTerminal(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("hands you a terminal");
+    // And it names the verb that *is* the machine-readable view.
+    expect(run.err.join("\n")).toContain("session logs");
+  });
+
+  it("wants a session id, and only one", async () => {
+    await withRegisteredCore();
+    const none = await cli().run(["session", "attach"], { terminal: fakeTerminal() });
+    expect(none.code).toBe(EXIT_USAGE);
+    expect(none.err.join("\n")).toContain("a session id is required");
+
+    const two = await cli().run(["session", "attach", "task_1", "task_2"], {
+      terminal: fakeTerminal(),
+    });
+    expect(two.code).toBe(EXIT_USAGE);
+    expect(two.err.join("\n")).toContain('unexpected argument "task_2"');
+  });
+
+  it("refuses a flag that belongs to another verb rather than ignoring it", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "attach", "task_1", "--wait"], {
+      terminal: fakeTerminal(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--wait does not apply here");
+  });
+
+  it("refuses `--read-only` on a verb that does not attach", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "kill", "task_1", "--read-only"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--read-only does not apply here");
+  });
+});

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -19,7 +19,7 @@ import {
   type CliFixture,
 } from "./cli-harness.ts";
 import { SessionGatewayError, type SessionRow } from "../session-gateway.ts";
-import { EXIT_FAILURE, EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "../exit-codes.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 
 let fixture: CliFixture | null = null;
 function cli(): CliFixture {
@@ -63,11 +63,18 @@ describe("actana session — the command tree", () => {
     expect(bare.code).toBe(EXIT_USAGE);
   });
 
-  it("names #163 for `attach` rather than failing as an unknown verb", async () => {
+  it("refuses `attach` from something that is not a terminal, rather than half-doing it", async () => {
+    // The fixture's default terminal is not a TTY, which is what a pipe or a CI
+    // job gets. `attach` is raw mode and keystrokes; there is nothing partial it
+    // could usefully do there, and it dials nothing to say so — the fixture
+    // throws on `openAttach`, so a run that reached the wire would fail here.
+    await withRegisteredCore();
     const run = await cli().run(["session", "attach", "task_1"]);
-    // The distinction `exit-codes.ts` exists to draw: reserved, not mistyped.
-    expect(run.code).toBe(EXIT_UNIMPLEMENTED);
-    expect(run.err.join("\n")).toContain("#163");
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("not a terminal");
+    // And it points at the two verbs that *do* work from a script.
+    expect(run.err.join("\n")).toContain("session logs");
+    expect(run.err.join("\n")).toContain("session send");
   });
 
   it("rejects an unknown verb without dialling anything", async () => {

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -14,6 +14,7 @@ import { openCoreShell } from "./core-shell-channel.ts";
 import { terminalFromProcess } from "./cli-terminal.ts";
 import { connectCore } from "./core-connection.ts";
 import { openSessionGateway } from "./session-gateway.ts";
+import { openSessionAttach } from "./session-attach-channel.ts";
 import { EXIT_FAILURE } from "./exit-codes.ts";
 import { homedir } from "node:os";
 
@@ -51,6 +52,9 @@ const code = await runActanaCli({
   // one file that knows about one (#129 D11).
   terminal: terminalFromProcess(process),
   openShell: openCoreShell,
+  // The other command that holds the terminal, and the only one that holds a
+  // Session write lock for as long as it runs (#163, ADR 0024 D3–D7).
+  openAttach: openSessionAttach,
 }).catch((err: unknown) => {
   // A throw that reached here is a defect, not an operator error: every
   // expected failure returns an exit code. Print the message and nothing about

--- a/packages/cli/src/cli-args.ts
+++ b/packages/cli/src/cli-args.ts
@@ -53,6 +53,15 @@ export type ParsedArgs = {
   enter: boolean;
   /** `--dangerously-skip-permissions`: start the harness without permission prompts. */
   skipPermissions: boolean;
+  /**
+   * `--read-only`: attach without claiming the Session's write lock (#163).
+   *
+   * A Session starts unlocked and its creator gets no privilege (ADR 0024 D5),
+   * so an ordinary `attach` on a Session nobody has claimed takes the lock — and
+   * an operator who only meant to watch an automation would take it from the
+   * automation that was about to. This is how they say "watch, do not take".
+   */
+  readOnly: boolean;
   /** Flags this build does not know, in the order they appeared. */
   unknown: string[];
   /** A flag that takes a value and was given none, or null. */
@@ -91,6 +100,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     raw: false,
     enter: false,
     skipPermissions: false,
+    readOnly: false,
     unknown: [],
     missingValue: null,
   };
@@ -153,6 +163,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--dangerously-skip-permissions":
         parsed.skipPermissions = true;
+        break;
+      case "--read-only":
+        parsed.readOnly = true;
         break;
       case "-h":
       case "--help":

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -12,6 +12,7 @@ import type { CliTerminal } from "./cli-terminal.ts";
 import type { OpenCoreShellFn } from "./core-shell-channel.ts";
 import type { CoreConnectFn } from "./core-connection.ts";
 import type { OpenSessionGateway } from "./session-gateway.ts";
+import type { OpenSessionAttachFn } from "./session-attach-channel.ts";
 
 export type ActanaCliDeps = {
   /** `process.argv.slice(2)`. */
@@ -67,4 +68,14 @@ export type ActanaCliDeps = {
   terminal: CliTerminal;
   /** How `core shell` opens a shell on a Core. See `core-shell-channel.ts`. */
   openShell: OpenCoreShellFn;
+  /**
+   * How `session attach` reaches a running Session — and claims its write lock
+   * on the way in. See `session-attach-channel.ts` (#163, ADR 0024 D3–D7).
+   *
+   * Separate from {@link openSessions} rather than a verb on the gateway,
+   * because the two are different lifetimes: a gateway is opened per verb, hands
+   * back plain data and is closed on the way out, while an attach is a live
+   * stream *and* a lock held for exactly as long as one connection is open.
+   */
+  openAttach: OpenSessionAttachFn;
 };

--- a/packages/cli/src/session-attach-channel.ts
+++ b/packages/cli/src/session-attach-channel.ts
@@ -1,0 +1,339 @@
+// The link `actana session attach` runs a terminal over (#163, #129 D10/D11).
+//
+// The third seam in this package after `core-probe.ts` and `core-shell-channel.ts`,
+// and the same shape for the same reason: one module dials, and the command
+// takes what it hands back as a dependency — so raw mode, the detach key and
+// every teardown path are exercised by unit tests with no Core anywhere near
+// them.
+//
+// **What makes this one different from the shell's is the write lock, and the
+// lock is in here rather than in the command** (ADR 0024 D3–D7, #144). `attach`
+// writes to a Session somebody else may be driving, so authority is settled
+// before the operator's terminal is touched at all:
+//
+//   1. **A `claim` goes out before anything is painted** (D6 — claiming is
+//      explicit; a mutation never acquires the lock). Its answer is the whole of
+//      {@link SessionAttachment.authority}, and the command renders read-only
+//      off that rather than discovering it by having a keystroke refused.
+//   2. **A refused claim is an answer, not a failure.** Another client holding
+//      the Session gives a read-only attachment with a reason on it — not an
+//      error, and not a takeover. `forceTakeover` exists (D7) and this command
+//      does not send it: an attach that stole the lock from a running automation
+//      because somebody typed a session id is the accident the lock was added to
+//      prevent.
+//   3. **This object cannot write without the lock.** {@link SessionAttachment.write}
+//      throws {@link SessionWriteRefused} before reaching the wire when the
+//      authority is not a writing one, and turns the Core's own `session-locked`
+//      refusal into the same error when the lock is taken away mid-session. The
+//      command has one thing to handle, and a read-only attachment that grew a
+//      write path by accident would be refused here as well as there.
+//   4. **`release` is the ordinary ending, and the link dropping is the other
+//      one.** D7 ends a lock on explicit release *or* on the connection going
+//      away, which is why {@link SessionAttachment.release} answers `false`
+//      rather than throwing on a link that is already gone: there is nothing
+//      left to release, because the Core has done it. Nothing here waits on a
+//      dead socket to find that out.
+//
+// **A Core that does not announce `multiConnection` has no lock table at all**
+// (ADR 0024 D11), and the SDK answers `supported: false` for it. That is
+// {@link SessionAttachment.authority} `"no-lock-table"` and it is **writable** —
+// such a Core serves every mutation this client makes. Rendering it read-only
+// would tell an operator who is that Core's only client that somebody else is
+// typing.
+//
+// **The SDK is untouched (D11).** Everything below is `@actana/sdk`'s existing
+// vocabulary — `claim`, `release`, `ptySubscribe`, `replay`, `write`, `resize`,
+// `onData`, `onExit` — with no TTY, no signal and no raw-mode call near it.
+
+import { CoreClient, CoreLinkRequestError } from "@actana/sdk/core-client.ts";
+import { SESSION_LOCKED_ERROR_CODE } from "@actana/sdk/core-link-frames.ts";
+import { SessionGatewayError } from "./session-gateway.ts";
+import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
+import type { Unsubscribe } from "./cli-terminal.ts";
+
+/** How a harness's process ended, while somebody was attached to it. */
+export type SessionAttachExit = { exitCode: number; signal?: number };
+
+/**
+ * What this attachment may do to the Session, decided once at attach time.
+ *
+ * Four states rather than a boolean, because "may I write" and "why not" are
+ * one question to an operator and the reason is the difference between a bug
+ * report and an explanation. `held` and `no-lock-table` write; the other two do
+ * not.
+ */
+export type AttachAuthority =
+  /** The `claim` was granted. This attachment holds the Session's write lock. */
+  | "held"
+  /** Another Core client holds it. Read-only, and the Core said so (D4/D6). */
+  | "held-by-another"
+  /** `--read-only`: no claim was sent, by request. The Session may be unlocked. */
+  | "not-claimed"
+  /** This Core publishes no lock state (D11). Writable — there is no lock to lose. */
+  | "no-lock-table";
+
+/** Do the rules let this attachment put bytes into the Session? */
+export function authorityWrites(authority: AttachAuthority): boolean {
+  return authority === "held" || authority === "no-lock-table";
+}
+
+/**
+ * A write this attachment is not allowed to make.
+ *
+ * One error for two moments that are the same fact: a read-only attachment that
+ * tried to write, and a writing one whose lock was taken away underneath it
+ * (D7's force takeover — the previous holder's next mutation is refused). Both
+ * mean *stop writing and say so*, and a command that had to tell them apart
+ * would end up parsing the Core's prose to do it.
+ */
+export class SessionWriteRefused extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionWriteRefused";
+  }
+}
+
+/**
+ * One attached Session, as the command sees it.
+ *
+ * Narrower than a `CoreClient` on purpose — the same argument
+ * `core-shell-channel.ts` makes: handing the command the whole client would let
+ * the terminal half reach for `forceTakeover`, and would make the fake this is
+ * tested against a re-implementation of the SDK.
+ */
+export type SessionAttachment = {
+  /** The Session this is attached to. */
+  readonly taskId: string;
+  /** The PTY the Core resolved that Session to, right now. */
+  readonly ptyId: string;
+  /** What the `claim` settled. See {@link AttachAuthority}. */
+  readonly authority: AttachAuthority;
+  /**
+   * The scrollback the Core still holds for this PTY, to paint before the live
+   * stream. Read at attach time because a `replay` that arrived later would
+   * paint history on top of the present.
+   */
+  readonly backlog: string;
+  /**
+   * Keystrokes into the Session, in the order they were typed.
+   *
+   * Throws {@link SessionWriteRefused} when this attachment holds no write
+   * authority — before the wire when it never had it, and after the Core's own
+   * refusal when it lost it.
+   */
+  write(data: string): Promise<void>;
+  /** Tell the PTY the terminal's new size. Only the writer calls it — see the command. */
+  resize(cols: number, rows: number): Promise<void>;
+  /** Bytes from the Session, live, from the moment this attachment opened. */
+  onData(cb: (data: string) => void): Unsubscribe;
+  /** The harness's process exited. The Session outlives it; this attachment does not. */
+  onExit(cb: (exit: SessionAttachExit) => void): Unsubscribe;
+  /** The link went away underneath. Not fired by {@link close}. */
+  onDisconnected(cb: (info: { error?: string }) => void): Unsubscribe;
+  /**
+   * Give the write lock back (D7).
+   *
+   * `false` means there was nothing to give back — this attachment never held
+   * one, or the link is already gone and the Core has released it. Never throws:
+   * it is called from a teardown, and a detach that failed to release loudly
+   * would still have detached.
+   */
+  release(): Promise<boolean>;
+  /** Hang up. Idempotent, and never throws. */
+  close(): void;
+};
+
+/** How `session attach` reaches a Session. Injected, so the command is testable. */
+export type OpenSessionAttachFn = (
+  blob: CoreRegistrationBlob,
+  opts: {
+    taskId: string;
+    cols: number;
+    rows: number;
+    connectTimeoutMs: number;
+    /** False for `--read-only`: attach as a Reader and send no `claim` at all. */
+    claimWrite: boolean;
+  },
+) => Promise<SessionAttachment>;
+
+/**
+ * Attach to a running Session: connect, claim, subscribe, and hand back the
+ * stream with the authority that claim settled.
+ *
+ * The order is the point. Authority first, because it decides what the operator
+ * is told before a byte is painted; the stream second, with the Core holding it
+ * until the scrollback has been served (`catchUp`), so nothing paints live bytes
+ * in front of its own history. Every failure after the claim releases the lock
+ * on the way out — a Session left locked by an attach that never opened is
+ * exactly the stranding this ticket is about.
+ */
+export const openSessionAttach: OpenSessionAttachFn = async (blob, opts) => {
+  const client = CoreClient.fromRegistrationBlob(blob, {
+    connectTimeoutMs: opts.connectTimeoutMs,
+    requestTimeoutMs: opts.connectTimeoutMs,
+  });
+
+  let claimed = false;
+  try {
+    await client.connect();
+    const ptyId = await livePty(client, opts.taskId);
+
+    // The claim, before anything is painted and before any input is wired. A
+    // refusal is an answer — `granted: false` becomes a read-only attachment —
+    // and `supported: false` is a third thing entirely: a Core with no lock
+    // table, which writes.
+    let authority: AttachAuthority = "not-claimed";
+    if (opts.claimWrite) {
+      const { supported, granted } = await client.claim(opts.taskId);
+      claimed = supported && granted;
+      authority = !supported ? "no-lock-table" : granted ? "held" : "held-by-another";
+    }
+
+    // `catchUp` says a `replay` follows and the Core must hold this PTY's live
+    // stream until it has been served. A caller that sets it owes that replay,
+    // and the two lines below are that debt paid — skipping it would leave the
+    // Session's output held on the Core until this connection went away.
+    await client.ptySubscribe(ptyId, { catchUp: true });
+    const { data: backlog } = await client.replay(ptyId);
+
+    return attachment(client, opts.taskId, ptyId, authority, backlog);
+  } catch (err) {
+    // A lock this connection took and is not going to use. The release goes
+    // first: `close()` would release it too, by dropping the connection (D7),
+    // but only once the Core noticed — and a Session that reads as locked to the
+    // next operator for as long as a socket takes to time out is the failure
+    // this ticket calls the one that strands a Session.
+    if (claimed) await client.release(opts.taskId).catch(() => ({ released: false }));
+    client.close();
+    throw err;
+  }
+};
+
+/**
+ * The PTY running for this Session, or the reason there is none to attach to.
+ *
+ * Two different sentences, because they are two different mistakes: a Session
+ * that finished half an hour ago is a `session logs` away from being useful, and
+ * a Session id this Core has never heard of is a typo. The Task list is read
+ * only when there is bad news to explain, so the ordinary attach still costs one
+ * round trip.
+ */
+async function livePty(client: CoreClient, taskId: string): Promise<string> {
+  const { ptyId } = await client.findByTask(taskId);
+  if (ptyId !== null) return ptyId;
+
+  const { tasks } = await client.tasksList();
+  if (!tasks.some((task) => task.taskId === taskId)) {
+    throw new SessionGatewayError("no-such-session", `this Core has no session ${taskId}`);
+  }
+  throw new SessionGatewayError(
+    "not-running",
+    `session ${taskId} has no harness running — there is no terminal to attach to`,
+  );
+}
+
+/** Present a connected client as a {@link SessionAttachment}. */
+function attachment(
+  client: CoreClient,
+  taskId: string,
+  ptyId: string,
+  authority: AttachAuthority,
+  backlog: string,
+): SessionAttachment {
+  // Two facts, not one. **May this attachment write** is true for a Core with no
+  // lock table as well as for the holder of a real lock; **does it hold a lock**
+  // is true only for the second, and is what decides whether there is anything to
+  // release. Collapsing them into one boolean makes a lock-less Core either
+  // unwritable or the subject of a `release` frame it has no vocabulary for.
+  let mayWrite = authorityWrites(authority);
+  let holdsLock = authority === "held";
+
+  // Live bytes, buffered from the moment the attachment exists rather than from
+  // the moment the command gets round to listening. The Core released its hold
+  // when the `replay` above was served, so output between that answer and the
+  // command's first `onData` belongs to this attach and would otherwise be a
+  // gap in the middle of a terminal nobody could explain.
+  const pending: string[] = [];
+  let sink: ((data: string) => void) | null = (data) => {
+    pending.push(data);
+  };
+  const forThisPty = client.onData((frame) => {
+    if (frame.ptyId === ptyId) sink?.(frame.data);
+  });
+
+  const forPty = <T extends { ptyId: string }>(cb: (frame: T) => void) => (frame: T) => {
+    if (frame.ptyId === ptyId) cb(frame);
+  };
+
+  return {
+    taskId,
+    ptyId,
+    authority,
+    backlog,
+
+    write: async (data) => {
+      if (!mayWrite) {
+        throw new SessionWriteRefused("this attachment does not hold this Session's write lock");
+      }
+      try {
+        await client.write(ptyId, data);
+      } catch (err) {
+        // The Core's refusal, in the one vocabulary the command handles. It
+        // arrives here only after a force takeover (D7): nothing else moves a
+        // lock out from under a holder, and the previous holder learns of it on
+        // its next mutation and no sooner.
+        if (err instanceof CoreLinkRequestError && err.code === SESSION_LOCKED_ERROR_CODE) {
+          mayWrite = false;
+          holdsLock = false;
+          throw new SessionWriteRefused("another Core client has taken this Session's write lock");
+        }
+        throw err;
+      }
+    },
+
+    resize: (cols, rows) => client.resize(ptyId, cols, rows).then(() => undefined),
+
+    onData: (cb) => {
+      sink = cb;
+      // Whatever arrived before the command was listening, in order, before
+      // anything that arrives after it.
+      for (const data of pending.splice(0)) cb(data);
+      return () => {
+        sink = null;
+        forThisPty();
+      };
+    },
+
+    onExit: (cb) =>
+      client.onExit(forPty((frame) => cb({ exitCode: frame.exitCode, signal: frame.signal }))),
+
+    onDisconnected: (cb) => client.onDisconnected(cb),
+
+    release: async () => {
+      // Nothing to give back, and — the case this ticket is really about —
+      // nothing to give it back *to*: a link that has dropped has already had
+      // its locks released by the Core (D7), so asking would be a request into a
+      // socket that is gone.
+      if (!holdsLock || !client.isConnected()) {
+        holdsLock = false;
+        mayWrite = false;
+        return false;
+      }
+      holdsLock = false;
+      mayWrite = false;
+      try {
+        const { released } = await client.release(taskId);
+        return released;
+      } catch {
+        // The link went away while the frame was in flight, which released the
+        // lock by the other route. A teardown must not fail on the way out.
+        return false;
+      }
+    },
+
+    close: () => {
+      forThisPty();
+      client.close();
+    },
+  };
+}

--- a/packages/cli/src/session-attach.ts
+++ b/packages/cli/src/session-attach.ts
@@ -42,10 +42,14 @@
 // is nothing to interrupt on the far side, so `Ctrl-C` detaches there too rather
 // than being swallowed.
 //
-// **A read-only attach does not resize the PTY.** The Core does not gate
+// **An attach that cannot write does not resize the PTY, and `Ctrl-C` detaches
+// it.** Both follow the lock as it stands, not the authority the attach opened
+// with — a force takeover demotes a holder to a Reader mid-session, and a demoted
+// attach that kept the holder's affordances would keep them against somebody
+// else's Session. The resize half is the one with teeth: the Core does not gate
 // `resize` on the lock (D4 covers `write`, `kill` and task mutations, and a
-// Reader has a viewport like anyone else), so this is the CLI's own restraint
-// and not a refusal it met: reflowing the terminal of the person actually typing
+// Reader has a viewport like anyone else), so this is the CLI's own restraint and
+// not a refusal it met — reflowing the terminal of the person actually typing
 // because an observer widened a window is interference in the one direction the
 // lock cannot see.
 
@@ -268,7 +272,7 @@ export async function runSessionAttach(
   }
 
   // Cooked again from here down, so it is safe to print lines.
-  return report(deps, terminal, taskId, blob.endpoint, end, state);
+  return report(deps, terminal, taskId, blob.endpoint, end, state, attached.authority);
 }
 
 /**
@@ -320,22 +324,35 @@ function runAttachedSession(
     // what lets the operator interrupt whatever the harness is doing.
     disposers.push(
       terminal.onInput((data) => {
+        // Current authority, not the authority this attach opened with. A force
+        // takeover (D7) demotes a holder to a Reader mid-session, and every key
+        // below has to follow the lock rather than the flag it was captured with.
+        const canWrite = writes && !state.lockLost;
         const detachAt = data.indexOf(DETACH_KEY);
-        // A read-only attach has nothing to interrupt on the far side, so
-        // `Ctrl-C` means the only thing left it can mean: leave.
-        const quitAt = writes ? -1 : data.indexOf(ETX);
+        // An attach that cannot write has nothing to interrupt on the far side,
+        // so `Ctrl-C` means the only thing left it can mean: leave. That has to
+        // include an attach that *lost* the lock — otherwise the one key the
+        // operator was just told they now have is the one that does nothing:
+        // neither forwarded (there is no lock) nor a detach.
+        const quitAt = canWrite ? -1 : data.indexOf(ETX);
         const stopAt = firstOf(detachAt, quitAt);
 
         const forward = stopAt === -1 ? data : data.slice(0, stopAt);
         if (forward.length > 0) {
-          if (writes && !state.lockLost) {
+          if (canWrite) {
             void attached.write(forward).catch((err: unknown) => {
               // A lock taken away underneath is not an ending. The Session is
               // still worth watching, and an attach that quit on it would take
               // the operator's view away as well as their keyboard.
               if (err instanceof SessionWriteRefused) {
                 state.lockLost = true;
-                paint(`\r\n[actana] ${err.message} — this attach is read-only from here.\r\n`);
+                // Says the affordance changed as well as the authority: `Ctrl-C`
+                // was going to the harness a keystroke ago and detaches from
+                // here, which is not something the operator can be left to
+                // discover by pressing it.
+                paint(
+                  `\r\n[actana] ${err.message} — this attach is read-only from here, and Ctrl-C now detaches instead of going to the harness.\r\n`,
+                );
                 return;
               }
               settle({
@@ -351,14 +368,18 @@ function runAttachedSession(
       }),
     );
 
-    // `SIGWINCH`, as a resize frame — and only from the attach that writes. See
-    // the module header: the Core would accept it from a Reader, and a Reader
-    // sending it reflows the writer's terminal. A failure is not worth ending a
-    // working session over; the harness keeps running and is merely drawing at
-    // the old size.
+    // `SIGWINCH`, as a resize frame — and only from the attach that writes *now*.
+    // See the module header: the Core would accept it from a Reader, and a Reader
+    // sending it reflows the writer's terminal. `state.lockLost` is in the guard
+    // because a demoted holder is a Reader like any other: the Core does not gate
+    // `resize` on the lock, so an attach that kept resizing after a takeover
+    // would reflow the *new* holder's PTY — the interference in the one
+    // direction the lock cannot see, arriving from the one attach that used to be
+    // allowed. A failure is not worth ending a working session over; the harness
+    // keeps running and is merely drawing at the old size.
     disposers.push(
       terminal.onResize(() => {
-        if (!writes) return;
+        if (!writes || state.lockLost) return;
         const { cols, rows } = terminal.size();
         void attached.resize(cols, rows).catch(() => {});
       }),
@@ -420,6 +441,7 @@ function report(
   endpoint: string,
   end: Ending,
   state: SessionState,
+  authority: AttachAuthority,
 ): number {
   // A Session that ended mid-line — a dropped link lands wherever the last byte
   // fell, and a full-screen harness leaves the cursor anywhere — would otherwise
@@ -430,7 +452,15 @@ function report(
   // that answered every key with a line would repaint the Session's screen out
   // from under the person reading it.
   if (state.dropped > 0) {
-    deps.err(`${state.dropped} keystrokes were not forwarded — this attach was read-only.`);
+    // "This attach was read-only" is true of an attach that opened read-only and
+    // misleading about one that opened holding the lock and had it taken: the
+    // operator typed those keys at a terminal that *was* writing, and being told
+    // it was read-only reads as though it never was.
+    deps.err(
+      state.lockLost
+        ? `${state.dropped} keystrokes were not forwarded — this attach lost the write lock partway through.`
+        : `${state.dropped} keystrokes were not forwarded — this attach was read-only.`,
+    );
   }
 
   switch (end.kind) {
@@ -453,7 +483,10 @@ function report(
       deps.err(
         `actana session attach: the link to ${endpoint} dropped${end.error ? ` — ${end.error}` : ""}.`,
       );
-      deps.err("The Core releases a dropped connection's Session locks, so this one is claimable again.");
+      {
+        const note = lockNoteOnDrop(authority, state);
+        if (note !== undefined) deps.err(note);
+      }
       return EXIT_FAILURE;
     case "signal":
       deps.err(`actana session attach: ${end.signal} — detached from session ${taskId}.`);
@@ -461,6 +494,33 @@ function report(
     case "link-error":
       deps.err(`actana session attach: ${end.message}`);
       return EXIT_FAILURE;
+  }
+}
+
+/**
+ * What a dropped link meant for *this* Session's lock — which depends entirely
+ * on whether this connection was the one holding it.
+ *
+ * D7's release-on-drop is about the locks the dropped connection held, so an
+ * attach that held none has nothing to report as freed. Saying it anyway is
+ * wrong twice over in the operator's favour: this connection released nothing,
+ * and the Session is still held by whoever actually has it. `no-lock-table` gets
+ * no line at all — that Core arbitrates no writes, so a drop changes nothing
+ * there is a word for.
+ */
+function lockNoteOnDrop(authority: AttachAuthority, state: SessionState): string | undefined {
+  if (state.lockLost) {
+    return "This attach had already lost the write lock, so the Session stays held by the client that took it.";
+  }
+  switch (authority) {
+    case "held":
+      return "The Core releases a dropped connection's Session locks, so this one is claimable again.";
+    case "held-by-another":
+      return "This attach never held the write lock, so the Session stays held by the client that does.";
+    case "not-claimed":
+      return "This attach never claimed the write lock (--read-only), so the drop leaves the Session's lock as it was.";
+    case "no-lock-table":
+      return undefined;
   }
 }
 

--- a/packages/cli/src/session-attach.ts
+++ b/packages/cli/src/session-attach.ts
@@ -1,0 +1,507 @@
+// `actana session attach <session>` — a terminal on a running Session (#163,
+// #129 D10).
+//
+// The last verb of the `session` noun and the only one that is a *terminal*
+// rather than a report: it paints what the harness is painting, and — when it is
+// allowed to — types into it. Everything hard about it is one of two things.
+//
+// **1. It writes to a Session, so it holds the write lock** (ADR 0024 D3–D7,
+// #144). That is not a check bolted onto a viewer; it is the first thing this
+// command does, in `session-attach-channel.ts`, before a byte reaches the
+// operator's terminal:
+//
+//   - A Session another Core client is writing gives a **read-only view with the
+//     reason on it** — not an error, and not a takeover. `forceTakeover` is D7's
+//     answer to a hung client and this command never sends it: an attach that
+//     stole the lock because somebody typed a session id is precisely the
+//     accident the lock exists to prevent.
+//   - **Detaching releases it**, and so does this process dying — the Core drops
+//     a connection's locks when the connection goes (D7), which is why the
+//     release below is skipped rather than retried on a link that is already
+//     gone. An attach that assumed it was the only way a lock could end is what
+//     strands a Session unwritable.
+//   - **Losing the lock mid-session is handled** rather than assumed away. A
+//     force takeover from elsewhere makes the next keystroke refused; this
+//     command says so, on the terminal, and carries on as a Reader.
+//   - A Core that publishes no lock state has no lock to hold, and that attach
+//     writes (D11). `supported: false` is not read-only.
+//
+// **2. The terminal is restored on every exit path**, which is the discipline
+// `core shell` landed in #162 and this reuses line for line: a `finally` around
+// the whole session, `SIGINT` and `SIGTERM` handled rather than fatal, a dropped
+// link treated as an ending like any other, a restore that is idempotent and
+// never throws, and — one layer down in `cli-terminal.ts` — a process `exit`
+// hook for the route no `finally` covers. The terminal goes back **before** the
+// release round trip, so a Core that has stopped answering costs a request
+// timeout rather than a request timeout's worth of unusable shell.
+//
+// **`Ctrl-C` is forwarded, so detaching needs a key of its own.** Raw mode turns
+// off `ISIG`; `Ctrl-C` is the byte `0x03` and belongs to the harness, which is
+// the whole reason a person attaches instead of reading `session logs`. `Ctrl-]`
+// — telnet's escape since 1983 — detaches instead. In a read-only attach there
+// is nothing to interrupt on the far side, so `Ctrl-C` detaches there too rather
+// than being swallowed.
+//
+// **A read-only attach does not resize the PTY.** The Core does not gate
+// `resize` on the lock (D4 covers `write`, `kill` and task mutations, and a
+// Reader has a viewport like anyone else), so this is the CLI's own restraint
+// and not a refusal it met: reflowing the terminal of the person actually typing
+// because an observer widened a window is interference in the one direction the
+// lock cannot see.
+
+import { resolveCore } from "./core-resolution.ts";
+import { authorityWrites, SessionWriteRefused } from "./session-attach-channel.ts";
+import { SessionGatewayError } from "./session-gateway.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
+import type { RegistryPaths } from "./blob-registry.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+import type { ParsedArgs } from "./cli-args.ts";
+import type { CliTerminal, Unsubscribe } from "./cli-terminal.ts";
+import type {
+  AttachAuthority,
+  SessionAttachExit,
+  SessionAttachment,
+} from "./session-attach-channel.ts";
+
+/** How long `session attach` waits for a Core to answer and hand back a stream. */
+const ATTACH_CONNECT_TIMEOUT_MS = 30_000;
+
+/** The signal numbers behind the two names, for the `128 + n` exit convention. */
+const SIGNAL_NUMBERS = { SIGINT: 2, SIGTERM: 15 } as const;
+
+/**
+ * `Ctrl-]` — the detach key.
+ *
+ * Telnet's escape character, which is the closest thing to a convention for
+ * "leave, do not send this". It has to be a key the harness will not miss:
+ * every other control byte is one a full-screen program on the far side might
+ * bind, and the two obvious candidates are exactly the two that must be
+ * forwarded — `Ctrl-C` interrupts the harness and `Ctrl-D` ends its input.
+ */
+const DETACH_KEY = "\u001D";
+
+/** `Ctrl-C`. Forwarded when this attach writes; a second detach key when it does not. */
+const ETX = "\u0003";
+
+/**
+ * How an attach ended. Exactly one of these settles a run, and every one of them
+ * goes through the same `finally` on the way out.
+ */
+type Ending =
+  /** The operator pressed the detach key. The Session carries on without them. */
+  | { kind: "detach" }
+  /** The harness's process exited while somebody was watching it. */
+  | { kind: "exit"; exit: SessionAttachExit }
+  /** The link went away underneath — a Core restart, a network drop. */
+  | { kind: "disconnected"; error?: string }
+  /** This process was signalled. Not `Ctrl-C`, which never gets this far. */
+  | { kind: "signal"; signal: "SIGINT" | "SIGTERM" }
+  /** A frame could not be sent, for a reason that was not the lock. */
+  | { kind: "link-error"; message: string };
+
+/** What the session did that the report has to account for afterwards. */
+type SessionState = {
+  /** Whether the last byte painted ended a line — see {@link report}. */
+  endedWithNewline: boolean;
+  /** Keystrokes a read-only attach did not forward. Counted, so it can say so. */
+  dropped: number;
+  /** True once the write lock was taken away mid-session (D7). */
+  lockLost: boolean;
+};
+
+/**
+ * Raw mode, with the restore made unmissable.
+ *
+ * The same guard `core-shell.ts` uses, and for the same reason: it is called
+ * from a `finally`, from two signal handlers and from an error path, and a
+ * restore that threw would replace a usable terminal with an unusable one at the
+ * exact moment nothing is left to catch it.
+ */
+class RawModeGuard {
+  private entered = false;
+  private restored = false;
+
+  constructor(private readonly terminal: CliTerminal) {}
+
+  /** Enter raw mode. Throws if the terminal refuses — the caller must not continue. */
+  enter(): void {
+    this.terminal.setRawMode(true);
+    this.entered = true;
+  }
+
+  /** Put the terminal back. Safe to call any number of times, from anywhere. */
+  restore(): void {
+    if (!this.entered || this.restored) return;
+    this.restored = true;
+    try {
+      this.terminal.setRawMode(false);
+    } catch {
+      // Nothing above this can do anything useful with the failure, and the
+      // caller is on its way to an exit code either way.
+    }
+  }
+}
+
+/**
+ * `actana session attach <session>` — take the terminal to a running Session.
+ *
+ * Reads like the session it runs: refuse what cannot work, settle authority,
+ * *then* take the terminal, and give it back before printing a word.
+ */
+export async function runSessionAttach(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  // `--json` is a promise this verb cannot keep, for the reason `core shell`
+  // cannot either: stdout here is a terminal somebody is looking at, and there
+  // is no document to emit. `session logs --json` is the machine-readable view
+  // of a Session's output.
+  if (args.json) {
+    deps.err("actana session attach: --json means nothing here — this verb hands you a terminal.");
+    deps.err("`actana session logs <session> --json` is the machine-readable view of one.");
+    return EXIT_USAGE;
+  }
+
+  const [taskId, ...extra] = rest;
+  if (taskId === undefined) {
+    deps.err("actana session attach: a session id is required — `actana session attach <session>`.");
+    return EXIT_USAGE;
+  }
+  if (extra.length > 0) {
+    deps.err(`actana session attach: unexpected argument "${extra[0]}".`);
+    return EXIT_USAGE;
+  }
+
+  const terminal = deps.terminal;
+  if (!terminal.isTty) {
+    deps.err("actana session attach: this is an interactive command and stdin/stdout are not a terminal.");
+    deps.err("To read a Session from a script: `actana session logs`. To type into one: `actana session send`.");
+    return EXIT_USAGE;
+  }
+
+  const resolved = resolveCore({ paths, env: deps.env, home: deps.home, coreFlag: args.core });
+  if (!resolved.ok) {
+    deps.err(`actana session attach: ${resolved.error}`);
+    return EXIT_FAILURE;
+  }
+  const { name, blob } = resolved.core;
+  deps.verbose(`dialling ${blob.endpoint}`);
+
+  // Dial, resolve the Session and settle the lock before touching the terminal.
+  // A Session that is not running, a Core that is down and a claim that was
+  // refused are all ordinary outcomes of this command, and none of them has any
+  // business happening while the operator's terminal is in raw mode.
+  const { cols, rows } = terminal.size();
+  let attached: SessionAttachment;
+  try {
+    attached = await deps.openAttach(blob, {
+      taskId,
+      cols,
+      rows,
+      connectTimeoutMs: ATTACH_CONNECT_TIMEOUT_MS,
+      claimWrite: !args.readOnly,
+    });
+  } catch (err) {
+    deps.err(`actana session attach: ${attachFailure(blob.endpoint, err)}`);
+    return EXIT_FAILURE;
+  }
+
+  const writes = authorityWrites(attached.authority);
+  deps.verbose(`pty ${attached.ptyId} on ${name ?? blob.endpoint}, ${cols}x${rows}`);
+  // Said before the screen fills with the harness's output, because a read-only
+  // attach that announced itself *after* the scrollback would announce itself
+  // where nobody is looking. Both lines go to stderr: stdout is about to become
+  // a terminal.
+  deps.err(banner(taskId, attached.authority));
+  deps.err(detachHint(writes));
+
+  const guard = new RawModeGuard(terminal);
+  try {
+    guard.enter();
+  } catch (err) {
+    // Nothing is in raw mode, so there is nothing to restore — but there is a
+    // write lock this connection may be holding, and a Session left locked by an
+    // attach that never opened is the stranding this ticket is about.
+    await releaseQuietly(attached);
+    safely(() => attached.close());
+    deps.err(`actana session attach: could not put this terminal into raw mode — ${messageOf(err)}`);
+    return EXIT_FAILURE;
+  }
+
+  let end: Ending;
+  const disposers: Unsubscribe[] = [];
+  const state: SessionState = { endedWithNewline: true, dropped: 0, lockLost: false };
+
+  /**
+   * Give the terminal back. Idempotent in both halves — `disposers` is drained
+   * as it is walked and {@link RawModeGuard.restore} is a no-op the second time
+   * — so it can be called the moment the session ends *and* from the `finally`
+   * that has to run whatever happened.
+   */
+  const releaseTerminal = () => {
+    for (const dispose of disposers.splice(0)) safely(dispose);
+    guard.restore();
+  };
+
+  try {
+    end = await runAttachedSession(terminal, attached, disposers, state, writes);
+    // Hand the terminal back before touching the far side, exactly as `core
+    // shell` does: what follows is a round trip to a Core that may already be
+    // gone, and every millisecond of it would be a millisecond the operator's
+    // terminal was still raw.
+    releaseTerminal();
+    // The lock goes back on every ending except the one that has already
+    // returned it. A dropped link releases a connection's locks at the Core
+    // (D7), so there is nothing to send and nothing to wait for — and waiting
+    // would be waiting on a socket that is gone.
+    if (end.kind !== "disconnected") await releaseQuietly(attached);
+  } finally {
+    // The guarantee, not the routine case: every path out of the `try` — a
+    // detach, the harness exiting, a signal, a dropped link, a defect in any of
+    // the code above — arrives here, and the terminal is restored before the
+    // socket is closed so that even a `close` that throws leaves a usable one
+    // behind.
+    releaseTerminal();
+    safely(() => attached.close());
+  }
+
+  // Cooked again from here down, so it is safe to print lines.
+  return report(deps, terminal, taskId, blob.endpoint, end, state);
+}
+
+/**
+ * Wire the terminal to the Session and wait for one of them to end it.
+ *
+ * Every listener registered here goes into `disposers`, which the caller's
+ * `finally` drains — a listener that outlived the session would keep stdin's
+ * `data` handler attached, and a process with a live stdin listener does not
+ * exit.
+ */
+function runAttachedSession(
+  terminal: CliTerminal,
+  attached: SessionAttachment,
+  disposers: Unsubscribe[],
+  state: SessionState,
+  writes: boolean,
+): Promise<Ending> {
+  return new Promise<Ending>((resolve) => {
+    let settled = false;
+    const settle = (ending: Ending) => {
+      // First ending wins. A harness exiting is routinely followed by the link
+      // closing, and a signal by both; "which ending do we report" is exactly
+      // the question the exit status answers.
+      if (settled) return;
+      settled = true;
+      resolve(ending);
+    };
+
+    const paint = (data: string) => {
+      if (data.length > 0) state.endedWithNewline = data.endsWith("\n");
+      terminal.write(data);
+    };
+
+    // The scrollback first, then the live stream. In that order and with no gap:
+    // the Core held this PTY's output until the replay behind `backlog` was
+    // served (`catchUp`), and the channel buffered whatever arrived after that
+    // until this line, so the terminal shows the Session's history followed by
+    // its present with nothing missing in between.
+    paint(attached.backlog);
+    disposers.push(attached.onData(paint));
+
+    disposers.push(attached.onExit((exit) => settle({ kind: "exit", exit })));
+    disposers.push(
+      attached.onDisconnected((info) => settle({ kind: "disconnected", error: info.error })),
+    );
+
+    // Local → remote. **`Ctrl-C` is in here and has no special case when this
+    // attach writes**: in raw mode it is the byte `0x03`, and forwarding it is
+    // what lets the operator interrupt whatever the harness is doing.
+    disposers.push(
+      terminal.onInput((data) => {
+        const detachAt = data.indexOf(DETACH_KEY);
+        // A read-only attach has nothing to interrupt on the far side, so
+        // `Ctrl-C` means the only thing left it can mean: leave.
+        const quitAt = writes ? -1 : data.indexOf(ETX);
+        const stopAt = firstOf(detachAt, quitAt);
+
+        const forward = stopAt === -1 ? data : data.slice(0, stopAt);
+        if (forward.length > 0) {
+          if (writes && !state.lockLost) {
+            void attached.write(forward).catch((err: unknown) => {
+              // A lock taken away underneath is not an ending. The Session is
+              // still worth watching, and an attach that quit on it would take
+              // the operator's view away as well as their keyboard.
+              if (err instanceof SessionWriteRefused) {
+                state.lockLost = true;
+                paint(`\r\n[actana] ${err.message} — this attach is read-only from here.\r\n`);
+                return;
+              }
+              settle({
+                kind: "link-error",
+                message: `the Session stopped accepting input — ${messageOf(err)}`,
+              });
+            });
+          } else {
+            state.dropped += forward.length;
+          }
+        }
+        if (stopAt !== -1) settle({ kind: "detach" });
+      }),
+    );
+
+    // `SIGWINCH`, as a resize frame — and only from the attach that writes. See
+    // the module header: the Core would accept it from a Reader, and a Reader
+    // sending it reflows the writer's terminal. A failure is not worth ending a
+    // working session over; the harness keeps running and is merely drawing at
+    // the old size.
+    disposers.push(
+      terminal.onResize(() => {
+        if (!writes) return;
+        const { cols, rows } = terminal.size();
+        void attached.resize(cols, rows).catch(() => {});
+      }),
+    );
+
+    // The two signals, handled rather than fatal — handled *because* the default
+    // action is fatal, and a CLI killed by the default action never reaches its
+    // `finally`, never restores the terminal, and never releases the lock.
+    // `Ctrl-C` does not arrive here: raw mode means the terminal driver never
+    // raises it. What does is `kill` from another window, a supervisor stopping
+    // this process, or a terminal closing.
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      disposers.push(terminal.onSignal(signal, () => settle({ kind: "signal", signal })));
+    }
+  });
+}
+
+/**
+ * What the operator is told they are looking at, before they are looking at it.
+ *
+ * The ticket's first criterion is that a Session somebody else is writing gives
+ * a read-only view **with a visible reason** — so the reason is in the line, and
+ * each of the four authorities has its own. `no-lock-table` is deliberately not
+ * a warning: that Core has no lock, so this attach writes.
+ */
+function banner(taskId: string, authority: AttachAuthority): string {
+  switch (authority) {
+    case "held":
+      return `Attached to session ${taskId}. You hold the write lock — what you type goes to the harness.`;
+    case "held-by-another":
+      return `Attached to session ${taskId}, READ-ONLY: another Core client holds this Session's write lock, so keystrokes are not forwarded.`;
+    case "not-claimed":
+      return `Attached to session ${taskId}, READ-ONLY: --read-only, so no claim was sent and keystrokes are not forwarded.`;
+    case "no-lock-table":
+      return `Attached to session ${taskId}. This Core publishes no Session lock, so nothing arbitrates writes — what you type goes to the harness.`;
+  }
+}
+
+/** How to leave, which is not obvious and is not `Ctrl-C` when this attach writes. */
+function detachHint(writes: boolean): string {
+  return writes
+    ? "Ctrl-] detaches and releases the lock. Ctrl-C goes to the harness."
+    : "Ctrl-] or Ctrl-C detaches.";
+}
+
+/**
+ * Turn an ending into an exit status, and say what happened.
+ *
+ * **A harness that exited is not this command's failure.** `core shell` returns
+ * the remote status because the remote shell *is* the command; an attach is a
+ * terminal onto somebody else's Session, and a script that could not tell "the
+ * attach failed" from "the harness you were watching exited 1" would be worse
+ * off than one that reads the line.
+ */
+function report(
+  deps: ActanaCliDeps,
+  terminal: CliTerminal,
+  taskId: string,
+  endpoint: string,
+  end: Ending,
+  state: SessionState,
+): number {
+  // A Session that ended mid-line — a dropped link lands wherever the last byte
+  // fell, and a full-screen harness leaves the cursor anywhere — would otherwise
+  // have the operator's next prompt painted on top of it.
+  if (!state.endedWithNewline) terminal.write("\r\n");
+
+  // Said once, at the end, rather than on every keystroke: a read-only attach
+  // that answered every key with a line would repaint the Session's screen out
+  // from under the person reading it.
+  if (state.dropped > 0) {
+    deps.err(`${state.dropped} keystrokes were not forwarded — this attach was read-only.`);
+  }
+
+  switch (end.kind) {
+    case "detach":
+      deps.err(`Detached from session ${taskId}. The harness keeps running.`);
+      return EXIT_OK;
+    case "exit": {
+      const { exitCode, signal } = end.exit;
+      deps.err(
+        signal !== undefined && signal > 0
+          ? `The harness for session ${taskId} was killed by signal ${signal}.`
+          : `The harness for session ${taskId} exited with code ${exitCode}.`,
+      );
+      return EXIT_OK;
+    }
+    case "disconnected":
+      // Worth saying explicitly, because it is the one ending where this process
+      // did not hand the lock back itself — and an operator who did not know
+      // that would reasonably assume the Session was now stuck.
+      deps.err(
+        `actana session attach: the link to ${endpoint} dropped${end.error ? ` — ${end.error}` : ""}.`,
+      );
+      deps.err("The Core releases a dropped connection's Session locks, so this one is claimable again.");
+      return EXIT_FAILURE;
+    case "signal":
+      deps.err(`actana session attach: ${end.signal} — detached from session ${taskId}.`);
+      return 128 + SIGNAL_NUMBERS[end.signal];
+    case "link-error":
+      deps.err(`actana session attach: ${end.message}`);
+      return EXIT_FAILURE;
+  }
+}
+
+/** Whichever of two indices comes first, ignoring the ones that are not there. */
+function firstOf(a: number, b: number): number {
+  if (a === -1) return b;
+  if (b === -1) return a;
+  return Math.min(a, b);
+}
+
+/**
+ * Give the lock back, best effort. A teardown must not fail on the way out, and
+ * a release that failed has been performed by the Core anyway the moment this
+ * connection closes (D7).
+ */
+async function releaseQuietly(attached: SessionAttachment): Promise<void> {
+  try {
+    await attached.release();
+  } catch {
+    // The link is already gone, or the lock already moved. Either way this
+    // Session is not this process's to hold any more.
+  }
+}
+
+/** Why an attach never opened, in the vocabulary the gateway already speaks. */
+function attachFailure(endpoint: string, err: unknown): string {
+  if (err instanceof SessionGatewayError) return err.message;
+  return `${endpoint} did not attach — ${messageOf(err)}`;
+}
+
+/** Run a teardown step that has no business throwing, and survive it if it does. */
+function safely(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // A disposer or a socket close that throws must not skip the ones after it
+    // — one of those is the raw-mode restore.
+  }
+}
+
+/** An error's message, never its inputs — see the header of `actana-cli.ts`. */
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -6,10 +6,16 @@
 //   actana session resume <session> [prompt] pick a conversation back up
 //   actana session send <session> <text>     type into a running Session
 //   actana session kill <session>            stop the harness, whoever started it
-//   actana session attach                    scaffolded here, built in #163
+//   actana session attach <session>          take the terminal (#163)
 //
 // Three rules this noun is built around. The first two are the ticket's, the
 // third is what makes the other two usable from a script.
+//
+// **`attach` is the one verb that is a terminal**, and it lives in
+// `session-attach.ts` because it is built out of things no other verb here needs
+// — raw mode, a detach key, signal handling, and the Session write lock held for
+// as long as it runs (ADR 0024 D3–D7). Everything below dials, prints and hangs
+// up; that one takes the terminal and gives it back.
 //
 // **The Core delivers prompts (ADR 0026, #129 D3).** `start` hands its prompt to
 // the SDK, which hands it to the Core, which waits for the harness's TUI to
@@ -40,7 +46,8 @@
 import { resolveCore } from "./core-resolution.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { isKnownHarness, KNOWN_HARNESSES } from "./session-gateway.ts";
-import { EXIT_FAILURE, EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "./exit-codes.ts";
+import { runSessionAttach } from "./session-attach.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { RegistryPaths } from "./blob-registry.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
 import type { ParsedArgs } from "./cli-args.ts";
@@ -74,7 +81,7 @@ Usage
   actana session resume <session> [prompt]  start a Session that continues one
   actana session send <session> <text>      write text into a running Session
   actana session kill <session>             stop the harness running for it
-  actana session attach <session>           take the terminal (not built — #163)
+  actana session attach <session>           watch a Session live, and type into it
 
 Flags
   --core <name>       which registered Core to talk to
@@ -86,6 +93,7 @@ Flags
   --title <text>      start: what the Session is called in \`ls\`
   --raw               logs: the bytes, escape codes and all, unrendered
   --enter             send: follow the text with a carriage return
+  --read-only         attach: watch without claiming the Session's write lock
   --dangerously-skip-permissions
                       start/resume: run the harness without permission prompts
   --verbose           explain the steps, on stderr. Never prints a blob.
@@ -103,6 +111,13 @@ What \`logs\` can show you
   The Core's replay ring, which belongs to the harness's PTY — so a Session that
   has already exited has no transcript left to print, and the way to keep one is
   \`start --wait --json\`, whose object carries the screen as it settled.
+
+Attaching, and who is allowed to type
+  \`attach\` claims the Session's write lock. If another Core client already holds
+  it — a Panel, an automation, a second terminal — you get a read-only view and
+  a line saying so, never an error and never a takeover. Detaching gives the lock
+  back, and so does this process dying: the Core releases a dropped connection's
+  locks. Ctrl-] detaches; Ctrl-C goes to the harness.
 
 Who delivers the prompt
   The Core does (ADR 0026). It waits for the harness to settle, answers the
@@ -136,8 +151,15 @@ export async function runSessionCommand(
       return sessionSend(deps, args, paths, rest);
     case "kill":
       return sessionKill(deps, args, paths, rest);
-    case "attach":
-      return sessionAttach(deps);
+    case "attach": {
+      // The flag check every other verb makes, made here rather than inside
+      // `session-attach.ts`: the table of this noun's flags lives in this file,
+      // and a second copy of it in the one verb that is a terminal is how the
+      // two drift.
+      const misused = misusedFlag(args, ["--read-only"]);
+      if (misused) return usage(deps, "attach", misused);
+      return runSessionAttach(deps, args, paths, rest);
+    }
     default:
       deps.err(`actana session: unknown verb "${verb}".`);
       deps.err("Verbs: start, ls, logs, resume, kill, send, attach. `actana session --help` lists them.");
@@ -515,21 +537,6 @@ async function sessionKill(
   });
 }
 
-/**
- * `actana session attach` — scaffolded, not built.
- *
- * Deliberately a separate ticket: attaching is raw mode, resize forwarding and
- * signal handling on *this* terminal, and none of the rest of this noun needs a
- * terminal at all. It is in the tree and in the help for the reason `core shell`
- * is — the noun's shape is decided in one place — and it exits
- * {@link EXIT_UNIMPLEMENTED} rather than pretending.
- */
-function sessionAttach(deps: ActanaCliDeps): number {
-  deps.err("actana session attach: not built yet — it is #163, in this phase.");
-  deps.err("Until then: `actana session logs <session>` reads the transcript and `session send` types into it.");
-  return EXIT_UNIMPLEMENTED;
-}
-
 // ─── The plumbing every verb shares ──────────────────────────────────────────
 
 /**
@@ -595,6 +602,7 @@ const SESSION_FLAGS: ReadonlyArray<{ name: string; used: (args: ParsedArgs) => b
   { name: "--raw", used: (args) => args.raw },
   { name: "--enter", used: (args) => args.enter },
   { name: "--dangerously-skip-permissions", used: (args) => args.skipPermissions },
+  { name: "--read-only", used: (args) => args.readOnly },
 ];
 
 /**


### PR DESCRIPTION
Closes #163. Phase 2, step 3 — `session attach` of [#129](https://github.com/actana/control/issues/129) D10.

Base is `feat/cli-and-publishing`, not `main`. Train `beta/0.2.2`.

## What landed

```
actana session attach <session>              take the terminal: read it live, type into it
actana session attach <session> --read-only  watch it without claiming the write lock
```

## The lock is the command, not a check on top of it

`attach` writes to a Session, so it claims the Session write lock (#144, ADR 0024 D3–D7) before a
byte reaches the operator's terminal — in `session-attach-channel.ts`, on the way in, from the first
commit. The claim's answer *is* what the attach then is:

| Claim | What you get |
| --- | --- |
| granted | you type; detaching hands the lock back |
| refused | a **read-only view with the reason on it** — not an error, not a takeover |
| `--read-only` | no `claim` frame at all |
| Core announces no `multiConnection` | **writable** — `supported: false` is not `granted: false` |

`forceTakeover` exists (D7) and this command does not send it. An attach that stole the lock from a
running automation because somebody typed a session id is the accident the lock was added to
prevent. The last row matters as much as the second: such a Core has no lock table and serves every
mutation this client makes, so rendering it read-only would tell an operator who is its only client
that somebody else is typing.

`--read-only` is there because a Session starts unlocked and its creator gets no privilege (D5). An
ordinary `attach` on an unclaimed Session takes the lock; an operator who only meant to watch an
automation would take it from the automation that was about to claim.

The attachment cannot write without the authority. It throws before the wire when it never had one,
and turns the Core's own `session-locked` refusal into the same error when a force takeover moves
the lock underneath a live attach — where the command says so on the terminal and **carries on
reading** rather than quitting. Losing your keyboard is not a reason to lose your view.

## Lock release on an abrupt disconnect

The trap the ticket names. A lock ends on explicit release, on the connection dropping, or on a
force takeover (D7) — so the two endings are deliberately asymmetric here:

- **A detach sends `release`.** So does a `SIGINT`/`SIGTERM`, which is a detach somebody else asked
  for.
- **A dropped link sends nothing.** The Core has already released it, and a teardown that asked
  anyway would be waiting on a socket that is gone, with the terminal still raw behind it. The
  operator is told the Session is claimable again, because otherwise they would reasonably assume
  the one they were driving is now stuck.

`session-attach-live.test.ts` proves the second against a real Core rather than asserting the
intention: a live attach holding the lock has its socket **terminated** — no close frame, no
`release`, nothing the client chose — and the next attach is granted the lock and types into the
PTY. Staging that needed one addition to the in-process rig (`InProcessCore.dropConnections`),
because no client can do it to itself: hanging up politely is a different event, and stopping the
whole Core proves nothing about a lock table that died with it.

## The terminal, and the keyboard

Raw-mode discipline is #203's, reused rather than rewritten: a `finally` around the whole session,
`SIGINT` and `SIGTERM` handled rather than fatal, a dropped link treated as an ending like any
other, a restore that is idempotent and never throws, and the process `exit` hook one layer down in
`cli-terminal.ts`. The terminal is handed back **before** the release round trip — a Core that has
stopped answering costs a request timeout, not a request timeout's worth of unusable shell.

`Ctrl-C` is forwarded to the harness, which is the whole reason a person attaches instead of reading
`session logs`. So **`Ctrl-]` detaches** (telnet's escape). A read-only attach has nothing to
interrupt on the far side, so `Ctrl-C` detaches there too rather than appearing broken, and the
keystrokes it dropped are counted and reported once at the end instead of repainting the Session's
screen with a warning per key.

A read-only attach also **does not resize the PTY**. The Core would accept it — `resize` is not
gated on the lock, and D4's comment there argues that deliberately — so this is the CLI's own
restraint: reflowing the terminal of the person actually typing because an observer widened a window
is interference in the one direction the lock cannot see.

A harness that exits is reported and exits `0`, unlike `core shell`: an attach is a terminal onto
somebody else's Session, and a script that could not tell "the attach failed" from "the harness you
were watching exited 1" would be worse off than one that reads the line.

## Boundaries

- `packages/cli` only. No file under `packages/sdk`, `release.yml` or `docs/reference` is touched —
  all terminal handling is CLI-side (D11) and the SDK's existing vocabulary (`claim`, `release`,
  `ptySubscribe`, `replay`, `write`, `resize`, `onData`, `onExit`) is used, not extended.
- `session attach` leaves `exit-codes.ts`'s reservation list, which is the shape a reservation is
  supposed to end in. `project cp` / `project files` are the two left, still #168's.
- **#129 D5's one-connection rationale is dead** by this train and nothing here leans on it. This
  command does not own the Core: it is one of many connections, holds one Session's lock, and
  subscribes to one PTY's stream.

## Checks

- `pnpm --filter @actana/cli test` — **291 passed, 3 skipped**, including both new suites.
- `pnpm typecheck` clean repo-wide; `pnpm lint` **0 errors**, 0 findings in `packages/cli`.
- `commitlint --from origin/feat/cli-and-publishing --to HEAD` — 0 problems across all three commits.

New suites:

- `session-attach.test.ts` (31 tests) — the ticket's "done when" as its outline. One test per exit
  path for the terminal; the four authorities; the release asymmetry; the takeover mid-session; the
  detach key against a chunk that carries both keystrokes and the key.
- `session-attach-live.test.ts` (4 tests) — the real `openSessionAttach` against the real
  `PtyCoreLinkServer` on a real `wss://` port, two attaches at a time: one writes and one reads,
  detach hands the lock over, and the abrupt drop above.

Not covered by an automated test, and the ticket says so up front: a real harness's TUI painted into
a real terminal. `attach` has no headless test story for the *feel* of it — everything provable
without a person is proved above, and the rest is the acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
