### PR TITLE
fix(sdk): point project.files.list at the Core's /files/list, and pin the seam with a contract test

### DIFF
--- a/docs/external-api.md
+++ b/docs/external-api.md
@@ -184,6 +184,7 @@ const { stream } = await project.files.download({ path });
 
 | Property | Why it is that way |
 | --- | --- |
+| `list` is an async iterable of entries, from `GET …/files/list` | the same `{path, kind, size, mtime, mode, sha256}` lines the route streams, parsed. `path` and `depth` pass through, and `sha256: true` asks for digests — off by default, because a listing has no bytes in hand. `skipped` lines are passed over; an `error` line throws rather than ending the tree early |
 | `download` returns a **stream, never a buffer** | a gigabyte file must not be resident. There is no method on the result that hands over bytes, so a caller that wants the whole thing writes that themselves |
 | `upload` takes a stream and returns progress as an async iterable | one line per entry, each naming `written` or `overwritten`; a `done` line closes it. A mid-transfer failure is the last line, not a status code |
 | all three are **pull-driven** | nothing runs ahead of the consumer. A slow reader becomes backpressure on the socket and then on the Core, rather than a queue filling in the client |
@@ -195,10 +196,13 @@ The client presents its certificate through an undici `Agent` — `fetch` has no
 **undici's own `fetch`** rather than the global one, because a dispatcher only
 satisfies the undici implementation it came from and Node embeds its own copy.
 
-**Listing is not on this table yet.** `project.files.list` reads an NDJSON
-manifest of `{path, size, mtime, mode, sha256}` from the same origin; the Core
-route that serves it is [#166](https://github.com/actana/control/issues/166),
-and this row lands when it does.
+The client's listing URL and the route above are held together by a contract
+test that drives `project.files.list` against the Core's real handler in one
+process, registered in **both** packages' suites
+([#218](https://github.com/actana/control/issues/218)). They disagreed once —
+the client sent `?list=1` on the read route while the Core served
+`…/files/list` — and every suite stayed green, because each side was checked
+against its own idea of the other. A URL is not a fact either half owns alone.
 
 ## The Panel's own routes
 

--- a/packages/core/src/__tests__/core-files-list-contract.test.ts
+++ b/packages/core/src/__tests__/core-files-list-contract.test.ts
@@ -1,0 +1,16 @@
+// The Core's registration of the shared listing contract (#218).
+//
+// The body lives in the SDK's test tree — `packages/sdk/src/__tests__/
+// files-list-contract.ts` — because that is where the rig that stands this
+// surface up already lives, and it is reached here by package name through the
+// same test-only alias `@actana/sdk` already uses.
+//
+// It runs here as well as there on purpose. This package owns one half of the
+// listing URL and the SDK owns the other; the two disagreed for two merged pull
+// requests without a single red test, because each suite proved its own half
+// against its own idea of the other. A contract test that only the SDK's suite
+// runs is one this package's author does not run before pushing — which is the
+// arrangement that let #218 happen. Do not "tidy" this file away.
+import { describeFilesListContract } from "@actana/sdk/__tests__/files-list-contract";
+
+describeFilesListContract();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -28,5 +28,15 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  // The listing contract (#218) is registered in both packages' suites and its
+  // body lives in the SDK's test tree, which is written for the SDK's
+  // toolchain: ESM, `Bundler` resolution, and relative imports carrying their
+  // `.ts` extension so plain `node` can load them. Type-checking it from here
+  // would mean turning on `allowImportingTsExtensions` for the whole Core and
+  // pulling the SDK's client and test rig into this program to serve one
+  // import. It is checked where it is written — `@actana/sdk`'s own `tsc`
+  // covers `src/__tests__` — and it is *run* here, which is the point of it.
+  // vitest resolves it through the alias in `vitest.config.ts` and does not
+  // consult this file.
+  "exclude": ["node_modules", "dist", "src/__tests__/core-files-list-contract.test.ts"]
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
       // The core-link frames are in `@actana/sdk` (ADR 0025).
       "@actana/sdk": path.resolve(__dirname, "../sdk/src"),
       "@actana/shared": path.resolve(__dirname, "../shared/src"),
+      // This package, by its own name. Only the shared listing contract
+      // (#218) needs it: that spec is written for both suites, so it reaches
+      // the file routes the way the SDK's suite reaches them rather than by a
+      // relative path that would only resolve from one of the two.
+      "@actana/core": path.resolve(__dirname, "src"),
     },
   },
 });

--- a/packages/sdk/src/__tests__/core-files-list-contract.test.ts
+++ b/packages/sdk/src/__tests__/core-files-list-contract.test.ts
@@ -1,0 +1,8 @@
+// The SDK's registration of the shared listing contract (#218).
+//
+// The body is in `files-list-contract.ts` and the Core's suite registers the
+// same one, so a change to either half of the listing URL goes red on both
+// sides. See that file for why it is shared rather than written twice.
+import { describeFilesListContract } from "./files-list-contract";
+
+describeFilesListContract();

--- a/packages/sdk/src/__tests__/core-files-surface.test.ts
+++ b/packages/sdk/src/__tests__/core-files-surface.test.ts
@@ -4,7 +4,7 @@
 // Every assertion here goes over a real loopback socket to the Core's own route
 // handler, writing to a real directory — see `files-rig.ts` for why a fake
 // would prove nothing this ticket cares about.
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -225,15 +225,15 @@ describe("download", () => {
 });
 
 describe("list", () => {
-  beforeEach(() => {
-    // Every assertion in this block reads the #166 stand-in described in
-    // `files-rig.ts`: the manifest shape PR 215 established, served in process.
-    // The reader is what #167 owns; the route is #166's.
-  });
-
+  // Every assertion in this block goes to the Core's real listing route, like
+  // every other block in this file. It used to read a stand-in mounted ahead of
+  // the handler, which is how #218 stayed invisible; `files-rig.ts` says what
+  // that cost. Paths are sorted before comparison because the real walk hands
+  // entries back in the filesystem's order and promises no more than that —
+  // sorting a directory means holding all of it, which is what the walk exists
+  // not to do.
   it("is an async iterable over the tree, in the manifest shape", async () => {
     const core = await open({
-      listing: true,
       seed: { "a.txt": "aaa", "src/b.txt": "bb", "src/deep/c.txt": "c" },
     });
     const project = core.project(rig!.projectId);
@@ -241,26 +241,38 @@ describe("list", () => {
     const entries = [];
     for await (const entry of project.files.list()) entries.push(entry);
 
-    expect(entries.map((entry) => entry.path)).toEqual([
+    expect(entries.map((entry) => entry.path).sort()).toEqual([
       "a.txt",
       "src",
       "src/b.txt",
       "src/deep",
       "src/deep/c.txt",
     ]);
-    expect(entries[0]).toEqual({
+    expect(entries.find((entry) => entry.path === "a.txt")).toEqual({
       path: "a.txt",
       kind: "file",
       size: 3,
       mtime: expect.any(Number),
       mode: expect.any(Number),
-      sha256: sha256("aaa"),
+      // Null because nobody asked: a listing has no bytes in hand, so digests
+      // cost a read of every file under the path and are opt-in (ADR 0027 D6).
+      sha256: null,
     });
+  });
+
+  it("computes digests when they are asked for", async () => {
+    const core = await open({ seed: { "a.txt": "aaa" } });
+    const project = core.project(rig!.projectId);
+
+    const entries = [];
+    for await (const entry of project.files.list({ sha256: true })) entries.push(entry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.sha256).toBe(sha256("aaa"));
   });
 
   it("lists a subtree to a depth", async () => {
     const core = await open({
-      listing: true,
       seed: { "a.txt": "a", "src/b.txt": "b", "src/deep/c.txt": "c" },
     });
     const project = core.project(rig!.projectId);
@@ -268,11 +280,11 @@ describe("list", () => {
     const entries = [];
     for await (const entry of project.files.list({ path: "src", depth: 1 })) entries.push(entry);
 
-    expect(entries.map((entry) => entry.path)).toEqual(["src/b.txt", "src/deep"]);
+    expect(entries.map((entry) => entry.path).sort()).toEqual(["src/b.txt", "src/deep"]);
   });
 
   it("sends nothing until the iterable is consumed", async () => {
-    const core = await open({ listing: true, seed: { "a.txt": "a" } });
+    const core = await open({ seed: { "a.txt": "a" } });
     const project = core.project(rig!.projectId);
 
     const listing = project.files.list();

--- a/packages/sdk/src/__tests__/core-files-unavailable.test.ts
+++ b/packages/sdk/src/__tests__/core-files-unavailable.test.ts
@@ -30,7 +30,7 @@ afterAll(() => cleanupRoots());
 
 /** A Core with a real file surface behind it that never announces one. */
 async function silentCore(): Promise<CoreClient> {
-  rig = await startFilesRig({ seed: { "a.txt": "a" }, listing: true });
+  rig = await startFilesRig({ seed: { "a.txt": "a" } });
   const connected = await connectedClient(rig, { announceFiles: false });
   client = connected.client;
   coreRig = connected.coreRig;

--- a/packages/sdk/src/__tests__/files-list-contract.ts
+++ b/packages/sdk/src/__tests__/files-list-contract.ts
@@ -1,0 +1,187 @@
+// The listing contract, driven across the seam: `project.files.list()` from
+// `@actana/sdk` against the Core's own `createCoreFilesRequestHandler`, in one
+// process, over a real socket (#218).
+//
+// ## Why this file exists at all
+//
+// The SDK and the Core each shipped a listing URL — `?list=1` on the read route
+// and `…/files/list` — each documented the choice at length, and neither knew
+// the other had picked the opposite. Both suites were green the whole time, and
+// that is the part worth fixing rather than the URL. The SDK's suite mounted a
+// stand-in that answered the SDK's own URL by construction; the Core's suite
+// called its own route by hand. Each side proved itself against its own idea of
+// the other, so **nothing either side could write would have gone red.**
+//
+// A test that only exercises one half cannot catch that class of drift, no
+// matter how thorough it is. This one dials the real client method and lets the
+// real handler answer, so the URL is agreed on by two modules rather than
+// asserted twice against a constant.
+//
+// ## Why it is a function rather than a suite
+//
+// It has to fail on **both** sides' CI, which in this repository means both
+// packages' suites: `pnpm --filter @actana/core test` and
+// `pnpm --filter @actana/sdk test` (the root `pnpm test` runs both). A test
+// living in one package is a test the other package's author does not run
+// before pushing — and either author can break this contract. So the body lives
+// here once and two one-line `.test.ts` files register it, one in each package:
+//
+//   packages/sdk/src/__tests__/core-files-list-contract.test.ts
+//   packages/core/src/__tests__/core-files-list-contract.test.ts
+//
+// Delete either registration and half the seam stops being watched, which is
+// the state this ticket found the repository in.
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { CoreFilesRequestError } from "../core-files-http";
+import type { CoreClient } from "../core-client";
+import type { CoreFileEntry } from "../core-files";
+import { cleanupRoots, connectedClient, startFilesRig, type FilesRig } from "./files-rig";
+
+/** Register the contract in the calling package's suite. */
+export function describeFilesListContract(): void {
+  let rig: FilesRig | null = null;
+  let client: CoreClient | null = null;
+  let closeCoreRig: (() => void) | null = null;
+
+  afterEach(async () => {
+    client?.close();
+    client = null;
+    closeCoreRig?.();
+    closeCoreRig = null;
+    await rig?.close();
+    rig = null;
+  });
+
+  afterAll(() => cleanupRoots());
+
+  /** A connected client over a real Core file surface holding `seed`. */
+  async function open(seed: Record<string, string>): Promise<CoreClient> {
+    rig = await startFilesRig({ seed });
+    const connected = await connectedClient(rig);
+    client = connected.client;
+    closeCoreRig = () => connected.coreRig.close();
+    return connected.client;
+  }
+
+  async function listing(
+    core: CoreClient,
+    opts: Parameters<ReturnType<CoreClient["project"]>["files"]["list"]>[0] = {},
+  ): Promise<CoreFileEntry[]> {
+    const entries: CoreFileEntry[] = [];
+    for await (const entry of core.project(rig!.projectId).files.list(opts)) entries.push(entry);
+    return entries;
+  }
+
+  describe("the listing contract, SDK to Core, in process", () => {
+    it("round-trips a tree: what the client asks for is what the Core lists", async () => {
+      const core = await open({ "a.txt": "aaa", "src/b.txt": "bb", "src/deep/c.txt": "c" });
+
+      const entries = await listing(core);
+
+      // Sorted before comparison: the walk hands entries back in the
+      // filesystem's order on purpose, because sorting a directory means
+      // holding all of it.
+      expect(entries.map((entry) => entry.path).sort()).toEqual([
+        "a.txt",
+        "src",
+        "src/b.txt",
+        "src/deep",
+        "src/deep/c.txt",
+      ]);
+      expect(entries.find((entry) => entry.path === "src")).toMatchObject({ kind: "directory" });
+      expect(entries.find((entry) => entry.path === "a.txt")).toMatchObject({
+        kind: "file",
+        size: 3,
+      });
+
+      // The old failure had no exception in it, which is why it survived
+      // review: `?list=1` was a valid *read* of the Project root, so the Core
+      // streamed a tar and this reader fed it to the NDJSON line parser. Naming
+      // the field the tar could never have carried is what makes this
+      // assertion about the URL rather than about the parser.
+      for (const entry of entries) {
+        expect(typeof entry.mtime).toBe("number");
+        expect(entry.sha256).toBeNull();
+      }
+    });
+
+    it("dials a URL the Core dispatches to its listing handler, not to its read handler", async () => {
+      const core = await open({ "src/b.txt": "bb" });
+      await listing(core, { path: "src" });
+
+      // The URL the client actually put on the wire — not one this test wrote
+      // out again, which would only prove the constant equals itself. Replaying
+      // it asks the Core the question that matters: *given this URL, which
+      // handler answers?*
+      const [request] = rig!.requests;
+      expect(request).toBeDefined();
+      const replay = await fetch(`${rig!.baseUrl}${request!.url}`, { method: "HEAD" });
+
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get("x-actana-transfer-kind")).toBe("listing");
+      expect(replay.headers.get("content-type")).toBe("application/x-ndjson");
+    });
+
+    it("keeps listing a folder and downloading a folder on separate URLs", async () => {
+      // The Core's stated reason for a path segment: the two requests answer
+      // with entirely different things, and a query parameter a proxy or a
+      // hand-edited URL can drop would silently turn the cheap one into the
+      // expensive one. That is only true while the two URLs actually differ, so
+      // it is pinned here rather than left to the comment that argues for it.
+      const core = await open({ "src/b.txt": "bb" });
+      const project = core.project(rig!.projectId);
+
+      const entries = await listing(core, { path: "src" });
+      const download = await project.files.download({ path: "src" });
+      await download.stream.cancel();
+
+      expect(entries.map((entry) => entry.path)).toEqual(["src/b.txt"]);
+      expect(download.kind).toBe("tar");
+
+      const [listRequest, readRequest] = rig!.requests;
+      expect(listRequest!.url).not.toBe(readRequest!.url);
+      expect(new URL(listRequest!.url, rig!.baseUrl).pathname).not.toBe(
+        new URL(readRequest!.url, rig!.baseUrl).pathname,
+      );
+    });
+
+    it("carries `depth` across as the Core reads it", async () => {
+      const core = await open({ "a.txt": "a", "src/b.txt": "b", "src/deep/c.txt": "c" });
+
+      const entries = await listing(core, { path: "src", depth: 1 });
+
+      // Both sides have to agree that `1` means the immediate children, not
+      // "one level below them" — an off-by-one no single-sided suite can see.
+      expect(entries.map((entry) => entry.path).sort()).toEqual(["src/b.txt", "src/deep"]);
+    });
+
+    it("carries `sha256` across, and leaves it null when nobody asked", async () => {
+      const core = await open({ "a.txt": "aaa" });
+
+      const asked = await listing(core, { sha256: true });
+      expect(asked[0]!.sha256).toBe(createHash("sha256").update("aaa").digest("hex"));
+
+      const unasked = await listing(core);
+      // Not a digest the client skipped reading — a digest the Core never
+      // computed, which is the whole of why the parameter exists (ADR 0027 D6).
+      expect(unasked[0]!.sha256).toBeNull();
+    });
+
+    it("refuses a path that is not there, rather than yielding an empty tree", async () => {
+      const core = await open({ "a.txt": "a" });
+
+      const failure = await core
+        .project(rig!.projectId)
+        .files.list({ path: "nope" })
+        .next()
+        .then(() => null, (err: unknown) => err);
+
+      // An empty listing and a missing directory are different answers, and a
+      // caller diffing against the first would read it as "everything here was
+      // deleted".
+      expect(failure).toBeInstanceOf(CoreFilesRequestError);
+      expect(failure).toMatchObject({ status: 404, code: "not-found" });
+    });
+  });
+}

--- a/packages/sdk/src/__tests__/files-rig.ts
+++ b/packages/sdk/src/__tests__/files-rig.ts
@@ -12,7 +12,15 @@
 // So: `node:http` on loopback, with `createCoreFilesRequestHandler` mounted
 // exactly as `core-files-wiring.ts` mounts it, over a real directory on a real
 // disk.
-import { createHash } from "node:crypto";
+//
+// **Every route is that handler's, listing included.** This rig used to answer
+// `?list=1` with a hand-rolled manifest, intercepted *ahead of* the real
+// handler, while #166's route was still being built in parallel. It outlived
+// its reason: once the route merged, that stand-in was the only thing making
+// the SDK's suite green about a URL the Core does not serve, and it answered
+// the SDK's own URL by construction, so no test on either side could see the
+// disagreement (#218). Nothing here shims the Core any more, and nothing here
+// should.
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
@@ -45,18 +53,6 @@ export type FilesRigOptions = {
   /** Files to seed the Project with. `dir/` keys make empty directories. */
   seed?: Record<string, string | { content?: string; mode?: number }>;
   authVerifier?: FilesAuthVerifier;
-  /**
-   * Answer `?list=1` with an NDJSON manifest — **the #166 stand-in**.
-   *
-   * Issue 166 owns the Core's listing route and is being built in parallel, so
-   * nothing here creates or modifies one. What this serves is the contract that
-   * ticket inherits: the manifest shape PR 215 established — `{path, size,
-   * mtime, mode, sha256}` per entry — streamed as NDJSON on the file route's
-   * origin. That is enough to prove the *reader* in `CoreFiles.list`, which is
-   * the SDK's half and the only half #167 owns. The live wiring lands when #166
-   * merges; what changes then is a URL, not this shape.
-   */
-  listing?: boolean;
 };
 
 /** Stand up a Core file surface on loopback. */
@@ -74,7 +70,6 @@ export async function startFilesRig(opts: FilesRigOptions = {}): Promise<FilesRi
 
   const server = http.createServer((req, res) => {
     requests.push({ method: req.method ?? "?", url: req.url ?? "" });
-    if (opts.listing && serveListing(req, res, root, projectId)) return;
     if (routes.handle(req, res)) return;
     res.writeHead(404, { "content-type": "application/json" });
     res.end(JSON.stringify({ code: "not-found", error: "no route" }));
@@ -133,58 +128,6 @@ export async function connectedClient(
   });
   await client.connect();
   return { client, coreRig };
-}
-
-/**
- * The #166 stand-in: walk the tree and stream it as NDJSON.
- *
- * Answers `true` when it took the request. `sha256` is computed eagerly here
- * because a fixture can afford it and the reader under test must cope with the
- * field being present — #166 gets to decide whether a real Core computes it
- * eagerly or on request, and `CoreFileEntry.sha256` is nullable so that either
- * answer is readable.
- */
-function serveListing(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  root: string,
-  projectId: string,
-): boolean {
-  const url = new URL(req.url ?? "/", "http://rig.invalid");
-  if (!url.searchParams.has("list")) return false;
-  if (url.pathname !== `/v1/projects/${encodeURIComponent(projectId)}/files`) return false;
-
-  const base = url.searchParams.get("path") ?? "";
-  const maxDepth = url.searchParams.has("depth") ? Number(url.searchParams.get("depth")) : Infinity;
-  res.writeHead(200, { "content-type": "application/x-ndjson", "cache-control": "no-store" });
-  for (const entry of walk(root, base, maxDepth)) res.write(`${JSON.stringify(entry)}\n`);
-  res.write(`${JSON.stringify({ type: "done" })}\n`);
-  res.end();
-  return true;
-}
-
-function* walk(
-  root: string,
-  base: string,
-  maxDepth: number,
-  depth = 1,
-): Generator<Record<string, unknown>> {
-  const absolute = path.join(root, base);
-  for (const name of fs.readdirSync(absolute).sort()) {
-    const child = path.join(absolute, name);
-    const relative = base.length > 0 ? `${base}/${name}` : name;
-    const stats = fs.lstatSync(child);
-    const directory = stats.isDirectory();
-    yield {
-      path: relative,
-      kind: directory ? "directory" : stats.isSymbolicLink() ? "symlink" : "file",
-      size: stats.size,
-      mtime: Math.floor(stats.mtimeMs),
-      mode: stats.mode & 0o777,
-      sha256: directory ? null : createHash("sha256").update(fs.readFileSync(child)).digest("hex"),
-    };
-    if (directory && depth < maxDepth) yield* walk(root, relative, maxDepth, depth + 1);
-  }
 }
 
 /** Seed a directory. A `dir/` key makes an empty directory. */

--- a/packages/sdk/src/core-files.ts
+++ b/packages/sdk/src/core-files.ts
@@ -63,10 +63,11 @@ export type CoreFileWriteResult = "written" | "overwritten";
  * `path` is **Project-relative**, which is the address space F1 gives the
  * operator — the same string that goes back to `download`.
  *
- * `sha256` is nullable on purpose. #166's own trap is that hashing every entry
- * of a large tree is expensive, and whether it is computed eagerly or on request
- * is that ticket's call to make; a type that promised the digest would have to
- * change if it decides "on request", so it promises the field and not the value.
+ * `sha256` is nullable on purpose, and the Core settled which way it means:
+ * hashing every entry of a large tree is expensive, so a listing computes
+ * digests **on request** ({@link CoreFileListOptions.sha256}) and a transfer
+ * computes them eagerly, the bytes being already in hand. So `null` reads as
+ * "no bytes" for a directory and "nobody asked" for anything else.
  */
 export type CoreFileEntry = {
   path: string;
@@ -144,8 +145,15 @@ export type CoreFileDownloadOptions = {
 export type CoreFileListOptions = {
   /** Subtree to list, Project-relative. Default: the whole Project. */
   path?: string;
-  /** Maximum depth to descend. Default: the whole tree. */
+  /** Maximum depth to descend. `1` is the immediate children. Default: the whole tree. */
   depth?: number;
+  /**
+   * Ask the Core to compute {@link CoreFileEntry.sha256} for every file and
+   * symlink under the path. **Off by default, and not free**: a listing does not
+   * have the bytes in hand, so digests mean reading every one of them (ADR 0027
+   * D6). Left off, every `sha256` comes back `null`.
+   */
+  sha256?: boolean;
   signal?: AbortSignal;
 };
 
@@ -180,22 +188,16 @@ export class CoreFiles {
   /**
    * The Project's tree, one entry at a time.
    *
-   * ### Live wiring lands with #166
+   * Reads the Core's real listing route — `GET …/files/list`, see
+   * {@link listUrl} — which streams `{path, kind, size, mtime, mode, sha256}`
+   * per entry as NDJSON. `core-files-list-contract.test.ts` drives this method
+   * against that route in process and runs in **both** packages' suites, so the
+   * two halves of the URL cannot drift apart again without a red test (#218).
    *
-   * The Core's listing route is #166's to build and this module deliberately
-   * does not create or modify it. What is written against here is the contract
-   * that ticket inherits and cannot really move: the manifest shape PR 215
-   * established — `{path, size, mtime, mode, sha256}` per entry, streamed as
-   * NDJSON — on the file route's own origin. The suites drive it against an
-   * in-process fixture answering exactly that, so this reader is proven today
-   * and the remaining risk is one URL.
-   *
-   * That URL is {@link listUrl}, kept as a single override-able method for the
-   * same reason: when #166 merges, agreeing with it is a one-line change here
-   * and the parsing, the laziness and the error handling below are unaffected.
-   * Both plausible line shapes are accepted — a bare manifest entry and one
-   * wrapped as `{type: "entry", …}`, which is what the write route already
-   * emits — so whichever #166 picks, this reads it.
+   * Both line shapes are accepted — a bare manifest entry and one wrapped as
+   * `{type: "entry", …}`, which is what the Core's listing and its write route
+   * both emit. `skipped` lines are passed over: a path the walk could not read
+   * is a fact about the tree, not an entry in it, and not a reason to stop.
    */
   async *list(opts: CoreFileListOptions = {}): AsyncGenerator<CoreFileEntry, void, undefined> {
     this.requireAvailable("listing a Project's files");
@@ -332,28 +334,51 @@ export class CoreFiles {
   }
 
   /**
-   * The listing URL — the one line #166 gets to disagree with.
+   * `…/v1/projects/:projectId/files/list?path=<relative>` — a route of its own.
    *
-   * A query parameter on the existing route rather than a new path segment,
-   * because the Core's `parseRoute` matches `/v1/projects/:id/files` on an exact
-   * four-segment split: a `…/files/list` leaf is a change to that parser, and a
-   * parameter is not. `protected` so a caller pinned to a Core that chose
-   * otherwise can subclass rather than wait for a release.
+   * This module used to send `?list=1` on the read route instead, and argued for
+   * it on cost: the Core's `parseRoute` matched `/v1/projects/:id/files` on an
+   * exact four-segment split, so a `…/files/list` leaf was a change to that
+   * parser and a query parameter was not. That cost is now paid — #216 shipped a
+   * parser that reads the fifth segment — and what is left is the Core's
+   * argument, which was never about cost: a listing and a read of the same
+   * folder answer with completely different things, one a manifest and one a
+   * tar. A query parameter that a proxy, a redirect or a hand-edited URL can
+   * drop turns "list this folder" into "download this folder", which for a
+   * `node_modules` is a mistake measured in gigabytes rather than in a 400. A
+   * path segment cannot be dropped silently. See issue 218.
+   *
+   * Still `protected`: a caller pinned to an older Core can subclass rather than
+   * wait for a release.
    */
   protected listUrl(opts: CoreFileListOptions): string {
-    const url = new URL(this.fileUrl(opts.path ?? ""));
-    url.searchParams.set("list", "1");
+    const url = this.routeUrl("files/list");
+    url.searchParams.set("path", opts.path ?? "");
     if (opts.depth !== undefined) url.searchParams.set("depth", String(opts.depth));
+    // Off unless asked for, which is the Core's default too: a digest means
+    // reading every byte under the path, and a listing never has them in hand.
+    if (opts.sha256) url.searchParams.set("sha256", "1");
     return url.toString();
   }
 
-  /** `…/v1/projects/:projectId/files?path=<relative>`. */
+  /** `…/v1/projects/:projectId/files?path=<relative>` — the read and write route. */
   protected fileUrl(filePath: string): string {
-    const base = this.opts.baseUrl.replace(/\/+$/, "");
-    const project = encodeURIComponent(this.opts.projectId);
-    const url = new URL(`${base}/v1/projects/${project}/files`);
+    const url = this.routeUrl("files");
     url.searchParams.set("path", filePath);
     return url.toString();
+  }
+
+  /**
+   * `<baseUrl>/v1/projects/:projectId/<leaf>`, with the Project id escaped.
+   *
+   * The two routes above differ by their leaf and by nothing else, and that is
+   * worth having in one place: the day this surface gains a third, the origin,
+   * the version prefix and the escaping should not be a third opportunity to get
+   * one of them subtly wrong.
+   */
+  private routeUrl(leaf: string): URL {
+    const base = this.opts.baseUrl.replace(/\/+$/, "");
+    return new URL(`${base}/v1/projects/${encodeURIComponent(this.opts.projectId)}/${leaf}`);
   }
 
   private authHeaders(): Record<string, string> {
@@ -496,8 +521,8 @@ function isReadableStream(source: CoreFileSource): source is ReadableStream<Uint
  *
  * `path` is the only field worth refusing a line over — an entry with no path
  * names nothing and is unusable. The rest default, because a listing that
- * decided `sha256` is computed on request (#166's open question) or that a
- * directory has no meaningful size is still a listing.
+ * computes `sha256` only on request — which is what the Core settled on — or
+ * that gives a directory no meaningful size is still a listing.
  */
 function readEntry(record: Record<string, unknown>): CoreFileEntry | null {
   if (typeof record.path !== "string") return null;


### PR DESCRIPTION
Closes #218.

The SDK sent `GET /v1/projects/:id/files?path=<p>&list=1`; the Core serves
`GET /v1/projects/:id/files/list`. Both landed on `feat/project-files`, both sides
documented the choice, neither knew the other had picked the opposite.

## Which URL wins, on the two recorded rationales

**The Core's** — `…/files/list`.

The SDK's argument was about **cost**, and the cost has since been paid:

> A query parameter on the existing route rather than a new path segment, because the
> Core's `parseRoute` matches `/v1/projects/:id/files` on an exact four-segment split …
> a `…/files/list` leaf is a change to that parser, and a parameter is not.

That was true when it was written and is not true now. #216 shipped `parseRoute`
reading a fifth segment (`core-files-routes.ts`, `leaf: "files" | "list"`), along with
the rule that a listing is `GET`/`HEAD` only — so `PUT …/files/list` cannot fall
through and create a *file called `list`*. The parser change the SDK was avoiding is
already in the branch. The argument bought a saving that no longer exists.

The Core's argument was never about cost, and nothing has touched it:

> A query parameter that a proxy, redirect or hand-edited URL can drop would turn
> "list this folder" into "download this folder", which for a `node_modules` is a
> mistake measured in gigabytes rather than in a 400. A path segment cannot be
> dropped silently.

It also has the sharper claim of the two, because it describes a failure that is
**silent**. Dropping `?list=1` leaves a perfectly valid request that answers with the
wrong thing; there is no status code in which to notice. That is not a hypothetical
here — it is exactly how this bug behaved: the Core streamed a tar, the SDK fed it to
the NDJSON line parser, and the first sign of trouble was a parse error about a
character position in a record that was actually a tar header.

A cost argument that has been overtaken loses to a safety argument that has not.
`depth` and `sha256` are already query params on the Core's route, so the SDK's
options map onto it with nothing left over.

## The alignment

- `packages/sdk/src/core-files.ts` — `listUrl()` now builds `…/files/list?path=…`,
  and carries `depth` and `sha256`. It stays `protected`, so a caller pinned to an
  older Core can still subclass. The comment recording the losing rationale is
  replaced by one that says why it lost.
- `docs/external-api.md` — the stale paragraph ("**Listing is not on this table
  yet.** … the Core route that serves it is #166, and this row lands when it does")
  is gone; `project.files.list` has its row in the `project.files.*` table.

## The real deliverable: a test that could not have passed before

One line of the above is the defect. The rest of this PR is about why **both suites
were green** across two merged pull requests while the two halves disagreed.

They were green because neither test crossed the seam. `files-rig.ts` mounted a
hand-rolled listing stand-in *ahead of* the real Core handler, keyed on `?list=1`, so
the SDK's suite proved its reader against a fixture that answered the SDK's own URL by
construction. The Core's suite called its own route directly. Each side was checked
against its own idea of the other, so nothing either author could write would have
gone red.

- The stand-in is **deleted**. `startFilesRig` is now the Core's real handler and
  nothing else — its `listing?: boolean` option is gone.
- `packages/sdk/src/__tests__/files-list-contract.ts` dials `project.files.list()`
  against `createCoreFilesRequestHandler` in one process over a real loopback socket,
  and round-trips a seeded tree: paths and kinds, `depth`, `sha256` both asked for and
  not, and a 404 for a path that is not there rather than an empty tree.
- The sharpest case replays **the URL the client actually put on the wire** (read off
  the rig's request log, not written out again in the test) and asserts the Core
  answers it with `x-actana-transfer-kind: listing`. It asks the Core the question
  that matters — *given this URL, which handler answers?* — rather than asserting a
  constant equals itself.
- One case pins the hazard the Core's rationale names: listing a folder and
  downloading a folder must stay different URLs answering different things.

Verified red before the fix. With `listUrl()` reverted to `?list=1`, five of the six
cases fail, with the tar arriving at the NDJSON parser exactly as #218 describes:

```
CoreFilesStreamError: the Core's progress stream ended mid-line —
"a.txt … 0000644 0000000 0000"… is not a complete NDJSON record
```

(The sixth — a 404 for a missing path — passes either way; it is contract coverage,
not drift detection.)

### Where it runs

Registered in **both** packages' suites, by two one-line files:

| File | Runs under |
| --- | --- |
| `packages/sdk/src/__tests__/core-files-list-contract.test.ts` | `pnpm --filter @actana/sdk test` |
| `packages/core/src/__tests__/core-files-list-contract.test.ts` | `pnpm --filter @actana/core test` |

`pnpm test` — what CI runs — runs both. Putting it in one package would leave the
other package's author not running it before pushing, and either side can break this
contract. That is the arrangement that produced #218 in the first place.

## Two judgement calls beyond the issue's checklist

- **`sha256` is now a `CoreFileListOptions` field.** `CoreFileEntry.sha256` was
  documented as deliberately leaving open "whether it is computed eagerly or on
  request … that ticket's call to make". The Core made it: on request for a listing,
  eagerly for a transfer. Without a flag to send, the field could only ever be `null`
  through the SDK, so aligning the URL without it would leave the seam half-joined.
- **`packages/core/tsconfig.json` excludes the Core's registration file.** The shared
  spec lives in the SDK's test tree, which is written for the SDK's toolchain — ESM,
  `Bundler` resolution, relative imports carrying `.ts` so plain `node` can load them
  (`plain-node-consumption.test.ts` depends on that). Type-checking it from the Core
  would mean turning on `allowImportingTsExtensions` for the whole Core package and
  pulling the SDK's client and test rig into that program to serve one import. It is
  type-checked where it is written — the SDK's own `tsc` covers `src/__tests__` — and
  *run* from both, which is the point. `packages/core/vitest.config.ts` gains an
  `@actana/core` self-alias so the shared spec can reach the file routes by package
  name from either runner. Both are commented at the site.

## Checks

| Command | Result |
| --- | --- |
| `pnpm --filter @actana/sdk test` | 236 passed, 5 skipped (21 files) |
| `pnpm --filter @actana/core test` | 1071 passed (58 files) |
| `pnpm typecheck` | clean across all five packages |
| `pnpm lint` | 0 errors; no new warnings |

Nothing is released — reads, writes and listing all ship on the same unreleased train
— so this is an integration-branch inconsistency, not a user-facing break.

Base is `feat/project-files`, not `main`. Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
