### PR TITLE
fix(ci): grant id-token to the release call so the nested npm job can request provenance

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -521,6 +521,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     permissions:
       contents: write
+      id-token: write
     secrets: inherit
     with:
       tag: v${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
One line: the `release:` call job in `promote.yml` adds `id-token: write` under its `permissions:`.

Every `promote.yml` dispatch currently dies at startup:

> Error calling workflow release.yml — the nested job 'npm' is requesting 'id-token: write', but is only allowed 'id-token: none'.

The npm provenance leg landed during the 0.2.2 train; today's dispatch was the first to read it from `main`, and a caller job caps its called workflow's permissions. Verified against the run annotation on 31786677332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)