### PR TITLE
chore(release): complete the beta/0.3.0 cut with the sixth manifest

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actana/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Actana Control CLI — the `actana` command's client half: the blob registry that names Cores, and the client nouns built on @actana/sdk.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

The auto-cut at `67f47e51` bumped five manifests to 0.3.0 and missed the sixth,
`packages/cli`, which stayed at 0.2.2. This PR sets it to 0.3.0. That is the
whole diff — one line, one file.

The cut ran `promote.yml` as it stood on the **pre-promotion `main`**, where the
manifest list still had five entries. The sixth entry landed one commit earlier
in the tree being cut, in #212 (`6a33b80`, the parent of the cut commit). So the
workflow doing the writing did not yet know about the package the tree already
had, and `packages/cli/package.json` was never rewritten.

The result is `@actana/cli@0.2.2` depending on `@actana/sdk@0.3.0`, which the npm
publish rehearsal refuses under ADR 0023 D3 — one version line. Two packages
published from the same tag on the same train cannot sit on two version lines.
That is what fails Unit Tests in
[run 31691319757](https://github.com/actana/control/actions/runs/31691319757):

```
[rehearse-npm-publish] @actana/cli: @actana/cli@0.2.2 depends on @actana/sdk@0.3.0,
not on 0.2.2. D13 is one version line, and these two packages are published from
the same tag on the same train ...
```

`packages/cli` declares `"@actana/sdk": "workspace:*"`, so only the `version`
field needed changing — the dependency already resolves to this train's SDK.

## The next auto-cut cannot repeat this

Checked read-only on `beta/0.3.0`. **Both workflows now list six manifests, and
both include `packages/cli`.** They are the same set:

`.github/workflows/ci.yml` — `Train rules` job, lines 236–238:

```
MANIFESTS=(package.json packages/cli/package.json \
           packages/core/package.json packages/panel/package.json \
           packages/sdk/package.json packages/shared/package.json)
```

`.github/workflows/promote.yml` — the cut step, line 733:

```
files=(package.json packages/cli/package.json packages/core/package.json packages/panel/package.json packages/sdk/package.json packages/shared/package.json)
```

Beyond the lists themselves, `ci.yml`'s `assert_manifest_set` walks
`packages/*/package.json` and fails if any workspace package is absent from its
list, so a *seventh* package fails the check rather than being silently skipped
by the cut. `promote.yml` also re-reads every file with `jq` after rewriting and
fails the cut if one does not carry the train's version.

Both fixes came in via #157. They were in the tree at `67f47e51` but not in the
workflow definition that ran the cut — a one-time ordering gap, now closed for
every future cut.

## Related issues

No issue was filed for this; it is repair of the `beta/0.3.0` cut itself.
Refs #157 (the sixth-manifest amendment) and #212 (which introduced the package).

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🔧 Build / CI / tooling

## How was this tested?

Locally on this branch, with `pnpm install --frozen-lockfile` clean (no lockfile
change; all six workspace packages now resolve at 0.3.0):

- **The npm rehearsal, directly** — `node scripts/rehearse-npm-publish.mjs` exits
  0 and packs `@actana/sdk@0.3.0` and `@actana/cli@0.3.0`. On `beta/0.3.0` it
  exits 1 on the D13 rule.
- **`npm-publish`, `rehearsal`, `workflows` suites** — 3 files, 100 tests, all
  passing. The five real-pack tests that CI *skipped* when the suite aborted in
  `beforeAll` (`packs both published packages for real`, `ships one version line,
  with the CLI pinned to this SDK`, and the three after them) now actually run
  and pass.
- **Root `vitest run`** — 473 passed, 1 failed: `core-launcher.test.mjs > execs
  the bundled node on the bundled actana CLI`. That failure is environmental to
  the machine this ran on — a real `/opt/actana` install shadows the test's temp
  install root — and is unrelated to this change. It passed in run 31691319757.
- **`pnpm -r test`** — `packages/panel` reported two 5000 ms timeouts
  (`operator-auth.test.ts`, `panel-link/__tests__/live-read-path.test.ts`). Both
  pass in isolation on re-run; they are load flakes under the full parallel run,
  and a version string in `packages/cli` cannot reach the Panel server tests.

CI on this branch is the real check for those last two.

## Checklist

- [x] This PR targets the **open train** (`beta/0.3.0`), not `main`
- [x] My PR title and every commit in the branch follow Conventional Commits, and the branch name follows the branching convention
- [x] I performed a self-review of my own code
- [x] No secrets, credentials, or personal data are included in this change
- [x] No new tests: the rule that catches this already exists and already fails; this PR makes it pass
- [x] No documentation change: ADR 0023 D3 already describes six manifests as amended by #157
