### PR TITLE
chore(docs): freeze the prototype CLI as a read-only reference under docs/reference/ (D15)

### DIFF
--- a/docs/reference/experiment-cli/README.md
+++ b/docs/reference/experiment-cli/README.md
@@ -1,0 +1,284 @@
+# experiment
+
+Tooling for running an Actana Core locally in a container and driving it from
+the command line — creating projects, launching Claude Code sessions inside it,
+reading what they said, and wiring a Panel to visualise the lot.
+
+Two things live here:
+
+- **`run-core-local.sh`** — builds the Core image and runs one instance
+- **`core-client.ts`** — talks to that Core over its core-link protocol
+
+## Requirements
+
+- Docker
+- Node 24 (`node` must be v24 — the client is TypeScript run directly, and the
+  repo's build scripts refuse anything older)
+- The `mission-control-updated` checkout beside this folder, for the image build
+  and for the `ws` dependency reached through the `node_modules` symlink
+
+## Quick start
+
+```bash
+./run-core-local.sh                                  # build and run the Core
+docker exec rest-test cat /home/core/.config/actana/registration-blob.txt > blob.txt
+node core-client.ts status                           # prove the connection
+node core-client.ts project create /home/core/work   # register a directory
+node core-client.ts session start <projectId> "summarise the README"
+node core-client.ts session logs <taskId>
+```
+
+---
+
+# `run-core-local.sh`
+
+Builds the Core tarball and image if they are missing, then creates the
+container. Safe to re-run: it reuses what exists and recreates only the
+container.
+
+```bash
+./run-core-local.sh [--rebuild] [--reset]
+```
+
+| Argument | Meaning |
+|---|---|
+| `--rebuild` | force a fresh tarball and image even if they exist |
+| `--reset` | destroy the volume too — **this unpairs the Core** and loses its data |
+
+| Environment | Default | Meaning |
+|---|---|---|
+| `NAME` | `rest-test` | container name |
+| `PORT` | `9443` | host port, and the Core's own port (they must match) |
+| `PUBLIC_HOST` | `127.0.0.1` | the address baked into the certificate and pairing token |
+| `IMAGE` | `actana-core:$NAME` | image tag |
+| `VOLUME` | `$NAME-home` | named volume holding all Core state |
+| `REPO` | current directory | path to the mission-control-updated checkout |
+
+On macOS the Core tarball is built inside a Linux container automatically:
+native modules are copied from the build host and never cross-compiled, so a
+tarball built on macOS cannot go into a Linux image.
+
+---
+
+# `core-client.ts`
+
+```bash
+node core-client.ts <resource> <verb> [target] [options]
+```
+
+Resource first, then verb. The verbs repeat across resources, so `project ls`,
+`session ls` and `harness ls` all behave the same way. `node core-client.ts
+help` prints this from the CLI, and `help <resource>` drills into one.
+
+**Targets** are flexible: a project is named by its id, its name or its path; a
+session by its task id or its pty id.
+
+**`--core <name>`** picks which Core to run against, the way kubectl picks a
+context. It is global — it may appear anywhere in the line, and every resource
+honours it.
+
+## core
+
+Each Core is one blob file in `blobs/`, named by the file's basename.
+
+| Command | Arguments | What it does |
+|---|---|---|
+| `core ls` | — | list them: name, endpoint, label; `*` marks the one in effect |
+
+| Name | Container | Endpoint |
+|---|---|---|
+| `developer` | `rest-test-2` | `wss://127.0.0.1:9444` |
+| `pr` | `rest-test` | `wss://127.0.0.1:9443` |
+
+```bash
+node core-client.ts core ls
+node core-client.ts --core pr project ls
+node core-client.ts project ls --core pr     # identical
+AC_CORE=pr node core-client.ts project ls    # for a whole shell
+```
+
+Naming them by purpose rather than by container or port is the point: a rebuild
+that moves a port leaves `--core pr` working where a memorised
+`wss://127.0.0.1:9443` would not.
+
+Cores are separate machines as far as this client is concerned. Projects,
+sessions and harness logins on one are invisible to the other, so a task id from
+`developer` means nothing to `pr`.
+
+Adding one is copying its blob in:
+
+```bash
+docker exec <container> cat /home/core/.config/actana/registration-blob.txt > blobs/<name>.txt
+```
+
+**Output** splits by stream — data on stdout, commentary on stderr:
+
+```bash
+SID=$(node core-client.ts session start scratch "summarise the README")
+```
+
+## project
+
+Directories on the Core that sessions are allowed to run in. Registration is
+not bookkeeping: the Core rejects any session whose working directory is not
+inside a registered project.
+
+| Command | Arguments | What it does |
+|---|---|---|
+| `project ls` | — | list projects: id, name, path |
+| `project create` | `<path> [name]` | register a directory on the Core; name defaults to the last path segment |
+| `project rm` | `<project> --yes` | unregister a project **and every session under it**; the directory on disk is untouched |
+| `project browse` | `[path]` | browse the Core's filesystem, to find a path worth registering |
+| `project inspect` | `<project>` | full detail as JSON |
+
+## session
+
+| Command | Arguments | What it does |
+|---|---|---|
+| `session ls` | `[--all]` | sessions with a live PTY; `--all` includes finished ones |
+| `session start` | `<project> [prompt]` | launch a session, print its task id, exit |
+| `session logs` | `<session>` | what the session has said so far |
+| `session attach` | `<session>` | print the scrollback and keep streaming |
+| `session send` | `<session> <text>` | wait for the screen to settle, type text, submit |
+| `session enter` | `<session>` | press Enter only — unsticks a pending paste |
+| `session interrupt` | `<session>` | press Escape — stop the turn, keep the session |
+| `session resume` | `<task>` | relaunch a finished session with its conversation intact |
+| `session kill` | `<session>` | end the session's process group for good |
+| `session inspect` | `<task>` | full detail as JSON |
+
+`interrupt` and `kill` are not the same thing: interrupt stops what Claude is
+doing and leaves the session usable, kill ends it.
+
+## harness
+
+The agent CLIs the Core can launch. They are not baked into the image — they
+install at runtime into the Core's home, which is the persistent volume.
+
+| Command | Arguments | What it does |
+|---|---|---|
+| `harness ls` | — | availability, version and install path per harness |
+| `harness install` | `<id>` | start installing one; returns immediately |
+
+Ids: `claude-code`, `codex`, `cursor-cli`, `opencode`.
+
+`install` is fire and forget. The install runs on the Core and takes minutes,
+and the protocol only acknowledges the start, never the outcome — so the
+command returns and `harness ls` is how you check whether it landed. The Core
+re-probes when the install finishes; success means the probe now finds it.
+
+Installing gets you the binary, not a login. Harness credentials live in the
+Core's home directory, so each Core authenticates separately.
+
+## status and events
+
+| Command | Arguments | What it does |
+|---|---|---|
+| `status` | — | endpoint, label, protocol version, project and session counts, harness availability |
+| `events` | `[--since N] [--kind <prefix>]` | stream the Core's event log |
+
+`status` is also the cheapest proof the credentials work: it opens a real mTLS
+connection and authenticates before printing anything.
+
+Event kinds are prefixed `task:`, `session:`, `pty:`, `project:`, `agents:` and
+`harness:`.
+
+## Options
+
+| Option | Applies to | Effect |
+|---|---|---|
+| `--core <name>` | everything | which Core to run against; may go anywhere in the line |
+| `--follow` | `session start`, `session logs` | stream instead of returning |
+| `--all` | `session ls` | include finished sessions |
+| `--lines N` | `session logs` | how many lines to show (40) |
+| `--raw` | `session logs` | untouched bytes, no terminal emulation |
+| `--cols N` `--rows N` | `session logs` | replay geometry; must match the spawn (120x32) |
+| `--harness <id>` | `session start` | which harness to launch (default `claude-code`) |
+| `--model <id>` | `session start`, `session resume` | model to launch with |
+| `--title <text>` | `session start` | task title instead of one derived from the prompt |
+| `--enter` / `--no-enter` | `session send` | press Enter after the text (default), or hold it unsubmitted |
+| `--now` | `session send` | skip the settle wait |
+| `--ask-permissions` | `session start`, `session resume` | launch **without** auto mode |
+| `--yes` | `project rm` | confirm the cascade |
+| `--since N` `--kind <prefix>` | `events` | resume point, and filter by prefix |
+| `--help` | anywhere | help for that resource |
+
+## Credentials
+
+The pairing blob is resolved in order:
+
+| Source | Notes |
+|---|---|
+| `--core <name>` | `blobs/<name>.txt` |
+| `AC_BLOB` | the base64 blob itself |
+| `AC_BLOB_FILE` | a file holding it |
+| `AC_CORE` | `blobs/<name>.txt`, the ambient default |
+| `./blob.txt` | the unnamed local copy, as before |
+| `docker exec` | against `$AC_CONTAINER`, default `rest-test` |
+
+Nothing is cached between runs: each invocation decodes the blob, opens the
+mTLS socket, and sends `auth` as its first frame. Each blob carries a client key
+and a bearer — **do not commit them**. `blobs/` is mode 700 and its files 600,
+and a `.gitignore` beside them excludes the directory.
+
+A `--core` name is a bare identifier, not a path: `--core ../../something` is
+rejected as an invalid name rather than read.
+
+---
+
+## Behaviour worth knowing before you rely on it
+
+**Auto mode is the default.** Sessions launch with
+`--dangerously-skip-permissions`, so Claude does not ask for tool approvals —
+inside the container it reads, writes and executes in the project directory
+unattended. `--ask-permissions` opts out.
+
+**Startup dialogs are answered automatically.** Claude opens two blocking
+dialogs — the bypass-permissions warning and the folder-trust prompt — once per
+project per Core, and they are stored in the Core's home volume, so a new Core
+means meeting them again. A session parked on one accepts no input at all, and
+the bypass warning's highlighted default is `1. No, exit`, so anything that
+presses Enter at it quits Claude instantly. `session start` and `session resume`
+watch the screen and answer them, which is what makes auto mode unattended
+rather than merely unprompted.
+
+**`start` types the prompt itself** once the TUI stops redrawing. The Core's own
+initial-input path fires 450 ms after spawn, before Claude accepts input, and
+loses it.
+
+**`send` sends the Enter separately** from the text, after a pause that scales
+with length. Claude treats a burst of input as a paste and absorbs a same-frame
+carriage return into it, leaving `[Pasted text #1 +1 lines]` unsubmitted.
+
+**`logs` emulates a terminal** rather than stripping escape codes, because a TUI
+positions text with cursor moves instead of spaces. It only works while the
+session is alive — the scrollback belongs to the PTY.
+
+**`resume` needs the harness session id** to have been recorded on the task. A
+session that died early may not have one.
+
+---
+
+## The Panel
+
+A Panel container visualises the same Core in a browser.
+
+| Container | Port | Purpose |
+|---|---|---|
+| `panel-test` | `127.0.0.1:7420` | the Panel, volume `panel-test-data` |
+| `panel-test-link` | — | socat relay inside the Panel's network namespace |
+
+The relay exists because the pairing token points at `wss://127.0.0.1:9443` and
+the Core's certificate is issued for that exact address — inside another
+container `127.0.0.1` would be that container. It forwards raw TCP to the
+Core's published port on the host, so the TLS passes through untouched.
+
+To pair: open http://localhost:7420, create the Operator, and paste `blob.txt`
+into **Add Core** (`pbcopy < blob.txt`).
+
+## Other documents
+
+| File | Contents |
+|---|---|
+| [note.md](note.md) | the requirements, as asked for |
+| [action.md](action.md) | what was built and where things stand |
+| [client-reference.md](client-reference.md) | the client's internals and module layout |

--- a/docs/reference/experiment-cli/README.md
+++ b/docs/reference/experiment-cli/README.md
@@ -1,3 +1,26 @@
+<!-- FROZEN REFERENCE — added by #158. Everything below the rule is the
+     prototype's own README, copied unchanged. -->
+
+# The prototype CLI, frozen
+
+This directory is a **read-only, frozen copy** of the prototype `core-client`
+CLI — the throwaway tool that drove a real Core over core-link before
+`packages/cli` existed. It is kept only so the parity check in phase 2 step 4
+has something to check the shipped `actana` command against.
+
+**It is not built, linted, typechecked, tested or published**, and it is not a
+workspace package: the pnpm workspace globs `packages/*` and the npm publish
+discovery in `scripts/lib/npm-packages.mjs` both read `packages/` only, so
+nothing here is reachable from the toolchain. Do not import from it, do not fix
+it, and do not bring it up to date — `src/protocol.ts` is a hand-copied
+90-line mirror of the core-link protocol and is **deliberately stale**. Its
+drift from the real protocol is the thing being preserved.
+
+**This directory is deleted at the end of phase 2, by #164.** Nothing may come
+to depend on it.
+
+---
+
 # experiment
 
 Tooling for running an Actana Core locally in a container and driving it from

--- a/docs/reference/experiment-cli/action.md
+++ b/docs/reference/experiment-cli/action.md
@@ -1,0 +1,138 @@
+# Where we are
+
+What was built, in the order it happened, and what is running now.
+
+## 1. Building the Core image
+
+The Core image is defined in `mission-control-updated/deploy/core.Dockerfile`:
+Ubuntu 24.04 pinned by digest, Node 24 and npm fetched from source and
+checksum-verified, the build toolchain in, a `core` user pinned at uid/gid 1000
+with passwordless sudo, tini as PID 1 and `actana daemon` as the command.
+Harnesses are deliberately not baked in — they install at runtime into `$HOME`,
+which is the persistent volume.
+
+The image needs a Core release tarball baked into it, and that tarball is
+per-platform: native modules are copied from the build host, never
+cross-compiled. On macOS `pnpm core:tarball` therefore produces a `mac-arm64`
+tarball the Linux image cannot use. The tarball was built inside a Linux
+container instead, which is the path the repo documents in
+`docs/core-linux-rehearsal.md`. One deviation was needed: pnpm refused to purge
+a `node_modules` tree installed under a different store without a TTY, so the
+build runs with `CI=true`.
+
+Result: `actana-core-0.1.0-linux-arm64.tar.gz`, baked into the image
+`actana-core:rest-test`.
+
+`run-core-local.sh` reproduces all of this end to end.
+
+## 2. Running the Core
+
+One container, `rest-test`, published on `127.0.0.1:9443`, state on the named
+volume `rest-test-home` mounted at `/home/core`.
+
+`ACTANA_PORT` matches the published port deliberately: the pairing token embeds
+the Core's own host and port, so a rewritten mapping would hand out a token
+pointing at the wrong place.
+
+On first boot the Core minted its identity and printed a pairing token. That
+identity lives on the volume, so container restarts keep it — only destroying
+the volume mints a new one. Verified: recreating the container produced no
+second token.
+
+Claude Code (v2.1.224) ended up installed at `/home/core/.local/bin/claude`,
+inside the volume, so it survives image upgrades.
+
+## 3. The client
+
+`core-client.ts` talks to the Core over its core-link protocol. Node 24 runs the
+TypeScript directly, so there is no build step; the only dependency is `ws`,
+reached through a `node_modules` symlink into the repo.
+
+The protocol, established by reading the Core's source:
+
+- One JSON object per WebSocket message, flat envelope, correlated by `reqId`.
+- mTLS is mandatory. The CA, client certificate and client key all come out of
+  the pairing blob.
+- `auth` must be the **first** frame sent. Anything else first gets
+  `not-authenticated` and the socket is closed.
+- The Core speaks first, unsolicited, with a `ready` frame carrying the
+  protocol version (0.15.0).
+- Sessions are spawned against a registered project: the Core validates that
+  the working directory sits inside a known project root, that argv[0] is the
+  harness's canonical binary, and that every flag is on an allow-list.
+
+The pairing blob was then saved to `blob.txt` beside the script and is read from
+there, rather than shelling into the container on every call.
+
+## 4. What had to be fixed along the way
+
+Four things broke in ways that were not obvious, and each needed a real fix
+rather than a workaround:
+
+**The prompt never reached Claude.** The Core's `initialInput` types the prompt
+450ms after spawn, and Claude's TUI is not accepting input that early — the text
+went nowhere and every session came up with an empty input box. The client now
+delivers the prompt itself, watching the output stream and waiting for the first
+gap in the redraws, which is when the TUI has finished painting.
+
+**Auto mode killed sessions instantly.** Launching with
+`--dangerously-skip-permissions` opens a blocking warning screen whose
+highlighted default is `1. No, exit`. The prompt's Enter selected it, so Claude
+quit before doing anything. Isolated by testing each variable separately: auto
+mode alone survived, a prompt alone survived, the two together died in under
+three seconds. The acceptance is stored per directory in `$HOME`, so answering
+it once fixed it.
+
+**`tail` was unreadable.** It stripped escape codes, which does not work on a
+TUI: Claude positions text with cursor moves rather than spaces, so every frame
+of every spinner redraw concatenated into one line of soup. `tail` now replays
+the output through a small terminal emulator — cursor movement, erases, line
+insert and delete, scrolling — and reads back what a terminal would be showing.
+Lines that scroll off the top are kept, which is where the conversation
+transcript lives.
+
+**Long input sat unsubmitted.** `send` wrote the text and the carriage return in
+one frame; Claude treats a burst of input as a paste and absorbed the return
+into it, showing `[Pasted text #1 +1 lines]` and waiting. The Enter is now a
+separate keystroke sent after a pause that scales with the length of the text.
+
+Proof it works end to end: a session was given "please git clone the actana
+control repo here", found `actana/control` through the GitHub org membership,
+and cloned it to `/home/core/work/control`.
+
+## 5. The Panel
+
+A second container, `panel-test`, built fresh from `deploy/panel.Dockerfile` and
+published on `127.0.0.1:7420`, with its state on the volume `panel-test-data`.
+
+Wiring it to the Core needed one piece of care. The pairing token points at
+`wss://127.0.0.1:9443` and the Core's certificate is issued for that exact
+address — inside a second container, `127.0.0.1` is that container itself. The
+repo's own reference deployment solves this by giving the Core a service name as
+its public host, but that would have meant recreating the running Core.
+
+Instead a third container, `panel-test-link`, runs a socat forwarder inside the
+Panel's network namespace, relaying `127.0.0.1:9443` to the Core's published
+port on the host. It is a raw TCP relay, so the Core's TLS passes through
+untouched and the certificate still validates. Nothing about the Core changed.
+
+## Running now
+
+| | |
+|---|---|
+| `rest-test` | the Core, `127.0.0.1:9443`, volume `rest-test-home` |
+| `panel-test` | the Panel, `127.0.0.1:7420`, volume `panel-test-data` |
+| `panel-test-link` | socat relay in the Panel's namespace, 9443 → host |
+| project `scratch` | `p-msip6kgd-54d3f5` → `/home/core/work` |
+| cloned repo | `/home/core/work/control` |
+
+Images: `actana-core:rest-test`, `actana-panel:local`.
+
+## Not done
+
+- **The Panel is not paired yet.** That means opening http://localhost:7420,
+  creating the Operator, and pasting `blob.txt` into "Add Core" — account
+  creation is yours to do.
+- Several idle sessions from the debugging runs are still alive on the Core.
+- `resume`, `attach`, `install`, `events`, `ls` and `project delete` are written
+  but have not been exercised against the live Core.

--- a/docs/reference/experiment-cli/client-reference.md
+++ b/docs/reference/experiment-cli/client-reference.md
@@ -1,0 +1,142 @@
+# core-client — reference
+
+```bash
+node core-client.ts <resource> <verb> [target] [options]
+```
+
+Node 24 runs the TypeScript directly, so there is no build step. The only
+dependency is `ws`, reached through the `node_modules` symlink into the
+mission-control-updated repo.
+
+`node core-client.ts help` prints all of this from the CLI itself, and
+`help <resource>` drills into one.
+
+## Layout
+
+```
+core-client.ts          entry point: routing, connection, error reporting
+package.json            makes this a package (and silences Node's module warning)
+src/
+  protocol.ts           wire types, the request→result table, protocol version
+  blob.ts               where the pairing credentials come from
+  client.ts             the authenticated connection and its RPC correlation
+  args.ts               flag parsing and the command context
+  terminal.ts           the terminal emulator behind `session logs`
+  commands/
+    project.ts  session.ts  harness.ts  status.ts  events.ts  help.ts
+```
+
+Each command module exports one `run(client, ctx)`. Adding a resource means
+adding a file and one line in `RESOURCES`.
+
+## Grammar
+
+Resource first, then verb, following Docker's shape. The verbs repeat, so
+`project ls`, `session ls` and `harness ls` all behave the same way.
+
+| Resource | Verbs |
+|---|---|
+| `core` | `ls` |
+| `project` | `ls` · `create` · `rm` · `browse` · `inspect` |
+| `session` | `ls` · `start` · `logs` · `attach` · `send` · `enter` · `interrupt` · `resume` · `kill` · `inspect` |
+| `harness` | `ls` · `install` |
+| `status` | — |
+| `events` | — |
+
+**Targets.** A project is named by its id, its name, or its path. A session is
+named by its task id (durable) or its pty id (lives only as long as the
+process). Both are accepted anywhere a session is asked for.
+
+**Output.** Data on stdout, commentary on stderr, so ids can be captured:
+
+```bash
+SID=$(node core-client.ts session start scratch "summarise the README")
+```
+
+**Aliases.** Every flat command from before still works and expands to its
+resource form: `projects`, `add-project`, `ls`, `sessions`, `start`, `tail`,
+`attach`, `send`, `enter`, `resume`, `kill`, `harnesses`, `install`. `stop`
+remains Escape — it maps to `session interrupt`, since changing what an
+existing command does silently would be worse than the inconsistency.
+
+## Options
+
+| Option | Effect |
+|---|---|
+| `--core <name>` | which Core to run against — global, position-independent |
+| `--follow` | `session start` / `session logs` stream instead of returning |
+| `--all` | `session ls` includes finished sessions |
+| `--lines N` | `session logs`: how many lines (40) |
+| `--raw` | `session logs`: untouched bytes, no emulation |
+| `--cols N` `--rows N` | `session logs`: replay geometry, must match the spawn (120x32) |
+| `--harness <id>` | `claude-code` (default), `codex`, `cursor-cli`, `opencode` |
+| `--model <id>` | model to launch the harness with |
+| `--title <text>` | task title instead of one derived from the prompt |
+| `--ask-permissions` | launch without auto mode |
+| `--yes` | confirm `project rm` |
+| `--since N` `--kind <prefix>` | `events`: resume point and filter |
+
+## Credentials
+
+Resolved in order: `--core <name>` → `AC_BLOB` → `AC_BLOB_FILE` → `AC_CORE` →
+`./blob.txt` → `docker exec` against `$AC_CONTAINER` (default `rest-test`). The
+last two are what the CLI did before named Cores existed, kept so that commands
+already written keep working. Nothing is cached between runs: each invocation
+decodes the blob, opens the mTLS socket, and authenticates.
+
+`--core <name>` reads `blobs/<name>.txt`. The name is validated as a bare
+identifier, so it cannot be used to read an arbitrary path. `core-client.ts`
+strips the flag out of argv before routing, which is what makes it
+position-independent and keeps it out of each verb's positionals; `core` is
+itself answered from disk without opening a connection.
+
+Each blob carries a client key and a bearer. Do not commit them.
+
+## Behaviour worth knowing
+
+**Projects gate everything.** A session may only run inside a registered project
+root — the Core rejects any spawn whose working directory is outside one.
+
+**Cores are isolated.** Ids do not cross: a task or project id from one Core
+means nothing to another, and harness logins are per-Core because they live in
+that Core's home volume.
+
+**Auto mode is the default.** Sessions launch with
+`--dangerously-skip-permissions`. Inside the container Claude will read, write
+and execute in the project directory unattended.
+
+**Startup dialogs are answered automatically.** Claude opens a
+"Bypass Permissions mode" warning and a folder-trust prompt once per directory
+per Core, recorded in that Core's home volume. A session parked on one accepts
+no input at all, and the bypass warning's highlighted default is `1. No, exit`,
+so anything that presses Enter at it quits Claude. `start` and `resume` render
+the screen, match the dialog and answer it before delivering a prompt.
+
+**Output frames are per-connection, not per-session.** The Core sends `data` for
+every PTY on the link, so anything watching the stream must filter on `ptyId`.
+`start` and `resume` route through `PtyStream`, which holds pre-spawn frames per
+PTY and adopts its own once the spawn reply names it — without that, a second
+session launched while the first is working never sees a gap in the output and
+stalls for the full length of every timeout.
+
+**`start` types the prompt itself.** It waits for the output to go quiet — the
+TUI has finished painting — then types and submits. The Core's own
+`initialInput` fires 450 ms after spawn, before Claude accepts input, and loses
+the prompt.
+
+**`send` splits the Enter from the text.** Claude treats a burst of input as a
+paste, and a carriage return in the same frame is absorbed into it: the TUI
+shows `[Pasted text #1 +1 lines]` and waits. The pause between the two scales
+with length. `enter` sends the keystroke alone, to unstick one.
+
+**`logs` emulates a terminal.** A TUI positions text with cursor moves rather
+than spaces, so deleting escape codes yields unreadable soup. The output is
+replayed into a screen buffer with scrollback and read back as text. It works
+only while the session is alive.
+
+**`interrupt` and `kill` are different.** Interrupt sends Escape: the turn
+stops, the session survives with its conversation. Kill ends the process group.
+
+**`harness install` is fire and forget.** The request acknowledges the start,
+never the outcome, and the install takes minutes on the Core — so the command
+returns immediately and `harness ls` is how you check whether it landed.

--- a/docs/reference/experiment-cli/core-client.ts
+++ b/docs/reference/experiment-cli/core-client.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// core-client — drive an Actana Core over its core-link protocol.
+//
+// Node 24 runs this TypeScript directly (type stripping), so there is no build
+// step. `core-client help` is the manual.
+//
+// This file is the entry point only: argument routing, the connection, and
+// error reporting. Everything a command does lives in src/commands/.
+
+import { makeCtx, UsageError } from "./src/args.ts";
+import type { Ctx } from "./src/args.ts";
+import { loadBlob } from "./src/blob.ts";
+import { CoreClient } from "./src/client.ts";
+import * as core from "./src/commands/core.ts";
+import * as events from "./src/commands/events.ts";
+import * as harness from "./src/commands/harness.ts";
+import { printHelp } from "./src/commands/help.ts";
+import * as project from "./src/commands/project.ts";
+import * as session from "./src/commands/session.ts";
+import * as status from "./src/commands/status.ts";
+
+type Command = (client: CoreClient, ctx: Ctx) => Promise<void>;
+
+const RESOURCES: Record<string, Command> = {
+  project: project.run,
+  session: session.run,
+  harness: harness.run,
+  status: status.run,
+  events: events.run,
+};
+
+/**
+ * The flat command names, kept working.
+ *
+ * These were the whole CLI before it grew resources, and scripts already use
+ * them. Each expands into its `<resource> <verb>` form, so there is one
+ * implementation and no drift.
+ */
+const ALIASES: Record<string, string[]> = {
+  projects: ["project", "ls"],
+  "add-project": ["project", "create"],
+  ls: ["project", "browse"],
+  sessions: ["session", "ls"],
+  start: ["session", "start"],
+  logs: ["session", "logs"],
+  tail: ["session", "logs"],
+  attach: ["session", "attach"],
+  send: ["session", "send"],
+  enter: ["session", "enter"],
+  // `stop` meant Escape before the resources existed. Keeping that meaning is
+  // the honest choice — anything else silently changes what an old command
+  // does. `session interrupt` is the name to use now.
+  stop: ["session", "interrupt"],
+  interrupt: ["session", "interrupt"],
+  resume: ["session", "resume"],
+  kill: ["session", "kill"],
+  harnesses: ["harness", "ls"],
+  install: ["harness", "install"],
+  cores: ["core", "ls"],
+};
+
+/**
+ * Pull `--core <name>` out of the arguments, wherever it sits.
+ *
+ * It selects which Core the whole command runs against, so it is global rather
+ * than per-verb: `--core pr session ls` and `session ls --core pr` mean the same
+ * thing. Removing it here also keeps it out of the verb's own positionals.
+ */
+function extractCore(argv: string[]): { core?: string; rest: string[] } {
+  const rest: string[] = [];
+  let core: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--core") {
+      core = argv[++i];
+      if (core === undefined) throw new UsageError("--core needs a Core name");
+      continue;
+    }
+    rest.push(argv[i]);
+  }
+  return { core, rest };
+}
+
+async function main(): Promise<void> {
+  const { core: selected, rest: raw } = extractCore(process.argv.slice(2));
+
+  // Help needs neither credentials nor a connection.
+  if (!raw.length || raw[0] === "help" || raw[0] === "--help" || raw[0] === "-h") {
+    printHelp(raw[1]);
+    return;
+  }
+
+  const expanded = ALIASES[raw[0]] ? [...ALIASES[raw[0]], ...raw.slice(1)] : raw;
+
+  // `core` is answered from the blobs on disk — no credentials, no connection.
+  if (expanded[0] === "core") {
+    if (expanded.includes("--help") || expanded.includes("-h")) printHelp("core");
+    else core.run(expanded.slice(1), selected);
+    return;
+  }
+
+  const resource = expanded[0];
+  const command = RESOURCES[resource];
+
+  if (!command) {
+    printHelp();
+    console.error(`\ncore-client: unknown command "${resource}"`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (expanded.includes("--help") || expanded.includes("-h")) {
+    printHelp(resource);
+    return;
+  }
+
+  const ctx = makeCtx(expanded.slice(1));
+  const client = await CoreClient.connect(loadBlob(selected));
+  try {
+    await command(client, ctx);
+  } finally {
+    // Streaming commands own the socket until they exit the process.
+    if (!ctx.keepOpen) client.close();
+  }
+}
+
+main().catch((err: Error) => {
+  if (err instanceof UsageError) {
+    printHelp(err.resource);
+    console.error(`\ncore-client: ${err.message}`);
+    process.exit(2);
+  }
+  console.error(`core-client: ${err.message}`);
+  process.exit(1);
+});

--- a/docs/reference/experiment-cli/package.json
+++ b/docs/reference/experiment-cli/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "core-client",
+  "version": "0.1.0",
+  "description": "Drive an Actana Core over its core-link protocol",
+  "type": "module",
+  "bin": {
+    "core-client": "./core-client.ts"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/docs/reference/experiment-cli/src/args.ts
+++ b/docs/reference/experiment-cli/src/args.ts
@@ -1,0 +1,69 @@
+// Argument parsing, and the context object every command receives.
+
+/**
+ * Flags that take a value. Everything else is boolean, so the token after it is
+ * a positional and must not be swallowed.
+ */
+export const VALUE_FLAGS = new Set([
+  "--core",
+  "--harness",
+  "--model",
+  "--title",
+  "--lines",
+  "--cols",
+  "--rows",
+  "--name",
+  "--since",
+  "--kind",
+]);
+
+export function positionalArgs(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      if (VALUE_FLAGS.has(arg)) i++;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+export type Ctx = {
+  /** Every argument after the resource name, flags included. */
+  argv: string[];
+  /** The same, with flags and their values removed. `[0]` is the verb. */
+  positional: string[];
+  /** Value of `--name`, or undefined. */
+  flag: (name: string) => string | undefined;
+  /** Whether a boolean flag is present. */
+  has: (name: string) => boolean;
+  /**
+   * Set by commands that keep streaming after they return, so the runner does
+   * not close the socket out from under them.
+   */
+  keepOpen: boolean;
+};
+
+export function makeCtx(argv: string[]): Ctx {
+  return {
+    argv,
+    positional: positionalArgs(argv),
+    flag: (name: string) => {
+      const i = argv.indexOf(`--${name}`);
+      return i === -1 ? undefined : argv[i + 1];
+    },
+    has: (name: string) => argv.includes(`--${name}`),
+    keepOpen: false,
+  };
+}
+
+/** Thrown when arguments are wrong; the runner turns it into help output. */
+export class UsageError extends Error {
+  resource: string | undefined;
+  constructor(message: string, resource?: string) {
+    super(message);
+    this.resource = resource;
+  }
+}

--- a/docs/reference/experiment-cli/src/blob.ts
+++ b/docs/reference/experiment-cli/src/blob.ts
@@ -1,0 +1,125 @@
+// Where the pairing credentials come from, and which Core they point at.
+//
+// The blob carries a client key and a bearer. It is real credentials — keep it
+// out of version control.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { RegistrationBlob } from "./protocol.ts";
+
+/** Where the Core keeps it inside the container. */
+const CONTAINER_BLOB_PATH = "/home/core/.config/actana/registration-blob.txt";
+
+const packageRoot = path.resolve(import.meta.dirname, "..");
+
+/** The local copy. Saves a `docker exec` per invocation, and works even when
+ *  the container is stopped or the Core lives on another machine. */
+export const LOCAL_BLOB = path.join(packageRoot, "blob.txt");
+
+/**
+ * Named Cores.
+ *
+ * One blob per file, named by what the Core is *for* rather than by container
+ * or port — `--core pr` survives a rebuild that moves the port, a hardcoded
+ * `wss://127.0.0.1:9443` does not. The name is the file's basename, the way
+ * kubectl names a context.
+ */
+export const BLOBS_DIR = path.join(packageRoot, "blobs");
+
+export function blobPath(name: string): string {
+  return path.join(BLOBS_DIR, `${name}.txt`);
+}
+
+/** The Cores that have a blob on disk, in listing order. */
+export function listCores(): string[] {
+  if (!fs.existsSync(BLOBS_DIR)) return [];
+  return fs
+    .readdirSync(BLOBS_DIR)
+    .filter((f) => f.endsWith(".txt"))
+    .map((f) => f.slice(0, -4))
+    .sort();
+}
+
+function readNamedCore(name: string): string {
+  // A name is a bare identifier, not a path: `--core ../../secrets` should fail
+  // as an unknown Core rather than read an arbitrary file.
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    throw new Error(`"${name}" is not a valid Core name (letters, digits, dot, dash, underscore)`);
+  }
+  const file = blobPath(name);
+  if (!fs.existsSync(file)) {
+    const known = listCores();
+    throw new Error(
+      `no Core named "${name}" — ${
+        known.length ? `known Cores: ${known.join(", ")}` : `${BLOBS_DIR} has no blobs in it`
+      }`,
+    );
+  }
+  return fs.readFileSync(file, "utf8").trim();
+}
+
+/**
+ * Resolve the blob for this invocation.
+ *
+ * Order, most explicit first:
+ *   1. `--core <name>`   blobs/<name>.txt
+ *   2. `AC_BLOB`         the blob itself
+ *   3. `AC_BLOB_FILE`    a file holding it
+ *   4. `AC_CORE`         blobs/<name>.txt, the ambient default
+ *   5. `./blob.txt`      the unnamed local copy, as before
+ *   6. `docker exec`     against `$AC_CONTAINER`
+ *
+ * Steps 5 and 6 are what the CLI did before named Cores existed, kept so that
+ * every command already written keeps working untouched.
+ */
+export function loadBlob(core?: string): RegistrationBlob {
+  let raw: string | undefined;
+  let source: string;
+
+  if (core) {
+    raw = readNamedCore(core);
+    source = `--core ${core}`;
+  } else if (process.env.AC_BLOB?.trim()) {
+    raw = process.env.AC_BLOB.trim();
+    source = "AC_BLOB";
+  } else if (process.env.AC_BLOB_FILE) {
+    raw = fs.readFileSync(process.env.AC_BLOB_FILE, "utf8").trim();
+    source = `AC_BLOB_FILE=${process.env.AC_BLOB_FILE}`;
+  } else if (process.env.AC_CORE?.trim()) {
+    raw = readNamedCore(process.env.AC_CORE.trim());
+    source = `AC_CORE=${process.env.AC_CORE.trim()}`;
+  } else if (fs.existsSync(LOCAL_BLOB)) {
+    raw = fs.readFileSync(LOCAL_BLOB, "utf8").trim();
+    source = "blob.txt";
+  } else {
+    const container = process.env.AC_CONTAINER ?? "rest-test";
+    try {
+      raw = execFileSync("docker", ["exec", container, "cat", CONTAINER_BLOB_PATH], {
+        encoding: "utf8",
+      }).trim();
+      source = `docker exec ${container}`;
+    } catch {
+      const known = listCores();
+      throw new Error(
+        `could not read the pairing blob from container "${container}". ` +
+          (known.length ? `Try --core <${known.join("|")}>, or set ` : `Set `) +
+          `AC_CONTAINER, or pass the blob via AC_BLOB / AC_BLOB_FILE, ` +
+          `or save it to ${LOCAL_BLOB}.`,
+      );
+    }
+  }
+
+  let blob: RegistrationBlob;
+  try {
+    // Standard base64 of the JSON — not base64url.
+    blob = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as RegistrationBlob;
+  } catch {
+    throw new Error(`the blob from ${source} is not valid base64 JSON`);
+  }
+  if (!blob.endpoint?.startsWith("wss://")) {
+    throw new Error(`blob endpoint from ${source} is not wss://: ${blob.endpoint}`);
+  }
+  return blob;
+}

--- a/docs/reference/experiment-cli/src/client.ts
+++ b/docs/reference/experiment-cli/src/client.ts
@@ -1,0 +1,240 @@
+// The transport: an authenticated core-link connection with request/response
+// correlation and the three unsolicited streams (pty data, pty exit, events).
+
+import WebSocket from "ws";
+
+import { PROTOCOL_VERSION, RESULT_OF } from "./protocol.ts";
+import type { Frame, RegistrationBlob } from "./protocol.ts";
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * `AC_DEBUG=1` traces every frame and step, with a millisecond clock.
+ *
+ * A command that stops producing output tells you nothing about *where* it
+ * stopped. This does: the last line printed is the last thing that happened.
+ */
+const DEBUG = Boolean(process.env.AC_DEBUG);
+const started = Date.now();
+
+export function trace(message: string): void {
+  if (!DEBUG) return;
+  const ms = String(Date.now() - started).padStart(6);
+  console.error(`[${ms}ms] ${message}`);
+}
+
+/** Frames carry whole terminal screens; log the shape, not the payload. */
+function summarise(frame: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (frame.reqId) parts.push(String(frame.reqId));
+  if (frame.ptyId) parts.push(String(frame.ptyId));
+  if (typeof frame.data === "string") parts.push(`${frame.data.length}B`);
+  if (frame.message) parts.push(String(frame.message).slice(0, 80));
+  return parts.join(" ");
+}
+
+type Pending = {
+  resolve: (frame: Frame) => void;
+  reject: (error: Error) => void;
+  want: string;
+  timer: NodeJS.Timeout;
+};
+
+export class CoreClient {
+  ws: WebSocket;
+  blob: RegistrationBlob;
+  seq = 0;
+  pending = new Map<string, Pending>();
+  onData: ((ptyId: string, data: string) => void) | null = null;
+  onExit: ((ptyId: string, code: number) => void) | null = null;
+  onEvent: ((event: Record<string, unknown>) => void) | null = null;
+  /** Set once the socket is gone, so later requests fail fast rather than
+   *  waiting out a timeout against a socket nobody is reading. */
+  closed = false;
+
+  constructor(blob: RegistrationBlob) {
+    this.blob = blob;
+    // mTLS: the blob's CA is the trust root for the Core's server certificate,
+    // and clientCert/clientKey are our identity. The Core sets requestCert and
+    // rejectUnauthorized, so all three are mandatory.
+    this.ws = new WebSocket(blob.endpoint, {
+      ca: blob.caCert,
+      cert: blob.clientCert,
+      key: blob.clientKey,
+      rejectUnauthorized: true,
+    });
+  }
+
+  /**
+   * Connect, then authenticate.
+   *
+   * `auth` MUST be the first frame sent: the Core answers anything else with
+   * `not-authenticated` and closes the socket.
+   */
+  static async connect(blob: RegistrationBlob): Promise<CoreClient> {
+    const client = new CoreClient(blob);
+    const ws = client.ws;
+
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", resolve);
+      ws.once("error", (err: Error) => reject(new Error(`connect failed: ${err.message}`)));
+    });
+
+    ws.on("message", (raw: Buffer) => client.dispatch(raw));
+
+    // The Core keeps exactly one connection: `onConnection` closes the previous
+    // socket when a new client connects. So a Panel pointed at the same Core
+    // will evict this process the moment it reconnects, and anything sent after
+    // that is discarded by a socket the server has already closed — silently,
+    // because `ws.send()` on a closing socket does not throw. Without this the
+    // symptom is a command that pauses and then dies on a request timeout with
+    // no indication why.
+    const failPending = (reason: string) => {
+      client.closed = true;
+      const err = new Error(reason);
+      for (const [reqId, waiter] of client.pending) {
+        clearTimeout(waiter.timer);
+        client.pending.delete(reqId);
+        waiter.reject(err);
+      }
+    };
+    ws.on("close", (code: number) => {
+      trace(`socket closed by the Core (code ${code})`);
+      failPending(
+        `the Core closed the connection (code ${code}). It accepts one client at a time, ` +
+          `so a Panel or another core-client pointed at the same Core will have taken it over. ` +
+          `Close the Panel on this Core, or use a different Core, and retry.`,
+      );
+    });
+    ws.on("error", (err: Error) => {
+      trace(`socket error: ${err.message}`);
+      failPending(`connection lost: ${err.message}`);
+    });
+
+    const authReqId = `auth-${++client.seq}`;
+    const authed = new Promise<Frame>((resolve, reject) => {
+      client.pending.set(authReqId, {
+        resolve,
+        reject,
+        want: "authOk",
+        timer: setTimeout(() => reject(new Error("auth timed out")), 30_000),
+      });
+    });
+    ws.send(JSON.stringify({ type: "auth", reqId: authReqId, bearer: blob.bearer }));
+    await authed;
+    return client;
+  }
+
+  dispatch(raw: Buffer): void {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(String(raw)) as Frame;
+    } catch {
+      trace(`<- unparseable frame, ${raw.length}B`);
+      return;
+    }
+    trace(`<- ${frame.type} ${summarise(frame as Record<string, unknown>)}`);
+
+    // Unsolicited frames: correlated by ptyId, or by nothing at all.
+    switch (frame.type) {
+      case "ready": {
+        const version = String(frame.version);
+        // major.minor equality is the compatibility rule; the Core never rejects.
+        const theirs = version.split(".").slice(0, 2).join(".");
+        const ours = PROTOCOL_VERSION.split(".").slice(0, 2).join(".");
+        if (theirs !== ours) {
+          console.error(`[warn] Core speaks core-link ${version}, this client targets ${PROTOCOL_VERSION}`);
+        }
+        return;
+      }
+      case "data":
+        this.onData?.(String(frame.ptyId), String(frame.data));
+        return;
+      case "exit":
+        this.onExit?.(String(frame.ptyId), Number(frame.exitCode));
+        return;
+      case "event":
+        this.onEvent?.(frame.event as Record<string, unknown>);
+        return;
+      case "eventsReplayed":
+        return;
+    }
+
+    const reqId = frame.reqId;
+    if (!reqId) return;
+    const waiter = this.pending.get(reqId);
+    if (!waiter) return;
+
+    if (frame.type === waiter.want) {
+      clearTimeout(waiter.timer);
+      this.pending.delete(reqId);
+      waiter.resolve(frame);
+      return;
+    }
+    // spawnError / authError / error all land on the same reqId.
+    if (frame.type === "error" || frame.type === "spawnError" || frame.type === "authError") {
+      clearTimeout(waiter.timer);
+      this.pending.delete(reqId);
+      waiter.reject(new Error(String(frame.message ?? frame.reason ?? frame.type)));
+    }
+  }
+
+  /** Send a request and resolve with the whole answering frame. */
+  request(type: string, body: Record<string, unknown> = {}, timeoutMs = 30_000): Promise<Frame> {
+    const spec = RESULT_OF[type];
+    if (!spec) throw new Error(`unknown request type: ${type}`);
+    if (this.closed || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error(
+        `cannot send ${type}: the connection to the Core is gone. It accepts one client at a time — ` +
+          `a Panel on the same Core will have taken it over.`,
+      );
+    }
+    const reqId = `r${++this.seq}`;
+    const done = new Promise<Frame>((resolve, reject) => {
+      this.pending.set(reqId, {
+        resolve,
+        reject,
+        want: spec.type,
+        timer: setTimeout(() => {
+          this.pending.delete(reqId);
+          reject(new Error(`${type} timed out after ${timeoutMs}ms`));
+        }, timeoutMs),
+      });
+    });
+    trace(`-> ${type} ${reqId} (want ${spec.type})`);
+    this.ws.send(JSON.stringify({ ...body, type, reqId }));
+    return done;
+  }
+
+  /** The request's payload field, for calls with one obvious answer. */
+  async call<T>(type: string, body: Record<string, unknown> = {}, timeoutMs?: number): Promise<T> {
+    const frame = await this.request(type, body, timeoutMs);
+    const field = RESULT_OF[type].field;
+    return (field ? frame[field] : frame) as T;
+  }
+
+  /** Events only flow after this. */
+  subscribe(lastEventId = 0): Promise<Frame> {
+    return this.request("subscribe", { lastEventId });
+  }
+
+  close(): void {
+    trace(`closing (${this.pending.size} request(s) still outstanding)`);
+    try {
+      this.ws.close();
+    } catch {
+      /* already closed */
+    }
+    // A socket the Core never finishes closing keeps Node's event loop alive,
+    // so a command that has already done its work sits there looking hung.
+    // Nothing is outstanding by this point — the connection is not worth
+    // waiting on.
+    const hard = setTimeout(() => {
+      trace("close handshake did not complete — terminating the socket");
+      this.ws.terminate();
+    }, 1_000);
+    hard.unref();
+  }
+}

--- a/docs/reference/experiment-cli/src/commands/core.ts
+++ b/docs/reference/experiment-cli/src/commands/core.ts
@@ -1,0 +1,59 @@
+// core — which Cores this client knows about.
+//
+// Purely local: it reads the blobs on disk and decodes them. Nothing here opens
+// a connection, which is the point — it answers "what can I talk to" when the
+// answer might be "nothing reachable".
+
+import * as fs from "node:fs";
+
+import { UsageError } from "../args.ts";
+import { BLOBS_DIR, blobPath, listCores } from "../blob.ts";
+import type { RegistrationBlob } from "../protocol.ts";
+
+function peek(name: string): { endpoint: string; label: string } {
+  try {
+    const raw = fs.readFileSync(blobPath(name), "utf8").trim();
+    const blob = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as RegistrationBlob;
+    return { endpoint: blob.endpoint ?? "?", label: blob.label ?? "" };
+  } catch {
+    return { endpoint: "(unreadable)", label: "" };
+  }
+}
+
+/** The Core that would be used if no --core were given. */
+function ambient(): string | undefined {
+  if (process.env.AC_BLOB?.trim()) return undefined;
+  if (process.env.AC_BLOB_FILE) return undefined;
+  return process.env.AC_CORE?.trim() || undefined;
+}
+
+export function list(selected?: string): void {
+  const names = listCores();
+  if (!names.length) {
+    console.log(`(no Cores — put a blob in ${BLOBS_DIR} as <name>.txt)`);
+    return;
+  }
+  const active = selected ?? ambient();
+  console.log(`${"".padEnd(2)}${"NAME".padEnd(16)} ${"ENDPOINT".padEnd(24)} LABEL`);
+  for (const name of names) {
+    const { endpoint, label } = peek(name);
+    const mark = name === active ? "* " : "  ";
+    console.log(`${mark}${name.padEnd(16)} ${endpoint.padEnd(24)} ${label}`);
+  }
+  if (!active) {
+    console.log(`\n(none selected — blob.txt is the fallback; pass --core <name> or set AC_CORE)`);
+  }
+}
+
+/** No client: `core` is answered before any connection is opened. */
+export function run(argv: string[], selected?: string): void {
+  const verb = argv[0];
+  switch (verb) {
+    case "ls":
+    case undefined:
+      list(selected);
+      return;
+    default:
+      throw new UsageError(`unknown verb: core ${verb}`, "core");
+  }
+}

--- a/docs/reference/experiment-cli/src/commands/events.ts
+++ b/docs/reference/experiment-cli/src/commands/events.ts
@@ -1,0 +1,19 @@
+// events — the Core's event log: task and session lifecycle, harness installs.
+
+import type { Ctx } from "../args.ts";
+import type { CoreClient } from "../client.ts";
+
+export async function run(client: CoreClient, ctx: Ctx): Promise<void> {
+  // lastEventId 0 replays the log from the beginning; --since picks up later.
+  const since = Number(ctx.flag("since") ?? 0);
+  await client.subscribe(Number.isFinite(since) ? since : 0);
+  ctx.keepOpen = true;
+
+  const only = ctx.flag("kind");
+  client.onEvent = (event) => {
+    const kind = String(event.kind);
+    if (only && !kind.startsWith(only)) return;
+    console.log(`${event.eventId}\t${kind}\t${String(event.payload)}`);
+  };
+  console.error("[streaming events — ctrl-c to stop]");
+}

--- a/docs/reference/experiment-cli/src/commands/harness.ts
+++ b/docs/reference/experiment-cli/src/commands/harness.ts
@@ -1,0 +1,51 @@
+// harness — which agent CLIs the Core can launch, and installing them.
+
+import { UsageError } from "../args.ts";
+import type { Ctx } from "../args.ts";
+import type { CoreClient } from "../client.ts";
+import type { HarnessAvailability } from "../protocol.ts";
+
+export async function availability(client: CoreClient): Promise<Record<string, HarnessAvailability>> {
+  return await client.call<Record<string, HarnessAvailability>>("agentsAvailabilityList");
+}
+
+async function list(client: CoreClient): Promise<void> {
+  for (const [id, entry] of Object.entries(await availability(client))) {
+    const detail =
+      entry.status === "available"
+        ? `${entry.version ?? "?"} at ${entry.path ?? "?"}`
+        : (entry.requiredVersion ?? "");
+    console.log(`${id.padEnd(12)} ${entry.status.padEnd(10)} ${detail}`);
+  }
+}
+
+/**
+ * Start installing a harness on the Core, and return.
+ *
+ * Fire and forget on purpose. The install runs on the Core and takes minutes;
+ * the request only ever acknowledges the *start*, never the outcome, so there
+ * is nothing to usefully wait for on this connection. `harness ls` is how you
+ * find out whether it landed — the Core re-probes when the install finishes,
+ * and success is defined as "the probe now finds it".
+ */
+async function install(client: CoreClient, target: string): Promise<void> {
+  const ack = await client.request("harnessInstall", { harness: target });
+  if (ack.accepted === false) throw new Error(`install refused: ${String(ack.message ?? "")}`);
+  console.log(`installing ${target} on the Core — check with \`harness ls\``);
+}
+
+export async function run(client: CoreClient, ctx: Ctx): Promise<void> {
+  const [verb, ...args] = ctx.positional;
+  switch (verb) {
+    case "ls":
+    case undefined:
+      await list(client);
+      return;
+    case "install":
+      if (!args[0]) throw new UsageError("harness install needs a harness id", "harness");
+      await install(client, args[0]);
+      return;
+    default:
+      throw new UsageError(`unknown verb: harness ${verb}`, "harness");
+  }
+}

--- a/docs/reference/experiment-cli/src/commands/help.ts
+++ b/docs/reference/experiment-cli/src/commands/help.ts
@@ -1,0 +1,257 @@
+// help — the whole surface, per resource.
+
+const OVERVIEW = `core-client — drive an Actana Core over its core-link protocol
+
+USAGE
+  core-client <resource> <verb> [target] [options]
+
+  Resources group by what they act on; the verbs repeat across them, so
+  \`project ls\`, \`session ls\` and \`harness ls\` all behave the same way.
+
+RESOURCES
+  core       which Cores this client can talk to
+  project    directories on the Core that sessions may run in
+  session    harness sessions: launch, drive, read, end
+  harness    which agent CLIs the Core can launch
+  status     is this Core reachable, and what is on it
+  events     the Core's event log
+
+  core-client help <resource>    everything about one resource
+  core-client <resource> --help  the same
+
+COMMON
+  core-client status
+  core-client project ls
+  core-client session start <project> "do the thing"
+  core-client session logs <session>
+  core-client session send <session> "and now this"
+  core-client session interrupt <session>
+
+TARGETS
+  A project is named by its id, its name, or its path — whichever you have.
+  A session is named by its task id (durable) or its pty id (lives only as long
+  as the process). Both are accepted everywhere a session is asked for.
+
+OUTPUT
+  Data goes to stdout, commentary to stderr, so ids can be captured:
+      SID=$(core-client session start scratch "summarise the README")
+
+SELECTING A CORE
+  --core <name> picks which Core the command runs against, the way kubectl
+  picks a context. It is global: it may go anywhere in the line, and every
+  resource honours it.
+
+      core-client --core pr project ls
+      core-client project ls --core pr        the same thing
+      AC_CORE=pr core-client project ls       the same, for a whole shell
+
+  \`core ls\` lists what is available. Cores are separate machines as far as
+  this client is concerned: projects, sessions and harness logins on one are
+  invisible to the other.
+
+CREDENTIALS
+  The pairing blob is resolved in this order:
+      --core <name>  blobs/<name>.txt
+      AC_BLOB        the base64 blob itself
+      AC_BLOB_FILE   a file holding it
+      AC_CORE        blobs/<name>.txt, the ambient default
+      ./blob.txt     the unnamed local copy, as before
+      docker exec    against $AC_CONTAINER (default: rest-test)
+
+  It carries a client key and a bearer. Treat it as a secret.`;
+
+const CORE = `core-client core — which Cores this client can talk to
+
+  core ls                    list them: name, endpoint, label
+
+  A Core is one blob file in blobs/, named by the file's basename. The name is
+  what --core takes:
+
+      core-client --core pr session ls
+      core-client --core developer session ls
+
+  Naming them by purpose rather than by container or port is deliberate: a
+  rebuild that moves a port leaves \`--core pr\` working, where a memorised
+  wss://127.0.0.1:9443 would not.
+
+  Adding one is copying its blob in:
+      docker exec <container> cat /home/core/.config/actana/registration-blob.txt \\
+        > blobs/<name>.txt
+
+  Selection order is --core, then AC_CORE, then blob.txt as the unnamed
+  fallback. \`core ls\` marks the one in effect with an asterisk.
+
+  These are credentials — a client key and a bearer each. The directory is
+  mode 700 and the files 600. Do not commit them.
+
+  Aliases: \`cores\` → core ls`;
+
+const PROJECT = `core-client project — directories the Core may run sessions in
+
+  project ls                        list projects
+  project create <path> [name]      register a directory as a project
+  project rm <project> --yes        unregister a project and its sessions
+  project browse [path]             browse the Core's filesystem
+  project inspect <project>         full detail as JSON
+
+  The path is a path on the Core, not on your machine, and the Core validates
+  it: absolute, resolvable, and a directory. \`project browse\` is how you find
+  one worth registering.
+
+  Registration is not bookkeeping. A session may only run inside a registered
+  project root — the Core rejects any spawn whose working directory is outside
+  one.
+
+  \`rm\` needs --yes because the Core's removal operation cascades: every
+  session recorded under the project goes with it. The directory on disk is
+  left alone; the project is unregistered, not erased.
+
+  Aliases: \`projects\` → project ls, \`add-project\` → project create,
+           \`ls\` → project browse`;
+
+const SESSION = `core-client session — launch, drive, read and end sessions
+
+  session ls [--all]                sessions with a live PTY
+  session start <project> [prompt]  launch one; prints its id and exits
+  session logs <session>            what it has said so far
+  session attach <session>          stream it live
+  session send <session> <text>     type into it and submit (--no-enter to hold)
+  session enter <session>           press Enter only
+  session interrupt <session>       press Escape — stop the turn, keep the session
+  session resume <task>             relaunch a finished session, conversation intact
+  session kill <session>            end it for good
+  session inspect <task>            full detail as JSON
+
+LAUNCHING
+  \`start\` is fire and forget: it prints the task id to stdout as soon as the
+  session exists, and the session keeps running on the Core after it exits.
+
+  Two steps beat one when it matters:
+
+      ID=\$(core-client session start myproject)
+      core-client session logs \$ID          # see it is at the prompt
+      core-client session send \$ID "do the thing"
+
+  \`start <project> "prompt"\` still works and does the same thing in one go,
+  but the split is what to reach for when a prompt is not landing: each half
+  reports separately, and \`logs\` in between shows exactly which one failed.
+
+  Either way the text is typed by this client once the screen holds still. The
+  Core's own initial-input path fires 450ms after spawn, before Claude accepts
+  input, and loses the prompt.
+
+  Auto mode is the default: sessions launch with
+  --dangerously-skip-permissions, so Claude does not ask for tool approvals.
+  Use --ask-permissions to opt out.
+
+  Claude's blocking startup dialogs are answered automatically — the bypass
+  permissions warning and the folder-trust prompt. Both appear once per project
+  per Core, and a session parked on one accepts no input at all; the bypass one
+  is worse, since its highlighted default is "No, exit", so any Enter sent at
+  it quits Claude. Answering them is what makes auto mode actually unattended.
+
+READING
+  \`logs\` replays the session's output through a terminal emulator, because a
+  TUI paints with cursor moves rather than plain text — stripping escape codes
+  produces unreadable soup. It only works while the session is alive: the
+  scrollback belongs to the PTY and goes when the process does.
+
+STOPPING
+  \`interrupt\` sends Escape: the turn stops, the session lives on and can be
+  given something else. \`kill\` ends the process group. They are not the same
+  and the difference matters.
+
+SENDING
+  \`send\` waits for the screen to hold still before it types, then sends the
+  Enter as a separate write after a pause that scales with length. Both halves
+  matter: text typed into a still-painting TUI is dropped, and an Enter in the
+  same frame as a long paste is absorbed into it.
+
+      --enter     press Enter after the text (the default; spell it if you like)
+      --no-enter  type it and stop, leaving it unsubmitted
+      --now       skip the settle wait, for a session known to be idle
+
+  \`session enter\` submits whatever is already sitting there.
+
+OPTIONS
+  --follow          start/logs stream instead of returning
+  --all             ls includes finished sessions
+  --lines N         logs: how many lines (40)
+  --raw             logs: untouched bytes, no emulation
+  --cols N --rows N logs: replay geometry, must match the spawn (120x32)
+  --harness <id>    claude-code (default), codex, cursor-cli, opencode
+  --model <id>      model to launch with
+  --title <text>    task title instead of one derived from the prompt
+  --ask-permissions launch without auto mode
+
+  Aliases: \`sessions\` → session ls, \`start\`, \`send\`, \`enter\`, \`attach\`,
+           \`resume\`, \`kill\` and \`tail\` (→ session logs) all work bare.
+           \`stop\` is a deprecated alias for \`session interrupt\`.`;
+
+const HARNESS = `core-client harness — the agent CLIs the Core can launch
+
+  harness ls                 availability, version and install path
+  harness install <id>       start installing one on the Core
+
+  Harnesses are not baked into the Core image. They install at runtime into the
+  Core's home directory, which is the persistent volume, so they survive image
+  upgrades and self-update in place.
+
+  \`install\` is fire and forget: it starts the install and returns. The work
+  runs on the Core and takes minutes, and the protocol only ever acknowledges
+  the start, never the outcome. Run \`harness ls\` to see whether it landed —
+  the Core re-probes when the install finishes, and success means "the probe
+  now finds it".
+
+  Installing gets you the binary, not a login. Harness credentials live in the
+  Core's home directory too, and each Core authenticates separately.
+
+  Known ids: claude-code, codex, cursor-cli, opencode
+
+  Aliases: \`harnesses\` → harness ls, \`install\` → harness install`;
+
+const STATUS = `core-client status — is this Core reachable, and what is on it
+
+  status
+
+  Prints the endpoint being dialled, the Core's label, the protocol version
+  this client speaks, how many projects exist, how many sessions are running
+  against how many total, and each harness's availability.
+
+  It is also the cheapest proof that the credentials still work: it opens a
+  real mTLS connection and authenticates before printing anything.`;
+
+const EVENTS = `core-client events — the Core's event log
+
+  events [--since N] [--kind prefix]
+
+  Streams task and session lifecycle, project changes, and harness install
+  outcomes. Replays from the beginning by default; --since resumes from an
+  event id, --kind filters by prefix (\`task:\`, \`session:\`, \`pty:\`,
+  \`project:\`, \`agents:\`, \`harness:\`).
+
+  Some outcomes exist only here. A harness install reports success and failure
+  as events, never as a reply to the request that started it.`;
+
+const TOPICS: Record<string, string> = {
+  core: CORE,
+  project: PROJECT,
+  session: SESSION,
+  harness: HARNESS,
+  status: STATUS,
+  events: EVENTS,
+};
+
+export function printHelp(topic?: string): void {
+  if (!topic) {
+    console.log(OVERVIEW);
+    return;
+  }
+  const text = TOPICS[topic];
+  if (!text) {
+    console.log(OVERVIEW);
+    console.log(`\n(no help topic "${topic}" — the resources are: ${Object.keys(TOPICS).join(", ")})`);
+    return;
+  }
+  console.log(text);
+}

--- a/docs/reference/experiment-cli/src/commands/project.ts
+++ b/docs/reference/experiment-cli/src/commands/project.ts
@@ -1,0 +1,87 @@
+// project — the directories on the Core that sessions are allowed to run in.
+
+import { UsageError } from "../args.ts";
+import type { Ctx } from "../args.ts";
+import type { CoreClient } from "../client.ts";
+import type { DirListing, Project } from "../protocol.ts";
+
+/** Accepts an id, a name, or a path. */
+export async function findProject(client: CoreClient, ref: string): Promise<Project> {
+  const projects = await client.call<Project[]>("projectsList");
+  const project = projects.find((p) => p.projectId === ref || p.name === ref || p.path === ref);
+  if (!project) throw new Error(`no such project: ${ref} (try \`project ls\`)`);
+  return project;
+}
+
+async function list(client: CoreClient): Promise<void> {
+  const projects = await client.call<Project[]>("projectsList");
+  if (!projects.length) {
+    console.log("(no projects — create one with `project create <path>`)");
+    return;
+  }
+  for (const p of projects) console.log(`${p.projectId}  ${p.name}\t${p.path}`);
+}
+
+async function create(client: CoreClient, path: string, name?: string): Promise<void> {
+  // `path` is validated on the Core: absolute, resolvable, and a directory.
+  const label = name ?? path.split("/").filter(Boolean).pop() ?? path;
+  const project = await client.call<Project | null>("projectsMutate", {
+    mutation: { op: "create", name: label, path },
+  });
+  if (!project) throw new Error("the Core refused to create the project");
+  console.log(`${project.projectId}  ${project.name}\t${project.path}`);
+}
+
+async function remove(client: CoreClient, ref: string, confirmed: boolean): Promise<void> {
+  const project = await findProject(client, ref);
+  // The Core's removal op is `archive`, and it cascades: every task under the
+  // project goes with it. The files on disk are untouched — this unregisters
+  // the project, it does not delete the directory.
+  if (!confirmed) {
+    throw new Error(
+      `removing "${project.name}" (${project.projectId}) also removes every session recorded under it. ` +
+        `The directory ${project.path} is left alone. Re-run with --yes to confirm.`,
+    );
+  }
+  await client.call("projectsMutate", { mutation: { op: "archive", projectId: project.projectId } });
+  console.log(`removed ${project.projectId}  ${project.name}`);
+}
+
+async function browse(client: CoreClient, path?: string): Promise<void> {
+  const listing = await client.call<DirListing>("dirList", { path: path ?? null });
+  console.log(listing.path);
+  for (const entry of listing.entries ?? []) {
+    console.log(`  ${entry.isDirectory ? "d" : "-"} ${entry.name}`);
+  }
+}
+
+async function inspect(client: CoreClient, ref: string): Promise<void> {
+  console.log(JSON.stringify(await findProject(client, ref), null, 2));
+}
+
+export async function run(client: CoreClient, ctx: Ctx): Promise<void> {
+  const [verb, ...args] = ctx.positional;
+  switch (verb) {
+    case "ls":
+    case undefined:
+      await list(client);
+      return;
+    case "create":
+      if (!args[0]) throw new UsageError("project create needs a path", "project");
+      await create(client, args[0], args[1] ?? ctx.flag("name"));
+      return;
+    case "rm":
+      if (!args[0]) throw new UsageError("project rm needs a project", "project");
+      await remove(client, args[0], ctx.has("yes"));
+      return;
+    case "browse":
+      await browse(client, args[0]);
+      return;
+    case "inspect":
+      if (!args[0]) throw new UsageError("project inspect needs a project", "project");
+      await inspect(client, args[0]);
+      return;
+    default:
+      throw new UsageError(`unknown verb: project ${verb}`, "project");
+  }
+}

--- a/docs/reference/experiment-cli/src/commands/session.ts
+++ b/docs/reference/experiment-cli/src/commands/session.ts
@@ -1,0 +1,649 @@
+// session — launching, driving, reading and ending harness sessions.
+
+import { randomUUID } from "node:crypto";
+
+import { UsageError } from "../args.ts";
+import type { Ctx } from "../args.ts";
+import { delay, trace } from "../client.ts";
+import type { CoreClient } from "../client.ts";
+import type { Harness, Project, Session, SpawnOptions, Task } from "../protocol.ts";
+import { renderTerminal } from "../terminal.ts";
+import { findProject } from "./project.ts";
+
+const COLS = 120;
+const ROWS = 32;
+
+/**
+ * The canonical binary per harness — the Core matches argv[0] against exactly
+ * this and rejects anything else with `command-not-on-allowlist`. Only
+ * `cursor-cli` differs from its own id, which is why it was the only harness
+ * that could not launch.
+ *
+ * LOCAL STOPGAP for actana/control#177. Delete when the proper fix lands.
+ */
+const HARNESS_COMMAND: Record<Harness, string> = {
+  "claude-code": "claude",
+  codex: "codex",
+  "cursor-cli": "cursor-agent",
+  opencode: "opencode",
+};
+
+/**
+ * The auto-mode flag per harness. The spawn *option* alone does not put a
+ * harness in auto mode — the Core only rejects a flag without the option, never
+ * an option without the flag, so a missing flag here launches interactive while
+ * the client believes it is unattended. OpenCode has no such flag.
+ *
+ * LOCAL STOPGAP for actana/control#177. Delete when the proper fix lands.
+ */
+const HARNESS_AUTO_FLAG: Partial<Record<Harness, string>> = {
+  "claude-code": "--dangerously-skip-permissions",
+  codex: "--yolo",
+  "cursor-cli": "--force",
+};
+
+/** Accept either a pty id or a task id wherever a session is named. */
+export async function resolvePty(client: CoreClient, ref: string): Promise<string | null> {
+  if (ref.startsWith("pty-")) return ref;
+  return await client.call<string | null>("findByTask", { taskId: ref });
+}
+
+async function livePtyOrThrow(client: CoreClient, ref: string): Promise<string> {
+  const ptyId = await resolvePty(client, ref);
+  if (!ptyId) throw new Error(`${ref} has no live PTY`);
+  return ptyId;
+}
+
+/**
+ * Type text into a session and submit it.
+ *
+ * The Enter goes in a *separate* write, after a pause. Claude Code treats a
+ * burst of input as a paste rather than typing, and a carriage return in the
+ * same frame is swallowed into that block — the TUI shows
+ * `[Pasted text #1 +1 lines]` and sits there waiting, because as far as it is
+ * concerned you have not pressed Enter yet. Splitting the two makes the return
+ * a keystroke against an already-pasted buffer, which submits.
+ *
+ * The pause scales with length: a long paste takes the TUI longer to ingest,
+ * and an Enter that lands mid-ingest is swallowed the same way.
+ */
+export async function typeInto(
+  client: CoreClient,
+  ptyId: string,
+  text: string,
+  { enter = true } = {},
+): Promise<void> {
+  await client.call<boolean>("write", { ptyId, data: text });
+  if (!enter) return;
+  await delay(Math.min(1500, 250 + text.length / 4));
+  await client.call<boolean>("write", { ptyId, data: "\r" });
+}
+
+/** What `start` accumulates while a session boots, so it can tell what is on
+ *  screen and when the painting has stopped. */
+export type StreamState = { sawData: boolean; lastAt: number; buffer: string };
+
+export function newStreamState(): StreamState {
+  return { sawData: false, lastAt: 0, buffer: "" };
+}
+
+/** Enough to hold a boot screen; older bytes cannot still be on screen. */
+const BUFFER_CAP = 256 * 1024;
+
+export function recordOutput(state: StreamState, data: string): void {
+  state.sawData = true;
+  state.lastAt = Date.now();
+  state.buffer = (state.buffer + data).slice(-BUFFER_CAP);
+}
+
+/**
+ * One session's slice of the connection's output.
+ *
+ * Every PTY on the Core shares a single link, and the Core sends `data` frames
+ * for all of them, so a handler that ignores the ptyId records other sessions'
+ * bytes as if they were its own. That is not cosmetic: the settle detector is
+ * waiting for a *gap* in the output, and a second session launched while the
+ * first one is working never sees one — it stalls for the full length of every
+ * timeout and only then delivers its prompt. The dialog matcher, meanwhile,
+ * ends up reading two sessions' bytes interleaved.
+ *
+ * The subscription has to exist before the spawn so nothing is missed, but the
+ * ptyId only arrives with the spawn reply. Frames that turn up in between are
+ * held per PTY, and the one that turns out to be ours is adopted after.
+ */
+export class PtyStream {
+  readonly state = newStreamState();
+  private ptyId: string | null = null;
+  private held = new Map<string, string>();
+  private mirror: ((data: string) => void) | null;
+
+  constructor(mirror?: (data: string) => void) {
+    this.mirror = mirror ?? null;
+  }
+
+  /** True once we know our ptyId and this frame belongs to it. */
+  isOurs(id: string): boolean {
+    return this.ptyId !== null && id === this.ptyId;
+  }
+
+  accept(id: string, data: string): void {
+    if (this.ptyId === null) {
+      this.held.set(id, ((this.held.get(id) ?? "") + data).slice(-BUFFER_CAP));
+      return;
+    }
+    if (id !== this.ptyId) return;
+    recordOutput(this.state, data);
+    this.mirror?.(data);
+  }
+
+  adopt(ptyId: string): void {
+    this.ptyId = ptyId;
+    const early = this.held.get(ptyId);
+    this.held.clear();
+    if (early) {
+      recordOutput(this.state, early);
+      this.mirror?.(early);
+    }
+  }
+}
+
+/**
+ * Blocking dialogs Claude Code opens before it will accept a prompt, and the
+ * key that clears each.
+ *
+ * These are the reason a launched session can look alive and ignore
+ * everything, or die on the spot. The bypass-permissions warning is the
+ * dangerous one: its highlighted default is "No, exit", so a prompt's Enter
+ * quits Claude instead of submitting. Both are recorded per directory in the
+ * Core's home volume, so they appear once per project per Core — which is
+ * exactly often enough to keep surprising you.
+ *
+ * Matching happens against the *rendered* screen, not the raw bytes: a TUI
+ * writes the spaces between words as cursor moves, so "Yes, I accept" does not
+ * appear literally in the stream.
+ */
+const STARTUP_DIALOGS: { name: string; seen: (screen: string) => boolean; key: string }[] = [
+  {
+    name: "bypass-permissions",
+    seen: (s) => /Bypass Permissions mode/i.test(s) && /Yes, I accept/i.test(s),
+    key: "2",
+  },
+  {
+    name: "folder-trust",
+    seen: (s) => /trust/i.test(s) && /Yes, I trust this folder/i.test(s),
+    key: "1",
+  },
+];
+
+/**
+ * Cells that change on their own, without the screen meaning anything new.
+ *
+ * A Claude Code TUI at rest is not silent: the spinner glyph cycles and the
+ * "(3s · esc to interrupt)" counter ticks, so bytes arrive forever. Waiting for
+ * a gap in the output therefore never succeeds — it waits out the whole timeout
+ * on every launch and looks like a hang. Waiting for the *rendered screen* to
+ * stop changing is the signal that was actually wanted, and these are what has
+ * to be ignored for two frames of it to compare equal.
+ */
+const RESTLESS = /[·✢✳∗✻✽⠁-⠿◐◓◑◒]|\d+/g;
+
+function normalizeScreen(screen: string): string {
+  return screen.replace(RESTLESS, "").replace(/[ \t]+/g, " ").trim();
+}
+
+/** The screen as it would be seen right now. */
+function currentScreen(state: StreamState): string {
+  return renderTerminal(state.buffer, COLS, ROWS).join("\n");
+}
+
+/**
+ * Wait until the TUI has settled: the same screen, ignoring the restless cells,
+ * across consecutive samples.
+ *
+ * Returns false on timeout. Callers carry on regardless — a prompt typed into a
+ * busy screen is recoverable, a prompt never typed is not.
+ */
+async function waitForSettled(
+  state: StreamState,
+  { sampleMs = 500, stableSamples = 2, timeoutMs = 15_000 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let previous: string | null = null;
+  let matches = 0;
+
+  for (;;) {
+    await delay(sampleMs);
+    if (state.sawData) {
+      const screen = normalizeScreen(currentScreen(state));
+      if (previous !== null && screen === previous) {
+        if (++matches >= stableSamples) return true;
+      } else {
+        matches = 0;
+      }
+      previous = screen;
+    }
+    if (Date.now() >= deadline) return false;
+  }
+}
+
+/**
+ * Answer the startup dialogs, so "auto mode" actually means unattended.
+ *
+ * Runs whether or not there is a prompt: a session left sitting on one of
+ * these accepts no input at all, and would look simply broken.
+ */
+export async function clearStartupDialogs(
+  client: CoreClient,
+  ptyId: string,
+  state: StreamState,
+  { timeoutMs = 20_000 } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    if (!(await waitForSettled(state, { timeoutMs: remaining }))) return;
+
+    const screen = currentScreen(state);
+    const dialog = STARTUP_DIALOGS.find((d) => d.seen(screen));
+    if (!dialog) return;
+
+    console.error(`[answering ${dialog.name} dialog]`);
+    await client.call<boolean>("write", { ptyId, data: dialog.key });
+    await delay(200);
+    await client.call<boolean>("write", { ptyId, data: "\r" });
+
+    // The answer repaints the screen. Drop what was matched so the same dialog
+    // cannot match twice, and wait for the repaint to settle before looking
+    // again — dialogs can follow one another.
+    state.buffer = "";
+    state.lastAt = Date.now();
+    if (Date.now() >= deadline) return;
+  }
+}
+
+/**
+ * Type a prompt into a freshly spawned session, once it is ready to receive it.
+ *
+ * "Ready" is inferred from the output stream rather than a fixed delay: a TUI
+ * booting redraws continuously, so the first gap in the data frames is the
+ * point where it has finished painting and is waiting on the user. A fixed
+ * sleep cannot work here — the boot takes as long as it takes, and guessing
+ * short is exactly why the Core's own `initialInput` loses the prompt.
+ */
+async function deliverPrompt(
+  client: CoreClient,
+  ptyId: string,
+  prompt: string,
+  state: StreamState,
+  { timeoutMs = 15_000 } = {},
+): Promise<void> {
+  if (!(await waitForSettled(state, { timeoutMs }))) {
+    console.error(`[the TUI never settled in ${timeoutMs / 1000}s — sending the prompt anyway]`);
+  }
+  await typeInto(client, ptyId, prompt);
+}
+
+/**
+ * The claude launch command.
+ *
+ * The Core re-validates every argv element against a per-harness allow-list, so
+ * this has to be built exactly, not improvised:
+ *   • argv[0] must be the harness's canonical binary — `claude`
+ *   • allowed flags: --bare, --session-id, --resume, --model,
+ *     --dangerously-skip-permissions
+ *   • no shell metacharacters anywhere in argv
+ *   • --dangerously-skip-permissions in the string REQUIRES the matching spawn
+ *     option, or the Core rejects the spawn
+ */
+export function buildClaudeCommand(mode: {
+  sessionId?: string;
+  resume?: string;
+  model?: string;
+  bare?: boolean;
+  skipPermissions?: boolean;
+}): { command: string; sessionId: string } {
+  const sessionId = mode.resume ?? mode.sessionId ?? randomUUID();
+  const parts = ["claude"];
+  if (mode.bare) parts.push("--bare");
+  parts.push(mode.resume ? "--resume" : "--session-id", sessionId);
+  if (mode.model) parts.push("--model", mode.model);
+  if (mode.skipPermissions) parts.push("--dangerously-skip-permissions");
+  return { command: parts.join(" "), sessionId };
+}
+
+async function startSession(
+  client: CoreClient,
+  opts: {
+    projectId: string;
+    cwd: string;
+    title: string;
+    harness: Harness;
+    model?: string;
+    skipPermissions: boolean;
+  },
+): Promise<{ taskId: string; ptyId: string }> {
+  const task = await client.call<Task | null>("tasksMutate", {
+    mutation: { op: "create", projectId: opts.projectId, title: opts.title, agent: opts.harness },
+  });
+  if (!task) throw new Error("the Core refused to create the task");
+
+  // PTYs outlive any client, and re-spawning a live session fails with
+  // "session id already in use".
+  const existing = await client.call<string | null>("findByTask", { taskId: task.taskId });
+  if (existing) return { taskId: task.taskId, ptyId: existing };
+
+  const { command } = buildClaudeCommand({ model: opts.model, skipPermissions: opts.skipPermissions });
+
+  // No `initialInput`. The Core writes it 450ms after spawn, and Claude Code's
+  // TUI is not accepting input that early — the text lands nowhere and the
+  // prompt is silently lost. `deliverPrompt()` does it instead.
+  const spawnOpts: SpawnOptions = {
+    taskId: task.taskId,
+    cwd: opts.cwd,
+    command:
+      opts.harness === "claude-code"
+        ? command
+        : [
+            HARNESS_COMMAND[opts.harness],
+            ...(opts.model ? ["--model", opts.model] : []),
+            ...(opts.skipPermissions && HARNESS_AUTO_FLAG[opts.harness]
+              ? [HARNESS_AUTO_FLAG[opts.harness]!]
+              : []),
+          ].join(" "),
+    cols: COLS,
+    rows: ROWS,
+    agent: opts.harness,
+    dangerouslySkipPermissions: opts.skipPermissions,
+  };
+
+  const spawned = await client.request("spawn", { opts: spawnOpts });
+  return { taskId: task.taskId, ptyId: String(spawned.ptyId) };
+}
+
+async function list(client: CoreClient, all: boolean): Promise<void> {
+  // A session is live exactly when it still has a ptyId; finished ones keep
+  // their row with ptyId null, so they are filtered out by default.
+  const sessions = await client.call<Session[]>("sessionsList");
+  const tasks = await client.call<Task[]>("tasksList");
+  const byTask = new Map(tasks.map((t) => [t.taskId, t]));
+  const rows = sessions.filter((s) => all || s.ptyId);
+  if (!rows.length) {
+    console.log(all ? "(no sessions)" : "(nothing running — add --all to include finished sessions)");
+    return;
+  }
+  console.log(`${"PTY".padEnd(22)} ${"TASK".padEnd(20)} ${"STATUS".padEnd(10)} HARNESS  TITLE`);
+  for (const s of rows) {
+    const task = byTask.get(s.taskId);
+    console.log(
+      `${(s.ptyId ?? "—").padEnd(22)} ${s.taskId.padEnd(20)} ${s.status.padEnd(10)} ` +
+        `${(task?.agent ?? "?").padEnd(12)} ${task?.title ?? ""}`,
+    );
+  }
+}
+
+async function start(client: CoreClient, ctx: Ctx, ref: string, prompt?: string): Promise<void> {
+  const project = await findProject(client, ref);
+  const harness = (ctx.flag("harness") ?? "claude-code") as Harness;
+  // Auto mode is the default, matching the Panel: every harness that has such a
+  // flag launches with it. The command string and the spawn option must agree,
+  // so this single value feeds both.
+  const skipPermissions = !ctx.has("ask-permissions");
+  const follow = ctx.has("follow");
+
+  // Installed before the spawn so nothing is missed: it feeds both the settle
+  // detector and the dialog matcher, and with --follow mirrors the terminal.
+  const pty = new PtyStream(follow ? (data) => process.stdout.write(data) : undefined);
+  client.onData = (id, data) => pty.accept(id, data);
+  if (follow) {
+    ctx.keepOpen = true;
+    client.onExit = (id, code) => {
+      // Another session ending is not our business.
+      if (!pty.isOurs(id)) return;
+      console.log(`\n[session exited ${code}]`);
+      client.close();
+      process.exit(code === 0 ? 0 : 1);
+    };
+  }
+
+  const { taskId, ptyId } = await startSession(client, {
+    projectId: project.projectId,
+    cwd: project.path,
+    title: ctx.flag("title") ?? prompt?.slice(0, 60) ?? "core-client session",
+    harness,
+    model: ctx.flag("model"),
+    skipPermissions,
+  });
+  pty.adopt(ptyId);
+
+  // The id exists now, so print it now. The typing below takes seconds, and
+  // withholding the one piece of output that proves the session was created is
+  // what made a working launch look like a hung command. `$(… start …)` is
+  // unaffected: the shell waits for exit either way.
+  console.log(taskId);
+  console.error(follow ? `[pty ${ptyId}] streaming — ctrl-c detaches, the session keeps running` : `pty ${ptyId}`);
+
+  // Always, prompt or not: a session parked on a startup dialog accepts no
+  // input, and the bypass-permissions one quits Claude if anything presses
+  // Enter at it.
+  await clearStartupDialogs(client, ptyId, pty.state);
+
+  // Fire and forget still, but the prompt has to be typed before this process
+  // may exit — a second or two, not the life of the session.
+  if (prompt) {
+    console.error("[waiting for the TUI to settle, then typing the prompt]");
+    await deliverPrompt(client, ptyId, prompt, pty.state);
+    console.error("[prompt delivered]");
+  }
+}
+
+async function logs(client: CoreClient, ctx: Ctx, ref: string, follow = ctx.has("follow")): Promise<void> {
+  const ptyId = await resolvePty(client, ref);
+  // The scrollback buffer lives with the PTY, so a finished session has nothing
+  // left to show — resume it instead.
+  if (!ptyId) throw new Error(`${ref} has no live PTY — its buffer is gone; \`session resume\` restarts it`);
+
+  if (follow) {
+    ctx.keepOpen = true;
+    client.onData = (id, data) => {
+      if (id === ptyId) process.stdout.write(data);
+    };
+    client.onExit = (id, code) => {
+      if (id !== ptyId) return;
+      console.log(`\n[session exited ${code}]`);
+      client.close();
+      process.exit(0);
+    };
+    // Subscribe to data before replaying: a replay issued first would drop
+    // everything emitted in between.
+    const replay = await client.request("replay", { ptyId });
+    process.stdout.write(String(replay.data ?? ""));
+    console.error(`\n[attached to ${ptyId}]`);
+    return;
+  }
+
+  const replay = await client.request("replay", { ptyId });
+  const raw = String(replay.data ?? "");
+  if (ctx.has("raw")) {
+    process.stdout.write(raw);
+    return;
+  }
+  // Geometry has to match the spawn or the wrapping lands in the wrong columns.
+  const lines = renderTerminal(raw, Number(ctx.flag("cols") ?? COLS), Number(ctx.flag("rows") ?? ROWS));
+  // Blank rows are the unpainted parts of the screen, not content.
+  const meaningful = lines.filter((line) => line.trim() !== "");
+  const count = Number(ctx.flag("lines") ?? 40);
+  console.log(meaningful.slice(-count).join("\n"));
+}
+
+async function resume(client: CoreClient, ctx: Ctx, taskId: string): Promise<void> {
+  const tasks = await client.call<Task[]>("tasksList");
+  const task = tasks.find((t) => t.taskId === taskId);
+  if (!task) throw new Error(`no such task: ${taskId} (try \`session ls --all\`)`);
+
+  ctx.keepOpen = true;
+  const pty = new PtyStream((data) => process.stdout.write(data));
+  client.onData = (id, data) => pty.accept(id, data);
+  client.onExit = (id, code) => {
+    if (!pty.isOurs(id)) return;
+    console.log(`\n[session exited ${code}]`);
+    client.close();
+    process.exit(0);
+  };
+
+  // Still alive? Then resume means re-attach — spawning a second PTY for the
+  // same session id fails with "already in use".
+  const live = await client.call<string | null>("findByTask", { taskId });
+  if (live) {
+    pty.adopt(live);
+    const replay = await client.request("replay", { ptyId: live });
+    process.stdout.write(String(replay.data ?? ""));
+    console.error(`\n[already running — attached to ${live}]`);
+    return;
+  }
+
+  if (task.agent !== "claude-code") throw new Error(`resume is claude-code only; this task runs ${task.agent}`);
+  if (!task.claudeSessionId) {
+    throw new Error(
+      `task ${taskId} never recorded a harness session id — there is no conversation to resume, start a fresh session`,
+    );
+  }
+  const projects = await client.call<Project[]>("projectsList");
+  const project = projects.find((p) => p.projectId === task.projectId);
+  if (!project) throw new Error(`task ${taskId} belongs to a project that no longer exists`);
+
+  const skipPermissions = !ctx.has("ask-permissions");
+  const { command } = buildClaudeCommand({
+    resume: task.claudeSessionId,
+    model: ctx.flag("model"),
+    skipPermissions,
+  });
+  const spawned = await client.request("spawn", {
+    opts: {
+      taskId,
+      cwd: project.path,
+      command,
+      cols: COLS,
+      rows: ROWS,
+      agent: "claude-code",
+      dangerouslySkipPermissions: skipPermissions,
+    },
+  });
+  const resumedPty = String(spawned.ptyId);
+  pty.adopt(resumedPty);
+  console.error(`[resumed ${task.claudeSessionId} — pty ${resumedPty}]`);
+  await clearStartupDialogs(client, resumedPty, pty.state);
+}
+
+export async function run(client: CoreClient, ctx: Ctx): Promise<void> {
+  const [verb, ...args] = ctx.positional;
+
+  switch (verb) {
+    case "ls":
+    case undefined:
+      await list(client, ctx.has("all"));
+      return;
+
+    case "start":
+      if (!args[0]) throw new UsageError("session start needs a project", "session");
+      await start(client, ctx, args[0], args[1]);
+      return;
+
+    case "logs":
+      if (!args[0]) throw new UsageError("session logs needs a session", "session");
+      await logs(client, ctx, args[0]);
+      return;
+
+    case "attach":
+      // attach is logs that keeps streaming.
+      if (!args[0]) throw new UsageError("session attach needs a session", "session");
+      await logs(client, ctx, args[0], true);
+      return;
+
+    case "send": {
+      if (!args[0] || args.length < 2) throw new UsageError("session send needs a session and text", "session");
+      const ptyId = await livePtyOrThrow(client, args[0]);
+      const text = args.slice(1).join(" ");
+      const enter = !ctx.has("no-enter");
+      trace(`send: pty ${ptyId}, ${text.length} chars, enter=${enter}`);
+
+      // Wait for the screen to hold still first. A `send` issued straight after
+      // `start` otherwise lands while the TUI is still painting, and text typed
+      // then goes nowhere — the failure this two-step flow exists to make
+      // visible. `--now` skips it for an interactive session known to be idle.
+      if (!ctx.has("now")) {
+        const pty = new PtyStream();
+        client.onData = (id, data) => pty.accept(id, data);
+        pty.adopt(ptyId);
+        // Seed from the replay so there is a screen to compare against. An idle
+        // Claude emits nothing at all — with no seed there is no first sample,
+        // and waiting for one would burn the whole timeout on a session that
+        // was ready before we asked.
+        const replay = await client.request("replay", { ptyId });
+        recordOutput(pty.state, String(replay.data ?? ""));
+        trace(`send: seeded ${pty.state.buffer.length}B of replay, waiting for the screen to settle`);
+        if (!(await waitForSettled(pty.state, { timeoutMs: 15_000 }))) {
+          console.error("[the TUI never settled in 15s — typing anyway]");
+        }
+        trace("send: settled");
+      }
+
+      trace("send: typing");
+      await typeInto(client, ptyId, text, { enter });
+      trace("send: typed");
+      console.log(enter ? "sent" : "typed (not submitted — `session enter` submits it)");
+      return;
+    }
+
+    case "enter": {
+      // Just the keystroke — for a session sitting on an unsubmitted paste or a
+      // dialog waiting to be confirmed.
+      if (!args[0]) throw new UsageError("session enter needs a session", "session");
+      const ptyId = await livePtyOrThrow(client, args[0]);
+      await client.call<boolean>("write", { ptyId, data: "\r" });
+      console.log("sent");
+      return;
+    }
+
+    case "interrupt": {
+      // Escape — stops whatever Claude is doing and hands the prompt back. Not
+      // `kill`: the session stays up and keeps its conversation.
+      if (!args[0]) throw new UsageError("session interrupt needs a session", "session");
+      const ptyId = await livePtyOrThrow(client, args[0]);
+      await client.call<boolean>("write", { ptyId, data: "\x1b" });
+      console.log("interrupted");
+      return;
+    }
+
+    case "resume":
+      if (!args[0]) throw new UsageError("session resume needs a task id", "session");
+      await resume(client, ctx, args[0]);
+      return;
+
+    case "kill":
+    case "rm": {
+      if (!args[0]) throw new UsageError(`session ${verb} needs a session`, "session");
+      const ptyId = await resolvePty(client, args[0]);
+      if (!ptyId) {
+        console.log("not running");
+        return;
+      }
+      console.log((await client.call<boolean>("kill", { ptyId })) ? "killed" : "not running");
+      return;
+    }
+
+    case "inspect": {
+      if (!args[0]) throw new UsageError("session inspect needs a task id", "session");
+      const tasks = await client.call<Task[]>("tasksList");
+      const task = tasks.find((t) => t.taskId === args[0]);
+      if (!task) throw new Error(`no such task: ${args[0]}`);
+      const ptyId = await resolvePty(client, task.taskId);
+      console.log(JSON.stringify({ ...task, ptyId }, null, 2));
+      return;
+    }
+
+    default:
+      throw new UsageError(`unknown verb: session ${verb}`, "session");
+  }
+}

--- a/docs/reference/experiment-cli/src/commands/status.ts
+++ b/docs/reference/experiment-cli/src/commands/status.ts
@@ -1,0 +1,25 @@
+// status — is this Core reachable, and what does it have on it.
+
+import type { Ctx } from "../args.ts";
+import type { CoreClient } from "../client.ts";
+import { PROTOCOL_VERSION } from "../protocol.ts";
+import type { Project, Session } from "../protocol.ts";
+import { availability } from "./harness.ts";
+
+export async function run(client: CoreClient, _ctx: Ctx): Promise<void> {
+  const harnesses = await availability(client);
+  const projects = await client.call<Project[]>("projectsList");
+  const sessions = await client.call<Session[]>("sessionsList");
+  const live = sessions.filter((s) => s.ptyId).length;
+
+  console.log(`endpoint    ${client.blob.endpoint}`);
+  console.log(`label       ${client.blob.label ?? "(none)"}`);
+  console.log(`protocol    ${PROTOCOL_VERSION} (client)`);
+  console.log(`projects    ${projects.length}`);
+  console.log(`sessions    ${live} running, ${sessions.length} total`);
+  console.log(
+    `harnesses   ${Object.entries(harnesses)
+      .map(([id, entry]) => `${id}=${entry.status}`)
+      .join("  ")}`,
+  );
+}

--- a/docs/reference/experiment-cli/src/protocol.ts
+++ b/docs/reference/experiment-cli/src/protocol.ts
@@ -1,0 +1,90 @@
+// The core-link wire protocol, as the Core defines it.
+//
+// Mirrors packages/shared/src/core-link-frames.ts in the mission-control-updated
+// repo. Frames are one JSON object per WebSocket message; the envelope is flat
+// and correlated by `reqId`. There is no `payload` wrapper.
+
+export const PROTOCOL_VERSION = "0.15.0";
+
+export type Harness = "claude-code" | "codex" | "cursor-cli" | "opencode";
+
+export const HARNESSES: Harness[] = ["claude-code", "codex", "cursor-cli", "opencode"];
+
+/** Decoded pairing token. Everything needed to open and authenticate a socket. */
+export type RegistrationBlob = {
+  endpoint: string; // wss://host:port — no path
+  label?: string;
+  caCert: string;
+  clientCert: string;
+  clientKey: string;
+  bearer: string;
+};
+
+export type Frame = { type: string; reqId?: string; [key: string]: unknown };
+
+export type SpawnOptions = {
+  taskId: string;
+  cwd: string;
+  command: string;
+  args?: string[];
+  cols?: number;
+  rows?: number;
+  agent?: Harness;
+  dangerouslySkipPermissions?: boolean;
+  initialInput?: string;
+};
+
+// The snapshots name their own key — `projectId`/`taskId`, never a bare `id`.
+
+export type Project = { projectId: string; name: string; path: string };
+
+export type Task = {
+  taskId: string;
+  projectId: string;
+  title: string;
+  agent: string;
+  status: string;
+  /** The harness's own session id, or null before one has been observed. This
+   *  is what `--resume` needs, so a task without it cannot be resumed. */
+  claudeSessionId: string | null;
+};
+
+/** `ptyId` is null once the process is gone — that is what "still running" means. */
+export type Session = { taskId: string; ptyId: string | null; status: string; updatedAt: number };
+
+export type HarnessAvailability = {
+  status: string;
+  version?: string;
+  requiredVersion?: string;
+  path?: string;
+};
+
+export type DirListing = {
+  path: string;
+  entries: { name: string; isDirectory: boolean }[];
+};
+
+/**
+ * Which result frame answers which request, and where the payload sits on it.
+ *
+ * The Core replies with a differently-named frame per request rather than a
+ * generic envelope, so this table is what lets one `request()` serve them all.
+ */
+export const RESULT_OF: Record<string, { type: string; field?: string }> = {
+  projectsList: { type: "projectsListResult", field: "projects" },
+  projectsMutate: { type: "projectsMutateResult", field: "project" },
+  tasksList: { type: "tasksListResult", field: "tasks" },
+  tasksMutate: { type: "tasksMutateResult", field: "task" },
+  sessionsList: { type: "sessionsListResult", field: "sessions" },
+  agentsAvailabilityList: { type: "agentsAvailabilityListResult", field: "availability" },
+  harnessInstall: { type: "harnessInstallAck" },
+  dirList: { type: "dirListResult", field: "listing" },
+  dirCreate: { type: "dirCreateResult", field: "path" },
+  spawn: { type: "spawned" },
+  write: { type: "writeResult", field: "ok" },
+  resize: { type: "resizeResult", field: "ok" },
+  kill: { type: "killResult", field: "ok" },
+  findByTask: { type: "findByTaskResult", field: "ptyId" },
+  replay: { type: "replayResult" },
+  subscribe: { type: "subscribeAck" },
+};

--- a/docs/reference/experiment-cli/src/terminal.ts
+++ b/docs/reference/experiment-cli/src/terminal.ts
@@ -1,0 +1,236 @@
+// A minimal terminal emulator, so session output can be read as text.
+
+/**
+ * Replay raw PTY output into a screen buffer and read back what a terminal
+ * would be showing.
+ *
+ * Stripping escape codes does not work on a TUI. Claude Code paints by moving
+ * the cursor and overwriting cells — the spaces between words are cursor jumps,
+ * not space characters, and a spinner rewrites the same cell hundreds of times.
+ * Cut the escapes out and every frame of every redraw concatenates into one
+ * line of soup.
+ *
+ * So this interprets the sequences instead: cursor moves, erases, line
+ * insert/delete, and scrolling. Lines pushed off the top are kept in a
+ * scrollback array, which is where the conversation transcript ends up — the
+ * visible screen only ever holds the last `rows` lines.
+ *
+ * Colour (SGR) is parsed and discarded: the output is meant to be read, and the
+ * cell attributes are not needed to know what the session said.
+ */
+export function renderTerminal(data: string, cols: number, rows: number): string[] {
+  const blankRow = (): string[] => new Array(cols).fill(" ");
+  const screen: string[][] = Array.from({ length: rows }, blankRow);
+  const scrollback: string[][] = [];
+  let cx = 0;
+  let cy = 0;
+  let savedX = 0;
+  let savedY = 0;
+
+  const clampX = (): void => {
+    cx = Math.max(0, Math.min(cols - 1, cx));
+  };
+  const clampY = (): void => {
+    cy = Math.max(0, Math.min(rows - 1, cy));
+  };
+  const scrollUp = (): void => {
+    scrollback.push(screen.shift() ?? blankRow());
+    screen.push(blankRow());
+  };
+  const newline = (): void => {
+    cy++;
+    if (cy >= rows) {
+      scrollUp();
+      cy = rows - 1;
+    }
+  };
+
+  for (let i = 0; i < data.length; i++) {
+    const ch = data[i];
+
+    if (ch === "\x1b") {
+      const next = data[i + 1];
+
+      // CSI — the sequences that actually move and erase.
+      if (next === "[") {
+        let j = i + 2;
+        while (j < data.length && !/[@-~]/.test(data[j])) j++;
+        const final = data[j];
+        const params = data.slice(i + 2, j).replace(/^[?>!]/, "");
+        const nums = params.split(";").map((p) => Number.parseInt(p, 10));
+        const arg = (index: number, fallback: number): number =>
+          Number.isFinite(nums[index]) && nums[index] > 0 ? nums[index] : fallback;
+        i = j;
+
+        switch (final) {
+          case "H":
+          case "f":
+            cy = arg(0, 1) - 1;
+            cx = arg(1, 1) - 1;
+            clampX();
+            clampY();
+            break;
+          case "A":
+            cy -= arg(0, 1);
+            clampY();
+            break;
+          case "B":
+            cy += arg(0, 1);
+            clampY();
+            break;
+          case "C":
+            cx += arg(0, 1);
+            clampX();
+            break;
+          case "D":
+            cx -= arg(0, 1);
+            clampX();
+            break;
+          case "G":
+            cx = arg(0, 1) - 1;
+            clampX();
+            break;
+          case "d":
+            cy = arg(0, 1) - 1;
+            clampY();
+            break;
+          case "E":
+            cy += arg(0, 1);
+            cx = 0;
+            clampY();
+            break;
+          case "F":
+            cy -= arg(0, 1);
+            cx = 0;
+            clampY();
+            break;
+          case "J": {
+            // Erase in display. Mode 2/3 is the full-screen repaint a TUI does
+            // on resize; a real terminal drops those cells, so this does too.
+            const mode = Number.isFinite(nums[0]) ? nums[0] : 0;
+            if (mode === 0) {
+              for (let x = cx; x < cols; x++) screen[cy][x] = " ";
+              for (let y = cy + 1; y < rows; y++) screen[y] = blankRow();
+            } else if (mode === 1) {
+              for (let x = 0; x <= cx; x++) screen[cy][x] = " ";
+              for (let y = 0; y < cy; y++) screen[y] = blankRow();
+            } else {
+              for (let y = 0; y < rows; y++) screen[y] = blankRow();
+            }
+            break;
+          }
+          case "K": {
+            const mode = Number.isFinite(nums[0]) ? nums[0] : 0;
+            if (mode === 0) for (let x = cx; x < cols; x++) screen[cy][x] = " ";
+            else if (mode === 1) for (let x = 0; x <= cx; x++) screen[cy][x] = " ";
+            else screen[cy] = blankRow();
+            break;
+          }
+          case "L": {
+            // Insert blank lines at the cursor, pushing the rest down.
+            for (let n = 0; n < arg(0, 1); n++) {
+              screen.splice(cy, 0, blankRow());
+              screen.pop();
+            }
+            break;
+          }
+          case "M": {
+            for (let n = 0; n < arg(0, 1); n++) {
+              screen.splice(cy, 1);
+              screen.push(blankRow());
+            }
+            break;
+          }
+          case "P": {
+            // Delete characters, pulling the rest of the line left.
+            for (let n = 0; n < arg(0, 1); n++) {
+              screen[cy].splice(cx, 1);
+              screen[cy].push(" ");
+            }
+            break;
+          }
+          case "X": {
+            for (let n = 0, x = cx; n < arg(0, 1) && x < cols; n++, x++) screen[cy][x] = " ";
+            break;
+          }
+          case "S":
+            for (let n = 0; n < arg(0, 1); n++) scrollUp();
+            break;
+          case "s":
+            savedX = cx;
+            savedY = cy;
+            break;
+          case "u":
+            cx = savedX;
+            cy = savedY;
+            break;
+          default:
+            // SGR (m), mode set/reset (h/l), scroll region (r), device queries —
+            // nothing that changes which characters are on screen.
+            break;
+        }
+        continue;
+      }
+
+      // OSC — window title and friends. Runs to BEL or String Terminator.
+      if (next === "]") {
+        let j = i + 2;
+        while (j < data.length && data[j] !== "\x07" && !(data[j] === "\x1b" && data[j + 1] === "\\")) j++;
+        i = data[j] === "\x1b" ? j + 1 : j;
+        continue;
+      }
+
+      if (next === "7") {
+        savedX = cx;
+        savedY = cy;
+        i++;
+        continue;
+      }
+      if (next === "8") {
+        cx = savedX;
+        cy = savedY;
+        i++;
+        continue;
+      }
+      if (next === "M") {
+        // Reverse index — scroll down at the top of the screen.
+        if (cy === 0) {
+          screen.unshift(blankRow());
+          screen.pop();
+        } else cy--;
+        i++;
+        continue;
+      }
+      // Charset selection and other two-byte escapes.
+      i++;
+      continue;
+    }
+
+    if (ch === "\n") {
+      newline();
+      continue;
+    }
+    if (ch === "\r") {
+      cx = 0;
+      continue;
+    }
+    if (ch === "\b") {
+      cx = Math.max(0, cx - 1);
+      continue;
+    }
+    if (ch === "\t") {
+      cx = Math.min(cols - 1, (cx + 8) & ~7);
+      continue;
+    }
+    if (ch < " ") continue; // other control bytes paint nothing
+
+    if (cx >= cols) {
+      cx = 0;
+      newline();
+    }
+    screen[cy][cx] = ch;
+    cx++;
+  }
+
+  return [...scrollback, ...screen].map((row) => row.join("").replace(/\s+$/, ""));
+}


### PR DESCRIPTION
## Summary

The prototype `core-client` CLI — the throwaway tool that drove a real Core over core-link before `packages/cli` existed — is copied into `docs/reference/experiment-cli/` as a frozen, read-only reference, so the parity check in phase 2 step 4 has something to check the shipped `actana` command against.

This is repo hygiene, not documentation. The diff is 17 moved files plus a 23-line freeze notice. **Nothing in the prototype is refactored, reformatted or fixed** — including the parts that are wrong.

## Related issues

Closes #158
Refs #129, #164

## Type of change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation
- [x] 🔧 Build / CI / tooling

## What changed

The tarball carried **19 entries — 17 files and 2 directories** (`src/`, `src/commands/`), and 19 macOS AppleDouble `._*` resource forks alongside them. The `._*` files are `com.apple.provenance` xattr metadata, 163 bytes each, no content; they are **excluded**. The 17 files are 13 `.ts`, 3 `.md`, 1 `.json` — 2,620 lines, of which 2,056 are TypeScript and the manifest.

The copy is in **two commits on purpose**, so the fidelity claim is auditable rather than asserted:

- `6bc4740` — the tree, **byte-for-byte identical to the tarball**, verified with `diff -r`.
- `0f742bf` — the freeze notice, **additive only** (23 insertions, 0 deletions).

The prototype ships its own root `README.md`, so the required notice is prepended to it rather than put in a second file competing for the same path. The prototype's own text is untouched below a rule.

## Done-when, each proved by running the thing

### 1. Outside the reach of lint, typecheck, test and build; not a workspace package

The ticket's trap is that `docs/**` gets picked up more often than people expect, so each of these is a **run**, not a reading of config:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | links **5** workspace packages — cli, core, panel, sdk, shared. Prototype absent. Lockfile unchanged. |
| `pnpm typecheck` | clean; `Scope: 5 of 6 workspace projects` (the 6th is the root) |
| `pnpm lint` | 0 errors, 51 pre-existing warnings. **0 lines of output reference `docs/`** |
| `pnpm build` | clean |
| `pnpm test` | see below |
| `pnpm npm:rehearse` | discovers exactly `@actana/sdk` and `@actana/cli`; `absent=` empty |
| `pnpm scan:secrets` | `No obvious secrets found.` |

**No neutralization was needed, and none was applied** — the prototype `package.json` is left byte-faithful. It has no `private: true`, so the hazard in PR #200 is real in principle, but neither discovery path reaches it:

- **pnpm** — `pnpm-workspace.yaml` globs `packages/*` only.
- **npm publish discovery** — `workspaceManifests()` in `scripts/lib/npm-packages.mjs` is a `readdirSync` of `packages/`, not a `**/package.json` glob. It cannot see `docs/`.

Renaming it would have cost the byte-fidelity that the step-4 parity check depends on, for no gain the rehearsal doesn't already demonstrate. The rehearsal is the proof: `packages=@actana/sdk @actana/cli`, with `core-client` nowhere in it.

The other reason this matters: the prototype's `src/blob.ts` calls `execFileSync("docker", …)` to fetch its own credential — **exactly** what `packages/cli/src/__tests__/no-local-escape.test.ts` (#129 D9) forbids. That sweep is rooted at `packages/cli/src`, so the prototype is out of its reach by construction. Run explicitly, **7/7 pass**. Had this tree landed inside `packages/`, that test would be red — which is the sharpest available evidence the exclusion holds.

**The no-local-escape sweep and the secret scan both pass.**

### 2. Credentials and logs are excluded — checked **before** committing

The tarball was described as pre-scanned clean; it was verified independently anyway, in the scratchpad, **before any file entered the repository**:

- **High-entropy / token-shaped strings (≥32 chars)** — **zero matches** across all 17 files. This is the strongest single result here.
- **Base64 payloads (≥40 chars)** — zero. No PEM armour, no `BEGIN` of any kind, no JWT (`eyJ`) anywhere.
- **Credential keyword sweep** (`bearer`, `token`, `secret`, `password`, `api_key`, `credential`, `cookie`, `auth`, `session log`, `.pem`, `.key`) — many hits, **every one of them prose or code that *describes* credentials**: `blob.ts`'s header saying the blob is real credentials and must stay out of version control, `help.ts`'s CREDENTIALS topic, `client.ts` sending an `auth` frame it reads from a blob at runtime. No literal value is embedded.
- **Endpoints** — every host is loopback: `127.0.0.1:9443`, `127.0.0.1:9444`, `127.0.0.1:7420`, `localhost:7420`. No external endpoint, no IP, no credentialed URL (`scheme://user:pass@`).
- **Artifact sweep** — no `.log`, `.pem`, `.key`, `.crt`, `.p12`, `.env`, `.sqlite`, and **no blob file**. `src/blob.ts` is source that *reads* `blob.txt` and `blobs/*.txt` at runtime; neither those files nor the `blobs/` directory are in the tarball. File extensions present are exactly `.ts`, `.md`, `.json`.
- **No session logs.** The prototype streams session output over the wire; nothing captured is in the tree.
- The AppleDouble forks were inspected (`od -c`) before being dropped — macOS provenance metadata only.

`pnpm scan:secrets` was then run **pre-commit**, when the 17 files were untracked: the scanner's candidate set includes `git ls-files --others --exclude-standard`, so it genuinely enumerated all 17 and passed. Re-run post-commit against the tracked files: passes again.

### 3. The stale protocol mirror is present and left alone

`docs/reference/experiment-cli/src/protocol.ts`, **exactly 90 lines**, hand-copied, unmodified, and deliberately not brought up to date. Its drift from the real core-link protocol is the point of keeping it, and the README says so in as many words.

### 4. A README line saying what this is

`docs/reference/experiment-cli/README.md` opens with the notice: what the tree is, that it is frozen and read-only, that nothing may import it or fix it, that `src/protocol.ts` is stale on purpose, and that **the directory is deleted at the end of phase 2 by #164**.

## How was this tested?

- [ ] Unit tests added/updated — none; this ticket adds no code that runs
- [ ] Integration/E2E tests added/updated
- [x] Manually verified

Full suite run locally. **One pre-existing failure, unrelated to this change:** `scripts/__tests__/core-launcher.test.mjs` — "execs the bundled node on the bundled actana CLI" — expects a temp install root and gets `/opt/actana/app`, because this machine has a real `/opt/actana` install. It is the same failure PR #200 recorded. **Proved independent of this change** by moving `docs/reference/` out of the tree entirely and re-running: it fails identically.

Because the root `vitest run` aborts on that failure, `pnpm -r test` was run separately so the package suites — the half containing the no-local-escape sweep — actually ran:

| Suite | Result |
|---|---|
| root `vitest run` | 473 passed, 1 failed (pre-existing, above) |
| `packages/sdk` | 167 passed, 5 skipped |
| `packages/cli` | 297 passed, 3 skipped |
| `packages/shared` | 180 passed |
| `packages/core` | 826 passed |
| `packages/panel` | 1338 passed |

Everything except the one environment-caused failure is green.

## Notes for the reviewer

**The prototype is wrong in places, on purpose.** `protocol.ts` is stale, the README describes a `run-core-local.sh` that is not in the tarball, and `blob.ts` shells out to `docker`. None of it is fixed. If a reviewer's instinct is to correct something in this directory, the answer is no — it is a frozen record, and #164 deletes it.

**`docs/reference/` is new** and nothing indexes it. `docs/README.md` is deliberately not edited: no test asserts docs-index completeness, and the directory is temporary by construction, so adding it to an index only creates a dangling entry for #164 to clean up.

**Nothing was merged, `main` was not touched, and this PR is a draft.**
