### PR TITLE
feat(cli): actana project cp and project files — a folder both ways, every overwrite named

### DIFF
--- a/docs/external-api.md
+++ b/docs/external-api.md
@@ -204,6 +204,31 @@ the client sent `?list=1` on the read route while the Core served
 `…/files/list` — and every suite stayed green, because each side was checked
 against its own idea of the other. A URL is not a fact either half owns alone.
 
+### `actana project cp` / `actana project files` — the same surface, typed
+
+The CLI is the first consumer of that SDK surface and consumes it as one: it
+builds no URL, sets no header and has no `fetch` of its own
+([#168](https://github.com/actana/control/issues/168)). Two things live on its
+side of the seam because neither is the Core's to do.
+
+**A folder is packed and unpacked locally.** The archive is the Core's format
+([ADR 0029](adr/0029-a-folder-crosses-as-one-streamed-tar.md)) but whichever side owns
+the disk owns the walk, so the CLI has its own ustar codec for the local half.
+That is what carries `mode` across, which is what makes an executable arrive
+executable.
+
+**A local path is told apart from `<project>:<path>` by a rule.** A separator
+before the colon means local — `./notes:draft.md`, `C:\dist` — and a single
+letter followed by a colon and a separator is a Windows drive. Everything else
+with a colon splits at the **first** one, so a colon inside a Project-relative
+path needs no escaping. The `./` prefix is the escape hatch for a local file
+whose name contains one, exactly as it is under `scp`.
+
+The refusals cross intact rather than being reworded. `409
+transfer-in-progress` in particular reaches the operator with the Core's own
+sentence, which names the transfer holding the Project and when it started —
+"busy" without those two facts is not something anybody can act on.
+
 ## The Panel's own routes
 
 The Panel's `/api/*` surface exists to serve its own browser tab. It is

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,13 +51,22 @@ actana project files api:build --json  # what is in there, machine-readable
 A folder crosses as one streamed archive and keeps its permissions, so an
 executable arrives executable. Every file that replaced one already there is
 named in the output — never only counted — and `--json` lists them under
-`overwritten`. Progress appears on a terminal and never under `--json`, where
-stdout carries exactly one document.
+`overwritten`, on the failure document as well as the success one: a transfer
+that died part-way still replaced whatever it had already written, and that is
+the list you need most. Progress appears on a terminal and never under `--json`,
+where stdout carries exactly one document.
+
+`project files --json` emits `{entries, truncated}` rather than the bare array
+`project ls` emits, because `--limit` can clip the answer and `truncated` is how
+a script finds out. It is `false` on a complete listing, never absent.
 
 A local path is told apart from `<project>:<path>` by a rule rather than a
 guess: a separator before the colon means local, so `./notes:draft.md` and
 `C:\dist` are files on this machine, and that leading `./` is how you name any
-local file with a colon in it.
+local file with a colon in it. The one form this costs is a Windows
+*drive-relative* path — `C:dist`, meaning "the current directory on drive C" —
+which reads as a Project called `C`; `./C:dist` is the escape, the same one a
+filename with a colon in it uses.
 
 **Running a Core is the other half of the name.** `actana daemon`, and the rest
 of the machine-side lifecycle, ships with the Core itself and is not in this

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,9 +26,38 @@ actana core use laptop              # point `current` at one
 actana core status                  # reach it, and report what it says
 ```
 
-`session`, `project`, `harness` and `events` are reserved in the command tree
-and land later in the phase; they exit with a distinct code and a ticket number
-rather than reading as a typo.
+```sh
+actana project ls                   # the Projects that Core owns
+actana project files api            # what is inside one
+actana project cp ./dist api:build  # copy a folder into it — and the reverse
+actana session start api "fix CI"   # run a harness on it
+actana events tail                  # follow what happens
+```
+
+Every noun and verb in the tree is built. A name this CLI does not know is a
+typo and says so; a name reserved for a later train would exit with a distinct
+code and a ticket number instead, which is how the two are told apart.
+
+## Copying files, in either direction
+
+One side carries the Project and the other is on this machine — the `scp` shape.
+
+```sh
+actana project cp ./dist api:build     # up:   build becomes a copy of dist
+actana project cp api:build ./dist     # down: dist becomes a copy of build
+actana project files api:build --json  # what is in there, machine-readable
+```
+
+A folder crosses as one streamed archive and keeps its permissions, so an
+executable arrives executable. Every file that replaced one already there is
+named in the output — never only counted — and `--json` lists them under
+`overwritten`. Progress appears on a terminal and never under `--json`, where
+stdout carries exactly one document.
+
+A local path is told apart from `<project>:<path>` by a rule rather than a
+guess: a separator before the colon means local, so `./notes:draft.md` and
+`C:\dist` are files on this machine, and that leading `./` is how you name any
+local file with a colon in it.
 
 **Running a Core is the other half of the name.** `actana daemon`, and the rest
 of the machine-side lifecycle, ships with the Core itself and is not in this

--- a/packages/cli/src/__tests__/actana-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-cli.test.ts
@@ -6,11 +6,15 @@
 // and the fact that they are three rather than two. The distinction is the
 // whole of `exit-codes.ts`'s argument, and until now nothing asserted it at the
 // root — the reserved nouns exited `2` and `core shell` exited `3` for the same
-// underlying fact, which the review of #201 caught. #162 built `core shell` and
-// #160/#161 built the nouns, so what is reserved here is verbs inside a built
-// noun: `project cp` and `project files`. `session attach` was the third until
-// #163 built it, and it is the counter-example below — the thing a reservation
-// is supposed to stop being.
+// underlying fact, which the review of #201 caught.
+//
+// **Nothing in this build is reserved any more.** #160/#161 built the nouns,
+// #162 built `core shell`, #163 built `session attach`, and #168 built the last
+// two — `project cp` and `project files`. So what this suite asserts has turned
+// over: not "a reservation answers 3", but "every name in the tree either works
+// or is a typo, and the two are still told apart". The mechanism stays, because
+// #210 and #211 are the next things that will want it, and because a script
+// that already branches on 3 must keep meaning the same thing by it.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "../exit-codes.ts";
@@ -28,72 +32,52 @@ afterEach(() => {
 });
 
 /**
- * The reservations this build carries, and the ticket each names.
+ * Every name in the tree, noun and verb, run with no arguments.
  *
- * No *noun* is reserved any more: `session` left the list when #160 built it
- * and `project`, `harness` and `events` left when #161 did, which is the shape
- * a reservation is supposed to end in. `session attach` left it the same way
- * when #163 built it. What is still reserved is a verb waiting on phase 3 — and
- * the distinction the exit code draws is the same one either way, so these are
- * what assert it.
+ * The sweep that replaced the reservation table. A verb here may well answer
+ * `EXIT_USAGE` — most of them need arguments — and that is fine: what none of
+ * them may do is answer `EXIT_UNIMPLEMENTED`, because that is the code for "not
+ * on this train" and there is nothing left on the list.
  */
-const RESERVED = [
-  [["project", "cp"], "#168"],
-  [["project", "files"], "#168"],
+const EVERY_NAME = [
+  ["core", "ls"],
+  ["core", "status"],
+  ["core", "shell"],
+  ["project", "ls"],
+  ["project", "add"],
+  ["project", "browse"],
+  ["project", "cp"],
+  ["project", "files"],
+  ["harness", "ls"],
+  ["events", "tail"],
+  ["session", "ls"],
+  ["session", "attach"],
 ] as const;
 
 /** The nouns that are built, so the help below cannot go quiet about them. */
 const BUILT = ["core", "project", "harness", "events", "session"] as const;
 
-describe("a reservation is `not built yet`, not `you typed it wrong`", () => {
-  it.each(RESERVED)("exits EXIT_UNIMPLEMENTED for `actana %s`, naming its ticket", async (argv, ticket) => {
-    const run = await cli().run([...argv]);
-    // 3, not 2. A script written against a later train hits one of these long
-    // before it hits anything else, so this is the case the distinction was
-    // really written for — and it is the one that had it backwards.
-    expect(run.code).toBe(EXIT_UNIMPLEMENTED);
-    expect(run.err.join("\n")).toContain("not built yet");
-    expect(run.err.join("\n")).toContain(ticket);
-  });
-
-  it("is the answer for a name that is reserved, and not for one that is built", async () => {
-    // `core shell` was the reserved *verb* and shared this code until #162
-    // built it; `session attach` was the last one and #163 built it. Now they
-    // are commands like any other, and a build that answered `3` for either
-    // would be telling a script to come back on a later train for something
-    // already shipped.
-    const reserved = await cli().run(["project", "cp"]);
-    expect(reserved.code).toBe(EXIT_UNIMPLEMENTED);
-    for (const built of [["core", "shell"], ["session", "attach"]]) {
-      const run = await cli().run(built);
-      expect(run.code, built.join(" ")).not.toBe(EXIT_UNIMPLEMENTED);
-    }
-  });
-
-  it("answers the same for every reserved verb, and not for a built one beside it", async () => {
-    // One fact about this build, one exit code — and it has to stay a *fact
-    // about the build* rather than about a file. `project cp` and `project ls`
-    // sit in the same module and differ only in whether they are built, which
-    // is the difference the code is supposed to carry.
-    const cp = await cli().run(["project", "cp"]);
-    const files = await cli().run(["project", "files"]);
-    expect(cp.code).toBe(files.code);
-    const built = await cli().run(["project", "ls"]);
-    expect(built.code).not.toBe(cp.code);
-  });
-
-  it("dials nothing to say it — a reservation is answered before a Core is", async () => {
-    // The fixture throws on `connect`, so a reserved verb that reached the wire
-    // would fail here rather than pass. "Not built yet" is a fact about this
-    // build and needs no Core's opinion, which is also why it is the one answer
-    // that works with no Core registered at all.
-    for (const [argv] of RESERVED) {
+describe("nothing is reserved any more, and a typo is still a typo", () => {
+  it("answers `not built yet` for no name in the tree", async () => {
+    // The list emptied one ticket at a time and #168 took the last two off it.
+    // A name here that still answered 3 would be a build advertising a train
+    // that has already arrived.
+    for (const argv of EVERY_NAME) {
       const run = await cli().run([...argv]);
-      expect(run.code, argv.join(" ")).toBe(EXIT_UNIMPLEMENTED);
+      expect(run.code, argv.join(" ")).not.toBe(EXIT_UNIMPLEMENTED);
+      expect(run.err.join("\n"), argv.join(" ")).not.toContain("not built yet");
     }
   });
 
-  it("still separates a reservation from a typo", async () => {
+  it("keeps the three codes three, so a script that branches on them still can", () => {
+    // The mechanism outlives the last reservation on purpose: `project rm`
+    // (#210) and `--model` (#211) are the next names that will need it, and a
+    // code re-used in the meantime would silently change what a script reading
+    // `3` is being told.
+    expect(new Set([EXIT_OK, EXIT_USAGE, EXIT_UNIMPLEMENTED]).size).toBe(3);
+  });
+
+  it("still separates a name that does not exist from one that does", async () => {
     // The distinction this must not collapse: `sessoin` has no ticket number
     // and no later train that fixes it, and a script that retries on 3 must not
     // retry on it.
@@ -101,6 +85,15 @@ describe("a reservation is `not built yet`, not `you typed it wrong`", () => {
     expect(typo.code).toBe(EXIT_USAGE);
     expect(typo.err.join("\n")).toContain('unknown noun "sessoin"');
     expect(typo.err.join("\n")).not.toContain("not built yet");
+  });
+
+  it("keeps `cp` a typo at the root: the noun grammar holds (D8, F12)", async () => {
+    // #168 built `project cp` and deliberately did not build `actana cp`. The
+    // shorter name has to stay an unknown noun, or the grammar has a hole in it
+    // that nobody documented.
+    const run = await cli().run(["cp", "./a", "api:b"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain('unknown noun "cp"');
   });
 
   it("keeps `daemon` a usage error — it is the wrong package, not a later train", async () => {
@@ -130,14 +123,13 @@ describe("the root itself", () => {
     expect(run.out.join("\n")).not.toContain("Reserved, landing later");
   });
 
-  it("keeps each reserved verb's ticket in the help of the noun that owns it", async () => {
-    // The reservations that are left are verbs, and a reserved verb nobody can
-    // find in `--help` is a reservation only the source knows about.
-    for (const [argv, ticket] of RESERVED) {
-      const run = await cli().run([argv[0], "--help"]);
-      const help = run.out.join("\n");
-      expect(help, `${argv.join(" ")} is not in \`actana ${argv[0]} --help\``).toContain(argv[1]);
-      expect(help, `${argv.join(" ")} does not name ${ticket}`).toContain(ticket);
+  it("advertises no reserved verb either, now that there is none", async () => {
+    // The counterpart to the noun assertion above: a "Reserved, landing in
+    // phase 3" heading over verbs this build ships is the same lie one line
+    // further down the tree.
+    for (const noun of BUILT) {
+      const run = await cli().run([noun, "--help"]);
+      expect(run.out.join("\n"), `${noun} --help`).not.toContain("Reserved, landing");
     }
   });
 

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -413,6 +413,16 @@ export type FakeProjectFilesOptions = {
   progressFor?: (upload: FakeProjectFiles["uploads"][number]) => CoreFileProgress[];
   /** Throw instead of streaming progress — the F8 conflict, a refusal, a stream error. */
   uploadFails?: Error;
+  /**
+   * Stream the progress `progressFor` supplies, **then** throw.
+   *
+   * The part-way failure the Core models with `CoreFileStreamError`: entries
+   * really landed, and then the transfer died. Distinct from `uploadFails`,
+   * which dies before anything crosses — the difference is the whole point of
+   * the test, because what is at stake is what the CLI does with the entries it
+   * already knows about.
+   */
+  uploadFailsAfterProgress?: Error;
   /** What a download answers with, given the path. */
   downloadWith?: (path: string) => CoreFileDownload;
   /** Throw instead of answering a download. */
@@ -470,6 +480,7 @@ export function fakeProjectFiles(opts: FakeProjectFilesOptions = {}): FakeProjec
         state.uploads.push(upload);
         if (opts.uploadFails) throw projectFilesErrorFrom(opts.uploadFails);
         for (const line of opts.progressFor?.(upload) ?? []) yield line;
+        if (opts.uploadFailsAfterProgress) throw projectFilesErrorFrom(opts.uploadFailsAfterProgress);
       },
     }),
     download: async (downloadOpts) => {

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -23,6 +23,19 @@ import type {
 } from "../session-attach-channel.ts";
 import type { CoreConnectFn, CoreConnectOptions, CoreLinkClient } from "../core-connection.ts";
 import type { OpenSessionGateway, SessionGateway, StartedSession } from "../session-gateway.ts";
+import { projectFilesErrorFrom } from "../project-files-gateway.ts";
+import type {
+  OpenProjectFilesFn,
+  ProjectFileTransfers,
+  ProjectFilesGateway,
+} from "../project-files-gateway.ts";
+import type {
+  CoreFileDownload,
+  CoreFileEntry,
+  CoreFileListOptions,
+  CoreFileProgress,
+  CoreFileSource,
+} from "@actana/sdk/core-files.ts";
 import type {
   CoreLinkDirListing,
   CoreLinkEvent,
@@ -68,6 +81,8 @@ export type RunOptions = {
   connect?: CoreConnectFn;
   /** What the `session` noun's verbs get back, or a throw. */
   sessions?: OpenSessionGateway;
+  /** What `project cp` and `project files` get back, or a throw. */
+  files?: OpenProjectFilesFn;
   /**
    * Called with each stdout line as it is written, rather than at the end.
    *
@@ -204,6 +219,11 @@ export function makeCliFixture(): CliFixture {
           opts.sessions ??
           (async () => {
             throw new Error("this test did not expect to open a session gateway");
+          }),
+        openFiles:
+          opts.files ??
+          (async () => {
+            throw new Error("this test did not expect to open a file gateway");
           }),
         now: () => opts.now ?? Date.UTC(2026, 7, 12),
         // Terminal bytes are swept for credentials alongside the line sinks, so
@@ -344,6 +364,172 @@ export function fakeCore(opts: FakeCoreOptions = {}): FakeCore {
   };
 
   return state;
+}
+
+/** What a {@link fakeProjectFiles} was asked to transfer, and what it answered. */
+export type FakeProjectFiles = {
+  /** What `deps.openFiles` hands the verb under test. */
+  open: OpenProjectFilesFn;
+  /** Every Project name or id a verb asked to resolve, in order. */
+  resolved: string[];
+  /** Every listing, with the options it carried. */
+  lists: CoreFileListOptions[];
+  /**
+   * Every upload, **with its body drained to a buffer**.
+   *
+   * Draining rather than counting is what makes the round-trip suites possible:
+   * a `cp ./dir project:path` produces a real tar here, and a test can unpack it
+   * with `local-tar.ts` and assert on the modes that came out. The Core is
+   * faked; the archive is not.
+   */
+  uploads: Array<{
+    path: string;
+    kind: "file" | "tar";
+    mode: number | null;
+    mtime: number | null;
+    contentLength: number | null;
+    body: Buffer;
+  }>;
+  /** Every download, by the path it asked for. */
+  downloads: string[];
+  /** True once the verb hung up. A gateway left open is a defect worth failing on. */
+  closed: boolean;
+};
+
+export type FakeProjectFilesOptions = {
+  /** The Project every resolution answers with. */
+  project?: { projectId: string; name: string; path: string };
+  /** What `list` streams. */
+  entries?: CoreFileEntry[];
+  /** Refuse to resolve the Project — a bad name, or a Core that has none. */
+  refuseProject?: Error;
+  /**
+   * What an upload reports back, given what it was handed.
+   *
+   * The default reports nothing, because the *Core* is what decides whether an
+   * entry was an overwrite and a fake that guessed would be asserting on its own
+   * opinion. A suite about F5 supplies the `overwritten` lines it means to test.
+   */
+  progressFor?: (upload: FakeProjectFiles["uploads"][number]) => CoreFileProgress[];
+  /** Throw instead of streaming progress — the F8 conflict, a refusal, a stream error. */
+  uploadFails?: Error;
+  /** What a download answers with, given the path. */
+  downloadWith?: (path: string) => CoreFileDownload;
+  /** Throw instead of answering a download. */
+  downloadFails?: Error;
+  /** Throw instead of streaming a listing. */
+  listFails?: Error;
+};
+
+/**
+ * A Project's file surface that never opens a socket.
+ *
+ * The counterpart to {@link fakeCore} for the two verbs that do not use the
+ * core link for their bytes. What the `cp` and `files` suites are about — the
+ * direction parse, the progress rule, the overwrite naming, the `--json` shapes,
+ * the exit codes — is none of it a fact about HTTPS, and
+ * `project-files-live.test.ts` is where a real Core answers instead.
+ */
+export function fakeProjectFiles(opts: FakeProjectFilesOptions = {}): FakeProjectFiles {
+  const project = opts.project ?? { projectId: "p-api", name: "api", path: "/srv/api" };
+  const state: FakeProjectFiles = {
+    open: async () => gateway,
+    resolved: [],
+    lists: [],
+    uploads: [],
+    downloads: [],
+    closed: false,
+  };
+
+  const transfers: ProjectFileTransfers = {
+    projectId: project.projectId,
+    name: project.name,
+    path: project.path,
+    list: (listOpts = {}) => {
+      state.lists.push(listOpts);
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (opts.listFails) throw projectFilesErrorFrom(opts.listFails);
+          for (const entry of opts.entries ?? []) yield entry;
+        },
+      };
+    },
+    upload: (uploadOpts) => ({
+      async *[Symbol.asyncIterator]() {
+        // Drained first and always, exactly as a real transfer does: a body the
+        // caller never read is a file handle nobody closed, and a `cp` whose
+        // upload was abandoned half-way is a different test.
+        const upload = {
+          path: uploadOpts.path,
+          kind: uploadOpts.kind ?? ("file" as const),
+          mode: uploadOpts.mode ?? null,
+          mtime: uploadOpts.mtime ?? null,
+          contentLength: uploadOpts.contentLength ?? null,
+          body: await drain(uploadOpts.body),
+        };
+        state.uploads.push(upload);
+        if (opts.uploadFails) throw projectFilesErrorFrom(opts.uploadFails);
+        for (const line of opts.progressFor?.(upload) ?? []) yield line;
+      },
+    }),
+    download: async (downloadOpts) => {
+      state.downloads.push(downloadOpts.path);
+      if (opts.downloadFails) throw projectFilesErrorFrom(opts.downloadFails);
+      if (!opts.downloadWith) throw new Error("this test did not say what a download answers with");
+      return opts.downloadWith(downloadOpts.path);
+    },
+  };
+
+  const gateway: ProjectFilesGateway = {
+    project: async (wanted) => {
+      state.resolved.push(wanted);
+      if (opts.refuseProject) throw projectFilesErrorFrom(opts.refuseProject);
+      return transfers;
+    },
+    close: () => {
+      state.closed = true;
+    },
+  };
+
+  return state;
+}
+
+/** A `CoreFileSource` as one buffer — both shapes the SDK accepts. */
+async function drain(body: CoreFileSource): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  if (typeof (body as ReadableStream<Uint8Array>).getReader === "function") {
+    const reader = (body as ReadableStream<Uint8Array>).getReader();
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      if (next.value) chunks.push(Buffer.from(next.value));
+    }
+    return Buffer.concat(chunks);
+  }
+  for await (const chunk of body as AsyncIterable<Uint8Array | string>) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk, "utf8") : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Bytes as the `ReadableStream` a download hands back. */
+export function streamOf(bytes: Uint8Array | AsyncIterable<Uint8Array>): ReadableStream<Uint8Array> {
+  if (bytes instanceof Uint8Array) {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+  }
+  const iterator = bytes[Symbol.asyncIterator]();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const next = await iterator.next();
+      if (next.done) controller.close();
+      else controller.enqueue(next.value);
+    },
+  });
 }
 
 /** A project row with the columns a CLI renders and defaults for the rest. */

--- a/packages/cli/src/__tests__/local-tar.test.ts
+++ b/packages/cli/src/__tests__/local-tar.test.ts
@@ -1,0 +1,403 @@
+// The local tar codec: a folder survives the round trip, and its executable
+// bits survive with it (#168).
+//
+// Three layers, because "it round-trips through itself" is the weakest possible
+// evidence for a wire format:
+//
+//   1. **Round trip** — pack a tree, unpack it, compare. Catches the ordinary
+//      bugs and is where the mode assertions live.
+//   2. **The bytes are ustar** — the magic, the version, the field offsets and
+//      the checksum, read out of the buffer by hand. The Core reads these
+//      offsets, so a codec that only agrees with itself would pass layer 1 and
+//      fail in production.
+//   3. **GNU tar can read what this writes, and this can read what GNU tar
+//      writes.** An outside implementation is the only thing that makes layers
+//      1 and 2 mean what they claim. Skipped, loudly, on a machine with no
+//      `tar` — a test that silently passes when it did not run is worse than no
+//      test.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { LocalTarError, packLocalTree, unpackTarInto, type UnpackedEntry } from "../local-tar.ts";
+
+const temporary: string[] = [];
+
+function scratch(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-tar-"));
+  temporary.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (temporary.length > 0) fs.rmSync(temporary.pop()!, { recursive: true, force: true });
+});
+
+/** Whether this machine has a tar to check against. */
+const HAS_TAR = (() => {
+  try {
+    execFileSync("tar", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+async function pack(root: string): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of packLocalTree(root)) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function unpack(archive: Buffer, dest: string): Promise<UnpackedEntry[]> {
+  const seen: UnpackedEntry[] = [];
+  await unpackTarInto(oneChunk(archive), dest, (entry) => {
+    seen.push(entry);
+  });
+  return seen;
+}
+
+/** The archive as a stream, in awkward little pieces. */
+async function* oneChunk(archive: Buffer, size = 100): AsyncGenerator<Uint8Array> {
+  // Deliberately not a multiple of 512: every chunk boundary lands mid-header
+  // or mid-body, which is the case a reader that assumed block-aligned reads
+  // would get wrong, and it is what a real socket delivers.
+  for (let offset = 0; offset < archive.length; offset += size) {
+    yield archive.subarray(offset, Math.min(offset + size, archive.length));
+  }
+}
+
+/** A tree with the three node types, a nested folder, and one executable. */
+function buildTree(root: string): void {
+  fs.mkdirSync(path.join(root, "bin"), { recursive: true });
+  fs.mkdirSync(path.join(root, "src", "deep"), { recursive: true });
+  fs.writeFileSync(path.join(root, "readme.md"), "hello\n");
+  fs.writeFileSync(path.join(root, "bin", "deploy"), "#!/bin/sh\necho hi\n");
+  fs.chmodSync(path.join(root, "bin", "deploy"), 0o755);
+  fs.writeFileSync(path.join(root, "src", "deep", "index.ts"), "export const a = 1;\n");
+  fs.chmodSync(path.join(root, "src", "deep", "index.ts"), 0o644);
+  fs.symlinkSync("../readme.md", path.join(root, "src", "link.md"));
+}
+
+describe("a folder round-trips, and keeps its executable bits (#168)", () => {
+  it("restores every file, its contents and its mode", async () => {
+    const source = scratch();
+    buildTree(source);
+    const dest = scratch();
+
+    await unpack(await pack(source), dest);
+
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.readFileSync(path.join(dest, "src", "deep", "index.ts"), "utf8")).toBe(
+      "export const a = 1;\n",
+    );
+    // The whole reason a folder is an archive rather than N writes. An 0o755
+    // that came back 0o644 is a `./deploy` that will not run, and it is the
+    // failure this line exists to catch.
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+    expect(fs.statSync(path.join(dest, "src", "deep", "index.ts")).mode & 0o777).toBe(0o644);
+  });
+
+  it("survives a umask that would have masked the mode away", async () => {
+    // `open(…, mode)` is masked by the umask, so a codec that set the mode at
+    // creation would drop the group and other bits under an 0o077 umask and
+    // pass the test above on a developer's 0o022 machine. The explicit `chmod`
+    // is what makes this pass, and this is the test that would notice.
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "run"), "#!/bin/sh\n");
+    fs.chmodSync(path.join(source, "run"), 0o755);
+    const archive = await pack(source);
+
+    const previous = process.umask(0o077);
+    try {
+      const dest = scratch();
+      await unpack(archive, dest);
+      expect(fs.statSync(path.join(dest, "run")).mode & 0o777).toBe(0o755);
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  it("restores a symlink as a symlink, pointing where it did", async () => {
+    const source = scratch();
+    buildTree(source);
+    const dest = scratch();
+
+    await unpack(await pack(source), dest);
+
+    const link = path.join(dest, "src", "link.md");
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(link)).toBe("../readme.md");
+  });
+
+  it("copies the folder's contents to the destination, not the folder into it", async () => {
+    // `cp ./dist api:build` makes `build` a copy of `dist`. The alternative —
+    // `build/dist` — makes the round trip asymmetric, so copying down what you
+    // copied up would nest one level deeper every time.
+    const source = scratch();
+    buildTree(source);
+    const dest = scratch();
+
+    const entries = await unpack(await pack(source), dest);
+
+    expect(entries.map((entry) => entry.path).sort()).toEqual([
+      "bin",
+      "bin/deploy",
+      "readme.md",
+      "src",
+      "src/deep",
+      "src/deep/index.ts",
+      "src/link.md",
+    ]);
+    expect(fs.existsSync(path.join(dest, path.basename(source)))).toBe(false);
+  });
+
+  it("reports an empty folder as an archive with nothing in it", async () => {
+    const dest = scratch();
+    const entries = await unpack(await pack(scratch()), dest);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips a node it could not recreate anywhere, rather than failing the copy", async () => {
+    // A socket left behind by a running daemon is not a reason to refuse
+    // somebody's whole folder — and it could not be meaningfully recreated on
+    // another machine even if it were packed.
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "keep.txt"), "kept\n");
+    const socketPath = path.join(source, "daemon.sock");
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+    try {
+      expect(fs.lstatSync(socketPath).isSocket()).toBe(true);
+      const entries = await unpack(await pack(source), scratch());
+      expect(entries.map((entry) => entry.path)).toEqual(["keep.txt"]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe("every overwrite is named (F5)", () => {
+  it("says `written` the first time and `overwritten` the second", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "a.txt"), "one\n");
+    const archive = await pack(source);
+    const dest = scratch();
+
+    const first = await unpack(archive, dest);
+    expect(first.map((entry) => entry.result)).toEqual(["written"]);
+
+    const second = await unpack(archive, dest);
+    // Named, with its path — a count would be the thing F5 exists to prevent
+    // somebody being able to publish.
+    expect(second).toEqual([expect.objectContaining({ path: "a.txt", result: "overwritten" })]);
+  });
+
+  it("counts a file landing on a directory as an overwrite, and removes the directory", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "thing"), "now a file\n");
+    const dest = scratch();
+    fs.mkdirSync(path.join(dest, "thing"), { recursive: true });
+    fs.writeFileSync(path.join(dest, "thing", "inside.txt"), "gone\n");
+
+    const entries = await unpack(await pack(source), dest);
+
+    expect(entries[0]).toMatchObject({ path: "thing", result: "overwritten" });
+    expect(fs.readFileSync(path.join(dest, "thing"), "utf8")).toBe("now a file\n");
+  });
+});
+
+describe("an archive off the network cannot write outside where it was aimed", () => {
+  // Not the confinement #168 rules out — that is the Core's rule about the
+  // Core's disk. This is about *this* disk, and the bytes came off a socket.
+  it("refuses an entry with a `..` segment", async () => {
+    const archive = await pack(scratch());
+    const forged = forgeEntry("../escape.txt", "gotcha\n");
+    const dest = scratch();
+
+    await expect(unpack(Buffer.concat([forged, archive]), dest)).rejects.toThrow(LocalTarError);
+    expect(fs.existsSync(path.join(path.dirname(dest), "escape.txt"))).toBe(false);
+  });
+
+  it("refuses an absolute entry path", async () => {
+    const dest = scratch();
+    await expect(unpack(forgeEntry("/tmp/actana-escape.txt", "gotcha\n"), dest)).rejects.toThrow(
+      /absolute path/,
+    );
+  });
+
+  it("refuses a Windows-style absolute entry path too", async () => {
+    const dest = scratch();
+    await expect(unpack(forgeEntry("C:\\escape.txt", "gotcha\n"), dest)).rejects.toThrow(LocalTarError);
+  });
+
+  it("does not follow a symlink an earlier entry wrote", async () => {
+    // The classic two-entry attack: a link out of the tree, then a file
+    // "inside" it. The link itself is legal — a copy that dropped links would
+    // not be a copy — so what has to hold is that the *file* is resolved and
+    // refused rather than written through it.
+    const outside = scratch();
+    const dest = scratch();
+    const archive = Buffer.concat([
+      forgeSymlink("out", outside),
+      forgeEntry("out/pwned.txt", "gotcha\n"),
+    ]);
+
+    await expect(unpack(archive, dest)).rejects.toThrow(LocalTarError);
+    expect(fs.existsSync(path.join(outside, "pwned.txt"))).toBe(false);
+  });
+});
+
+describe("the bytes are ustar, at the offsets the Core reads", () => {
+  it("writes the magic, the version and a matching checksum", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "a.txt"), "x");
+    const archive = await pack(source);
+
+    expect(archive.subarray(257, 263).toString("ascii")).toBe("ustar\0");
+    expect(archive.subarray(263, 265).toString("ascii")).toBe("00");
+
+    let unsigned = 0;
+    for (let i = 0; i < 512; i += 1) unsigned += i >= 148 && i < 156 ? 0x20 : archive[i]!;
+    expect(Number.parseInt(archive.subarray(148, 154).toString("ascii"), 8)).toBe(unsigned);
+  });
+
+  it("puts the mode where a reader looks for it, in octal", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "run"), "#!/bin/sh\n");
+    fs.chmodSync(path.join(source, "run"), 0o755);
+    const archive = await pack(source);
+
+    expect(archive.subarray(0, 3).toString("ascii")).toBe("run");
+    expect(archive.subarray(100, 107).toString("ascii")).toBe("0000755");
+    expect(String.fromCharCode(archive[156]!)).toBe("0");
+  });
+
+  it("flattens ownership to zero, because two machines share no passwd file", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "a.txt"), "x");
+    const archive = await pack(source);
+    expect(archive.subarray(108, 115).toString("ascii")).toBe("0000000");
+    expect(archive.subarray(116, 123).toString("ascii")).toBe("0000000");
+  });
+
+  it("closes the archive with two zero blocks", async () => {
+    const archive = await pack(scratch());
+    expect(archive.length).toBe(1024);
+    expect(archive.every((byte) => byte === 0)).toBe(true);
+  });
+
+  it("reaches for a pax header when a name will not fit in ustar's 100 bytes", async () => {
+    const source = scratch();
+    const deep = path.join(source, "a".repeat(60), "b".repeat(60));
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(deep, "c.txt"), "deep\n");
+
+    const archive = await pack(source);
+    expect(archive.includes(Buffer.from("PaxHeaders/"))).toBe(true);
+
+    // And it reads its own: the long path comes back whole, not truncated to
+    // the 100 bytes the ustar field could hold.
+    const dest = scratch();
+    const entries = await unpack(archive, dest);
+    expect(entries.map((entry) => entry.path)).toContain(`a`.repeat(60) + "/" + "b".repeat(60) + "/c.txt");
+    expect(fs.readFileSync(path.join(deep.replace(source, dest), "c.txt"), "utf8")).toBe("deep\n");
+  });
+
+  it("refuses a header whose checksum does not match, rather than writing garbage", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "a.txt"), "x");
+    const archive = await pack(source);
+    archive[0] = "z".charCodeAt(0);
+    await expect(unpack(archive, scratch())).rejects.toThrow(/checksum/);
+  });
+
+  it("says so when the stream stops in the middle of a file", async () => {
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "a.txt"), "x".repeat(2000));
+    const archive = await pack(source);
+    await expect(unpack(archive.subarray(0, 900), scratch())).rejects.toThrow(/ended/);
+  });
+});
+
+describe("GNU tar agrees, in both directions", () => {
+  it.skipIf(!HAS_TAR)("reads an archive this codec wrote, modes intact", async () => {
+    const source = scratch();
+    buildTree(source);
+    const archive = await pack(source);
+    const archivePath = path.join(scratch(), "out.tar");
+    fs.writeFileSync(archivePath, archive);
+
+    const dest = scratch();
+    execFileSync("tar", ["-xf", archivePath, "-C", dest]);
+
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+    expect(fs.readlinkSync(path.join(dest, "src", "link.md"))).toBe("../readme.md");
+  });
+
+  it.skipIf(!HAS_TAR)("reads an archive GNU tar wrote, modes intact", async () => {
+    const source = scratch();
+    buildTree(source);
+    const archivePath = path.join(scratch(), "gnu.tar");
+    // `.` as the member, so the archive holds the folder's *contents* under
+    // relative names — the same shape this codec writes.
+    execFileSync("tar", ["-cf", archivePath, "-C", source, "."]);
+
+    const dest = scratch();
+    await unpack(fs.readFileSync(archivePath), dest);
+
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+    expect(fs.readlinkSync(path.join(dest, "src", "link.md"))).toBe("../readme.md");
+  });
+
+  it.skipIf(!HAS_TAR)("reads GNU tar's long-name encoding, whichever one it used", async () => {
+    const source = scratch();
+    const deep = path.join(source, "a".repeat(60), "b".repeat(60));
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(deep, "c.txt"), "deep\n");
+    const archivePath = path.join(scratch(), "gnu-long.tar");
+    execFileSync("tar", ["-cf", archivePath, "-C", source, "."]);
+
+    const dest = scratch();
+    await unpack(fs.readFileSync(archivePath), dest);
+    expect(fs.readFileSync(path.join(deep.replace(source, dest), "c.txt"), "utf8")).toBe("deep\n");
+  });
+});
+
+// ─── Forging entries a well-behaved packer would never emit ──────────────────
+
+function forgeEntry(name: string, contents: string): Buffer {
+  const body = Buffer.from(contents, "utf8");
+  const padded = Buffer.alloc(Math.ceil(body.length / 512) * 512);
+  body.copy(padded);
+  return Buffer.concat([forgeHeader(name, body.length, "0", ""), padded]);
+}
+
+function forgeSymlink(name: string, target: string): Buffer {
+  return forgeHeader(name, 0, "2", target);
+}
+
+/** A valid ustar header for a name this codec would have refused to produce. */
+function forgeHeader(name: string, size: number, typeflag: string, linkname: string): Buffer {
+  const block = Buffer.alloc(512);
+  block.write(name, 0, 100, "utf8");
+  block.write("0000644\0", 100, 8, "ascii");
+  block.write("0000000\0", 108, 8, "ascii");
+  block.write("0000000\0", 116, 8, "ascii");
+  block.write(`${size.toString(8).padStart(11, "0")}\0`, 124, 12, "ascii");
+  block.write(`${(0).toString(8).padStart(11, "0")}\0`, 136, 12, "ascii");
+  block.write("        ", 148, 8, "ascii");
+  block.write(typeflag, 156, 1, "ascii");
+  block.write(linkname, 157, 100, "utf8");
+  block.write("ustar\0", 257, 6, "ascii");
+  block.write("00", 263, 2, "ascii");
+  let unsigned = 0;
+  for (let i = 0; i < 512; i += 1) unsigned += i >= 148 && i < 156 ? 0x20 : block[i]!;
+  block.write(`${unsigned.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+  return block;
+}

--- a/packages/cli/src/__tests__/never-logs-a-blob.test.ts
+++ b/packages/cli/src/__tests__/never-logs-a-blob.test.ts
@@ -19,6 +19,7 @@ import {
   fakeAttachment,
   fakeTerminal,
   fakeCore,
+  fakeProjectFiles,
   fakeSessionGateway,
   fakeStartedSession,
   healthyProbe,
@@ -111,6 +112,28 @@ describe("no verb prints a blob, with --verbose on", () => {
       expectNoSecrets(what, run.all);
     }
 
+    // …and the two verbs that reach a Core over HTTPS rather than the link
+    // (#168). Their gateway holds the same bearer and the same PEM material,
+    // and both of them quote paths back in every message they print — including
+    // the refusals, which is where an error that reached for its whole input
+    // would show up.
+    const files = fakeProjectFiles({
+      entries: [
+        { path: "readme.md", kind: "file", size: 6, mtime: 0, mode: 0o644, sha256: null },
+      ],
+      progressFor: () => [{ type: "done", entries: 0, bytes: 0 }],
+    });
+    const fileRuns: Array<[string, string[]]> = [
+      ["project files", ["project", "files", "api", "--verbose"]],
+      ["project files --json", ["project", "files", "api", "--json", "--verbose"]],
+      ["project cp (up)", ["project", "cp", cli().home, "api:build", "--verbose"]],
+      ["project cp (bad args)", ["project", "cp", "./a", "./b", "--verbose"]],
+    ];
+    for (const [what, argv] of fileRuns) {
+      const run = await cli().run(argv, { files: files.open });
+      expectNoSecrets(what, run.all);
+    }
+
     // …and the one that follows a stream, which has to be driven to its limit.
     const tail = cli().run(["events", "tail", "--since", "start", "--limit", "1", "--verbose"], {
       connect: core.connect,
@@ -126,12 +149,12 @@ describe("no verb prints a blob, with --verbose on", () => {
       ["project", "ls", "--verbose"],
       ["harness", "ls", "--verbose"],
       ["events", "tail", "--verbose"],
+      ["project", "files", "api", "--verbose"],
     ]) {
-      const run = await cli().run(argv, {
-        connect: async () => {
-          throw new Error("connect ECONNREFUSED");
-        },
-      });
+      const refuse = async () => {
+        throw new Error("connect ECONNREFUSED");
+      };
+      const run = await cli().run(argv, { connect: refuse, files: refuse });
       expect(run.code).not.toBe(0);
       expectNoSecrets(argv.join(" "), run.all);
     }

--- a/packages/cli/src/__tests__/project-command.test.ts
+++ b/packages/cli/src/__tests__/project-command.test.ts
@@ -148,13 +148,34 @@ describe("a Core-owned Project's path is immutable (ADR 0022)", () => {
     expect(core.mutations, "an edit verb reached the Core").toEqual([]);
   });
 
-  it("reserves the phase-3 verbs rather than leaving them to read as typos", async () => {
+  it("no longer reserves the phase-3 verbs: #168 built them", async () => {
+    // They were `EXIT_UNIMPLEMENTED` and named their ticket until this train.
+    // Now they are commands like any other, and answering `3` for either would
+    // be telling a script to come back later for something already shipped.
+    // What they *are* is `project-cp.test.ts` and `project-files-ls.test.ts`;
+    // what matters here is that this noun no longer disowns them.
     await withRegisteredCore();
     for (const verb of ["cp", "files"]) {
       const run = await cli().run(["project", verb]);
-      expect(run.code, `project ${verb}`).toBe(EXIT_UNIMPLEMENTED);
-      expect(run.err.join("\n")).toContain("#168");
+      expect(run.code, `project ${verb}`).not.toBe(EXIT_UNIMPLEMENTED);
+      expect(run.err.join("\n")).not.toContain("not built yet");
     }
+  });
+
+  it("lists both of them in the noun's help", async () => {
+    const run = await cli().run(["project", "--help"]);
+    expect(run.code).toBe(EXIT_OK);
+    const help = run.out.join("\n");
+    expect(help).toContain("actana project cp");
+    expect(help).toContain("actana project files");
+    // And the section they used to sit in is gone with them.
+    expect(help).not.toContain("Reserved, landing in phase 3");
+  });
+
+  it("still points at the noun grammar: there is no root-level `actana cp` (D8, F12)", async () => {
+    const run = await cli().run(["cp", "./a", "api:b"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain('unknown noun "cp"');
   });
 });
 

--- a/packages/cli/src/__tests__/project-cp.test.ts
+++ b/packages/cli/src/__tests__/project-cp.test.ts
@@ -1,0 +1,517 @@
+// `actana project cp` — the verb, without a Core (#168).
+//
+// The claims under test are the four "done when" lines of #168 plus the two
+// traps, and each is a fact about *this* program rather than about a Core:
+//
+//   - a folder copies both ways and keeps its executable bits
+//   - progress is visible on a terminal and absent under `--json`
+//   - every overwrite is named in the output
+//   - the F8 refusal says **who** holds the Project, not just "busy"
+//   - the `<project>:<path>` parse is unambiguous (its own suite, next door)
+//   - nothing here validates a remote path: the Core owns the disk (F3, F11)
+//
+// The gateway is faked, and the archive is not: an upload's tar is drained,
+// unpacked by `local-tar.ts`, and asserted on. So "keeps its executable bits"
+// is checked against real bytes on a real disk, with only the HTTPS hop
+// replaced.
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  fakeProjectFiles,
+  fakeTerminal,
+  makeCliFixture,
+  sentinelBlobText,
+  streamOf,
+  type CliFixture,
+} from "./cli-harness.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
+import { packLocalTree, unpackTarInto } from "../local-tar.ts";
+import { CoreFilesConflictError } from "@actana/sdk/core-files-http.ts";
+import type { CoreFileProgress } from "@actana/sdk/core-files.ts";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+
+const temporary: string[] = [];
+function scratch(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-cp-"));
+  temporary.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+  while (temporary.length > 0) fs.rmSync(temporary.pop()!, { recursive: true, force: true });
+});
+
+async function withRegisteredCore(): Promise<void> {
+  const added = await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() });
+  expect(added.code).toBe(EXIT_OK);
+}
+
+/** A folder with something executable in it, which is the point of the ticket. */
+function buildTree(root: string): string {
+  fs.mkdirSync(path.join(root, "bin"), { recursive: true });
+  fs.writeFileSync(path.join(root, "readme.md"), "hello\n");
+  fs.writeFileSync(path.join(root, "bin", "deploy"), "#!/bin/sh\necho hi\n");
+  fs.chmodSync(path.join(root, "bin", "deploy"), 0o755);
+  return root;
+}
+
+/** One `entry` progress line, as the Core reports one. */
+function entryLine(entryPath: string, result: "written" | "overwritten", size = 10): CoreFileProgress {
+  return { type: "entry", path: entryPath, result, size, mtime: 0, mode: 0o644, sha256: null };
+}
+
+describe("a folder copies both ways, and keeps its executable bits", () => {
+  it("goes up as one archive with the modes intact", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles();
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    // One archive, not N writes — which is what carries a mode at all.
+    expect(files.uploads).toHaveLength(1);
+    expect(files.uploads[0]).toMatchObject({ path: "build", kind: "tar" });
+
+    // And the archive is real: unpacked here, the executable is still one.
+    const landed = scratch();
+    await unpackTarInto(chunksOf(files.uploads[0]!.body), landed, () => {});
+    expect(fs.readFileSync(path.join(landed, "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.statSync(path.join(landed, "bin", "deploy")).mode & 0o777).toBe(0o755);
+    expect(files.closed, "project cp left the gateway open").toBe(true);
+  });
+
+  it("comes down as one archive with the modes intact", async () => {
+    await withRegisteredCore();
+    const remote = buildTree(scratch());
+    const dest = path.join(scratch(), "pulled");
+    const files = fakeProjectFiles({
+      downloadWith: () => ({
+        kind: "tar",
+        size: null,
+        mode: null,
+        mtime: null,
+        stream: streamOf(packLocalTree(remote)),
+      }),
+    });
+
+    const run = await cli().run(["project", "cp", "api:build", dest], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(files.downloads).toEqual(["build"]);
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+    // The other half of the ticket's first line. An 0o755 that came back 0o644
+    // is a `./deploy` that will not run.
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+  });
+
+  it("round-trips: what came down is what went up", async () => {
+    await withRegisteredCore();
+    const original = buildTree(scratch());
+
+    const up = fakeProjectFiles();
+    expect((await cli().run(["project", "cp", original, "api:build"], { files: up.open })).code).toBe(
+      EXIT_OK,
+    );
+
+    const archive = up.uploads[0]!.body;
+    const down = fakeProjectFiles({
+      downloadWith: () => ({
+        kind: "tar",
+        size: null,
+        mode: null,
+        mtime: null,
+        stream: streamOf(new Uint8Array(archive)),
+      }),
+    });
+    const dest = path.join(scratch(), "again");
+    expect((await cli().run(["project", "cp", "api:build", dest], { files: down.open })).code).toBe(
+      EXIT_OK,
+    );
+
+    expect(fs.readFileSync(path.join(dest, "bin", "deploy"), "utf8")).toBe("#!/bin/sh\necho hi\n");
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+    // Not `again/<name-of-original>/bin/deploy`: the folder's *contents* land
+    // at the destination, so the trip can be made twice without nesting.
+    expect(fs.existsSync(path.join(dest, path.basename(original)))).toBe(false);
+  });
+
+  it("sends a single file as bytes, with its mode and its length declared", async () => {
+    await withRegisteredCore();
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "run.sh"), "#!/bin/sh\n");
+    fs.chmodSync(path.join(source, "run.sh"), 0o755);
+    const files = fakeProjectFiles();
+
+    const run = await cli().run(["project", "cp", path.join(source, "run.sh"), "api:bin/run.sh"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(files.uploads[0]).toMatchObject({
+      path: "bin/run.sh",
+      kind: "file",
+      mode: 0o755,
+      // Declared so the Core can refuse `507` before the bytes cross rather
+      // than fail with ENOSPC half-way through.
+      contentLength: 10,
+    });
+    expect(files.uploads[0]!.body.toString("utf8")).toBe("#!/bin/sh\n");
+  });
+
+  it("names a file after itself when the destination is a folder", async () => {
+    await withRegisteredCore();
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "notes.md"), "n\n");
+    const files = fakeProjectFiles();
+
+    await cli().run(["project", "cp", path.join(source, "notes.md"), "api:docs/"], {
+      files: files.open,
+    });
+
+    expect(files.uploads[0]!.path).toBe("docs/notes.md");
+  });
+
+  it("brings a single file down and applies the mode the Core declared", async () => {
+    await withRegisteredCore();
+    const dest = path.join(scratch(), "run.sh");
+    const files = fakeProjectFiles({
+      downloadWith: () => ({
+        kind: "file",
+        size: 10,
+        mode: 0o755,
+        mtime: null,
+        stream: streamOf(Buffer.from("#!/bin/sh\n")),
+      }),
+    });
+
+    const run = await cli().run(["project", "cp", "api:bin/run.sh", dest], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(fs.readFileSync(dest, "utf8")).toBe("#!/bin/sh\n");
+    expect(fs.statSync(dest).mode & 0o777).toBe(0o755);
+  });
+});
+
+describe("progress is visible on a terminal and absent under --json", () => {
+  it("paints a status line when there is a terminal to paint it on", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const terminal = fakeTerminal({ isTty: true });
+    const files = fakeProjectFiles({
+      progressFor: () => [entryLine("readme.md", "written"), { type: "done", entries: 1, bytes: 6 }],
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build"], {
+      files: files.open,
+      terminal,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    // A rewriting line, and it erases itself: what is left on the screen after
+    // the command is the result, not a frozen half-finished tally.
+    expect(terminal.painted()).toContain("\r");
+    expect(terminal.painted()).toContain("readme.md");
+  });
+
+  it("paints nothing at all under --json, and stdout is one document", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const terminal = fakeTerminal({ isTty: true });
+    const files = fakeProjectFiles({
+      progressFor: () => [entryLine("readme.md", "written"), { type: "done", entries: 1, bytes: 6 }],
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: files.open,
+      terminal,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    // Absent, not merely redirected. A consumer parsing stdout must not have to
+    // filter a spinner out of it first.
+    expect(terminal.painted()).toBe("");
+    expect(() => JSON.parse(run.out.join("\n"))).not.toThrow();
+  });
+
+  it("paints nothing when the output is a pipe rather than a terminal", async () => {
+    // The fixture's default terminal is not a TTY, which is what a `| tee` or a
+    // `> log` gives the process. Carriage returns in that file would be noise
+    // nobody asked for.
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      progressFor: () => [entryLine("readme.md", "written")],
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).not.toContain("\r");
+  });
+});
+
+describe("every overwrite is named (F5)", () => {
+  it("names each one on the way up, rather than counting them", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      progressFor: () => [
+        entryLine("readme.md", "written"),
+        entryLine("bin/deploy", "overwritten"),
+        entryLine("config.json", "overwritten"),
+        { type: "done", entries: 3, bytes: 30 },
+      ],
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    const out = run.out.join("\n");
+    // The paths, in the output. A summary saying "3 entries" over a tree that
+    // quietly replaced two of them is the failure F5 exists to prevent.
+    expect(out).toContain("overwrote bin/deploy");
+    expect(out).toContain("overwrote config.json");
+    expect(out).not.toContain("overwrote readme.md");
+  });
+
+  it("lists them under `overwritten` in the --json payload", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      progressFor: () => [
+        entryLine("readme.md", "written"),
+        entryLine("bin/deploy", "overwritten"),
+        { type: "done", entries: 2, bytes: 20 },
+      ],
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: files.open,
+    });
+
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload).toMatchObject({
+      direction: "upload",
+      project: "api",
+      entries: 2,
+      written: 1,
+      overwritten: ["bin/deploy"],
+    });
+  });
+
+  it("names them on the way down too, where this side is the one that can see", async () => {
+    await withRegisteredCore();
+    const remote = buildTree(scratch());
+    const dest = scratch();
+    // Something already there, so the copy has something to replace.
+    fs.writeFileSync(path.join(dest, "readme.md"), "old\n");
+
+    const files = fakeProjectFiles({
+      downloadWith: () => ({
+        kind: "tar",
+        size: null,
+        mode: null,
+        mtime: null,
+        stream: streamOf(packLocalTree(remote)),
+      }),
+    });
+
+    const run = await cli().run(["project", "cp", "api:build", dest], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).toContain("overwrote readme.md");
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+  });
+
+  it("names a single file it replaced locally", async () => {
+    await withRegisteredCore();
+    const dest = path.join(scratch(), "run.sh");
+    fs.writeFileSync(dest, "old\n");
+    const files = fakeProjectFiles({
+      downloadWith: () => ({
+        kind: "file",
+        size: 4,
+        mode: null,
+        mtime: null,
+        stream: streamOf(Buffer.from("new\n")),
+      }),
+    });
+
+    const run = await cli().run(["project", "cp", "api:run.sh", dest], { files: files.open });
+
+    expect(run.out.join("\n")).toContain(`overwrote ${dest}`);
+  });
+});
+
+describe("a refusal by the one-write-per-Project rule says who holds it (F8)", () => {
+  it("carries the Core's own sentence through, path and start time and all", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    // The Core's real message: `transferInProgress` in core-files-routes.ts
+    // names *which* transfer and *since when*, because "try again" is useless
+    // advice without them.
+    const files = fakeProjectFiles({
+      uploadFails: new CoreFilesConflictError(
+        409,
+        "transfer-in-progress",
+        "another write transfer is already running on this Project " +
+          "(vendor/, started 2026-08-13T09:15:00.000Z) — " +
+          "one write at a time per Project; reads are unrestricted and concurrent",
+      ),
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const err = run.err.join("\n");
+    // Who, and since when. Not "the Project is busy" — the whole point of the
+    // trap is that a client must not throw the answer away.
+    expect(err).toContain("vendor/");
+    expect(err).toContain("2026-08-13T09:15:00.000Z");
+    expect(err).toContain("another write transfer is already running");
+    // And it says plainly that nothing was retried, which the Core cannot know.
+    expect(err).toContain("Nothing was retried");
+    expect(files.closed).toBe(true);
+  });
+
+  it("puts the same sentence in the --json payload rather than a shorter one", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      uploadFails: new CoreFilesConflictError(
+        409,
+        "transfer-in-progress",
+        "another write transfer is already running on this Project (vendor/, started 2026-08-13T09:15:00.000Z)",
+      ),
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(run.out.join("\n")).error).toContain("vendor/");
+  });
+});
+
+describe("the Core owns the disk, so nothing here validates a remote path (F3, F11)", () => {
+  it.each(["api:/etc/passwd", "api:../../escape", "api:", "api:a/../b"])(
+    "sends %o as typed and lets the Core answer",
+    async (target) => {
+      await withRegisteredCore();
+      const source = buildTree(scratch());
+      const files = fakeProjectFiles();
+
+      const run = await cli().run(["project", "cp", source, target], { files: files.open });
+
+      // No local refusal, no rewriting: the path crossed. A client-side copy of
+      // the Core's confinement rules would be a second implementation that
+      // cannot see the disk it is ruling on.
+      expect(run.code).toBe(EXIT_OK);
+      expect(files.uploads).toHaveLength(1);
+      expect(files.uploads[0]!.path).toBe(target.slice("api:".length).replace(/\/+$/, ""));
+    },
+  );
+
+  it("reports the Core's refusal rather than pre-empting it", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      uploadFails: new Error("../../escape leaves the Project root (dot-dot-segment)"),
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:../../escape"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("dot-dot-segment");
+  });
+
+  it("does answer for the local side, which is the disk it can see", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles();
+
+    const run = await cli().run(["project", "cp", "/no/such/folder", "api:build"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("not a file or folder on this machine");
+    expect(files.uploads).toHaveLength(0);
+  });
+});
+
+describe("the command line", () => {
+  it("needs two arguments, and dials nothing to say so", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "./only-one"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("a source and a destination are required");
+  });
+
+  it("refuses two local paths, and names the command that does that job", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "./a", "./b"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("one side must be <project>:<path>");
+  });
+
+  it("refuses two Projects rather than routing Core-to-Core through this laptop", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "api:build", "web:public"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("one local side");
+  });
+
+  it("points at the escape hatch when a local name has a colon in it", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "./a", "./b"]);
+    expect(run.err.join("\n")).toContain("./name:with-colon");
+  });
+
+  it("rejects a third argument rather than silently ignoring it", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "./a", "api:b", "./c"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("unexpected argument");
+  });
+
+  it("says which Project it could not find, and what the Core has instead", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      refuseProject: new Error('this Core has no Project "nope". It has: api, web'),
+    });
+
+    const run = await cli().run(["project", "cp", source, "nope:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("It has: api, web");
+  });
+
+  it("reports a Core that never answered, without promising a --json document it has not got", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "cp", "./a", "api:b"], {
+      files: async () => {
+        throw new Error("connect ECONNREFUSED");
+      },
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("did not answer");
+  });
+});
+
+/** A buffer as the chunked stream an unpacker reads. */
+async function* chunksOf(buffer: Buffer): AsyncGenerator<Uint8Array> {
+  yield new Uint8Array(buffer);
+}

--- a/packages/cli/src/__tests__/project-cp.test.ts
+++ b/packages/cli/src/__tests__/project-cp.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./cli-harness.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 import { packLocalTree, unpackTarInto } from "../local-tar.ts";
-import { CoreFilesConflictError } from "@actana/sdk/core-files-http.ts";
+import { CoreFilesConflictError, CoreFilesStreamError } from "@actana/sdk/core-files-http.ts";
 import type { CoreFileProgress } from "@actana/sdk/core-files.ts";
 
 let fixture: CliFixture | null = null;
@@ -351,6 +351,83 @@ describe("every overwrite is named (F5)", () => {
     const run = await cli().run(["project", "cp", "api:run.sh", dest], { files: files.open });
 
     expect(run.out.join("\n")).toContain(`overwrote ${dest}`);
+  });
+});
+
+describe("a transfer that fails part-way still names what it replaced (F5)", () => {
+  // The state the SDK models with `CoreFilesStreamError`: the status line was
+  // spent on the first entry, so a failure after that arrives as the last line
+  // of the progress stream. Entries really landed. F5 does not stop applying
+  // because the verb is about to exit non-zero — those files are exactly the
+  // ones an operator now has to reason about restoring.
+  const diedOnTheTwelfth = new CoreFilesStreamError(
+    "io-error",
+    "the transfer failed part-way through: write EPIPE",
+  );
+
+  it("names the overwrites it made before the connection went, in prose", async () => {
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      progressFor: () => [
+        entryLine("readme.md", "written"),
+        entryLine("bin/deploy", "overwritten"),
+        entryLine("config.json", "overwritten"),
+      ],
+      uploadFailsAfterProgress: diedOnTheTwelfth,
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const err = run.err.join("\n");
+    expect(err).toContain("overwrote bin/deploy");
+    expect(err).toContain("overwrote config.json");
+    expect(err).not.toContain("overwrote readme.md");
+    expect(err).toContain("2 files were replaced");
+    // The last thing on the screen is still why it stopped, not a list.
+    expect(run.err.at(-1)).toContain("failed part-way through");
+  });
+
+  it("carries the same `overwritten` array on the --json error document", async () => {
+    // Under `--json` this is the only channel there is: no progress line ever
+    // painted, so an operator who cannot read this document cannot find out at
+    // all. Same key, same shape as the success payload — the exit code is what
+    // says which of the two happened.
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({
+      progressFor: () => [entryLine("readme.md", "written"), entryLine("bin/deploy", "overwritten")],
+      uploadFailsAfterProgress: diedOnTheTwelfth,
+    });
+
+    const run = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.error).toContain("failed part-way through");
+    expect(payload.overwritten).toEqual(["bin/deploy"]);
+    expect(payload.entries).toBe(2);
+  });
+
+  it("says nothing extra when the transfer died before anything landed", async () => {
+    // The empty case must stay quiet: a failure that replaced nothing should
+    // not grow a report about the nothing it replaced.
+    await withRegisteredCore();
+    const source = buildTree(scratch());
+    const files = fakeProjectFiles({ uploadFails: diedOnTheTwelfth });
+
+    const run = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.overwritten).toEqual([]);
+    expect(payload.entries).toBe(0);
+    expect(run.err.join("\n")).not.toContain("were replaced");
   });
 });
 

--- a/packages/cli/src/__tests__/project-file-target.test.ts
+++ b/packages/cli/src/__tests__/project-file-target.test.ts
@@ -56,6 +56,46 @@ describe("a Windows path is local, not a Project called C", () => {
   });
 });
 
+describe("a drive-relative Windows path — C:dist and a bare C: — is remote, and that is the trade", () => {
+  // The one collision rule 3 does not close, pinned here under the spelling a
+  // future reader will search for rather than by proxy through `x:src/main.ts`.
+  //
+  // `C:dist` is a real, if rare, Windows form: the current directory *on drive
+  // C*. It has no separator after the colon, so it is indistinguishable from a
+  // Project called `C` with a path called `dist`, and this parse chooses the
+  // Project. That is deliberate. Closing it would mean rule 3 firing on a
+  // single letter alone, which would make every one-character Project name
+  // untypeable — a live cost paid by everyone, to buy off a form that is
+  // ambiguous in the shell too and that `./C:dist` already escapes. `scp` makes
+  // exactly this trade.
+  //
+  // If this ever needs to change, it changes here first: this test failing is
+  // the decision being revisited, not a regression.
+  it.each(["C:dist", "C:", "c:build\\out", "Z:relative/path"])(
+    "reads %o as a Project, not as this machine's drive",
+    (token) => {
+      expect(parseTransferTarget(token).kind).toBe("remote");
+    },
+  );
+
+  it("names the Project as the drive letter, so the failure that follows is legible", () => {
+    // The consolation: nothing is silently copied to the wrong place. The Core
+    // is asked for a Project literally called `C`, and "no such Project: C" is
+    // an error an operator can act on.
+    expect(parseTransferTarget("C:dist")).toEqual({
+      kind: "remote",
+      project: "C",
+      path: "dist",
+      token: "C:dist",
+    });
+  });
+
+  it("is escaped the documented way, with the same ./ that escapes a colon in a filename", () => {
+    expect(parseTransferTarget("./C:dist").kind).toBe("local");
+    expect(parseTransferTarget(".\\C:dist").kind).toBe("local");
+  });
+});
+
 describe("a file whose name contains a colon", () => {
   // The second hazard, and the one with an escape hatch rather than a rule:
   // `notes:draft.md` really is ambiguous — it is a legal Project reference and

--- a/packages/cli/src/__tests__/project-file-target.test.ts
+++ b/packages/cli/src/__tests__/project-file-target.test.ts
@@ -1,0 +1,149 @@
+// The `<project>:<path>` parse, which #168 asks to have *decided and tested*
+// rather than left to whatever a regex does.
+//
+// Two arguments in the wild contain a colon and are not remote — a Windows path
+// and a filename with a colon in it — and getting either wrong sends an
+// operator's files somewhere they did not ask for. So the four rules in
+// `project-file-target.ts` are pinned here one at a time, and the two hazards
+// get a block each.
+
+import { describe, it, expect } from "vitest";
+import {
+  parseTransferTarget,
+  remoteFileDestination,
+  transferDirection,
+} from "../project-file-target.ts";
+
+describe("a plain path is local", () => {
+  it.each([
+    "dist",
+    "./dist",
+    "../dist",
+    "/srv/work/dist",
+    "~/dist",
+    ".",
+    "",
+  ])("reads %o as this machine", (token) => {
+    expect(parseTransferTarget(token)).toEqual({ kind: "local", path: token, token });
+  });
+});
+
+describe("a Windows path is local, not a Project called C", () => {
+  // The first hazard, and the one that would be silent: `C:\Users\me\dist` read
+  // as a Project would go looking for one called `C` and fail with a confusing
+  // "no such Project" — or, on a Core that happens to have one, succeed.
+  it.each(["C:\\Users\\me\\dist", "c:\\dist", "D:/build", "Z:\\"])("reads %o as this machine", (token) => {
+    expect(parseTransferTarget(token).kind).toBe("local");
+  });
+
+  it("still lets a one-character Project name through, because the rule needs both halves", () => {
+    // A drive letter is followed by a separator. A Project-relative path is not,
+    // so `x:src/main.ts` is unambiguous and stays reachable — the rule is not
+    // "one letter means Windows", which would make a whole class of Project
+    // names untypeable.
+    expect(parseTransferTarget("x:src/main.ts")).toEqual({
+      kind: "remote",
+      project: "x",
+      path: "src/main.ts",
+      token: "x:src/main.ts",
+    });
+  });
+
+  it("reads a colon inside a Windows path as part of it", () => {
+    // `C:\logs\a:b` — the drive rule fires on the *first* colon, and everything
+    // after it is one local path.
+    expect(parseTransferTarget("C:\\logs\\a:b").kind).toBe("local");
+  });
+});
+
+describe("a file whose name contains a colon", () => {
+  // The second hazard, and the one with an escape hatch rather than a rule:
+  // `notes:draft.md` really is ambiguous — it is a legal Project reference and
+  // a legal filename — so the parse picks the remote reading and `./` is how an
+  // operator says they meant the file. That is `scp`'s answer, and it has the
+  // advantage of already being in people's fingers.
+  it("is remote when it is bare, which is the documented reading", () => {
+    expect(parseTransferTarget("notes:draft.md")).toEqual({
+      kind: "remote",
+      project: "notes",
+      path: "draft.md",
+      token: "notes:draft.md",
+    });
+  });
+
+  it.each(["./notes:draft.md", "docs/notes:draft.md", "/srv/notes:draft.md", ".\\notes:draft.md"])(
+    "is local the moment a separator comes before the colon — %o",
+    (token) => {
+      expect(parseTransferTarget(token)).toEqual({ kind: "local", path: token, token });
+    },
+  );
+
+  it("leaves a colon inside the remote path alone: only the first one is structural", () => {
+    expect(parseTransferTarget("api:src/a:b.txt")).toEqual({
+      kind: "remote",
+      project: "api",
+      path: "src/a:b.txt",
+      token: "api:src/a:b.txt",
+    });
+  });
+
+  it("reads a leading colon as a local name, since no Project is called the empty string", () => {
+    expect(parseTransferTarget(":weird").kind).toBe("local");
+  });
+});
+
+describe("a Project reference", () => {
+  it("keeps an empty path, which is the Project root", () => {
+    expect(parseTransferTarget("api:")).toEqual({
+      kind: "remote",
+      project: "api",
+      path: "",
+      token: "api:",
+    });
+  });
+
+  it("takes a Project id as readily as a name — resolution is the Core's answer, not this one's", () => {
+    expect(parseTransferTarget("p-api:src")).toMatchObject({ kind: "remote", project: "p-api" });
+  });
+});
+
+describe("the direction is read off the pair", () => {
+  it("is an upload when the destination carries the Project", () => {
+    const direction = transferDirection("./dist", "api:build");
+    expect(direction).toMatchObject({ ok: true, direction: "upload", local: "./dist" });
+  });
+
+  it("is a download when the source does", () => {
+    const direction = transferDirection("api:build", "./dist");
+    expect(direction).toMatchObject({ ok: true, direction: "download", local: "./dist" });
+  });
+
+  it("refuses two local sides, and says which command that is", () => {
+    const direction = transferDirection("./a", "./b");
+    expect(direction.ok).toBe(false);
+    if (!direction.ok) expect(direction.error).toContain("one side must be <project>:<path>");
+  });
+
+  it("refuses two remote sides rather than routing a Core-to-Core copy through this laptop", () => {
+    const direction = transferDirection("api:build", "web:public");
+    expect(direction.ok).toBe(false);
+    if (!direction.ok) expect(direction.error).toContain("A transfer has one local side");
+  });
+});
+
+describe("a single file pointed at a folder takes its own name", () => {
+  // Path *shaping*, not path validation: nothing here asks whether the
+  // destination exists on the Core or is legal there. It decides what string to
+  // send when the operator's ended in a separator, which is what `cp` does.
+  it("appends the basename when the remote path ends in a slash", () => {
+    expect(remoteFileDestination("docs/", "./notes.md")).toBe("docs/notes.md");
+  });
+
+  it("appends it when the remote path is the Project root", () => {
+    expect(remoteFileDestination("", "./notes.md")).toBe("notes.md");
+  });
+
+  it("leaves a named destination exactly as typed, including a rename", () => {
+    expect(remoteFileDestination("docs/readme.md", "./notes.md")).toBe("docs/readme.md");
+  });
+});

--- a/packages/cli/src/__tests__/project-files-gateway.test.ts
+++ b/packages/cli/src/__tests__/project-files-gateway.test.ts
@@ -1,0 +1,110 @@
+// The seam between the SDK's file surface and the two verbs above it (#168).
+//
+// One thing is worth testing here and it is not the plumbing: **which SDK error
+// becomes which kind, and whether the Core's sentence survives the trip.** The
+// F8 refusal is the reason — #168 asks that a transfer refused by the
+// one-write-per-Project rule *say who holds it, not just "busy"* — and the only
+// place that can be lost is this mapping. Every verb's message is built from
+// what comes out of here.
+
+import { describe, it, expect } from "vitest";
+import { ProjectFilesError, projectFilesErrorFrom } from "../project-files-gateway.ts";
+import {
+  CoreFilesConflictError,
+  CoreFilesRequestError,
+  CoreFilesStreamError,
+  CoreFilesUnavailableError,
+} from "@actana/sdk/core-files-http.ts";
+
+/** The Core's real words, from `transferInProgress` in core-files-routes.ts. */
+const CORE_CONFLICT =
+  "another write transfer is already running on this Project " +
+  "(vendor/, started 2026-08-13T09:15:00.000Z) — " +
+  "one write at a time per Project; reads are unrestricted and concurrent";
+
+describe("the F8 refusal keeps the only answer to `busy with what?`", () => {
+  it("becomes a conflict, with the Core's sentence intact", () => {
+    const translated = projectFilesErrorFrom(
+      new CoreFilesConflictError(409, "transfer-in-progress", CORE_CONFLICT),
+    );
+
+    expect(translated).toBeInstanceOf(ProjectFilesError);
+    const error = translated as ProjectFilesError;
+    expect(error.kind).toBe("conflict");
+    // Word for word. A client that shortened this to "the Project is busy"
+    // would be discarding the path and the start time, which are the two facts
+    // an operator can actually act on.
+    expect(error.message).toBe(CORE_CONFLICT);
+    expect(error.message).toContain("vendor/");
+    expect(error.message).toContain("2026-08-13T09:15:00.000Z");
+  });
+
+  it("keeps the code a script branches on, separately from the prose", () => {
+    // A message is a sentence somebody will reword; `transfer-in-progress` is
+    // the contract.
+    const error = projectFilesErrorFrom(
+      new CoreFilesConflictError(409, "transfer-in-progress", CORE_CONFLICT),
+    ) as ProjectFilesError;
+    expect(error.code).toBe("transfer-in-progress");
+  });
+
+  it("keeps `directory-in-the-way` a conflict too — it shares the status and the rule", () => {
+    const error = projectFilesErrorFrom(
+      new CoreFilesConflictError(409, "directory-in-the-way", "config is a directory holding 4 entries"),
+    ) as ProjectFilesError;
+    expect(error.kind).toBe("conflict");
+    expect(error.message).toContain("4 entries");
+  });
+});
+
+describe("the rest of the taxonomy", () => {
+  it("keeps a Core with no file surface distinguishable from an outage", () => {
+    // Not a fault and not a needs-update: it is every Core that shipped before
+    // the surface existed (F9), and the operator should be told that rather
+    // than sent to check their network.
+    const error = projectFilesErrorFrom(
+      new CoreFilesUnavailableError("this Core announced no `files` capability"),
+    ) as ProjectFilesError;
+    expect(error.kind).toBe("unavailable");
+    expect(error.message).toContain("no `files` capability");
+  });
+
+  it("separates a 404 from every other refusal", () => {
+    const error = projectFilesErrorFrom(
+      new CoreFilesRequestError(404, "not-found", "src/nope does not exist in this Project"),
+    ) as ProjectFilesError;
+    expect(error.kind).toBe("not-found");
+    expect(error.code).toBe("not-found");
+  });
+
+  it("carries a path refusal through as the Core worded it, and does not second-guess it", () => {
+    // The other half of "no client-side path validation": this side has no
+    // opinion about `dot-dot-segment`, it just reports what came back.
+    const error = projectFilesErrorFrom(
+      new CoreFilesRequestError(400, "dot-dot-segment", "../escape leaves the Project root"),
+    ) as ProjectFilesError;
+    expect(error.kind).toBe("refused");
+    expect(error.message).toContain("leaves the Project root");
+  });
+
+  it("says a stream failure was part-way through, because that changes what to do next", () => {
+    const error = projectFilesErrorFrom(
+      new CoreFilesStreamError("write-failed", "ENOSPC writing vendor/big.bin"),
+    ) as ProjectFilesError;
+    expect(error.kind).toBe("refused");
+    // A retry after this one is resuming into a half-written tree, not starting
+    // clean, and the operator is the one who has to decide about that.
+    expect(error.message).toContain("part-way through");
+    expect(error.message).toContain("ENOSPC");
+  });
+
+  it("passes an ordinary error through untouched rather than dressing it up", () => {
+    const original = new Error("socket hang up");
+    expect(projectFilesErrorFrom(original)).toBe(original);
+  });
+
+  it("does not re-wrap one of its own", () => {
+    const already = new ProjectFilesError("no-such-project", 'this Core has no Project "nope"');
+    expect(projectFilesErrorFrom(already)).toBe(already);
+  });
+});

--- a/packages/cli/src/__tests__/project-files-live.test.ts
+++ b/packages/cli/src/__tests__/project-files-live.test.ts
@@ -191,7 +191,7 @@ describe("the Core names the overwrites, and the CLI prints what it named", () =
 });
 
 describe("project files reads the Core's real listing route", () => {
-  it("lists the tree with modes, and --json is one array", async () => {
+  it("lists the tree with modes, and --json is one document", async () => {
     await withRegisteredCore();
     const core = await startCore();
     buildTree(core.root);
@@ -199,12 +199,14 @@ describe("project files reads the Core's real listing route", () => {
     const run = await cli().run(["project", "files", "api", "--json"], { files: core.open });
 
     expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
-    const payload = JSON.parse(run.out.join("\n")) as Array<{
-      path: string;
-      kind: string;
-      mode: number;
-      sha256: string | null;
-    }>;
+    const document = JSON.parse(run.out.join("\n")) as {
+      entries: Array<{ path: string; kind: string; mode: number; sha256: string | null }>;
+      truncated: boolean;
+    };
+    // Nothing asked for a `--limit`, so the Core's walk ended on its own and
+    // the document says the tree is whole.
+    expect(document.truncated).toBe(false);
+    const payload = document.entries;
     const deploy = payload.find((row) => row.path === "bin/deploy");
     expect(deploy).toBeDefined();
     expect(deploy!.mode & 0o777).toBe(0o755);
@@ -222,7 +224,8 @@ describe("project files reads the Core's real listing route", () => {
       files: core.open,
     });
 
-    const [row] = JSON.parse(run.out.join("\n")) as Array<{ sha256: string | null }>;
+    const [row] = (JSON.parse(run.out.join("\n")) as { entries: Array<{ sha256: string | null }> })
+      .entries;
     // sha256 of "hello\n".
     expect(row!.sha256).toBe("5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03");
   });
@@ -236,7 +239,9 @@ describe("project files reads the Core's real listing route", () => {
       files: core.open,
     });
 
-    const paths = (JSON.parse(run.out.join("\n")) as Array<{ path: string }>).map((row) => row.path);
+    const paths = (
+      JSON.parse(run.out.join("\n")) as { entries: Array<{ path: string }> }
+    ).entries.map((row) => row.path);
     expect(paths).toContain("bin");
     expect(paths).not.toContain("bin/deploy");
   });

--- a/packages/cli/src/__tests__/project-files-live.test.ts
+++ b/packages/cli/src/__tests__/project-files-live.test.ts
@@ -1,0 +1,269 @@
+// `project cp` and `project files`, against the **Core's own file routes** on a
+// real socket over a real disk (#168).
+//
+// Every other suite for these verbs replaces the gateway, which is the right
+// trade for a table, an exit code or a flag. It is the wrong one for the two
+// claims that are about a *format* rather than about this program:
+//
+//   - the archive this CLI packs is one the Core's unpacker accepts, and the
+//     executable bit survives the trip onto the Core's disk
+//   - the archive the Core packs is one this CLI unpacks, and the bit survives
+//     coming back
+//
+// A tar that only round-trips through its own codec proves neither, and the
+// failure mode is the worst kind: green here, and a corrupt-archive refusal the
+// first time somebody copies a folder to a real Core.
+//
+// So the whole path is real except one link. `createCoreFilesRequestHandler` is
+// the Core's actual handler, mounted the way `core-files-wiring.ts` mounts it;
+// the SDK's `CoreFiles` is the real client; `undici` really dials loopback. Only
+// the core link is stubbed, because the single thing this CLI uses it for on
+// this path is turning the name `api` into a Project id, and standing a whole
+// PTY server up to answer one frame would not make the tar any more real.
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createCoreFilesRequestHandler } from "@actana/core/core-files-routes";
+import { CoreFiles } from "@actana/sdk/core-files.ts";
+import { createCoreFilesFetch } from "@actana/sdk/core-files-http.ts";
+import { makeCliFixture, sentinelBlobText, type CliFixture } from "./cli-harness.ts";
+import { bindProjectFiles, type OpenProjectFilesFn } from "../project-files-gateway.ts";
+import { EXIT_FAILURE, EXIT_OK } from "../exit-codes.ts";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+
+const temporary: string[] = [];
+const servers: http.Server[] = [];
+
+function scratch(): string {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "actana-live-")));
+  temporary.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  fixture?.cleanup();
+  fixture = null;
+  while (servers.length > 0) {
+    const server = servers.pop()!;
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  while (temporary.length > 0) fs.rmSync(temporary.pop()!, { recursive: true, force: true });
+});
+
+const PROJECT = { projectId: "proj_live", name: "api", path: "" };
+
+/** The Core's file surface on loopback, and a `deps.openFiles` pointed at it. */
+async function startCore(): Promise<{ root: string; open: OpenProjectFilesFn }> {
+  const root = scratch();
+  const routes = createCoreFilesRequestHandler({
+    filesPort: { projectRoot: (id) => (id === PROJECT.projectId ? root : null) },
+  });
+  const server = http.createServer((req, res) => {
+    if (routes.handle(req, res)) return;
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ code: "not-found", error: "no route" }));
+  });
+  server.on("checkContinue", (req, res) => {
+    if (routes.handleContinue(req, res)) return;
+    res.writeHead(404).end();
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("the Core did not bind a port");
+
+  const files = new CoreFiles({
+    projectId: PROJECT.projectId,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    bearer: null,
+    // A loopback Core authenticates neither its link nor its routes, which is
+    // the trade `core-files-wiring.ts` states out loud.
+    availability: () => ({ available: true }),
+    fetch: createCoreFilesFetch(null),
+  });
+
+  return {
+    root,
+    open: async () => ({
+      project: async () => bindProjectFiles(files, { ...PROJECT, path: root }),
+      close: () => {},
+    }),
+  };
+}
+
+async function withRegisteredCore(): Promise<void> {
+  expect((await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() })).code).toBe(EXIT_OK);
+}
+
+/** A folder with an executable in it, which is the point of the ticket. */
+function buildTree(root: string): string {
+  fs.mkdirSync(path.join(root, "bin"), { recursive: true });
+  fs.writeFileSync(path.join(root, "readme.md"), "hello\n");
+  fs.writeFileSync(path.join(root, "bin", "deploy"), "#!/bin/sh\necho hi\n");
+  fs.chmodSync(path.join(root, "bin", "deploy"), 0o755);
+  return root;
+}
+
+describe("a folder copies both ways through a real Core, and keeps its executable bits", () => {
+  it("lands on the Core's disk with the modes it left with", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    const source = buildTree(scratch());
+
+    const run = await cli().run(["project", "cp", source, "api:build"], { files: core.open });
+
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    // On the Core's disk, written by the Core's own unpacker out of the archive
+    // this CLI packed. This is the assertion the faked suites cannot make.
+    expect(fs.readFileSync(path.join(core.root, "build", "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.statSync(path.join(core.root, "build", "bin", "deploy")).mode & 0o777).toBe(0o755);
+  });
+
+  it("comes back with them, out of the archive the Core packed", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    buildTree(path.join(core.root, "build"));
+    const dest = path.join(scratch(), "pulled");
+
+    const run = await cli().run(["project", "cp", "api:build", dest], { files: core.open });
+
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    expect(fs.readFileSync(path.join(dest, "readme.md"), "utf8")).toBe("hello\n");
+    expect(fs.statSync(path.join(dest, "bin", "deploy")).mode & 0o777).toBe(0o755);
+  });
+
+  it("round-trips a single file with its mode", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    const source = scratch();
+    fs.writeFileSync(path.join(source, "run.sh"), "#!/bin/sh\n");
+    fs.chmodSync(path.join(source, "run.sh"), 0o755);
+
+    expect(
+      (await cli().run(["project", "cp", path.join(source, "run.sh"), "api:bin/run.sh"], {
+        files: core.open,
+      })).code,
+    ).toBe(EXIT_OK);
+    expect(fs.statSync(path.join(core.root, "bin", "run.sh")).mode & 0o777).toBe(0o755);
+
+    const back = path.join(scratch(), "run.sh");
+    expect((await cli().run(["project", "cp", "api:bin/run.sh", back], { files: core.open })).code).toBe(
+      EXIT_OK,
+    );
+    expect(fs.readFileSync(back, "utf8")).toBe("#!/bin/sh\n");
+    expect(fs.statSync(back).mode & 0o777).toBe(0o755);
+  });
+});
+
+describe("the Core names the overwrites, and the CLI prints what it named", () => {
+  it("reports a second copy over the first as overwrites, by path", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    const source = buildTree(scratch());
+
+    expect((await cli().run(["project", "cp", source, "api:build"], { files: core.open })).code).toBe(
+      EXIT_OK,
+    );
+    const second = await cli().run(["project", "cp", source, "api:build", "--json"], {
+      files: core.open,
+    });
+
+    expect(second.code).toBe(EXIT_OK);
+    const payload = JSON.parse(second.out.join("\n"));
+    // The Core decided these, entry by entry, and they arrived on its NDJSON
+    // progress stream. Nothing here guessed — and the paths are the Core's
+    // own, which is to say **Project-relative** rather than relative to the
+    // archive: `build/readme.md` is what an operator would type back into
+    // `project files`, and it is what the Core reports.
+    expect(payload.overwritten).toContain("build/readme.md");
+    expect(payload.overwritten).toContain("build/bin/deploy");
+    expect(payload.written).toBe(payload.entries - payload.overwritten.length);
+  });
+});
+
+describe("project files reads the Core's real listing route", () => {
+  it("lists the tree with modes, and --json is one array", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    buildTree(core.root);
+
+    const run = await cli().run(["project", "files", "api", "--json"], { files: core.open });
+
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n")) as Array<{
+      path: string;
+      kind: string;
+      mode: number;
+      sha256: string | null;
+    }>;
+    const deploy = payload.find((row) => row.path === "bin/deploy");
+    expect(deploy).toBeDefined();
+    expect(deploy!.mode & 0o777).toBe(0o755);
+    expect(payload.find((row) => row.path === "bin")?.kind).toBe("directory");
+    // Off unless asked for: a listing has no bytes in hand (ADR 0027 D6).
+    expect(payload.every((row) => row.sha256 === null)).toBe(true);
+  });
+
+  it("asks the Core for digests when --sha256 is typed, and gets them", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    fs.writeFileSync(path.join(core.root, "a.txt"), "hello\n");
+
+    const run = await cli().run(["project", "files", "api", "--sha256", "--json"], {
+      files: core.open,
+    });
+
+    const [row] = JSON.parse(run.out.join("\n")) as Array<{ sha256: string | null }>;
+    // sha256 of "hello\n".
+    expect(row!.sha256).toBe("5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03");
+  });
+
+  it("descends only as far as --depth says", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    buildTree(core.root);
+
+    const run = await cli().run(["project", "files", "api", "--depth", "1", "--json"], {
+      files: core.open,
+    });
+
+    const paths = (JSON.parse(run.out.join("\n")) as Array<{ path: string }>).map((row) => row.path);
+    expect(paths).toContain("bin");
+    expect(paths).not.toContain("bin/deploy");
+  });
+});
+
+describe("the Core answers for its own disk, and the CLI does not pre-empt it", () => {
+  it("passes a `..` path through and reports the Core's refusal", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+    const source = buildTree(scratch());
+
+    const run = await cli().run(["project", "cp", source, "api:../escape"], { files: core.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    // The Core's code and the Core's words — this side had no opinion, which is
+    // what F3 and F11 ask of it.
+    expect(run.err.join("\n")).toContain("dot-dot-segment");
+    expect(fs.existsSync(path.join(path.dirname(core.root), "escape"))).toBe(false);
+  });
+
+  it("reports a path that is not there rather than inventing an empty listing", async () => {
+    await withRegisteredCore();
+    const core = await startCore();
+
+    const run = await cli().run(["project", "files", "api:nope"], { files: core.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("actana project files:");
+  });
+});

--- a/packages/cli/src/__tests__/project-files-ls.test.ts
+++ b/packages/cli/src/__tests__/project-files-ls.test.ts
@@ -2,10 +2,13 @@
 //
 // The claim under test is the ticket's fourth "done when": *`project files
 // --json` is machine-readable, like every other list command in the CLI.* What
-// makes that true is not that a JSON flag exists, but that its output has the
-// same shape every other list in this tree emits — one array, alone on stdout,
-// with the diagnostics that would corrupt it on stderr. The rest of the suite
-// is the table, the two flags that cost the Core real work, and the exit codes.
+// makes that true is not that a JSON flag exists, but that its output is one
+// document, alone on stdout, with the diagnostics that would corrupt it on
+// stderr — and that the document says everything the answer depends on. That
+// last part is why this verb carries `{entries, truncated}` where `project ls`
+// carries a bare array: `--limit` can clip the answer, and a consumer reading
+// stdout has no other way to find out. The rest of the suite is the table, the
+// two flags that cost the Core real work, and the exit codes.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { fakeProjectFiles, makeCliFixture, sentinelBlobText, type CliFixture } from "./cli-harness.ts";
@@ -38,7 +41,7 @@ const TREE: CoreFileEntry[] = [
 ];
 
 describe("--json is machine-readable, like every other list command", () => {
-  it("emits one array on stdout and nothing else, with --verbose on", async () => {
+  it("emits one document on stdout and nothing else, with --verbose on", async () => {
     await withRegisteredCore();
     const files = fakeProjectFiles({ entries: TREE });
 
@@ -48,25 +51,28 @@ describe("--json is machine-readable, like every other list command", () => {
 
     expect(run.code).toBe(EXIT_OK);
     const payload = JSON.parse(run.out.join("\n"));
-    expect(payload).toEqual([
-      { path: "bin", kind: "directory", size: 0, mtime: 1_760_000_000_000, mode: 0o755, sha256: null },
-      {
-        path: "bin/deploy",
-        kind: "file",
-        size: 18,
-        mtime: 1_760_000_000_000,
-        mode: 0o755,
-        sha256: null,
-      },
-      { path: "readme.md", kind: "file", size: 6, mtime: 1_760_000_000_000, mode: 0o644, sha256: null },
-      { path: "link.md", kind: "symlink", size: 9, mtime: 1_760_000_000_000, mode: 0o777, sha256: null },
-    ]);
+    expect(payload).toEqual({
+      entries: [
+        { path: "bin", kind: "directory", size: 0, mtime: 1_760_000_000_000, mode: 0o755, sha256: null },
+        {
+          path: "bin/deploy",
+          kind: "file",
+          size: 18,
+          mtime: 1_760_000_000_000,
+          mode: 0o755,
+          sha256: null,
+        },
+        { path: "readme.md", kind: "file", size: 6, mtime: 1_760_000_000_000, mode: 0o644, sha256: null },
+        { path: "link.md", kind: "symlink", size: 9, mtime: 1_760_000_000_000, mode: 0o777, sha256: null },
+      ],
+      truncated: false,
+    });
     // The diagnostics went somewhere, and it was not the stream being parsed.
     expect(run.err.length).toBeGreaterThan(0);
     expect(files.closed, "project files left the gateway open").toBe(true);
   });
 
-  it("emits an empty array for an empty Project, not a sentence", async () => {
+  it("emits an empty entries array for an empty Project, not a sentence", async () => {
     // The shape a script reads must not change with the number of rows: `[]` is
     // an answer, and "Nothing under api." is a parse error.
     await withRegisteredCore();
@@ -75,7 +81,7 @@ describe("--json is machine-readable, like every other list command", () => {
     const run = await cli().run(["project", "files", "api", "--json"], { files: files.open });
 
     expect(run.code).toBe(EXIT_OK);
-    expect(JSON.parse(run.out.join("\n"))).toEqual([]);
+    expect(JSON.parse(run.out.join("\n"))).toEqual({ entries: [], truncated: false });
   });
 
   it("carries the mode as a number, so a consumer can test the executable bit", async () => {
@@ -84,8 +90,60 @@ describe("--json is machine-readable, like every other list command", () => {
 
     const run = await cli().run(["project", "files", "api", "--json"], { files: files.open });
 
-    const [row] = JSON.parse(run.out.join("\n"));
+    const [row] = JSON.parse(run.out.join("\n")).entries;
     expect(row.mode & 0o111).toBeTruthy();
+  });
+});
+
+describe("a clipped listing says so in the document, not only on stderr", () => {
+  // The gap this closes: a script running `--json --limit 100` could not tell a
+  // complete tree from a clipped one, and the warning it would have needed was
+  // on the stream it does not read.
+  it("carries truncated:true, and the entries it did read", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api", "--json", "--limit", "2"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.truncated).toBe(true);
+    expect(payload.entries.map((row: { path: string }) => row.path)).toEqual(["bin", "bin/deploy"]);
+    // Still exactly one document on stdout — the fact went into it, not beside it.
+    expect(run.err.join("\n")).toContain("--limit 2");
+  });
+
+  it("says truncated:false when the tree holds exactly --limit entries", async () => {
+    // The false positive: stopping at `>=` made a tree of exactly four entries
+    // claim there was a fifth. There is not, and a warning that fires on an
+    // exact fit is one an operator learns to ignore.
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api", "--json", "--limit", "4"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.truncated).toBe(false);
+    expect(payload.entries).toHaveLength(4);
+    expect(run.err.join("\n")).not.toContain("--limit");
+  });
+
+  it("stays quiet on an exact fit in the table mode too", async () => {
+    // Same rule, the other output mode — the count is decided before either
+    // branch, so neither can disagree with the other about it.
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api", "--limit", "4"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).toContain("link.md");
+    expect(run.err.join("\n")).not.toContain("--limit");
   });
 });
 

--- a/packages/cli/src/__tests__/project-files-ls.test.ts
+++ b/packages/cli/src/__tests__/project-files-ls.test.ts
@@ -1,0 +1,216 @@
+// `actana project files` — the listing (#168).
+//
+// The claim under test is the ticket's fourth "done when": *`project files
+// --json` is machine-readable, like every other list command in the CLI.* What
+// makes that true is not that a JSON flag exists, but that its output has the
+// same shape every other list in this tree emits — one array, alone on stdout,
+// with the diagnostics that would corrupt it on stderr. The rest of the suite
+// is the table, the two flags that cost the Core real work, and the exit codes.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { fakeProjectFiles, makeCliFixture, sentinelBlobText, type CliFixture } from "./cli-harness.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
+import type { CoreFileEntry } from "@actana/sdk/core-files.ts";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+});
+
+async function withRegisteredCore(): Promise<void> {
+  expect((await cli().run(["core", "add", "prod"], { stdin: sentinelBlobText() })).code).toBe(EXIT_OK);
+}
+
+function entry(overrides: Partial<CoreFileEntry> & Pick<CoreFileEntry, "path">): CoreFileEntry {
+  return { size: 0, mtime: 1_760_000_000_000, mode: 0o644, sha256: null, ...overrides };
+}
+
+const TREE: CoreFileEntry[] = [
+  entry({ path: "bin", kind: "directory", mode: 0o755 }),
+  entry({ path: "bin/deploy", kind: "file", size: 18, mode: 0o755 }),
+  entry({ path: "readme.md", kind: "file", size: 6 }),
+  entry({ path: "link.md", kind: "symlink", size: 9, mode: 0o777 }),
+];
+
+describe("--json is machine-readable, like every other list command", () => {
+  it("emits one array on stdout and nothing else, with --verbose on", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api", "--json", "--verbose"], {
+      files: files.open,
+    });
+
+    expect(run.code).toBe(EXIT_OK);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload).toEqual([
+      { path: "bin", kind: "directory", size: 0, mtime: 1_760_000_000_000, mode: 0o755, sha256: null },
+      {
+        path: "bin/deploy",
+        kind: "file",
+        size: 18,
+        mtime: 1_760_000_000_000,
+        mode: 0o755,
+        sha256: null,
+      },
+      { path: "readme.md", kind: "file", size: 6, mtime: 1_760_000_000_000, mode: 0o644, sha256: null },
+      { path: "link.md", kind: "symlink", size: 9, mtime: 1_760_000_000_000, mode: 0o777, sha256: null },
+    ]);
+    // The diagnostics went somewhere, and it was not the stream being parsed.
+    expect(run.err.length).toBeGreaterThan(0);
+    expect(files.closed, "project files left the gateway open").toBe(true);
+  });
+
+  it("emits an empty array for an empty Project, not a sentence", async () => {
+    // The shape a script reads must not change with the number of rows: `[]` is
+    // an answer, and "Nothing under api." is a parse error.
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: [] });
+
+    const run = await cli().run(["project", "files", "api", "--json"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(JSON.parse(run.out.join("\n"))).toEqual([]);
+  });
+
+  it("carries the mode as a number, so a consumer can test the executable bit", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: [entry({ path: "run.sh", kind: "file", mode: 0o755 })] });
+
+    const run = await cli().run(["project", "files", "api", "--json"], { files: files.open });
+
+    const [row] = JSON.parse(run.out.join("\n"));
+    expect(row.mode & 0o111).toBeTruthy();
+  });
+});
+
+describe("the table a person reads", () => {
+  it("shows the mode, the size and the path, with ls -F endings", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    const out = run.out.join("\n");
+    expect(out).toContain("MODE");
+    // Octal, because the reason this surface carries a mode at all is the
+    // executable bit surviving a transfer, and 755 is how somebody about to
+    // type `chmod` thinks about it.
+    expect(out).toContain("755");
+    expect(out).toContain("bin/");
+    expect(out).toContain("link.md@");
+    expect(out).not.toContain("SHA256");
+  });
+
+  it("says so plainly when there is nothing there", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: [] });
+    const run = await cli().run(["project", "files", "api:src"], { files: files.open });
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).toContain("Nothing under api:src");
+  });
+});
+
+describe("the flags that cost the Core work are opt-in", () => {
+  it("asks for no digests unless --sha256 was typed", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    await cli().run(["project", "files", "api"], { files: files.open });
+
+    // A listing has no bytes in hand, so a digest means reading every file
+    // under the path (ADR 0027 D6). Off is the Core's default and this one's.
+    expect(files.lists[0]).not.toHaveProperty("sha256");
+  });
+
+  it("passes --sha256 through and gives the digest a column", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({
+      entries: [entry({ path: "a.txt", kind: "file", sha256: "abc123" })],
+    });
+
+    const run = await cli().run(["project", "files", "api", "--sha256"], { files: files.open });
+
+    expect(files.lists[0]).toMatchObject({ sha256: true });
+    expect(run.out.join("\n")).toContain("SHA256");
+    expect(run.out.join("\n")).toContain("abc123");
+  });
+
+  it("passes a subtree and a --depth straight through", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    await cli().run(["project", "files", "api:src/lib", "--depth", "2"], { files: files.open });
+
+    expect(files.resolved).toEqual(["api"]);
+    expect(files.lists[0]).toMatchObject({ path: "src/lib", depth: 2 });
+  });
+
+  it("refuses a --depth that is not a number of levels, before dialling", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "files", "api", "--depth", "all"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--depth all");
+  });
+
+  it("stops at --limit and says the tree has more", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({ entries: TREE });
+
+    const run = await cli().run(["project", "files", "api", "--limit", "2"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).toContain("bin/deploy");
+    expect(run.out.join("\n")).not.toContain("readme.md");
+    // Silently truncating a listing is how a script comes to believe a folder
+    // has two files in it.
+    expect(run.err.join("\n")).toContain("--limit 2");
+  });
+});
+
+describe("the command line", () => {
+  it("needs a Project, and dials nothing to say so", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "files"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("a Project is required");
+  });
+
+  it("takes the subtree inside the same argument, not as a second one", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "files", "api", "src"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("api:src/lib");
+  });
+
+  it("reports a refusal on stderr, and as a document when --json promised one", async () => {
+    await withRegisteredCore();
+    const files = fakeProjectFiles({
+      entries: [],
+      listFails: new Error("src/nope does not exist in this Project (not-found)"),
+    });
+
+    const run = await cli().run(["project", "files", "api:src/nope", "--json"], { files: files.open });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(run.out.join("\n")).error).toContain("not-found");
+    expect(run.err.join("\n")).toContain("actana project files:");
+  });
+
+  it("reports a Core that never answered", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["project", "files", "api"], {
+      files: async () => {
+        throw new Error("connect ECONNREFUSED");
+      },
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("did not answer");
+  });
+});

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -14,6 +14,7 @@ import { openCoreShell } from "./core-shell-channel.ts";
 import { terminalFromProcess } from "./cli-terminal.ts";
 import { connectCore } from "./core-connection.ts";
 import { openSessionGateway } from "./session-gateway.ts";
+import { openProjectFiles } from "./project-files-gateway.ts";
 import { openSessionAttach } from "./session-attach-channel.ts";
 import { EXIT_FAILURE } from "./exit-codes.ts";
 import { homedir } from "node:os";
@@ -45,6 +46,10 @@ const code = await runActanaCli({
   probe: probeCore,
   connect: connectCore,
   openSessions: openSessionGateway,
+  // The file surface, which is the one thing in this program that does not
+  // cross the core link: `project cp` and `project files` reach the Core's
+  // HTTPS routes through the SDK (ADR 0028, #129 F12).
+  openFiles: openProjectFiles,
   now: () => Date.now(),
   // The real terminal, and the only place one is built. `core shell` is what
   // uses it; every other verb is handed it and never asks. It takes `process`

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -53,9 +53,14 @@ export const CLI_VERSION: string = manifest.version;
  * #160 built `session`, #161 built `project`, `harness` and `events`, and each
  * row left as its noun landed. The table stays because the distinction it draws
  * has not gone anywhere — a noun a later phase adds owes the reader a ticket
- * number, and a row here is the whole of saying so. The reservations this build
- * still carries are at the verb level: `project cp` / `project files` (#168,
- * phase-3 guardrail 3) and `core shell` (#162).
+ * number, and a row here is the whole of saying so.
+ *
+ * As of #168 the *verb*-level table in `project-command.ts` is empty too:
+ * `project cp` and `project files` were the last two reservations in the tree,
+ * and building them is what took them out of it. Nothing in this build answers
+ * {@link EXIT_UNIMPLEMENTED} any more — which is a fact about this train, not a
+ * reason to delete the mechanism, since #210 (`project rm`) and #211
+ * (`--model`) are the next things that will need it.
  */
 const RESERVED_NOUNS: Record<string, string> = {};
 
@@ -66,7 +71,7 @@ Usage
 
 Nouns
   core      register, select and inspect the Cores this machine can reach
-  project   the Projects a Core owns: ls, add, browse
+  project   the Projects a Core owns: ls, add, browse, files, cp
   harness   the coding agents a Core can run: ls, install
   events    follow a Core's event log: tail
   session   start, ls, logs, resume, kill and send to Sessions on one

--- a/packages/cli/src/cli-args.ts
+++ b/packages/cli/src/cli-args.ts
@@ -36,6 +36,20 @@ export type ParsedArgs = {
   kind: string[];
   /** `--limit <n>` — stop after this many rows. Raw, for the same reason as `since`. */
   limit: string | null;
+  // ─── The `project` noun's file flags (#168) ───
+  /**
+   * `--depth <n>` — how far `project files` descends. Raw, like `--limit`: the
+   * verb that reads it is the one that can say what `--depth all` means.
+   */
+  depth: string | null;
+  /**
+   * `--sha256`: ask the Core to digest every file in a listing.
+   *
+   * Off by default and not free — a listing has no bytes in hand, so a digest
+   * means reading every one of them (ADR 0027 D6). A flag rather than always-on
+   * for that reason alone.
+   */
+  sha256: boolean;
   // ─── The `session` noun's flags (#160) ───
   /** `--wait`: block until the Core reports a started Session settled. */
   wait: boolean;
@@ -74,6 +88,7 @@ const VALUE_FLAGS = new Set([
   "--since",
   "--kind",
   "--limit",
+  "--depth",
   "--wait-timeout",
   "--harness",
   "--cwd",
@@ -92,6 +107,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     since: null,
     kind: [],
     limit: null,
+    depth: null,
+    sha256: false,
     wait: false,
     waitTimeout: null,
     harness: null,
@@ -138,6 +155,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       // comma-joined string — puts a second syntax inside a flag value.
       else if (name === "--kind") parsed.kind.push(value);
       else if (name === "--limit") parsed.limit = value;
+      else if (name === "--depth") parsed.depth = value;
       else if (name === "--wait-timeout") parsed.waitTimeout = value;
       else if (name === "--harness") parsed.harness = value;
       else if (name === "--cwd") parsed.cwd = value;
@@ -151,6 +169,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--verbose":
         parsed.verbose = true;
+        break;
+      case "--sha256":
+        parsed.sha256 = true;
         break;
       case "--wait":
         parsed.wait = true;

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -12,6 +12,7 @@ import type { CliTerminal } from "./cli-terminal.ts";
 import type { OpenCoreShellFn } from "./core-shell-channel.ts";
 import type { CoreConnectFn } from "./core-connection.ts";
 import type { OpenSessionGateway } from "./session-gateway.ts";
+import type { OpenProjectFilesFn } from "./project-files-gateway.ts";
 import type { OpenSessionAttachFn } from "./session-attach-channel.ts";
 
 export type ActanaCliDeps = {
@@ -54,6 +55,19 @@ export type ActanaCliDeps = {
   connect: CoreConnectFn;
   /** How the `session` noun reaches a Core. See `session-gateway.ts`. */
   openSessions: OpenSessionGateway;
+  /**
+   * How `project cp` and `project files` reach a Core's file surface. See
+   * `project-files-gateway.ts` (#129 F12, #168).
+   *
+   * Its own seam rather than a verb on {@link connect}, because it is its own
+   * *protocol*: a Project's files cross the Core's HTTPS routes and deliberately
+   * not the core link (ADR 0028), so the client behind this is one that has both
+   * — a socket to resolve a Project's name on, and a `fetch` with the same mTLS
+   * material for the bytes. {@link CoreLinkClient} describes the socket half
+   * only, and widening it would put a file surface on the three nouns that have
+   * no use for one.
+   */
+  openFiles: OpenProjectFilesFn;
   /** Epoch ms. Only the bearer-expiry line reads it. */
   now: () => number;
   /**

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -23,12 +23,18 @@ export const EXIT_USAGE = 2;
  * should be able to tell them apart without parsing English off stderr.
  *
  * **Every reserved name in the tree returns this, whether noun or verb.** The
- * `session` / `project` / `harness` / `events` nouns (#160, #161, #163) and the
- * `core shell` verb (#162) each returned it until its build landed, and
- * `project cp` / `project files` (#168) still do: they are one fact about one
- * build, and the nouns are what a script written against a later train hits
- * first. Splitting them — 3 for a verb, 2 for a noun — would have meant this
- * comment arguing for a distinction the command tree did not make.
+ * `session` / `project` / `harness` / `events` nouns (#160, #161, #163), the
+ * `core shell` verb (#162) and `project cp` / `project files` (#168) each
+ * returned it until its build landed: they are one fact about one build, and
+ * the nouns are what a script written against a later train hits first.
+ * Splitting them — 3 for a verb, 2 for a noun — would have meant this comment
+ * arguing for a distinction the command tree did not make.
+ *
+ * **Nothing in this build returns it.** #168 built the last two reservations,
+ * so both tables are empty and every name in the tree either works or is a
+ * typo. The code stays exported and documented because the mechanism is what
+ * makes the *next* reservation cheap — `project rm` is #210 — and because a
+ * script that already branches on 3 must keep meaning the same thing by it.
  *
  * What it is *not* for is a verb the protocol cannot carry. `project set-path`
  * exits {@link EXIT_USAGE}, because a Core-owned Project's path is immutable

--- a/packages/cli/src/local-tar.ts
+++ b/packages/cli/src/local-tar.ts
@@ -1,0 +1,768 @@
+// A folder crosses as one streamed tar (ADR 0029), and this is the **local**
+// half of that: packing this machine's disk on the way up, unpacking onto it on
+// the way down.
+//
+// The Core owns the other half (`packages/core/src/files-tar.ts`) and the two
+// never share code — this package cannot import a private workspace package
+// (ADR 0025 D4, and `no-local-escape.test.ts` enforces it), and it should not:
+// the two halves guard different disks and their rules are not the same. What
+// they do share is a format, and it is a thirty-year-old one with an unusually
+// precise definition, so "compatible" here means ustar with pax extensions and
+// is checked against the Core's own codec by `local-tar.test.ts`.
+//
+// ## Why a codec rather than a dependency
+//
+// The same trade the Core made, arriving at the same answer for a different
+// reason. This package publishes with **one** runtime dependency it actually
+// chose (`@actana/sdk`), and `no-local-escape.test.ts` pins the whole list —
+// the CLI being one package deep is a property #129 D8 asks for out loud. A tar
+// library would be the third name on that list, resolved in every stranger's
+// global install, to do about four hundred lines of arithmetic on 512-byte
+// blocks that has not changed since 1988.
+//
+// ## What the executable bit has to do with any of this
+//
+// #168's "a folder copies both ways and keeps its executable bits" is the whole
+// reason a folder is a tar rather than N file writes. A mode is a property of
+// an entry in an archive; it is not a property of an HTTP request, and a
+// transfer that sent bytes and re-created files locally would have to invent a
+// side channel for it — or, as almost every such transfer does, silently give
+// every file 0o644 and leave the operator to discover it when their `./deploy`
+// will not run. `mode & 0o777` rides in the header both ways, and is applied on
+// the way out with an explicit `chmod`, because `open(…, mode)` is masked by
+// the process umask and a `0o755` would land as `0o755 & ~umask`.
+//
+// ## Confinement, and whose disk it is about
+//
+// `unpackTarInto` refuses an entry whose path is absolute, contains a `..`
+// segment, or resolves outside the destination directory. That is **not** the
+// client-side path validation #168 rules out: those rules are about the Core's
+// disk and the Core owns them (F3, F11). This one is about *this* disk, and the
+// bytes being unpacked came off a network. A tar is a list of filenames written
+// by somebody else, and "write it wherever it says" is how an archive
+// overwrites `~/.ssh/authorized_keys`.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const BLOCK = 512;
+const ZERO_BLOCK = new Uint8Array(BLOCK);
+
+/** The ustar type flags this codec writes and reads. */
+const TYPE_FILE = "0";
+const TYPE_FILE_OLD = "\0";
+const TYPE_SYMLINK = "2";
+const TYPE_DIRECTORY = "5";
+const TYPE_PAX_NEXT = "x";
+const TYPE_PAX_GLOBAL = "g";
+const TYPE_GNU_LONGNAME = "L";
+const TYPE_GNU_LONGLINK = "K";
+
+/** The largest size an 11-digit octal ustar field holds: 8 GiB, less a byte. */
+const MAX_USTAR_SIZE = 0o77777777777;
+
+export type LocalTarErrorCode = "corrupt-archive" | "unsafe-entry-path" | "read-failed" | "write-failed";
+
+/** Anything this module refuses or cannot finish, with a code a caller can branch on. */
+export class LocalTarError extends Error {
+  readonly code: LocalTarErrorCode;
+
+  constructor(code: LocalTarErrorCode, message: string) {
+    super(message);
+    this.name = "LocalTarError";
+    this.code = code;
+  }
+}
+
+/** One entry, in the same five-field shape the Core's manifest uses (#129 F10). */
+export type LocalTarEntry = {
+  /** Relative to the tree's root, always `/`-separated — a tar path, not a local one. */
+  path: string;
+  kind: "file" | "directory" | "symlink";
+  size: number;
+  /** Permission bits only. Ownership is deliberately not carried; see {@link packLocalTree}. */
+  mode: number;
+  /** Epoch milliseconds, though a tar header holds seconds and the round trip truncates. */
+  mtime: number;
+};
+
+/** How a written entry landed. `overwritten` is what F5 requires be named. */
+export type LocalWriteOutcome = "written" | "overwritten";
+
+export type UnpackedEntry = LocalTarEntry & { result: LocalWriteOutcome };
+
+// ─── Header codec ────────────────────────────────────────────────────────────
+
+type TarHeader = {
+  name: string;
+  mode: number;
+  size: number;
+  /** Epoch milliseconds. Converted to the header's seconds on the way out. */
+  mtime: number;
+  typeflag: string;
+  linkname: string;
+};
+
+function readString(block: Uint8Array, offset: number, length: number): string {
+  const slice = block.subarray(offset, offset + length);
+  const end = slice.indexOf(0);
+  return Buffer.from(end === -1 ? slice : slice.subarray(0, end)).toString("utf8");
+}
+
+/**
+ * A ustar numeric field: octal, or base-256 for anything that does not fit.
+ *
+ * The high bit of the first byte marks base-256 — a big-endian integer in the
+ * remaining bytes — and it is how GNU tar writes a size the 12-byte octal field
+ * cannot hold. Parsing one as octal yields `NaN`, and treating that as zero
+ * lands the file empty and then desynchronises every entry after it into a
+ * checksum failure, which is a bug report about "a corrupt archive" that is
+ * really a bug about one number.
+ */
+function readOctal(block: Uint8Array, offset: number, length: number): number {
+  const first = block[offset] ?? 0;
+  if ((first & 0x80) !== 0) {
+    if (first === 0xff) {
+      throw new LocalTarError("corrupt-archive", "a tar numeric field is negative, which no field here can be");
+    }
+    let value = first & 0x7f;
+    for (let i = offset + 1; i < offset + length; i += 1) value = value * 256 + (block[i] ?? 0);
+    return value;
+  }
+  const raw = readString(block, offset, length).trim();
+  if (raw.length === 0) return 0;
+  const value = Number.parseInt(raw, 8);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function writeString(block: Uint8Array, offset: number, length: number, value: string): void {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length > length) {
+    // Every overflow has already been routed through a pax record by
+    // `entryHeaderBlocks`, so reaching here is a bug in this file rather than
+    // an archive somebody is not allowed to write.
+    throw new LocalTarError("corrupt-archive", `tar field overflow writing ${JSON.stringify(value)}`);
+  }
+  block.set(bytes, offset);
+}
+
+function writeOctal(block: Uint8Array, offset: number, length: number, value: number): void {
+  const text = Math.max(0, Math.floor(value)).toString(8).padStart(length - 1, "0");
+  writeString(block, offset, length, `${text}\0`);
+}
+
+/**
+ * The header checksum, computed both ways.
+ *
+ * Historic tars summed the header bytes as signed and modern ones as unsigned,
+ * so an archive with a high byte anywhere in a filename matches one and not the
+ * other. Every reader in the world accepts either; rejecting on one would
+ * refuse legitimate output from `tar(1)`.
+ */
+function headerChecksums(block: Uint8Array): { unsigned: number; signed: number } {
+  let unsigned = 0;
+  let signed = 0;
+  for (let i = 0; i < BLOCK; i += 1) {
+    // The checksum field itself is counted as eight spaces, by definition.
+    const byte = i >= 148 && i < 156 ? 0x20 : block[i]!;
+    unsigned += byte;
+    signed += byte > 127 ? byte - 256 : byte;
+  }
+  return { unsigned, signed };
+}
+
+function parseHeader(block: Uint8Array): TarHeader {
+  const stored = readOctal(block, 148, 8);
+  const { unsigned, signed } = headerChecksums(block);
+  if (stored !== unsigned && stored !== signed) {
+    throw new LocalTarError(
+      "corrupt-archive",
+      "a tar header checksum does not match — the archive is damaged, or is not a tar",
+    );
+  }
+  const prefix = readString(block, 345, 155);
+  const name = readString(block, 0, 100);
+  return {
+    name: prefix.length > 0 ? `${prefix}/${name}` : name,
+    mode: readOctal(block, 100, 8) & 0o7777,
+    size: readOctal(block, 124, 12),
+    // ustar mtime is epoch *seconds*; everything this module hands out is
+    // milliseconds, because that is what `fs.Stats` and JSON consumers use.
+    mtime: readOctal(block, 136, 12) * 1000,
+    typeflag: String.fromCharCode(block[156]!),
+    linkname: readString(block, 157, 100),
+  };
+}
+
+function buildHeaderBlock(header: TarHeader): Uint8Array {
+  const block = new Uint8Array(BLOCK);
+  writeString(block, 0, 100, header.name);
+  writeOctal(block, 100, 8, header.mode & 0o7777);
+  // uid and gid are deliberately zero and no uname/gname is written: a transfer
+  // crosses machines that do not share a passwd file, so a preserved numeric
+  // owner restores a *stranger's* uid at the far end. The bit that has to
+  // survive is the executable one, and that rides `mode`.
+  writeOctal(block, 108, 8, 0);
+  writeOctal(block, 116, 8, 0);
+  writeOctal(block, 124, 12, header.size);
+  writeOctal(block, 136, 12, Math.floor(header.mtime / 1000));
+  writeString(block, 148, 8, "        ");
+  block[156] = header.typeflag.charCodeAt(0);
+  writeString(block, 157, 100, header.linkname);
+  writeString(block, 257, 6, "ustar\0");
+  writeString(block, 263, 2, "00");
+  const { unsigned } = headerChecksums(block);
+  writeString(block, 148, 8, `${unsigned.toString(8).padStart(6, "0")}\0 `);
+  return block;
+}
+
+function padding(size: number): number {
+  const remainder = size % BLOCK;
+  return remainder === 0 ? 0 : BLOCK - remainder;
+}
+
+// ─── Packing ─────────────────────────────────────────────────────────────────
+
+/** A pax extended header — how a name, a link target or a size overflows ustar. */
+function* paxRecordBlocks(name: string, records: Record<string, string>): Generator<Uint8Array> {
+  let body = "";
+  for (const [key, value] of Object.entries(records)) {
+    const payload = `${key}=${value}\n`;
+    // The length prefix counts itself, so it is solved for rather than measured.
+    let length = Buffer.byteLength(payload) + 1;
+    while (Buffer.byteLength(`${length}`) + Buffer.byteLength(` ${payload}`) !== length) {
+      length = Buffer.byteLength(`${length}`) + Buffer.byteLength(` ${payload}`);
+    }
+    body += `${length} ${payload}`;
+  }
+  const bytes = Buffer.from(body, "utf8");
+  yield buildHeaderBlock({
+    // Cosmetic — readers key off the type flag — but `tar tv` prints it, so it
+    // says which entry it belongs to.
+    name: `PaxHeaders/${path.basename(name).slice(0, 80)}`,
+    mode: 0o644,
+    size: bytes.length,
+    mtime: 0,
+    typeflag: TYPE_PAX_NEXT,
+    linkname: "",
+  });
+  yield bytes;
+  if (padding(bytes.length) > 0) yield ZERO_BLOCK.subarray(0, padding(bytes.length));
+}
+
+/** One entry's header blocks: a pax header first, when anything overflows ustar. */
+function* entryHeaderBlocks(header: TarHeader): Generator<Uint8Array> {
+  const nameTooLong = Buffer.byteLength(header.name) > 100;
+  const linkTooLong = Buffer.byteLength(header.linkname) > 100;
+  const sizeTooBig = header.size > MAX_USTAR_SIZE;
+  if (nameTooLong || linkTooLong || sizeTooBig) {
+    const records: Record<string, string> = {};
+    if (nameTooLong) records.path = header.name;
+    if (linkTooLong) records.linkpath = header.linkname;
+    if (sizeTooBig) records.size = String(header.size);
+    yield* paxRecordBlocks(header.name, records);
+  }
+  yield buildHeaderBlock({
+    ...header,
+    // Zero rather than the real size: the octal field cannot hold it, and the
+    // pax record above is what a reader takes. A reader that ignores pax sees
+    // an empty entry rather than a wrong one, which is the safe way to be wrong.
+    size: sizeTooBig ? 0 : header.size,
+    name: nameTooLong ? Buffer.from(header.name, "utf8").subarray(0, 100).toString("utf8") : header.name,
+    linkname: linkTooLong ? "" : header.linkname,
+  });
+}
+
+/**
+ * Walk a local directory and stream it as one tar, **lazily**.
+ *
+ * A generator rather than a buffer, for the reason the SDK's whole file surface
+ * is generators: this is handed to `fetch` as a request body, and a `pull` that
+ * reads one chunk per socket-write is what keeps a ten-gigabyte upload at a
+ * constant few hundred kilobytes of memory. Materialising the archive first
+ * would defeat every bit of streaming underneath it.
+ *
+ * Entries are the root's **contents**, at paths relative to it and sorted per
+ * directory — so `cp ./dist api:build` makes `build` a copy of `dist` rather
+ * than putting a `dist` inside it, and so the same tree produces the same bytes
+ * twice, which is what makes a transfer diffable and a test assertable.
+ *
+ * Anything that is not a file, directory or symlink — a socket, a fifo, a
+ * device node — is skipped rather than refused. The operator asked to copy the
+ * folder they have; a `.sock` left behind by a running daemon should not fail
+ * their upload, and it could not be meaningfully recreated on another machine.
+ */
+export async function* packLocalTree(
+  root: string,
+  onEntry?: (entry: LocalTarEntry) => void,
+): AsyncGenerator<Uint8Array> {
+  async function* walk(absolute: string, relative: string): AsyncGenerator<Uint8Array> {
+    const names = (await fs.promises.readdir(absolute)).sort();
+    for (const name of names) {
+      const childAbsolute = path.join(absolute, name);
+      const childRelative = relative.length > 0 ? `${relative}/${name}` : name;
+      const stats = await fs.promises.lstat(childAbsolute);
+
+      if (stats.isSymbolicLink()) {
+        const target = await fs.promises.readlink(childAbsolute);
+        yield* entryHeaderBlocks({
+          name: childRelative,
+          mode: 0o777,
+          size: 0,
+          mtime: stats.mtimeMs,
+          typeflag: TYPE_SYMLINK,
+          linkname: toTarPath(target),
+        });
+        onEntry?.({
+          path: childRelative,
+          kind: "symlink",
+          size: Buffer.byteLength(target),
+          mode: stats.mode & 0o777,
+          mtime: Math.floor(stats.mtimeMs),
+        });
+        continue;
+      }
+
+      if (stats.isDirectory()) {
+        yield* entryHeaderBlocks({
+          name: `${childRelative}/`,
+          mode: stats.mode & 0o777,
+          size: 0,
+          mtime: stats.mtimeMs,
+          typeflag: TYPE_DIRECTORY,
+          linkname: "",
+        });
+        onEntry?.({
+          path: childRelative,
+          kind: "directory",
+          size: 0,
+          mode: stats.mode & 0o777,
+          mtime: Math.floor(stats.mtimeMs),
+        });
+        yield* walk(childAbsolute, childRelative);
+        continue;
+      }
+
+      if (!stats.isFile()) continue;
+
+      yield* entryHeaderBlocks({
+        name: childRelative,
+        mode: stats.mode & 0o777,
+        size: stats.size,
+        mtime: stats.mtimeMs,
+        typeflag: TYPE_FILE,
+        linkname: "",
+      });
+      let written = 0;
+      const handle = await fs.promises.open(childAbsolute, "r");
+      try {
+        for await (const chunk of handle.createReadStream({ autoClose: false })) {
+          const bytes = chunk as Uint8Array;
+          // The header has already promised `stats.size`. A file being appended
+          // to underneath the walk would otherwise desynchronise every entry
+          // after it, so the stream is clamped to what was declared.
+          const room = stats.size - written;
+          if (room <= 0) break;
+          const slice = bytes.length > room ? bytes.subarray(0, room) : bytes;
+          written += slice.length;
+          yield slice;
+        }
+      } finally {
+        await handle.close();
+      }
+      // And a file that shrank leaves the promise unmet, so it is made good
+      // with zeros. Either way the archive stays well-formed.
+      if (written < stats.size) yield new Uint8Array(stats.size - written);
+      if (padding(stats.size) > 0) yield ZERO_BLOCK.subarray(0, padding(stats.size));
+      onEntry?.({
+        path: childRelative,
+        kind: "file",
+        size: stats.size,
+        mode: stats.mode & 0o777,
+        mtime: Math.floor(stats.mtimeMs),
+      });
+    }
+  }
+
+  yield* walk(path.resolve(root), "");
+  // Two zero blocks close a tar.
+  yield ZERO_BLOCK;
+  yield ZERO_BLOCK;
+}
+
+/** A local path as a tar path: `\` is a separator here and never inside an archive. */
+function toTarPath(local: string): string {
+  return local.split(path.sep).join("/");
+}
+
+// ─── Unpacking ───────────────────────────────────────────────────────────────
+
+/** Exactly-sized reads out of a chunked byte source. */
+class ByteReader {
+  private readonly iterator: AsyncIterator<Uint8Array>;
+  private buffered: Buffer[] = [];
+  private available = 0;
+  private exhausted = false;
+
+  constructor(source: AsyncIterable<Uint8Array>) {
+    this.iterator = source[Symbol.asyncIterator]();
+  }
+
+  private async fill(want: number): Promise<void> {
+    while (this.available < want && !this.exhausted) {
+      const next = await this.iterator.next();
+      if (next.done) {
+        this.exhausted = true;
+        return;
+      }
+      const chunk = Buffer.from(next.value.buffer, next.value.byteOffset, next.value.byteLength);
+      if (chunk.length === 0) continue;
+      this.buffered.push(chunk);
+      this.available += chunk.length;
+    }
+  }
+
+  private take(count: number): Buffer {
+    const out = Buffer.allocUnsafe(count);
+    let filled = 0;
+    while (filled < count) {
+      const head = this.buffered[0]!;
+      const usable = Math.min(head.length, count - filled);
+      head.copy(out, filled, 0, usable);
+      filled += usable;
+      if (usable === head.length) this.buffered.shift();
+      else this.buffered[0] = head.subarray(usable);
+    }
+    this.available -= count;
+    return out;
+  }
+
+  /** Exactly `count` bytes, or null at a clean end of stream. Throws on a partial tail. */
+  async exact(count: number): Promise<Buffer | null> {
+    await this.fill(count);
+    if (this.available === 0) return null;
+    if (this.available < count) {
+      throw new LocalTarError(
+        "corrupt-archive",
+        `the tar stream ended mid-record (${this.available} of ${count} bytes) — the transfer was cut short`,
+      );
+    }
+    return this.take(count);
+  }
+
+  /** Up to `max` bytes of whatever has already arrived. */
+  async some(max: number): Promise<Buffer | null> {
+    await this.fill(1);
+    if (this.available === 0) return null;
+    return this.take(Math.min(max, this.available));
+  }
+
+  async skip(count: number): Promise<void> {
+    let left = count;
+    while (left > 0) {
+      const chunk = await this.some(left);
+      if (!chunk) return;
+      left -= chunk.length;
+    }
+  }
+}
+
+function parsePaxRecords(body: Buffer): Record<string, string> {
+  const out: Record<string, string> = {};
+  let offset = 0;
+  while (offset < body.length) {
+    const space = body.indexOf(0x20, offset);
+    if (space === -1) break;
+    const length = Number.parseInt(body.subarray(offset, space).toString("ascii"), 10);
+    if (!Number.isFinite(length) || length <= 0 || offset + length > body.length) break;
+    const record = body.subarray(space + 1, offset + length).toString("utf8");
+    const eq = record.indexOf("=");
+    if (eq > 0) out[record.slice(0, eq)] = record.slice(eq + 1).replace(/\n$/, "");
+    offset += length;
+  }
+  return out;
+}
+
+function isZeroBlock(block: Uint8Array): boolean {
+  for (let i = 0; i < block.length; i += 1) if (block[i] !== 0) return false;
+  return true;
+}
+
+/**
+ * Where one entry lands, or a refusal.
+ *
+ * **The string checks are the cheap half and they are not the half that
+ * matters.** `..` and a leading `/` are caught first because they are free to
+ * catch, but an archive does not need either to escape: two entries do it, and
+ * neither one looks wrong on its own.
+ *
+ *     out -> /somewhere/else      a symlink. Legal — a copy that dropped links
+ *                                 would not be a copy.
+ *     out/pwned.txt               inside the destination, lexically. Written
+ *                                 through the link, to /somewhere/else.
+ *
+ * `path.resolve` does not resolve symlinks, so it says "inside" for the second
+ * entry and the bytes land outside. What closes it is resolving the entry's
+ * **parent directory as it exists at the moment of the write** — links written
+ * by earlier entries of this same archive included — and re-checking *that*
+ * against the destination's own real path. The parent is created first so there
+ * is something to resolve, which is work the write needed doing anyway.
+ *
+ * See the module header for whose disk this protects, and why it is not the
+ * client-side path validation #168 rules out.
+ */
+async function confineEntryTarget(
+  realRoot: string,
+  entryPath: string,
+): Promise<{ absolute: string; result: LocalWriteOutcome }> {
+  const cleaned = entryPath.replace(/\/+$/, "");
+  if (cleaned.length === 0) return { absolute: realRoot, result: "written" };
+  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned)) {
+    throw new LocalTarError(
+      "unsafe-entry-path",
+      `the Core sent an entry with an absolute path (${entryPath}), which will not be written to this machine`,
+    );
+  }
+  if (cleaned.split("/").includes("..")) {
+    throw new LocalTarError(
+      "unsafe-entry-path",
+      `the Core sent an entry with a ".." segment (${entryPath}), which will not be written to this machine`,
+    );
+  }
+
+  const segments = cleaned.split("/").filter((segment) => segment.length > 0 && segment !== ".");
+  const leaf = segments.pop();
+  if (leaf === undefined) return { absolute: realRoot, result: "written" };
+
+  const parent = path.resolve(realRoot, ...segments);
+  await fs.promises.mkdir(parent, { recursive: true });
+  const realParent = await fs.promises.realpath(parent);
+  if (realParent !== realRoot && !realParent.startsWith(`${realRoot}${path.sep}`)) {
+    throw new LocalTarError(
+      "unsafe-entry-path",
+      `the Core sent an entry that resolves outside ${realRoot} (${entryPath}) — ` +
+        "a symlink in the archive points out of the folder being written. Nothing was written for it",
+    );
+  }
+
+  const absolute = path.join(realParent, leaf);
+  // And the leaf itself: an existing symlink here would be written *through*
+  // for a file, and stepped into by `mkdir` for a directory. It is replaced
+  // rather than followed — the archive says what belongs at this name.
+  //
+  // What was already there is read *before* anything is removed, because that
+  // is the answer F5 needs: a path this replaced is an overwrite whether it
+  // held a file, a folder or a link, and clearing it first would leave nothing
+  // to report.
+  const existing = await fs.promises.lstat(absolute).catch(() => null);
+  if (existing?.isSymbolicLink()) await fs.promises.rm(absolute, { force: true });
+  return { absolute, result: existing ? "overwritten" : "written" };
+}
+
+export type UnpackResult = { entries: number; bytes: number };
+
+/**
+ * Unpack a tar into `destRoot`, one entry at a time.
+ *
+ * `onEntry` is awaited before the next entry is read, which is what keeps a
+ * progress display honest: the line has been rendered before the next file
+ * starts, rather than a batch of them arriving after the transfer finished.
+ *
+ * Modes are applied with an explicit `chmod` after the bytes land — see the
+ * module header. Times are restored too, best-effort: a failure to set one is
+ * swallowed, because a filesystem that will not take an mtime (some network
+ * mounts, some Windows configurations) has not damaged the copy.
+ */
+export async function unpackTarInto(
+  source: AsyncIterable<Uint8Array>,
+  destRoot: string,
+  onEntry: (entry: UnpackedEntry) => void | Promise<void>,
+): Promise<UnpackResult> {
+  const root = path.resolve(destRoot);
+  await fs.promises.mkdir(root, { recursive: true });
+  // Resolved once, and every entry is checked against *this* rather than
+  // against the path that was typed: a destination reached through a symlink
+  // (`/tmp` on macOS is one) would otherwise fail its own confinement check on
+  // the first entry.
+  const realRoot = await fs.promises.realpath(root);
+  const reader = new ByteReader(source);
+  let entries = 0;
+  let bytes = 0;
+  let zeroBlocks = 0;
+  // Overrides that apply to the *next* real entry, from a pax or GNU long-name
+  // header. Cleared the moment they are consumed.
+  let pendingName: string | null = null;
+  let pendingLink: string | null = null;
+  let pendingSize: number | null = null;
+
+  for (;;) {
+    const block = await reader.exact(BLOCK);
+    if (!block) break;
+    if (isZeroBlock(block)) {
+      zeroBlocks += 1;
+      // Two in a row close a tar. Some writers pad further; stopping here means
+      // trailing padding is simply not read.
+      if (zeroBlocks >= 2) break;
+      continue;
+    }
+    zeroBlocks = 0;
+
+    const header = parseHeader(block);
+
+    if (header.typeflag === TYPE_PAX_NEXT || header.typeflag === TYPE_PAX_GLOBAL) {
+      const body = (await reader.exact(header.size + padding(header.size))) ?? Buffer.alloc(0);
+      const records = parsePaxRecords(body.subarray(0, header.size));
+      // A global header describes the archive, not the next entry, so its
+      // records are read for well-formedness and then dropped.
+      if (header.typeflag === TYPE_PAX_NEXT) {
+        if (typeof records.path === "string") pendingName = records.path;
+        if (typeof records.linkpath === "string") pendingLink = records.linkpath;
+        if (typeof records.size === "string") {
+          const size = Number.parseInt(records.size, 10);
+          if (Number.isFinite(size)) pendingSize = size;
+        }
+      }
+      continue;
+    }
+
+    if (header.typeflag === TYPE_GNU_LONGNAME || header.typeflag === TYPE_GNU_LONGLINK) {
+      const body = (await reader.exact(header.size + padding(header.size))) ?? Buffer.alloc(0);
+      const value = body.subarray(0, header.size).toString("utf8").replace(/\0+$/, "");
+      if (header.typeflag === TYPE_GNU_LONGNAME) pendingName = value;
+      else pendingLink = value;
+      continue;
+    }
+
+    const name = pendingName ?? header.name;
+    const linkname = pendingLink ?? header.linkname;
+    const size = pendingSize ?? header.size;
+    pendingName = null;
+    pendingLink = null;
+    pendingSize = null;
+
+    if (header.typeflag === TYPE_DIRECTORY) {
+      const { absolute, result } = await confineEntryTarget(realRoot, name);
+      await fs.promises.mkdir(absolute, { recursive: true });
+      await fs.promises.chmod(absolute, header.mode & 0o777).catch(() => {});
+      entries += 1;
+      await onEntry({
+        path: tarPathOf(name),
+        kind: "directory",
+        size: 0,
+        mode: header.mode & 0o777,
+        mtime: header.mtime,
+        result,
+      });
+      continue;
+    }
+
+    if (header.typeflag === TYPE_SYMLINK) {
+      // The *target* is not resolved or checked. A symlink is a string on this
+      // disk until something follows it, and a copy that silently rewrote or
+      // dropped links would not be a copy — the Core's own packer preserves
+      // them the same way. What is checked is where the link itself lands, and
+      // an entry that later tries to write *through* this link is refused by
+      // the same check when its own turn comes.
+      const { absolute, result } = await confineEntryTarget(realRoot, name);
+      if (result === "overwritten") await fs.promises.rm(absolute, { force: true, recursive: true });
+      await fs.promises.symlink(linkname, absolute);
+      entries += 1;
+      await onEntry({
+        path: tarPathOf(name),
+        kind: "symlink",
+        size: Buffer.byteLength(linkname),
+        mode: header.mode & 0o777,
+        mtime: header.mtime,
+        result,
+      });
+      continue;
+    }
+
+    if (header.typeflag !== TYPE_FILE && header.typeflag !== TYPE_FILE_OLD) {
+      // A character device, a fifo, a hard link, a type this codec has never
+      // heard of. Skipped with its body, rather than refused: the alternative
+      // is failing a whole folder copy over one entry that could not have been
+      // recreated here anyway.
+      await reader.skip(size + padding(size));
+      continue;
+    }
+
+    const { absolute, result } = await confineEntryTarget(realRoot, name);
+    // A directory sitting where a file must land is removed first: `open`
+    // would fail with EISDIR. A symlink in the same position was already
+    // removed by `confineEntryTarget`, which is what stops the bytes being
+    // written through it to wherever it pointed.
+    if (result === "overwritten") {
+      const existing = await fs.promises.lstat(absolute).catch(() => null);
+      if (existing && !existing.isFile()) await fs.promises.rm(absolute, { force: true, recursive: true });
+    }
+
+    const handle = await fs.promises.open(absolute, "w");
+    try {
+      let left = size;
+      while (left > 0) {
+        const chunk = await reader.some(left);
+        if (!chunk) {
+          throw new LocalTarError(
+            "corrupt-archive",
+            `the tar stream ended inside ${name} — ${left} of ${size} bytes never arrived`,
+          );
+        }
+        await handle.write(chunk);
+        left -= chunk.length;
+        bytes += chunk.length;
+      }
+    } finally {
+      await handle.close();
+    }
+    await reader.skip(padding(size));
+    // After the bytes, and explicitly: `open(…, mode)` is masked by the umask,
+    // so a 0o755 handed to it would land as 0o755 & ~umask and an executable
+    // would arrive un-executable on most machines.
+    await fs.promises.chmod(absolute, header.mode & 0o777).catch(() => {});
+    if (header.mtime > 0) {
+      const when = new Date(header.mtime);
+      await fs.promises.utimes(absolute, when, when).catch(() => {});
+    }
+    entries += 1;
+    await onEntry({
+      path: tarPathOf(name),
+      kind: "file",
+      size,
+      mode: header.mode & 0o777,
+      mtime: header.mtime,
+      result,
+    });
+  }
+
+  return { entries, bytes };
+}
+
+/** An entry's name as it is reported: no trailing slash, whatever the header held. */
+function tarPathOf(name: string): string {
+  return name.replace(/\/+$/, "");
+}
+
+/**
+ * A web `ReadableStream` as an async iterable of chunks.
+ *
+ * `ReadableStream` is async-iterable on Node, but the SDK hands back the
+ * *global* declaration and the two are not always the same type to TypeScript —
+ * see the cast comment in `core-files-http.ts` for the same two-copies problem
+ * one layer down. Reading through `getReader()` is the spelling that is true of
+ * every copy, and the `finally` is what tells the Core that an abandoned
+ * download can stop: without it a cancelled transfer leaves the Core writing
+ * into a socket nobody reads until it times out.
+ */
+export async function* streamChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) return;
+      if (next.value) yield next.value;
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}

--- a/packages/cli/src/project-command.ts
+++ b/packages/cli/src/project-command.ts
@@ -3,6 +3,15 @@
 //   actana project ls [--json]         every Project on the selected Core
 //   actana project add <name> <path>   register one at a path on the Core
 //   actana project browse [path]       walk the Core's disk to find that path
+//   actana project cp <src> <dst>      copy files in or out of one (#168)
+//   actana project files <project>     list a Project's files (#168)
+//
+// The last two are phase 3's, and they hang off this noun rather than off the
+// root: **there is no `actana cp`** (#129 F12). D8's noun grammar holds — every
+// client verb hangs off a noun — and the two verbs are big enough that their
+// bodies live in `project-cp.ts` and `project-files-ls.ts` with the reasoning
+// that goes with them. What stays here is the dispatch and the help, so the
+// shape of the noun is still readable in one file.
 //
 // Two facts shape all three verbs, and both are about *whose machine* is being
 // talked about.
@@ -31,6 +40,8 @@
 // fact instead. Growing an op that carries a Core-validated path is #104.
 
 import { formatJson, formatTable } from "./cli-output.ts";
+import { runProjectCp } from "./project-cp.ts";
+import { runProjectFiles } from "./project-files-ls.ts";
 import { errorText, openCore, type CoreLinkClient } from "./core-connection.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_UNIMPLEMENTED, EXIT_USAGE } from "./exit-codes.ts";
 import type { RegistryPaths } from "./blob-registry.ts";
@@ -44,15 +55,31 @@ Usage
   actana project ls                    list the Projects on the selected Core
   actana project add <name> <path>     register a Project at a path on the Core
   actana project browse [path]         list folders on the Core's disk
-
-Reserved, landing in phase 3
-  actana project cp <src> <project>:<path>   copy files to a Project — #168
-  actana project files                       list a Project's files — #168
+  actana project files <project>       list the files inside a Project
+  actana project cp <src> <dst>        copy files in or out of a Project
 
 Flags
   --core <name>   which Core to talk to
-  --json          machine-readable output — \`ls\` and \`browse\`
+  --json          machine-readable output — every list command has it
+  --depth <n>     how far \`files\` descends. Default: the whole tree
+  --limit <n>     stop \`files\` after this many entries
+  --sha256        digest every file in a listing. Off by default: it reads them
   --verbose       explain the steps, on stderr. Never prints a blob.
+
+Copying files, in either direction
+  One side carries the Project, the other is on this machine — the \`scp\` shape.
+
+    actana project cp ./dist api:build     up: build becomes a copy of dist
+    actana project cp api:build ./dist     down: dist becomes a copy of build
+    actana project files api:build         what is in there now
+
+  A folder crosses as one archive and keeps its permissions, so an executable
+  arrives executable. Every file that replaced one already there is named in
+  the output, and \`--json\` lists them under "overwritten".
+
+  A local path is told apart from \`<project>:<path>\` by a rule, not a guess:
+  a separator before the colon means local (\`./notes:draft.md\`, \`C:\\dist\`),
+  and that leading \`./\` is how you name any local file with a colon in it.
 
 The path is the Core's, not this machine's
   \`add\` takes an absolute path on the Core and sends it as typed: nothing here
@@ -72,19 +99,19 @@ A Project's path is fixed once it exists
 const PATH_EDIT_VERBS = new Set(["edit", "mv", "move", "set-path", "setpath", "path", "update"]);
 
 /**
- * The two verbs phase 3 adds to this noun (#129 F12, #168), reserved in the
- * tree now rather than added to it later.
+ * The verbs this noun has reserved but not built.
  *
- * The reason is the one the `core` noun's `shell` scaffold gives: this ticket is
- * what decides the `project` noun's shape, and a verb bolted on by a different
- * ticket would be a second place that shape is decided. `actana cp` at the root
- * is explicitly not the spelling (F12) — the noun grammar holds — so reserving
- * them here is also what stops the shorter name looking available.
+ * **Empty on this train**, which is what a reservation is supposed to end as.
+ * `cp` and `files` were the two — reserved by #161 so that the shape of this
+ * noun was decided in one place rather than bolted on by whichever ticket got
+ * there first — and #168 built them, so each left the table as it landed. The
+ * table stays because the distinction it draws has not gone anywhere: a verb a
+ * later phase adds owes the reader a ticket number rather than "unknown verb",
+ * and a row here is the whole of saying so. `project rm` (#210) is the next one
+ * that will want it, and it is deliberately *not* pre-reserved: a reservation
+ * with no ticket in flight is a promise this build cannot keep.
  */
-const RESERVED_VERBS: Record<string, string> = {
-  cp: "`actana project cp <src> <project>:<path>` — file transfer, phase 3, #168",
-  files: "`actana project files` — listing a Project's files, phase 3, #168",
-};
+const RESERVED_VERBS: Record<string, string> = {};
 
 /** Dispatch a `project` verb. `args.positionals` still has `project` at [0]. */
 export async function runProjectCommand(
@@ -107,6 +134,10 @@ export async function runProjectCommand(
       return projectAdd(deps, args, paths, rest);
     case "browse":
       return projectBrowse(deps, args, paths, rest);
+    case "cp":
+      return runProjectCp(deps, args, paths, rest);
+    case "files":
+      return runProjectFiles(deps, args, paths, rest);
     default: {
       if (PATH_EDIT_VERBS.has(verb)) return refusePathEdit(deps, verb);
       const reserved = RESERVED_VERBS[verb];
@@ -115,7 +146,7 @@ export async function runProjectCommand(
         return EXIT_UNIMPLEMENTED;
       }
       deps.err(`actana project: unknown verb "${verb}".`);
-      deps.err("Verbs: ls, add, browse. `actana project --help` lists them.");
+      deps.err("Verbs: ls, add, browse, files, cp. `actana project --help` lists them.");
       return EXIT_USAGE;
     }
   }

--- a/packages/cli/src/project-cp.ts
+++ b/packages/cli/src/project-cp.ts
@@ -121,14 +121,21 @@ export async function runProjectCp(
     return failed(deps, args, `${resolved.core.blob.endpoint} did not answer — ${messageOf(err)}`);
   }
 
+  // Owned out here rather than inside the transfer, because a transfer that
+  // throws part-way has still written the entries it got to and those entries
+  // are the answer to "what did this replace?". A `landed` that lived inside
+  // `upload`/`download` would be discarded by the throw along with the only
+  // record of them (F5).
+  const landed: LandedEntry[] = [];
   try {
     const project = await gateway.project(direction.remote.project);
     deps.verbose(`Project "${project.name}" is ${project.projectId} at ${project.path} on the Core`);
 
-    const landed =
-      direction.direction === "upload"
-        ? await upload(deps, args, project, direction.local, direction.remote.path)
-        : await download(deps, args, project, direction.remote.path, direction.local);
+    if (direction.direction === "upload") {
+      await upload(deps, args, project, direction.local, direction.remote.path, landed);
+    } else {
+      await download(deps, args, project, direction.remote.path, direction.local, landed);
+    }
 
     return report(deps, args, {
       core: resolved.core.name,
@@ -139,7 +146,7 @@ export async function runProjectCp(
       landed,
     });
   } catch (err) {
-    return failed(deps, args, messageOf(err), err);
+    return failed(deps, args, messageOf(err), err, landed);
   } finally {
     gateway.close();
   }
@@ -166,7 +173,9 @@ async function upload(
   project: ProjectFileTransfers,
   localPath: string,
   remotePath: string,
-): Promise<LandedEntry[]> {
+  /** Appended to as entries land. The caller owns it, so a throw does not take it. */
+  landed: LandedEntry[],
+): Promise<void> {
   const stats = await fs.promises.stat(localPath).catch(() => null);
   if (!stats) {
     // This machine's disk, so this machine answers. Nothing about the *remote*
@@ -175,7 +184,6 @@ async function upload(
   }
 
   const progress = openProgress(deps, args);
-  const landed: LandedEntry[] = [];
   try {
     const stream = stats.isDirectory()
       ? project.upload({
@@ -201,7 +209,6 @@ async function upload(
   } finally {
     progress.close();
   }
-  return landed;
 }
 
 /** One progress line as a landed entry, or null for the `done` line's totals. */
@@ -228,10 +235,11 @@ async function download(
   project: ProjectFileTransfers,
   remotePath: string,
   localPath: string,
-): Promise<LandedEntry[]> {
+  /** Appended to as entries land. The caller owns it, so a throw does not take it. */
+  landed: LandedEntry[],
+): Promise<void> {
   const answer = await project.download({ path: remoteDirectorySource(remotePath) });
   const progress = openProgress(deps, args);
-  const landed: LandedEntry[] = [];
 
   try {
     if (answer.kind === "tar") {
@@ -240,7 +248,7 @@ async function download(
         landed.push(one);
         progress.landed(one, landed);
       });
-      return landed;
+      return;
     }
 
     // A file landing on an existing directory takes its own name inside it,
@@ -276,7 +284,6 @@ async function download(
     const one: LandedEntry = { path: destination, result, size: bytes };
     landed.push(one);
     progress.landed(one, landed);
-    return landed;
   } finally {
     progress.close();
   }
@@ -402,14 +409,50 @@ function report(
  * One failure, reported the same way every time: JSON on stdout when `--json`
  * promised a document, prose on stderr always.
  *
- * The F8 refusal gets a second line and it is the only special case in here.
- * The Core's message already names the transfer holding the Project and when it
- * started — #168 asks for exactly that, *who holds it, not just "busy"* — so
- * what is added is the one thing the Core cannot know: that waiting is the
- * remedy, and that nothing here has been retrying behind the operator's back.
+ * **A part-way failure still names what it replaced.** F5 says every overwrite
+ * is named in the output, and a transfer that replaced eleven files and lost
+ * the connection on the twelfth has overwritten eleven files — the criterion
+ * does not stop applying because the verb is about to exit non-zero. Those
+ * entries are the ones an operator most needs, because they are the ones they
+ * now have to reason about restoring, and under `--json` there is no progress
+ * line they might have watched scroll past. So `overwritten` appears on the
+ * error document with the same name and the same shape it has on the success
+ * one: a script reads one key either way, and the exit code says which
+ * happened. Prose puts them *above* the failure, so the last line on the
+ * screen is still why it stopped.
+ *
+ * The F8 refusal gets a second line and it is the only other special case in
+ * here. The Core's message already names the transfer holding the Project and
+ * when it started — #168 asks for exactly that, *who holds it, not just
+ * "busy"* — so what is added is the one thing the Core cannot know: that
+ * waiting is the remedy, and that nothing here has been retrying behind the
+ * operator's back.
  */
-function failed(deps: ActanaCliDeps, args: ParsedArgs, message: string, err?: unknown): number {
-  if (args.json) deps.out(formatJson({ error: message }));
+function failed(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  message: string,
+  err?: unknown,
+  landed: LandedEntry[] = [],
+): number {
+  const overwritten = landed.filter((entry) => entry.result === "overwritten");
+
+  if (args.json) {
+    deps.out(
+      formatJson({
+        error: message,
+        entries: landed.length,
+        overwritten: overwritten.map((entry) => entry.path),
+      }),
+    );
+  } else {
+    for (const entry of overwritten) deps.err(`  overwrote ${entry.path}`);
+    if (overwritten.length > 0) {
+      const many =
+        overwritten.length === 1 ? "1 file was replaced" : `${overwritten.length} files were replaced`;
+      deps.err(`${many} before this stopped, named above.`);
+    }
+  }
   deps.err(`actana project cp: ${message}`);
   if (err instanceof ProjectFilesError && err.kind === "conflict") {
     deps.err("Nothing was retried — one write at a time per Project (F8). Try again once that one is done.");

--- a/packages/cli/src/project-cp.ts
+++ b/packages/cli/src/project-cp.ts
@@ -1,0 +1,438 @@
+// `actana project cp` — files between this machine and a Project on a Core
+// (#129 F12, #168).
+//
+//   actana project cp ./dist api:build      up
+//   actana project cp api:build ./dist      down
+//
+// **There is no `actana cp`.** D8's noun grammar holds: every client verb hangs
+// off a noun, and this one is about a Project's files, so it lives on
+// `project`. A root-level `cp` would also be the one command in the tree whose
+// name promised something about the local filesystem that it does not do.
+//
+// ## Which side is remote, and why that is a whole module
+//
+// The direction is read off the arguments — one side carries `<project>:` and
+// the other does not — which is the `scp` shape and the one an operator's
+// fingers already know. It is also the shape with the famous ambiguity, so the
+// parse is decided, written down and tested in `project-file-target.ts` rather
+// than left to a regex here.
+//
+// ## A folder is one tar, and the executable bit is the reason
+//
+// A directory crosses as a single streamed archive (ADR 0029), packed by
+// `local-tar.ts` on the way up and unpacked by it on the way down. #168's "a
+// folder copies both ways and keeps its executable bits" is what that buys: a
+// mode is a field in a tar header, and a transfer that sent N files over N
+// requests would have to invent a side channel for it — or, like most such
+// transfers, quietly hand everything 0o644 and let the operator find out when
+// their `./deploy` will not run.
+//
+// The Core does the packing in the other direction, for the same reason it
+// does not do it here: whichever side owns the disk owns the walk.
+//
+// ## Two rules about output, and both are #168 asking for them
+//
+// **Progress is for a terminal, and `--json` has none.** A rewriting status
+// line goes to the terminal while the transfer runs, and only when there is a
+// terminal to write it to. Under `--json` there is not one byte of it: stdout
+// carries exactly one document, and a consumer parsing it must not have to
+// filter a spinner out first.
+//
+// **Every overwrite is named.** Not counted — named, with its path, in the
+// output. F5 exists to prevent a silent clobber, and a summary reading "412
+// files written" over a tree that quietly replaced eleven of them is precisely
+// the failure it is aimed at. The Core reports `written` / `overwritten` per
+// entry on the way up; on the way down this side checks what was already there
+// before it writes, because the local disk is the one it can see.
+//
+// ## What this file does not do
+//
+// It does not validate the remote path. Absolute, `..`, outside the root, too
+// long, already a directory — every one of those is the Core's answer (F3, F11,
+// ADR 0027 D5), and it gives them with a code and a sentence. A client-side
+// copy of those rules would be a second implementation that cannot see the
+// disk it is ruling on, and the two would drift the first time either moved.
+
+import fs from "node:fs";
+import path from "node:path";
+import { formatJson } from "./cli-output.ts";
+import { resolveCore } from "./core-resolution.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
+import { packLocalTree, streamChunks, unpackTarInto, LocalTarError } from "./local-tar.ts";
+import {
+  remoteDirectorySource,
+  remoteFileDestination,
+  transferDirection,
+} from "./project-file-target.ts";
+import { ProjectFilesError, type ProjectFileTransfers } from "./project-files-gateway.ts";
+import type { RegistryPaths } from "./blob-registry.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+import type { ParsedArgs } from "./cli-args.ts";
+import type { CoreFileProgress } from "@actana/sdk/core-files.ts";
+
+/**
+ * How long a transfer waits for the Core to *answer*, not to finish.
+ *
+ * The same 30s every other noun dials with. It is a connect and request
+ * deadline, and the file surface's own reads have no deadline at all — a
+ * ten-gigabyte folder takes as long as it takes, and a timer that killed it
+ * half-way would leave a partial tree behind and call it a timeout.
+ */
+const TRANSFER_TIMEOUT_MS = 30_000;
+
+/** One entry that landed, in the shape both directions report. */
+type LandedEntry = { path: string; result: "written" | "overwritten"; size: number };
+
+/** `actana project cp <src> <project>:<path>` — and the reverse. */
+export async function runProjectCp(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const [sourceToken, destToken, ...extra] = rest;
+  if (sourceToken === undefined || destToken === undefined) {
+    deps.err("actana project cp: a source and a destination are required —");
+    deps.err("  actana project cp <src> <project>:<path>     copy into a Project");
+    deps.err("  actana project cp <project>:<path> <dst>     copy out of one");
+    return EXIT_USAGE;
+  }
+  if (extra.length > 0) {
+    deps.err(`actana project cp: unexpected argument "${extra[0]}".`);
+    deps.err("Two paths, and a path with spaces in it needs quoting.");
+    return EXIT_USAGE;
+  }
+
+  const direction = transferDirection(sourceToken, destToken);
+  if (!direction.ok) {
+    deps.err(`actana project cp: ${direction.error}.`);
+    deps.err("A local file whose name contains a colon is unambiguous as `./name:with-colon`.");
+    return EXIT_USAGE;
+  }
+
+  const resolved = resolveCore({ paths, env: deps.env, home: deps.home, coreFlag: args.core });
+  if (!resolved.ok) return failed(deps, args, resolved.error);
+
+  deps.verbose(`dialling ${resolved.core.blob.endpoint}`);
+  let gateway;
+  try {
+    gateway = await deps.openFiles(resolved.core.blob, { timeoutMs: TRANSFER_TIMEOUT_MS });
+  } catch (err) {
+    return failed(deps, args, `${resolved.core.blob.endpoint} did not answer — ${messageOf(err)}`);
+  }
+
+  try {
+    const project = await gateway.project(direction.remote.project);
+    deps.verbose(`Project "${project.name}" is ${project.projectId} at ${project.path} on the Core`);
+
+    const landed =
+      direction.direction === "upload"
+        ? await upload(deps, args, project, direction.local, direction.remote.path)
+        : await download(deps, args, project, direction.remote.path, direction.local);
+
+    return report(deps, args, {
+      core: resolved.core.name,
+      project,
+      direction: direction.direction,
+      source: sourceToken,
+      destination: destToken,
+      landed,
+    });
+  } catch (err) {
+    return failed(deps, args, messageOf(err), err);
+  } finally {
+    gateway.close();
+  }
+}
+
+/**
+ * Local → Core.
+ *
+ * A directory becomes one tar and a file goes as raw bytes, and the branch is
+ * the whole difference: the Core reads `Content-Type` and nothing else to
+ * decide whether to unpack (the SDK's `kind`), so a folder sent as a file would
+ * land as a file *named* like the folder, and a file sent as a tar would be
+ * refused as a corrupt archive.
+ *
+ * `contentLength` is passed for the single-file case because it is what lets
+ * the Core run its free-space precheck and refuse `507` *before* the bytes
+ * cross rather than fail with `ENOSPC` half-way in. A tar's length is not known
+ * until the tree has been walked, so there is nothing honest to declare — and
+ * declaring a guess would be worse than declaring nothing.
+ */
+async function upload(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  project: ProjectFileTransfers,
+  localPath: string,
+  remotePath: string,
+): Promise<LandedEntry[]> {
+  const stats = await fs.promises.stat(localPath).catch(() => null);
+  if (!stats) {
+    // This machine's disk, so this machine answers. Nothing about the *remote*
+    // path is checked here — see the module header.
+    throw new Error(`${localPath} is not a file or folder on this machine`);
+  }
+
+  const progress = openProgress(deps, args);
+  const landed: LandedEntry[] = [];
+  try {
+    const stream = stats.isDirectory()
+      ? project.upload({
+          path: remoteDirectorySource(remotePath),
+          kind: "tar",
+          body: packLocalTree(localPath, (entry) => progress.packing(entry.path)),
+        })
+      : project.upload({
+          path: remoteFileDestination(remotePath, localPath),
+          kind: "file",
+          body: fs.createReadStream(localPath),
+          mode: stats.mode & 0o777,
+          mtime: Math.floor(stats.mtimeMs),
+          contentLength: stats.size,
+        });
+
+    for await (const line of stream) {
+      const entry = landedFrom(line);
+      if (!entry) continue;
+      landed.push(entry);
+      progress.landed(entry, landed);
+    }
+  } finally {
+    progress.close();
+  }
+  return landed;
+}
+
+/** One progress line as a landed entry, or null for the `done` line's totals. */
+function landedFrom(line: CoreFileProgress): LandedEntry | null {
+  if (line.type !== "entry") return null;
+  return { path: line.path, result: line.result, size: line.size };
+}
+
+/**
+ * Core → local.
+ *
+ * The Core decides which of the two shapes comes back: a folder is announced as
+ * `x-actana-transfer-kind: tar` and anything else is bytes. This side does not
+ * ask in advance and does not guess from the path — a `list` first would be a
+ * second round trip and a race, and the header is already authoritative.
+ *
+ * Overwrites are detected here rather than reported by anybody, because this is
+ * the disk being written to. `unpackTarInto` checks each entry as it lands; the
+ * single-file path checks once, below.
+ */
+async function download(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  project: ProjectFileTransfers,
+  remotePath: string,
+  localPath: string,
+): Promise<LandedEntry[]> {
+  const answer = await project.download({ path: remoteDirectorySource(remotePath) });
+  const progress = openProgress(deps, args);
+  const landed: LandedEntry[] = [];
+
+  try {
+    if (answer.kind === "tar") {
+      await unpackTarInto(streamChunks(answer.stream), localPath, (entry) => {
+        const one: LandedEntry = { path: entry.path, result: entry.result, size: entry.size };
+        landed.push(one);
+        progress.landed(one, landed);
+      });
+      return landed;
+    }
+
+    // A file landing on an existing directory takes its own name inside it,
+    // which is what `cp` does and what an operator typing `cp api:a.txt .`
+    // means. Any other destination is taken literally, including one that does
+    // not exist yet.
+    const destination = (await isDirectory(localPath))
+      ? path.join(localPath, path.basename(remotePath))
+      : localPath;
+    const existing = await fs.promises.lstat(destination).catch(() => null);
+    const result = existing ? "overwritten" : "written";
+
+    await fs.promises.mkdir(path.dirname(path.resolve(destination)), { recursive: true });
+    const handle = await fs.promises.open(destination, "w");
+    let bytes = 0;
+    try {
+      for await (const chunk of streamChunks(answer.stream)) {
+        await handle.write(chunk);
+        bytes += chunk.length;
+        progress.bytes(destination, bytes);
+      }
+    } finally {
+      await handle.close();
+    }
+    // Explicitly, and after the bytes: `open` masks a mode through the umask,
+    // so an executable written that way arrives un-executable on most machines.
+    if (answer.mode !== null) await fs.promises.chmod(destination, answer.mode & 0o777).catch(() => {});
+    if (answer.mtime !== null && answer.mtime > 0) {
+      const when = new Date(answer.mtime);
+      await fs.promises.utimes(destination, when, when).catch(() => {});
+    }
+
+    const one: LandedEntry = { path: destination, result, size: bytes };
+    landed.push(one);
+    progress.landed(one, landed);
+    return landed;
+  } finally {
+    progress.close();
+  }
+}
+
+async function isDirectory(candidate: string): Promise<boolean> {
+  const stats = await fs.promises.stat(candidate).catch(() => null);
+  return stats?.isDirectory() ?? false;
+}
+
+// ─── Progress ────────────────────────────────────────────────────────────────
+
+/**
+ * The live status line, and the two conditions under which there is not one.
+ *
+ * `--json` is the first and it is absolute: a document on stdout is the whole
+ * of that mode's output. **Not a terminal** is the second — a transfer whose
+ * output is piped into a file or another program should not fill it with
+ * carriage returns, and `isTty` is true only when *both* halves of the terminal
+ * are one, which is exactly the question being asked.
+ *
+ * It writes through {@link CliTerminal}, not `deps.out`: this is a line that
+ * gets overwritten rather than a line of output, and the last thing it does is
+ * erase itself, so what remains on the screen afterwards is only the result.
+ */
+type Progress = {
+  /** A file the local walk has read, on the way up. */
+  packing(entryPath: string): void;
+  /** An entry that landed, either direction. */
+  landed(entry: LandedEntry, all: LandedEntry[]): void;
+  /** Bytes into a single-file download, where there are no entries to count. */
+  bytes(destination: string, written: number): void;
+  close(): void;
+};
+
+function openProgress(deps: ActanaCliDeps, args: ParsedArgs): Progress {
+  if (args.json || !deps.terminal.isTty) {
+    return { packing: () => {}, landed: () => {}, bytes: () => {}, close: () => {} };
+  }
+
+  let painted = false;
+  const paint = (line: string): void => {
+    // Truncated to the terminal's width, because a line longer than the screen
+    // wraps and then `\r` returns to the start of the *last* row — leaving the
+    // earlier rows on screen and turning a status line into a growing wall.
+    const width = Math.max(20, deps.terminal.size().cols - 1);
+    const text = line.length > width ? `${line.slice(0, width - 1)}…` : line;
+    deps.terminal.write(`\r${text}${" ".repeat(Math.max(0, width - text.length))}`);
+    painted = true;
+  };
+
+  return {
+    packing: (entryPath) => paint(`  reading ${entryPath}`),
+    landed: (entry, all) => {
+      const overwritten = all.reduce((n, one) => (one.result === "overwritten" ? n + 1 : n), 0);
+      const tally = overwritten > 0 ? `${all.length} entries, ${overwritten} overwritten` : `${all.length} entries`;
+      paint(`  ${tally} — ${entry.path}`);
+    },
+    bytes: (destination, written) => paint(`  ${formatBytes(written)} — ${destination}`),
+    close: () => {
+      if (!painted) return;
+      const width = Math.max(20, deps.terminal.size().cols - 1);
+      deps.terminal.write(`\r${" ".repeat(width)}\r`);
+    },
+  };
+}
+
+// ─── Reporting ───────────────────────────────────────────────────────────────
+
+/**
+ * What happened, once — as a document under `--json`, as prose otherwise.
+ *
+ * Both name every overwrite. The JSON carries them as an array a script can act
+ * on, and the prose lists them one per line above the summary, because a count
+ * is what F5 is trying to stop somebody from being able to publish.
+ */
+function report(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  outcome: {
+    core: string | null;
+    project: ProjectFileTransfers;
+    direction: "upload" | "download";
+    source: string;
+    destination: string;
+    landed: LandedEntry[];
+  },
+): number {
+  const overwritten = outcome.landed.filter((entry) => entry.result === "overwritten");
+  const bytes = outcome.landed.reduce((total, entry) => total + entry.size, 0);
+
+  if (args.json) {
+    deps.out(
+      formatJson({
+        core: outcome.core,
+        project: outcome.project.name,
+        projectId: outcome.project.projectId,
+        direction: outcome.direction,
+        source: outcome.source,
+        destination: outcome.destination,
+        entries: outcome.landed.length,
+        bytes,
+        written: outcome.landed.length - overwritten.length,
+        // Named, not counted — the same rule the prose below keeps, in the
+        // shape a script can read.
+        overwritten: overwritten.map((entry) => entry.path),
+      }),
+    );
+    return EXIT_OK;
+  }
+
+  for (const entry of overwritten) deps.out(`  overwrote ${entry.path}`);
+  const what = outcome.landed.length === 1 ? "1 entry" : `${outcome.landed.length} entries`;
+  deps.out(`Copied ${what} (${formatBytes(bytes)}) — ${outcome.source} → ${outcome.destination}`);
+  if (overwritten.length > 0) {
+    const many = overwritten.length === 1 ? "1 was an overwrite" : `${overwritten.length} were overwrites`;
+    deps.out(`  ${many}, named above.`);
+  }
+  return EXIT_OK;
+}
+
+/**
+ * One failure, reported the same way every time: JSON on stdout when `--json`
+ * promised a document, prose on stderr always.
+ *
+ * The F8 refusal gets a second line and it is the only special case in here.
+ * The Core's message already names the transfer holding the Project and when it
+ * started — #168 asks for exactly that, *who holds it, not just "busy"* — so
+ * what is added is the one thing the Core cannot know: that waiting is the
+ * remedy, and that nothing here has been retrying behind the operator's back.
+ */
+function failed(deps: ActanaCliDeps, args: ParsedArgs, message: string, err?: unknown): number {
+  if (args.json) deps.out(formatJson({ error: message }));
+  deps.err(`actana project cp: ${message}`);
+  if (err instanceof ProjectFilesError && err.kind === "conflict") {
+    deps.err("Nothing was retried — one write at a time per Project (F8). Try again once that one is done.");
+  }
+  if (err instanceof LocalTarError && err.code === "unsafe-entry-path") {
+    deps.err("Nothing was written for that entry. The rest of the archive was not unpacked.");
+  }
+  return EXIT_FAILURE;
+}
+
+/** Bytes a human reads, at three significant figures and no more. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/cli/src/project-file-target.ts
+++ b/packages/cli/src/project-file-target.ts
@@ -1,0 +1,156 @@
+// `<project>:<path>` — one argument that names a place on a **Core**, and how
+// it is told apart from a place on this laptop (#129 F12, #168).
+//
+// `actana project cp` takes two arguments and exactly one of them is remote.
+// There is no `--to` / `--from` flag and no `--remote` marker: the direction is
+// read off which side carries a colon, which is the shape `scp` and `rsync`
+// established and the shape an operator's fingers already know.
+//
+// That shape has one famous hazard and this module exists to answer it. Two
+// perfectly ordinary local paths contain a colon:
+//
+//     C:\Users\me\dist        a Windows path — drive letter, then a colon
+//     notes:draft.md          a file whose *name* has a colon in it
+//
+// Read naively, the first is a Project called `C` and the second a Project
+// called `notes`, and both would send an operator's files somewhere they did
+// not ask for. So the parse is decided here, written down, and pinned by
+// `project-file-target.test.ts` rather than left to whatever the first regex
+// happened to do.
+//
+// ## The rules, in the order they are applied
+//
+//   1. **No colon at all → local.** The overwhelming majority of arguments.
+//   2. **A path separator before the colon → local.** `./notes:draft.md`,
+//      `dist/a:b`, `/srv/a:b`, `.\a:b`. A Project name cannot contain `/` or
+//      `\`, so a separator on the left of the colon settles it — and this is
+//      the **escape hatch**: any local file whose name contains a colon becomes
+//      unambiguous by writing `./` in front of it, which is exactly the advice
+//      `scp` has given for thirty years.
+//   3. **A single letter, then a colon, then a separator → local.** `C:\dist`
+//      and `C:/dist`. A one-character Project name is legal and reachable —
+//      `x:src/main.ts` is a Project — because the rule needs *both* halves: a
+//      drive letter is followed by a separator, and a Project's path is
+//      relative and is not.
+//   4. **Anything else with a colon → remote**, split at the **first** colon.
+//      `api:src/a:b.txt` is the Project `api` and the path `src/a:b.txt`; a
+//      colon inside a Project-relative path needs no escaping because only the
+//      first one is structural.
+//
+// What is deliberately *not* here: any judgement about whether the remote path
+// is legal. Absolute, `..`, too long, outside the root — every one of those is
+// the Core's to answer (F3, F11, ADR 0027 D5) and it answers them with a code
+// and a sentence. A client that pre-validated would be a second implementation
+// of a rule it cannot see the disk for, and the two would drift.
+
+import path from "node:path";
+
+/** One side of a `cp`, once it is known which machine it names. */
+export type TransferTarget =
+  | {
+      kind: "remote";
+      /** A Project name or id, exactly as it was typed. Resolved against the Core, not here. */
+      project: string;
+      /** Project-relative, and possibly empty — the empty string is the Project root. */
+      path: string;
+      /** What the operator actually typed, for error messages that quote them. */
+      token: string;
+    }
+  | { kind: "local"; path: string; token: string };
+
+/**
+ * Which machine one `cp` argument names.
+ *
+ * Total: every string is one or the other, and nothing throws. An argument that
+ * cannot be acted on — two local sides, two remote sides — is a fact about the
+ * *pair*, and {@link transferDirection} is where that is decided.
+ */
+export function parseTransferTarget(token: string): TransferTarget {
+  const colon = token.indexOf(":");
+  if (colon === -1) return { kind: "local", path: token, token };
+
+  const head = token.slice(0, colon);
+  const tail = token.slice(colon + 1);
+
+  // A leading colon (`:path`) names no Project. Local rather than an error: it
+  // is a legal, if odd, relative filename, and refusing it here would be this
+  // module deciding something about a disk it can see perfectly well.
+  if (head.length === 0) return { kind: "local", path: token, token };
+
+  // Rule 2 — a separator on the left of the colon.
+  if (head.includes("/") || head.includes("\\")) return { kind: "local", path: token, token };
+
+  // Rule 3 — a Windows drive: one letter, a colon, then a separator.
+  if (head.length === 1 && /^[A-Za-z]$/.test(head) && (tail.startsWith("\\") || tail.startsWith("/"))) {
+    return { kind: "local", path: token, token };
+  }
+
+  return { kind: "remote", project: head, path: tail, token };
+}
+
+/** A `cp` that can be performed: one local side, one remote side, and a direction. */
+export type TransferDirection =
+  | { ok: true; direction: "upload"; local: string; remote: Extract<TransferTarget, { kind: "remote" }> }
+  | { ok: true; direction: "download"; local: string; remote: Extract<TransferTarget, { kind: "remote" }> }
+  | { ok: false; error: string };
+
+/**
+ * Read the direction off the pair, or say why there is none.
+ *
+ * Both errors quote the arguments back and name the escape hatch, because both
+ * of them are usually rule 2 in disguise: somebody meant a remote path and
+ * typed a bare name, or meant a local file with a colon in it and did not know
+ * `./` was load-bearing.
+ */
+export function transferDirection(sourceToken: string, destToken: string): TransferDirection {
+  const source = parseTransferTarget(sourceToken);
+  const dest = parseTransferTarget(destToken);
+
+  if (source.kind === "local" && dest.kind === "local") {
+    return {
+      ok: false,
+      error:
+        `neither "${sourceToken}" nor "${destToken}" names a Project — one side must be <project>:<path>. ` +
+        "Copying one local folder to another is your operating system's `cp`",
+    };
+  }
+  if (source.kind === "remote" && dest.kind === "remote") {
+    return {
+      ok: false,
+      error:
+        `both "${sourceToken}" and "${destToken}" name a Project. A transfer has one local side: ` +
+        "Core-to-Core would put every byte through this laptop, so it is two commands and a folder in between",
+    };
+  }
+  if (source.kind === "remote") {
+    return { ok: true, direction: "download", local: dest.path, remote: source };
+  }
+  return { ok: true, direction: "upload", local: source.path, remote: (dest as Extract<TransferTarget, { kind: "remote" }>) };
+}
+
+/**
+ * The Project-relative destination for a **single file**, when the operator
+ * pointed at a folder rather than at a name.
+ *
+ * `actana project cp ./notes.md api:docs/` is a sentence people type, and the
+ * Core would take it literally: `docs/` is a path, and writing a file at it is
+ * either a refusal or a file with an odd name. Appending the source's basename
+ * is what `cp` and `scp` do, and it is the one piece of path *shaping* this
+ * client does.
+ *
+ * It is not path validation, which is the thing #168 says not to add: nothing
+ * here asks whether the path exists on the Core, whether it escapes the root or
+ * whether it is legal. Those stay the Core's answers. This only decides what
+ * string to send when the operator's ends in a separator or is empty.
+ */
+export function remoteFileDestination(remotePath: string, localSource: string): string {
+  const base = path.basename(localSource);
+  if (remotePath === "") return base;
+  if (remotePath.endsWith("/")) return `${remotePath}${base}`;
+  return remotePath;
+}
+
+/** The same shaping in the other direction, and it stays a `/` path for the Core. */
+export function remoteDirectorySource(remotePath: string): string {
+  return remotePath.replace(/\/+$/, "");
+}

--- a/packages/cli/src/project-files-gateway.ts
+++ b/packages/cli/src/project-files-gateway.ts
@@ -1,0 +1,307 @@
+// Reaching a Core for `project cp` and `project files` (#129 F12, #168).
+//
+// The seam `session-gateway.ts` opened for the `session` noun, at the same
+// width and for the same reason: one module that dials, so the verbs above it —
+// argument parsing, tables, `--json` shapes, exit codes, the progress display —
+// are exercised by unit tests with a fake and no Core anywhere near them.
+//
+// **This is where the SDK is used, and it is used rather than re-implemented.**
+// #168's line about it is not decoration: *the CLI consumes the SDK, it does
+// not talk HTTP itself.* Nothing in this package builds a URL, sets a bearer
+// header, or knows that a file crosses over HTTPS rather than over the core
+// link (ADR 0028). `client.project(id).files` is the whole of the contract, and
+// PR 217 wrote it; PR 219 settled where `list` points. A second HTTP client
+// here would be a second place the route lives, and #218 is the ticket about
+// what that costs.
+//
+// Three things do belong here rather than in the command module, because each
+// is a property of *talking to a Core* rather than of printing:
+//
+//   1. **A Project is named, not numbered.** An operator types `api:src`, not
+//      `p_01H…:src`. Resolution is a `projectsList` over the core link — the
+//      same one `session start` does, with the same refusal to guess when a
+//      name matches twice.
+//   2. **The one-write-per-Project rule keeps its sentence (F8).** The Core's
+//      `409` carries *which* transfer holds the Project and *when it started*,
+//      and that prose is carried through to the operator intact rather than
+//      flattened to "busy". See {@link ProjectFilesError}.
+//   3. **Nothing retries.** The SDK does not, deliberately, and neither does
+//      this: a conflict that resolved itself by sleeping would take an
+//      immediate, well-worded refusal and turn it into a hang with no output.
+//
+// Everything handed back is plain data or an async iterable of it. No
+// `CoreClient`, no `CoreProject`, and no `CoreFilesError` escapes — which is
+// what keeps `project-cp.ts` free of the SDK, and free of a socket.
+
+import { CoreClient } from "@actana/sdk/core-client.ts";
+import {
+  CoreFilesConflictError,
+  CoreFilesRequestError,
+  CoreFilesStreamError,
+  CoreFilesUnavailableError,
+} from "@actana/sdk/core-files-http.ts";
+import type { CoreFiles } from "@actana/sdk/core-files.ts";
+import type {
+  CoreFileDownload,
+  CoreFileDownloadOptions,
+  CoreFileEntry,
+  CoreFileListOptions,
+  CoreFileProgress,
+  CoreFileUploadOptions,
+} from "@actana/sdk/core-files.ts";
+import type { CoreLinkProjectSnapshot } from "@actana/sdk/core-link-frames.ts";
+import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
+
+/**
+ * What went wrong, in a vocabulary the verbs can turn into a message and an
+ * exit code without parsing English out of an SDK error.
+ *
+ * `conflict` is the one that earns its own kind rather than folding into
+ * `refused`. It is F8 — another write already holds this Project — and #168
+ * asks for it by name: *a transfer refused by the one-write-per-Project rule
+ * should say who holds it, not just "busy"*. The Core's message is the only
+ * thing that knows who: it names the path being written and the moment the
+ * transfer started. So the kind exists to stop a caller writing its own
+ * shorter sentence over the top of that one.
+ */
+export type ProjectFilesErrorKind =
+  | "no-such-project"
+  | "conflict"
+  | "unavailable"
+  | "not-found"
+  | "refused";
+
+export class ProjectFilesError extends Error {
+  readonly kind: ProjectFilesErrorKind;
+  /** The Core's own refusal code, when it sent one — `transfer-in-progress`, `not-found`, … */
+  readonly code: string | null;
+
+  constructor(
+    kind: ProjectFilesErrorKind,
+    message: string,
+    options: { cause?: unknown; code?: string | null } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "ProjectFilesError";
+    this.kind = kind;
+    this.code = options.code ?? null;
+  }
+}
+
+/** One Project's files, on one Core, with the Project already resolved. */
+export type ProjectFileTransfers = {
+  projectId: string;
+  /** The Project's name as the Core spells it — not necessarily what was typed. */
+  name: string;
+  /** The Project's path on the Core's machine, for output that says where bytes went. */
+  path: string;
+  /** The tree under a path, one entry at a time. */
+  list(opts?: CoreFileListOptions): AsyncIterable<CoreFileEntry>;
+  /**
+   * Write a stream in, and watch it land: one `entry` line per file, each
+   * carrying `written` or `overwritten`, then a `done` line with the totals.
+   *
+   * Lazy, like the SDK's — the request goes out on the first `next()`, so a
+   * caller that never drains it never sends anything.
+   */
+  upload(opts: CoreFileUploadOptions): AsyncIterable<CoreFileProgress>;
+  /** Read a file, or a folder as one streamed tar. Nothing is buffered. */
+  download(opts: CoreFileDownloadOptions): Promise<CoreFileDownload>;
+};
+
+export type ProjectFilesGateway = {
+  /** Resolve a Project by id or by name, and bind its file surface. */
+  project(wanted: string): Promise<ProjectFileTransfers>;
+  close(): void;
+};
+
+/** How the file verbs reach a Core. Injected, so every verb is testable. */
+export type OpenProjectFilesFn = (
+  blob: CoreRegistrationBlob,
+  opts: { timeoutMs: number },
+) => Promise<ProjectFilesGateway>;
+
+/**
+ * The real gateway: connect once, and hand back a Project handle bound to that
+ * connection.
+ *
+ * One connection for the whole command, because both verbs need two things off
+ * the same Core — a `projectsList` over the link to resolve the name, and the
+ * HTTPS file routes for the transfer itself. The client is what holds the
+ * bearer and the capability announcement that make the second one legal (F9),
+ * which is why the file surface is reached through it rather than built beside
+ * it.
+ */
+export const openProjectFiles: OpenProjectFilesFn = async (blob, opts) => {
+  const client = CoreClient.fromRegistrationBlob(blob, {
+    connectTimeoutMs: opts.timeoutMs,
+    requestTimeoutMs: opts.timeoutMs,
+  });
+  const info = await client.connect();
+  if (!info.compatible) {
+    client.close();
+    throw new Error(
+      `this Core speaks core-link ${info.protocolVersion ?? "(none reported)"}, which this CLI does not. ` +
+        "Update whichever of the two is older — `actana core status` reports both.",
+    );
+  }
+  return new CoreLinkProjectFilesGateway(client);
+};
+
+class CoreLinkProjectFilesGateway implements ProjectFilesGateway {
+  constructor(private readonly client: CoreClient) {}
+
+  async project(wanted: string): Promise<ProjectFileTransfers> {
+    const projects = await this.client.projectsList();
+    const project = resolveProject(projects, wanted);
+    return bindProjectFiles(this.client.project(project.projectId).files, project);
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}
+
+/**
+ * The SDK's `CoreFiles` as this module's {@link ProjectFileTransfers}.
+ *
+ * Separated from the gateway above so it can be handed a `CoreFiles` that came
+ * from somewhere else — which is exactly what `project-files-live.test.ts`
+ * does, driving the verbs against the Core's *real* HTTP routes with only the
+ * core link (and therefore only the name resolution) replaced. An adapter a
+ * live suite cannot reach is an adapter no live suite tests.
+ */
+export function bindProjectFiles(
+  files: CoreFiles,
+  project: { projectId: string; name: string; path: string },
+): ProjectFileTransfers {
+  return {
+    projectId: project.projectId,
+    name: project.name,
+    path: project.path,
+    list: (listOpts = {}) => translateIterable(() => files.list(listOpts)),
+    upload: (uploadOpts) => translateIterable(() => files.upload(uploadOpts)),
+    download: async (downloadOpts) => {
+      try {
+        return await files.download(downloadOpts);
+      } catch (err) {
+        throw projectFilesErrorFrom(err);
+      }
+    },
+  };
+}
+
+/**
+ * A Project by id, or by name.
+ *
+ * By id first, because an id is unambiguous and a name is what somebody types.
+ * A name matching two Projects is an error rather than a coin toss — the same
+ * call `session-gateway.ts` makes, and it matters more here: writing a folder
+ * into the wrong repository is a mistake that overwrites files.
+ */
+function resolveProject(projects: CoreLinkProjectSnapshot[], wanted: string): CoreLinkProjectSnapshot {
+  const byId = projects.find((project) => project.projectId === wanted);
+  if (byId) return byId;
+
+  const byName = projects.filter((project) => project.name === wanted);
+  if (byName.length === 1) return byName[0]!;
+  if (byName.length > 1) {
+    throw new ProjectFilesError(
+      "no-such-project",
+      `"${wanted}" names ${byName.length} Projects on this Core — use the Project id: ${byName
+        .map((project) => project.projectId)
+        .join(", ")}`,
+    );
+  }
+  const known = projects.map((project) => project.name).join(", ");
+  throw new ProjectFilesError(
+    "no-such-project",
+    known.length > 0
+      ? `this Core has no Project "${wanted}". It has: ${known}`
+      : "this Core has no Projects registered — `actana project add <name> <path>` registers one",
+  );
+}
+
+/**
+ * The SDK's error taxonomy, as this module's.
+ *
+ * **The message is carried, never rewritten.** Every branch keeps
+ * `err.message`, and the conflict branch is the reason the rule is absolute:
+ * the Core's `409` reads *"another write transfer is already running on this
+ * Project (vendor/, started 2026-08-13T…) — one write at a time per Project"*,
+ * and every word after "Project" is the part an operator can act on. A client
+ * that substituted "the Project is busy" would be throwing away the only
+ * available answer to "busy with what?".
+ *
+ * Exported because it is the *contract*, not an implementation detail: the fake
+ * gateway in `cli-harness.ts` throws through it, so a suite that hands a verb a
+ * real `CoreFilesConflictError` sees the same `ProjectFilesError` a real Core
+ * would have produced — rather than passing against a fake that agreed with the
+ * command module about a mapping neither of them performs.
+ */
+export function projectFilesErrorFrom(err: unknown): Error {
+  if (err instanceof ProjectFilesError) return err;
+  if (err instanceof CoreFilesConflictError) {
+    return new ProjectFilesError("conflict", err.message, { cause: err, code: err.code });
+  }
+  if (err instanceof CoreFilesUnavailableError) {
+    return new ProjectFilesError("unavailable", err.message, { cause: err });
+  }
+  if (err instanceof CoreFilesRequestError) {
+    const kind: ProjectFilesErrorKind =
+      err.status === 404 ? "not-found" : "refused";
+    return new ProjectFilesError(kind, err.message, { cause: err, code: err.code });
+  }
+  if (err instanceof CoreFilesStreamError) {
+    // A failure that arrived as the last line of a progress stream, after the
+    // `200`. Worth keeping distinguishable in the message rather than the kind:
+    // the transfer is *partly done*, and an operator needs to know that a retry
+    // is resuming into a half-written tree rather than starting clean.
+    return new ProjectFilesError("refused", `the transfer failed part-way through — ${err.message}`, {
+      cause: err,
+      code: err.code,
+    });
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
+ * An async iterable whose failures speak this module's vocabulary.
+ *
+ * A generator wrapper rather than a `.catch`, because the errors that matter
+ * most on this surface are thrown from `next()` and not from the call: `upload`
+ * sends nothing until it is first pulled, so the `409` that F8 is about arrives
+ * *inside* the `for await`, not around it. Laziness is preserved — the factory
+ * is not invoked until the first pull either.
+ */
+function translateIterable<T>(open: () => AsyncIterable<T>): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      let iterator: AsyncIterator<T>;
+      try {
+        iterator = open()[Symbol.asyncIterator]();
+      } catch (err) {
+        throw projectFilesErrorFrom(err);
+      }
+      try {
+        for (;;) {
+          let next: IteratorResult<T>;
+          try {
+            next = await iterator.next();
+          } catch (err) {
+            throw projectFilesErrorFrom(err);
+          }
+          if (next.done) return;
+          yield next.value;
+        }
+      } finally {
+        // A consumer that broke out early — a `--limit`, a failed local write —
+        // has to reach the SDK's own `finally`, which is what cancels the
+        // response body and lets the Core stop writing into a socket nobody is
+        // reading. Without this the Core holds the Project's write lease until
+        // its own timeout, and the *next* transfer gets a puzzling F8 refusal.
+        await iterator.return?.().catch(() => {});
+      }
+    },
+  };
+}

--- a/packages/cli/src/project-files-ls.ts
+++ b/packages/cli/src/project-files-ls.ts
@@ -1,0 +1,197 @@
+// `actana project files` — what is actually in a Project (#129 F12, #168).
+//
+//   actana project files api                the whole tree
+//   actana project files api:src            one subtree
+//   actana project files api --depth 1      the immediate children
+//   actana project files api --sha256       with a digest per file
+//   actana project files api --json         the same, machine-readable
+//
+// The Project is named the same way `cp` names it — `<project>` on its own, or
+// `<project>:<path>` for a subtree — so one form is learned once. The parse and
+// its ambiguities live in `project-file-target.ts`.
+//
+// **`--json` is the point of the verb as much as the table is.** #168 asks for
+// "machine-readable, like every other list command in the CLI", and the shape
+// that makes true is the one `project ls` and `session ls` already emit: a bare
+// array of objects on stdout, two-space indented, nothing else on the stream.
+// Not NDJSON, even though NDJSON is what crosses the wire — a consumer of this
+// CLI reads one document per command, and a list that streamed would be the
+// only one in the tree that did not.
+//
+// **`--sha256` is off unless asked for, and that is the Core's decision showing
+// through.** A listing does not have the bytes in hand, so a digest per entry
+// means reading every file under the path (ADR 0027 D6). Left off, every
+// `sha256` is null — which reads as "nobody asked", not "no digest exists".
+
+import { formatJson, formatTable } from "./cli-output.ts";
+import { resolveCore } from "./core-resolution.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
+import { parseTransferTarget, remoteDirectorySource } from "./project-file-target.ts";
+import type { RegistryPaths } from "./blob-registry.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+import type { ParsedArgs } from "./cli-args.ts";
+import type { CoreFileEntry, CoreFileListOptions } from "@actana/sdk/core-files.ts";
+
+/** The same dial deadline every other noun uses. */
+const LIST_TIMEOUT_MS = 30_000;
+
+/** `actana project files <project>[:<path>]`. */
+export async function runProjectFiles(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const [target, ...extra] = rest;
+  if (target === undefined) {
+    deps.err("actana project files: a Project is required —");
+    deps.err("  actana project files <project>[:<path>] [--depth <n>] [--sha256] [--json]");
+    return EXIT_USAGE;
+  }
+  if (extra.length > 0) {
+    deps.err(`actana project files: unexpected argument "${extra[0]}".`);
+    deps.err("A subtree is part of the same argument: `actana project files api:src/lib`.");
+    return EXIT_USAGE;
+  }
+
+  const parsed = parseTransferTarget(target);
+  // A bare `api` is the Project's root, and a `<project>:<path>` is a subtree.
+  // A token the parser called local is one that named no Project at all, which
+  // for this verb is only ever a typo — there is no local side to list.
+  const project = parsed.kind === "remote" ? parsed.project : target;
+  const subtree = parsed.kind === "remote" ? remoteDirectorySource(parsed.path) : "";
+
+  const depth = readDepth(args);
+  if (depth.error) {
+    deps.err(`actana project files: ${depth.error}.`);
+    return EXIT_USAGE;
+  }
+  const limit = readLimit(args);
+  if (limit.error) {
+    deps.err(`actana project files: ${limit.error}.`);
+    return EXIT_USAGE;
+  }
+
+  const resolved = resolveCore({ paths, env: deps.env, home: deps.home, coreFlag: args.core });
+  if (!resolved.ok) return failed(deps, args, resolved.error);
+
+  deps.verbose(`dialling ${resolved.core.blob.endpoint}`);
+  let gateway;
+  try {
+    gateway = await deps.openFiles(resolved.core.blob, { timeoutMs: LIST_TIMEOUT_MS });
+  } catch (err) {
+    return failed(deps, args, `${resolved.core.blob.endpoint} did not answer — ${messageOf(err)}`);
+  }
+
+  try {
+    const handle = await gateway.project(project);
+    const options: CoreFileListOptions = { path: subtree };
+    if (depth.value !== null) options.depth = depth.value;
+    if (args.sha256) options.sha256 = true;
+
+    const entries: CoreFileEntry[] = [];
+    let truncated = false;
+    for await (const entry of handle.list(options)) {
+      entries.push(entry);
+      if (limit.value !== null && entries.length >= limit.value) {
+        // Breaking out here is what cancels the stream — the gateway's
+        // `finally` reaches the SDK's, which cancels the response body and lets
+        // the Core stop walking a tree nobody is reading any more.
+        truncated = true;
+        break;
+      }
+    }
+
+    if (args.json) {
+      deps.out(
+        formatJson(
+          entries.map((entry) => ({
+            path: entry.path,
+            kind: entry.kind ?? "file",
+            size: entry.size,
+            mtime: entry.mtime,
+            mode: entry.mode,
+            sha256: entry.sha256,
+          })),
+        ),
+      );
+      return EXIT_OK;
+    }
+
+    if (entries.length === 0) {
+      const where = subtree.length > 0 ? `${handle.name}:${subtree}` : handle.name;
+      deps.out(`Nothing under ${where}.`);
+      return EXIT_OK;
+    }
+
+    const header = args.sha256 ? ["MODE", "SIZE", "SHA256", "PATH"] : ["MODE", "SIZE", "PATH"];
+    const table = formatTable(
+      header,
+      entries.map((entry) => {
+        const row = [modeOf(entry), String(entry.size), nameOf(entry)];
+        // The digest is long and the path is what a reader scans for, so the
+        // digest goes in the middle and the path stays last — the one column a
+        // table cannot pad without making every row ragged.
+        return args.sha256 ? [row[0]!, row[1]!, entry.sha256 ?? "—", row[2]!] : row;
+      }),
+    );
+    for (const line of table) deps.out(line);
+    if (truncated) {
+      deps.err(`warning: stopped at --limit ${limit.value} — the tree has more under it.`);
+    }
+    return EXIT_OK;
+  } catch (err) {
+    return failed(deps, args, messageOf(err));
+  } finally {
+    gateway.close();
+  }
+}
+
+/**
+ * The permission bits, in octal.
+ *
+ * Octal rather than `rwxr-xr-x` because this surface's whole reason for
+ * carrying a mode is the executable bit surviving a transfer (#168), and `755`
+ * is how somebody about to type `chmod` thinks about it. The `--json` payload
+ * carries the raw number, so nothing is lost to the choice.
+ */
+function modeOf(entry: CoreFileEntry): string {
+  return (entry.mode & 0o777).toString(8).padStart(3, "0");
+}
+
+/** `ls -F` conventions: a directory keeps its slash, a symlink gets an `@`. */
+function nameOf(entry: CoreFileEntry): string {
+  if (entry.kind === "directory") return `${entry.path}/`;
+  if (entry.kind === "symlink") return `${entry.path}@`;
+  return entry.path;
+}
+
+/** `--depth <n>`, or null. Raw off the command line, so this is where it means something. */
+function readDepth(args: ParsedArgs): { value: number | null; error?: string } {
+  if (args.depth === null) return { value: null };
+  const value = Number(args.depth);
+  if (!Number.isInteger(value) || value < 1) {
+    return { value: null, error: `--depth ${args.depth} is not a whole number of levels (1 or more)` };
+  }
+  return { value };
+}
+
+function readLimit(args: ParsedArgs): { value: number | null; error?: string } {
+  if (args.limit === null) return { value: null };
+  const value = Number(args.limit);
+  if (!Number.isInteger(value) || value < 1) {
+    return { value: null, error: `--limit ${args.limit} is not a whole number of entries (1 or more)` };
+  }
+  return { value };
+}
+
+/** One failure: a document on stdout when `--json` promised one, prose on stderr always. */
+function failed(deps: ActanaCliDeps, args: ParsedArgs, message: string): number {
+  if (args.json) deps.out(formatJson({ error: message }));
+  deps.err(`actana project files: ${message}`);
+  return EXIT_FAILURE;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/cli/src/project-files-ls.ts
+++ b/packages/cli/src/project-files-ls.ts
@@ -11,12 +11,22 @@
 // its ambiguities live in `project-file-target.ts`.
 //
 // **`--json` is the point of the verb as much as the table is.** #168 asks for
-// "machine-readable, like every other list command in the CLI", and the shape
-// that makes true is the one `project ls` and `session ls` already emit: a bare
-// array of objects on stdout, two-space indented, nothing else on the stream.
-// Not NDJSON, even though NDJSON is what crosses the wire — a consumer of this
-// CLI reads one document per command, and a list that streamed would be the
-// only one in the tree that did not.
+// "machine-readable, like every other list command in the CLI": one document on
+// stdout, two-space indented, nothing else on the stream. Not NDJSON, even
+// though NDJSON is what crosses the wire — a consumer of this CLI reads one
+// document per command, and a list that streamed would be the only one in the
+// tree that did not.
+//
+// That document is `{entries, truncated}` rather than the bare array `project
+// ls` and `session ls` emit, and the difference is `--limit`. Those two verbs
+// cannot clip their answer, so a bare array *is* the whole truth for them; this
+// one can, and a bare array has nowhere to say so. The warning on stderr does
+// not close it — a script reads stdout, and `2>/dev/null` is how most of them
+// are written, so the one consumer that most needs the fact is the one least
+// likely to see it. `project browse --json` already carries `truncated` beside
+// its `entries` for the same reason. The envelope is fixed: `truncated` is
+// present and `false` on every listing that was not clipped, so the shape does
+// not change with the answer.
 //
 // **`--sha256` is off unless asked for, and that is the Core's decision showing
 // through.** A listing does not have the bytes in hand, so a digest per entry
@@ -93,19 +103,30 @@ export async function runProjectFiles(
     let truncated = false;
     for await (const entry of handle.list(options)) {
       entries.push(entry);
-      if (limit.value !== null && entries.length >= limit.value) {
+      if (limit.value !== null && entries.length > limit.value) {
+        // Reading *one past* the limit is what tells a clipped tree from one
+        // that holds exactly `--limit` entries. Stopping at `>=` would report
+        // "there is more under it" for a tree with nothing more under it, and a
+        // warning that cries wolf on an exact fit is one an operator learns to
+        // ignore. The extra entry is dropped, never shown.
+        entries.pop();
+        truncated = true;
         // Breaking out here is what cancels the stream — the gateway's
         // `finally` reaches the SDK's, which cancels the response body and lets
         // the Core stop walking a tree nobody is reading any more.
-        truncated = true;
         break;
       }
+    }
+    // Said once, on stderr, in both modes: `--json` carries it in the document
+    // too, but a person watching a piped command still deserves the sentence.
+    if (truncated) {
+      deps.err(`warning: stopped at --limit ${limit.value} — the tree has more under it.`);
     }
 
     if (args.json) {
       deps.out(
-        formatJson(
-          entries.map((entry) => ({
+        formatJson({
+          entries: entries.map((entry) => ({
             path: entry.path,
             kind: entry.kind ?? "file",
             size: entry.size,
@@ -113,7 +134,11 @@ export async function runProjectFiles(
             mode: entry.mode,
             sha256: entry.sha256,
           })),
-        ),
+          // The fact a script cannot get anywhere else. `false` on a complete
+          // listing rather than absent, so `payload.truncated` is a question
+          // that always has an answer.
+          truncated,
+        }),
       );
       return EXIT_OK;
     }
@@ -136,9 +161,6 @@ export async function runProjectFiles(
       }),
     );
     for (const line of table) deps.out(line);
-    if (truncated) {
-      deps.err(`warning: stopped at --limit ${limit.value} — the tree has more under it.`);
-    }
     return EXIT_OK;
   } catch (err) {
     return failed(deps, args, messageOf(err));


### PR DESCRIPTION
The CLI half of **F12**, and the last two reservations in the command tree.

```sh
actana project cp ./dist api:build     # up
actana project cp api:build ./dist     # down
actana project files api:build --json  # what is in there
```

**No root-level `actana cp`.** D8's noun grammar holds — every client verb hangs off a noun — and a test keeps `cp` an unknown noun at the root, because a grammar with one undocumented hole in it is worse than one without the verb.

## The CLI consumes the SDK; it does not talk HTTP

`project-files-gateway.ts` is the only module that touches `client.project(id).files`, on the terms `session-gateway.ts` set for the `session` noun: it dials, and hands back plain data, so the verbs above it — flags, tables, exit codes, the progress display — are unit-tested with a fake and no socket. Nothing here builds a URL or sets a bearer. That surface is #217's and its listing route is #219's; a second implementation of either would be the drift #218 is about.

## The four "done when" lines, and where each lives

**A folder copies both ways and keeps its executable bits.** A folder crosses as one streamed tar (ADR 0029). Whichever side owns the disk owns the walk, so the Core packs on the way down and `local-tar.ts` packs on the way up. The mode rides in the header and is applied with an explicit `chmod`, because `open(…, mode)` is masked by the umask — an `0o755` handed to it lands as `0o755 & ~umask`, and the executable arrives un-executable on most machines. There is a test that runs under an `0o077` umask for exactly that.

`project-files-live.test.ts` drives both directions against `createCoreFilesRequestHandler` — the Core's real handler, on a real socket, over a real disk — and reads the mode off the file the Core's own unpacker wrote. A tar that only round-trips through its own codec proves nothing about a wire format, so GNU tar is also asserted to read what this writes and vice versa.

**Progress is visible on a terminal and absent under `--json`.** A rewriting status line, written through `CliTerminal`, erased when the transfer ends, and painted only when `isTty` — a pipe gets none. Under `--json` there is not one byte of it, and the test asserts *absence* rather than redirection: a consumer parsing stdout must not have to filter a spinner out of it first.

**Every overwrite is named.** Not counted. On the way up the Core reports `written` / `overwritten` per entry and each is printed with its path; on the way down this side checks what was there before it writes, because that is the disk it can see. `--json` lists them under `overwritten`. A summary reading "412 entries" over a tree that quietly replaced eleven of them is the exact failure F5 exists to prevent.

**`project files --json` is machine-readable, like every other list.** One array on stdout, two-space indented, diagnostics on stderr — the shape `project ls` and `session ls` already emit. Not NDJSON, though NDJSON is what crosses the wire: a consumer of this CLI reads one document per command. `--sha256` is opt-in because a listing has no bytes in hand and a digest means reading every file (ADR 0027 D6); `--depth` and `--limit` pass through, the latter cancelling the stream on the way out so the Core stops walking a tree nobody is reading.

## The traps

**The `<project>:<path>` form is decided, not guessed.** Two perfectly ordinary local paths contain a colon — `C:\Users\me\dist` and `notes:draft.md`. Four rules, applied in order:

1. no colon → local;
2. a path separator before the colon → local (`./notes:draft.md`, `dist/a:b`);
3. a single letter, then a colon, then a separator → local, a Windows drive;
4. anything else splits at the **first** colon, so `api:src/a:b.txt` needs no escaping.

Rule 3 needs both halves on purpose, so a one-character Project name stays typeable: `x:src` is a Project and `x:/src` is a drive. The `./` prefix is the escape hatch for a bare filename with a colon, which is the answer `scp` has given for thirty years. `project-file-target.test.ts` pins every rule and both hazards.

**The F8 refusal says who holds it.** The Core's `409` names the transfer holding the Project and when it started, and that prose reaches the operator word for word — "the Project is busy" would be discarding the only available answer to "busy with what?". `conflict` is its own kind in the error taxonomy so nobody writes a shorter version over the top of it, the CLI adds only the fact the Core cannot know (that nothing was retried), and `project-files-gateway.test.ts` pins the mapping.

**No client-side path validation.** Absolute, `..`, outside the root, a directory in the way — every one is the Core's answer (F3, F11, ADR 0027 D5). Four such paths are sent as typed in the suite and the Core's refusal is what gets reported; the live suite watches `api:../escape` come back as `dot-dot-segment` from the Core with nothing written.

The one thing that *is* checked locally is the archive being unpacked onto **this** disk: an entry that is absolute, holds a `..`, or resolves outside the destination is refused. The string checks are the cheap half; the half that matters resolves each entry's parent through the symlinks that exist when it is written, because two innocent-looking entries — a link out of the tree, then a file inside it — escape without either one containing a `..`. A test writes that pair and watches it be refused.

## Reserved-list bookkeeping

`project cp` and `project files` leave the reserved list, which empties it: no noun and no verb in this build answers `EXIT_UNIMPLEMENTED` any more. Both tables stay, and so does the code — #210 (`project rm`) and #211 (`--model`) are the next names that will want them, and a script already branching on `3` must keep meaning the same thing by it. `actana-cli.test.ts`'s reservation table became a sweep over every name in the tree asserting that none of them answers `3`.

## Scope

`packages/cli` only, plus two documentation files. `packages/panel` is #169's and is untouched. `project rm` (#210) and `--model` (#211) are deliberately not here. No new dependency: the tar codec is written out longhand rather than pulled from npm, for the reason the Core's is — this package publishes one package deep and `no-local-escape.test.ts` pins the list.

## Checks

`pnpm --filter @actana/cli test` (409 passed, 3 skipped), `typecheck`, `eslint`, `build`, and the root `npm-publish` suite all green. `events-tail-cursor.test.ts` timed out once in a full local run and passes in isolation — a known flake under load, not this branch.

Refs #168, #129
