### PR TITLE
fix(core-link): advance the live-event cursor only after a send actually lands

### DIFF
--- a/packages/core/src/__tests__/core-link-event-cursor-advance.test.ts
+++ b/packages/core/src/__tests__/core-link-event-cursor-advance.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import log from "../log";
+import {
+  PtyCoreLinkServer,
+  type EventLogPort,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+import type { CoreLinkEvent } from "@actana/sdk/core-link-frames";
+
+// The live-event cursor advances only behind a send that landed (issue 244).
+//
+// The bug these tests pin is an ordering: `pushLiveEvents` moved
+// `conn.lastSentEventId` past every event it *attempted*, and a send that fails
+// on this transport is silent — Node's `ws` does not throw on a `CLOSING`
+// socket, it emits an `error` event the server logs as a benign socket error.
+// Because the client's own cursor is driven by the events it *receives*, one
+// skipped frame plus one delivered frame behind it is a hole no reconnect
+// replay can close: the client asks for "everything after the later one" and
+// the server obliges.
+//
+// So the assertions here are about what the *client* ends up holding across a
+// failure and a reconnect, not about a server field. Each one fails on the old
+// ordering.
+
+type Listener = (...args: unknown[]) => void;
+
+/**
+ * A socket that fails the way a real one does: it never throws.
+ *
+ * Two failure modes, because the server has to survive both. `readyState`
+ * leaving `OPEN` is the reported remote-Core case — a link that went unwritable
+ * between the poll's tail read and its send, with the close handshake not yet
+ * run. `failEventOnce` is `ws`'s other one: the socket takes the frame,
+ * synchronously reports nothing, and reports the failure a tick later through
+ * the delivery callback (or, with no callback supplied, as an `error` event
+ * nobody can attribute to a frame).
+ */
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  closed = false;
+  /** eventId whose first send attempt fails asynchronously; null once spent. */
+  failEventOnce: number | null = null;
+  /** eventId whose first send attempt throws — the one failure `ws` reports synchronously. */
+  throwEventOnce: number | null = null;
+  /** Every frame the transport refused, in order — the loss the client cannot see. */
+  dropped: string[] = [];
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string, cb?: (err?: Error) => void): void {
+    if (this.throwEventOnce !== null && this.eventIdOf(data) === this.throwEventOnce) {
+      this.throwEventOnce = null;
+      this.dropped.push(data);
+      throw new Error("send failed");
+    }
+    const err = this.refusalFor(data);
+    if (err) {
+      this.dropped.push(data);
+      // Exactly what `ws` does: a callback gets the error on a later tick, and
+      // with no callback the socket emits `error` and the frame is gone.
+      if (cb) queueMicrotask(() => cb(err));
+      else queueMicrotask(() => this.emit("error", err));
+      return;
+    }
+    this.sent.push(data);
+    if (cb) queueMicrotask(() => cb());
+  }
+
+  /** Why this frame will not be delivered, or null if it will be. */
+  private refusalFor(data: string): Error | null {
+    if (this.readyState !== 1) return new Error("WebSocket is not open");
+    if (this.failEventOnce === null || this.eventIdOf(data) !== this.failEventOnce) return null;
+    this.failEventOnce = null;
+    return new Error("WebSocket is not open: readyState 2 (CLOSING)");
+  }
+
+  /** The eventId this frame carries, or null for anything that is not an `event`. */
+  private eventIdOf(data: string): number | null {
+    const frame = JSON.parse(data) as { type?: string; event?: { eventId?: number } };
+    return frame.type === "event" ? (frame.event?.eventId ?? null) : null;
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = 3;
+    this.emit("close");
+  }
+  /** The socket drops without a close handshake — `readyState` moves, no `close` fires. */
+  goUnwritable(): void {
+    this.readyState = 2;
+  }
+  becomeWritable(): void {
+    this.readyState = 1;
+  }
+  ping(): void {}
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(frame: unknown): void {
+    this.emit("message", JSON.stringify(frame));
+  }
+  ofType<T extends Record<string, unknown>>(type: string): T[] {
+    return this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === type) as T[];
+  }
+  /** The eventIds this client actually received, in arrival order. */
+  eventIds(): number[] {
+    return this.ofType<{ event: CoreLinkEvent }>("event").map((frame) => frame.event.eventId);
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike) => void) | null = null;
+  connect(ws: FakeWebSocket): void {
+    this.connCb?.(ws as unknown as WebSocketLike);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike) => void;
+  }
+}
+
+/** An in-memory event log — the same seam `event-log-store.ts` fills for real. */
+function fakeEventLog() {
+  const events: CoreLinkEvent[] = [];
+  const port: EventLogPort = {
+    appendEvent: (kind, payload, opts) => {
+      const eventId = events.length + 1;
+      events.push({
+        eventId,
+        ts: eventId,
+        kind,
+        payload,
+        ptyId: opts?.ptyId ?? null,
+        taskId: opts?.taskId ?? null,
+      });
+      return eventId;
+    },
+    readEventTail: (afterEventId, limit = 1_000) =>
+      events.filter((event) => event.eventId > afterEventId).slice(0, limit),
+    getLastEventId: () => events.length,
+  };
+  return { port, events };
+}
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+/**
+ * How a client's own cursor moves: it persists the highest eventId it applied,
+ * and that is the number it presents on the next `subscribe`. This is the whole
+ * mechanism by which a server-side skip becomes permanent.
+ */
+function clientCursor(...sockets: FakeWebSocket[]): number {
+  return sockets.flatMap((ws) => ws.eventIds()).reduce((max, id) => Math.max(max, id), 0);
+}
+
+describe("the live-event cursor advances only behind a send that landed (issue 244)", () => {
+  let wss: FakeWebSocketServer;
+  let server: PtyCoreLinkServer;
+  let logi: ReturnType<typeof fakeEventLog>;
+
+  function connect(): FakeWebSocket {
+    const ws = new FakeWebSocket();
+    wss.connect(ws);
+    return ws;
+  }
+
+  beforeEach(() => {
+    wss = new FakeWebSocketServer();
+    logi = fakeEventLog();
+    server = new PtyCoreLinkServer(mockCore(), {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      eventLog: logi.port,
+      liveEventPollMs: 5,
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+    vi.restoreAllMocks();
+  });
+
+  it("replays an event whose send failed, instead of skipping it forever", async () => {
+    const first = connect();
+    first.receive({ type: "subscribe", reqId: "s1", lastEventId: 0 });
+
+    // The event in the middle is the one the socket will refuse — the shape
+    // from the ticket: 1 and 3 land, 2 does not.
+    first.failEventOnce = 2;
+    logi.port.appendEvent("task:created", JSON.stringify({ taskId: "t1" }), { taskId: "t1" });
+    logi.port.appendEvent("session:finished", JSON.stringify({ taskId: "t1" }), { taskId: "t1" });
+    logi.port.appendEvent("task:updated", JSON.stringify({ taskId: "t1" }), { taskId: "t1" });
+
+    await vi.waitFor(() => expect(first.eventIds()).toContain(3));
+
+    // The client reconnects off its own cursor, exactly as it would after any
+    // drop, and the Core owes it whatever it has not seen.
+    const cursor = clientCursor(first);
+    first.close();
+    const second = connect();
+    second.receive({ type: "subscribe", reqId: "s2", lastEventId: cursor });
+    await vi.waitFor(() => expect(second.ofType("eventsReplayed")).toHaveLength(1));
+
+    // The property: every appended event reached the client by some path. On
+    // the old ordering the cursor moved past 2 on the failed send, the client's
+    // own cursor moved to 3 behind it, and `session:finished` — a one-shot
+    // notification no snapshot re-hydration carries — was gone for good.
+    const delivered = new Set([...first.eventIds(), ...second.eventIds()]);
+    expect([...delivered].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps the cursor put while the socket is unwritable, and delivers on recovery", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const ws = connect();
+    ws.receive({ type: "subscribe", reqId: "s1", lastEventId: 0 });
+    logi.port.appendEvent("task:created", "{}", { taskId: "t1" });
+    await vi.waitFor(() => expect(ws.eventIds()).toEqual([1]));
+
+    // The link goes unwritable with no close handshake — the remote-Core case.
+    // `ws.send` does not throw here; it never has.
+    ws.goUnwritable();
+    logi.port.appendEvent("session:lockChanged", "{}", { taskId: "t1" });
+    logi.port.appendEvent("session:finished", "{}", { taskId: "t1" });
+    // Nothing is even attempted at an unwritable socket — the poll notices
+    // before it writes, and says which event it is holding.
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledWith("core-link.event.undelivered", expect.objectContaining({ eventId: 2 })));
+    expect(ws.sent.filter((raw) => raw.includes("\"event\""))).toHaveLength(1);
+    expect(ws.eventIds()).toEqual([1]);
+
+    // Nothing was consumed by the refusal: the cursor is still below event 2,
+    // so the very next tick that finds a writable socket carries both.
+    ws.becomeWritable();
+    await vi.waitFor(() => expect(ws.eventIds()).toEqual([1, 2, 3]));
+  });
+
+  it("stops the subscribe replay at the last event the socket took", async () => {
+    logi.port.appendEvent("task:created", "{}", { taskId: "t1" });
+    logi.port.appendEvent("session:finished", "{}", { taskId: "t1" });
+    logi.port.appendEvent("task:updated", "{}", { taskId: "t1" });
+
+    const ws = connect();
+    // A send that throws is the one failure the old `try/catch` did see — and
+    // it still advanced the cursor past the frame it had just caught.
+    ws.throwEventOnce = 2;
+    ws.receive({ type: "subscribe", reqId: "s1", lastEventId: 0 });
+
+    // The replay is a cursor advance like any other: it stops where delivery
+    // stopped and reports that, rather than a tail it only partly wrote. A
+    // client told `lastEventId: 3` here would never ask for event 2 again.
+    expect(ws.eventIds()).toEqual([1]);
+    expect(ws.ofType<{ lastEventId: number }>("eventsReplayed")[0]?.lastEventId).toBe(1);
+
+    // And the live loop picks up from there — the refused event included.
+    await vi.waitFor(() => expect(ws.eventIds()).toEqual([1, 2, 3]));
+  });
+
+  it("names the undeliverable event in a log line", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const ws = connect();
+    ws.receive({ type: "subscribe", reqId: "s1", lastEventId: 0 });
+    ws.goUnwritable();
+    logi.port.appendEvent("session:finished", "{}", { taskId: "t1" });
+
+    // The absence of any line naming a lost eventId is why this class of bug
+    // was invisible: `core-link.connection.error` names a socket, never a frame.
+    await vi.waitFor(() =>
+      expect(
+        warn.mock.calls.some(
+          ([tag, payload]) =>
+            tag === "core-link.event.undelivered" &&
+            (payload as { eventId?: number } | undefined)?.eventId === 1,
+        ),
+      ).toBe(true),
+    );
+  });
+});

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -398,7 +398,16 @@ export interface WebSocketServerLike {
 
 export interface WebSocketLike {
   readonly readyState: number;
-  send(data: string): void;
+  /**
+   * Send one frame. The optional callback is Node `ws`'s delivery callback: it
+   * is invoked with an `Error` when the frame could not be handed to the
+   * socket, and with nothing when it was. Supplying it is what turns a failed
+   * send from an `error` event on the socket — which this server logs and
+   * shrugs at — into a fact the caller can act on. Transports that cannot
+   * report delivery simply never call it; see {@link PtyCoreLinkServer.sendResult}
+   * for what is inferred without it.
+   */
+  send(data: string, cb?: (err?: Error) => void): void;
   close(): void;
   on(event: "message", cb: (data: unknown) => void): void;
   on(event: "close", cb: () => void): void;
@@ -414,6 +423,24 @@ export interface WebSocketLike {
 
 const DEFAULT_LIVE_EVENT_POLL_MS = 500;
 const EVENT_TAIL_LIMIT = 1_000;
+
+/**
+ * `WebSocket.CLOSING` and `WebSocket.CLOSED`. Written out rather than imported
+ * from `ws` because {@link WebSocketLike} is transport-agnostic — the injected
+ * sockets the tests drive are not `ws` instances, and this module must not need
+ * `ws` loaded to decide whether a socket can still be written to.
+ *
+ * The test is "not closing or closed" rather than "is `OPEN`" deliberately.
+ * These two are the states a write is *known* to be lost in, and they are the
+ * ones this Core reaches: a server-side `ws` is already `OPEN` when the
+ * `connection` handler gets it, so the only direction it travels is towards
+ * closed. Demanding `OPEN` would additionally refuse `CONNECTING`, which on
+ * this side of a socket means a transport that reports its state on a delay
+ * rather than a socket that cannot take bytes — a distinction worth keeping,
+ * since refusing there would silently swallow the first frame of a connection.
+ */
+const WS_CLOSING = 2;
+const WS_CLOSED = 3;
 
 /**
  * The event-log kind each project mutation op appends. Typed on the op union
@@ -796,6 +823,12 @@ export class PtyCoreLinkServer {
    * append stays outside the loop, fires once, and a connection being skipped
    * (or there being no subscribers at all) never costs the log a row.
    *
+   * Delivery here goes through the same guard the event push uses (issue 244) —
+   * `send` refuses a socket that is closing or closed rather than writing into
+   * it — but nothing is gated on the result, because PTY loss is the recoverable
+   * kind: every chunk carries a `seq` and the replay window re-delivers it. The
+   * event log has neither, which is why only that path stops on a refusal.
+   *
    * The auth skip mirrors `pushLiveEvents`: with an `authVerifier` configured,
    * a connection that has not proved identity gets nothing pushed at it. PTY
    * output is strictly more sensitive than the event timeline, and a socket
@@ -906,8 +939,23 @@ export class PtyCoreLinkServer {
 
   /**
    * Push any events appended after the connection's lastSentEventId. Runs on
-   * the poll loop once the connection has subscribed. Also advances the
-   * connection cursor so the next tick only sees newer events.
+   * the poll loop once the connection has subscribed.
+   *
+   * The cursor advances **behind** the send, never in front of it (issue 244).
+   * That ordering is the whole ticket: the client's own cursor is driven by the
+   * events it *receives*, so a cursor moved past a frame the socket refused
+   * opens a hole that nothing closes. The next `subscribe` asks for everything
+   * after a *later* event the client did get, `readEventTail` obliges, and the
+   * skipped one is gone — no error at the client, no counter, no log line. A
+   * `session:finished` lost this way is a notification the operator simply
+   * never receives, and no re-hydration carries it.
+   *
+   * So a refused frame stops the loop with the cursor still below it, and the
+   * next tick starts again from the same event. If the socket is merely
+   * closing, every retry is refused for free by the `readyState` check until
+   * the connection goes, and the reconnect replay carries the backlog off the
+   * client's real cursor. Delivery is at-least-once and in order; it is never
+   * at-most-once.
    */
   private pushLiveEvents(conn: ActiveConnection): void {
     if (!conn.subscribed || !this.eventLog) return;
@@ -919,9 +967,51 @@ export class PtyCoreLinkServer {
     const after = conn.lastSentEventId;
     const tail = this.eventLog.readEventTail(after, EVENT_TAIL_LIMIT);
     for (const event of tail) {
-      this.send(conn.ws, { type: "event", event });
+      if (!this.deliverEvent(conn, event)) return;
       conn.lastSentEventId = event.eventId;
     }
+  }
+
+  /**
+   * Put one `event` frame on a connection and say whether the socket took it.
+   * Shared by the live push and the `subscribe` replay so both move a cursor on
+   * the same evidence. A refusal is logged *naming the event* — the absence of
+   * any such line is why this class of loss was invisible (issue 244).
+   */
+  private deliverEvent(conn: ActiveConnection, event: CoreLinkEvent): boolean {
+    const accepted = this.sendResult(conn.ws, { type: "event", event }, (err) =>
+      this.rewindEventCursor(conn, event.eventId, err.message),
+    );
+    if (!accepted) {
+      this.warnEventUndelivered(conn, event.eventId, `socket readyState ${conn.ws.readyState}`);
+    }
+    return accepted;
+  }
+
+  /**
+   * A frame the socket accepted synchronously turned out not to have been
+   * delivered. Put the cursor back below it so the next tick re-sends from
+   * there.
+   *
+   * Rewinding can re-deliver an event that *did* land — anything sent after
+   * this one in the same tick. That is the deliberate side of the trade: a
+   * duplicate is a Panel applying a fact it already holds, while a skip is a
+   * fact it never learns and cannot ask for. The guard keeps the cursor
+   * monotonically *backwards* here, so two failures in one tick settle on the
+   * earliest hole rather than fighting over it.
+   */
+  private rewindEventCursor(conn: ActiveConnection, eventId: number, reason: string): void {
+    if (conn.lastSentEventId < eventId) return;
+    conn.lastSentEventId = eventId - 1;
+    this.warnEventUndelivered(conn, eventId, reason);
+  }
+
+  private warnEventUndelivered(conn: ActiveConnection, eventId: number, reason: string): void {
+    log.warn("core-link.event.undelivered", {
+      eventId,
+      clientId: conn.clientId,
+      reason,
+    });
   }
 
   private async onMessage(conn: ActiveConnection, raw: unknown): Promise<void> {
@@ -1594,7 +1684,12 @@ export class PtyCoreLinkServer {
       : [];
     this.send(ws, { type: "subscribeAck", reqId: frame.reqId, fromEventId });
     for (const event of tail) {
-      this.send(ws, { type: "event", event });
+      // Same discipline as the live push (issue 244): the replay cursor stops
+      // at the last event the socket actually took. `eventsReplayed` then tells
+      // the client that same number, so its cursor and this one agree on where
+      // the stream got to instead of both jumping to the end of a tail that was
+      // only partly written.
+      if (!this.deliverEvent(conn, event)) break;
       lastSent = event.eventId;
     }
     conn.lastSentEventId = lastSent;
@@ -1667,12 +1762,66 @@ export class PtyCoreLinkServer {
     return this.sessionLocks.heldCount();
   }
 
+  /**
+   * Send one frame, fire and forget. For everything whose loss is bounded — a
+   * reply to a request the client will notice never came, a PTY chunk the
+   * `seq`/replay window can re-deliver. Anything that advances durable state on
+   * the strength of the send having landed must use {@link sendResult} instead.
+   */
   private send(ws: WebSocketLike, frame: CoreLinkServerFrame): void {
+    this.sendResult(ws, frame);
+  }
+
+  /**
+   * Send one frame and report whether the socket accepted it (issue 244).
+   *
+   * The `try/catch` this replaced looked like it covered a failed send and did
+   * not: Node's `ws` does **not** throw on a `CLOSING`/`CLOSED` socket. With no
+   * callback supplied it emits an `error` event, which this server logs as
+   * `core-link.connection.error` and carries on from — so a caller that read
+   * "no exception" as "delivered" was reading a signal that is never sent.
+   *
+   * Two signals replace it, because one alone is not enough:
+   *
+   * - `readyState` is the synchronous half, and the half that matters here. A
+   *   socket that is already closing or closed is the reported failure — the
+   *   poll loop's 500 ms window is ample for a remote link to go unwritable
+   *   between the tail read and the send — and it is knowable *before* writing.
+   * - the delivery callback is the asynchronous half, for a socket that is
+   *   `OPEN` at the instant of the call and fails after it. It cannot gate this
+   *   return value (it fires a tick later at the earliest), so callers that
+   *   care pass `onDeliveryError` and undo whatever the optimistic return let
+   *   them do.
+   *
+   * A transport that ignores the callback (every injected fake, and the browser
+   * `WebSocket`) degrades to the `readyState` check alone, which is strictly
+   * more than the old `try/catch` reported.
+   */
+  private sendResult(
+    ws: WebSocketLike,
+    frame: CoreLinkServerFrame,
+    onDeliveryError?: (err: Error) => void,
+  ): boolean {
+    if (ws.readyState === WS_CLOSING || ws.readyState === WS_CLOSED) return false;
+    const data = serializeCoreLinkFrame(frame);
     try {
-      ws.send(serializeCoreLinkFrame(frame));
+      // The callback goes on only when a caller asked for it. Supplying one
+      // unconditionally would be a quiet loss of observability everywhere else:
+      // `ws` reports a failed send *either* to the callback *or* as an `error`
+      // event, and that event is what puts `core-link.connection.error` in the
+      // log for every fire-and-forget frame.
+      if (onDeliveryError) {
+        ws.send(data, (err) => {
+          if (err) onDeliveryError(err);
+        });
+      } else {
+        ws.send(data);
+      }
     } catch {
       /* connection closed mid-send — the close handler will clean up */
+      return false;
     }
+    return true;
   }
 
   /**
@@ -1971,7 +2120,10 @@ function adaptWs(ws: WebSocket): WebSocketLike {
     get readyState() {
       return ws.readyState;
     },
-    send: (data: string) => ws.send(data),
+    // Forward the delivery callback when the caller wants one: `ws` reports a
+    // send it could not make through that callback and, without it, only
+    // through an `error` event on the socket (issue 244).
+    send: (data: string, cb?: (err?: Error) => void) => (cb ? ws.send(data, cb) : ws.send(data)),
     close: () => ws.close(),
     ping: () => {
       try {

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -443,6 +443,14 @@ const WS_CLOSING = 2;
 const WS_CLOSED = 3;
 
 /**
+ * What one send did. The `reason` is carried rather than re-derived by the
+ * caller so the log line names the actual refusal — a closed socket and a send
+ * that threw are different facts, and a line that reports the first for the
+ * second is the kind of log that sends the next reader down the wrong path.
+ */
+type SendOutcome = { ok: true } | { ok: false; reason: string };
+
+/**
  * The event-log kind each project mutation op appends. Typed on the op union
  * rather than written as a ternary chain so a new op cannot ship without
  * deciding what a reconnecting Panel replays for it — the compiler asks.
@@ -979,13 +987,11 @@ export class PtyCoreLinkServer {
    * any such line is why this class of loss was invisible (issue 244).
    */
   private deliverEvent(conn: ActiveConnection, event: CoreLinkEvent): boolean {
-    const accepted = this.sendResult(conn.ws, { type: "event", event }, (err) =>
+    const result = this.sendResult(conn.ws, { type: "event", event }, (err) =>
       this.rewindEventCursor(conn, event.eventId, err.message),
     );
-    if (!accepted) {
-      this.warnEventUndelivered(conn, event.eventId, `socket readyState ${conn.ws.readyState}`);
-    }
-    return accepted;
+    if (!result.ok) this.warnEventUndelivered(conn, event.eventId, result.reason);
+    return result.ok;
   }
 
   /**
@@ -1801,8 +1807,10 @@ export class PtyCoreLinkServer {
     ws: WebSocketLike,
     frame: CoreLinkServerFrame,
     onDeliveryError?: (err: Error) => void,
-  ): boolean {
-    if (ws.readyState === WS_CLOSING || ws.readyState === WS_CLOSED) return false;
+  ): SendOutcome {
+    if (ws.readyState === WS_CLOSING || ws.readyState === WS_CLOSED) {
+      return { ok: false, reason: `socket readyState ${ws.readyState}` };
+    }
     const data = serializeCoreLinkFrame(frame);
     try {
       // The callback goes on only when a caller asked for it. Supplying one
@@ -1817,11 +1825,11 @@ export class PtyCoreLinkServer {
       } else {
         ws.send(data);
       }
-    } catch {
+    } catch (err) {
       /* connection closed mid-send — the close handler will clean up */
-      return false;
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
-    return true;
+    return { ok: true };
   }
 
   /**


### PR DESCRIPTION
## Summary

`pushLiveEvents` advanced a connection's event cursor whether or not the frame it
pushed reached the socket, so a single failed send became a permanent hole no
reconnect replay could close. This makes the cursor advance **behind** the send:
a frame the socket refuses leaves `lastSentEventId` where it was and the next
poll tick retries from the same event.

The failure was silent by construction — Node's `ws` does not throw on a
`CLOSING`/`CLOSED` socket, it emits an `error` event the server logged as a
benign `core-link.connection.error` — so a refusal now also logs
`core-link.event.undelivered` naming the event id.

Base is `fix/session-and-event-reliability` (this ticket's train branch), not
`main` and not `beta/0.3.1`.

## Related issues

Closes #244

Adjacent, deliberately untouched:

- #208 — the `events-tail-cursor` CI flake sits on these same semantics and comes
  after this ticket in the train. The suite is green here; its harness is left
  exactly as it was for that ticket to change.
- #243 (session settle / hook ack / boot reconciliation) and #242
  (`session-drive-register.ts`, panel `router.ts`) are in flight in parallel and
  own those files. Nothing here touches either.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [ ] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## What changed

`packages/core/src/pty-core-link-server.ts`

- `sendResult(ws, frame, onDeliveryError?)` replaces the bare `send`, and reports
  whether the socket took the frame on two signals: a `readyState` of `CLOSING`
  or `CLOSED` is refused *before* the write (the remote-Core case — the 500 ms
  poll leaves ample room for a link to go unwritable between the tail read and
  the send), and a socket that fails *after* an accepted call reports through
  `ws`'s delivery callback, which `adaptWs` now forwards. The callback is only
  attached when a caller asks for it, so every other frame keeps emitting the
  socket `error` that puts `core-link.connection.error` in the log.
- `pushLiveEvents` stops at the first refusal with the cursor still below it; a
  late callback failure rewinds the cursor to the same place. Delivery is
  at-least-once and in order rather than at-most-once — a duplicate is a fact the
  Panel already holds, a skip is one it cannot ask for.
- `handleSubscribe` moves its replay cursor on the same evidence and reports the
  event it actually reached in `eventsReplayed`, instead of the end of a tail it
  only partly wrote.
- `fanOutPtyEvent` picks up the `readyState` guard through the same `send` but
  stays ungated on the result: PTY loss is recoverable via `seq` + replay, which
  is the difference the ticket calls out.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/E2E tests added/updated
- [x] Manually verified (describe steps below)

New: `packages/core/src/__tests__/core-link-event-cursor-advance.test.ts`, four
tests, each of which **fails on the old ordering**:

| Test | On `da2af3e` |
| --- | --- |
| replays an event whose send failed, instead of skipping it forever — the ticket's own repro: 3 events, the middle one refused, reconnect off the client's real cursor | delivered set is `[1, 3]`; event 2 is gone for good |
| keeps the cursor put while the socket is unwritable, and delivers on recovery | the events are consumed by the refusal and never arrive |
| stops the subscribe replay at the last event the socket took | `eventsReplayed` reports a tail that was only partly written |
| names the undeliverable event in a log line | only `core-link.connection.error`, which names no event |

The fake socket models both real failure modes: `readyState` leaving `OPEN` with
no close handshake, and a send that is accepted and then reported failed a tick
later — neither of which throws.

Suites run locally (`env -u AC_*`):

- `@actana/core` — 60 files, 1143 tests, green
- `@actana/sdk` — 19 files, 236 tests, green (it drives `PtyCoreLinkServer`
  through `fake-core-link`)
- `@actana/cli` — 30 files, 421 tests, green, `events-tail-cursor.test.ts`
  included and unmodified
- `pnpm typecheck` across the workspace, and `pnpm lint` (0 errors)

## Checklist

- [x] This PR targets the open train branch for this work (`fix/session-and-event-reliability`), not `main`
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix works, and all tests pass locally
- [ ] I updated documentation (README, docs/, changelog entry) where relevant — no docs surface changes; `CHANGELOG.md` has not been touched by a `0.3.x` commit and is written per release, not per PR
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (or this PR is marked as draft/stacked) — left as a **draft** on the train branch
