### PR TITLE
fix(core): settle Core-owned Sessions — hook ack, an unarmed backstop, and a boot sweep

### DIFF
--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -20,6 +20,9 @@ about everything else on a Core — as an Event replayed off its cursor.
 | Status/title writes + events | `packages/core/src/core-task-writer.ts` |
 | Title generation | `packages/core/src/core-title-generator.ts` |
 | PTY exit settle | `packages/core/src/pty-manager.ts` → `onSessionExit` |
+| Hook delivery misses | `packages/core/src/harness-hook-delivery.ts` |
+| Quiet-Session backstop | `packages/core/src/core-session-backstop.ts` |
+| Boot sweep | `packages/core/src/core-session-sweep.ts` |
 
 The Panel keeps a hook endpoint (`POST /api/hooks/<slug>`) for its own remaining
 local task rows, running the same shared pipeline. A Core-owned Session never
@@ -66,7 +69,8 @@ next turn's `Stop` for the whole TTL.
 
 Backstops, so a `SubagentStop` that never arrives (lost POST, killed process) —
 or a healed `running` that no `Stop` will ever follow — cannot hold a task on
-`running` forever:
+`running` forever. The first three are armed **by a hook that arrived**; the
+fourth is armed by nothing, which is the point (issue 243):
 
 - Tracked entries expire after 2 hours (kept long on purpose — a short TTL would
   prematurely finish sessions whose subagents legitimately run long).
@@ -80,6 +84,28 @@ or a healed `running` that no `Stop` will ever follow — cannot hold a task on
 - Tracking is dropped outright when a new session id is captured, on
   `SessionStart` with `source: "clear"` (same session id, but `/clear` kills
   background work), and when the PTY process exits.
+- **The quiet-Session backstop** (`core-session-backstop.ts`) sweeps the
+  database once a minute and settles any row still claiming `running` that has
+  gone quiet. Nothing arms it, so it covers the case the three above cannot: a
+  turn whose terminal `Stop` was the POST that dropped, where nothing was held,
+  nothing was healed and no subagent was ever tracked.
+
+Elapsed time is not what "quiet" means, and it could not be — a turn may run for
+hours. A working harness never stops talking: every tool call fires the
+unmatched `PostToolUse`, and its TUI redraws a spinner and elapsed-time counter
+into the PTY about once a second. So **hooks and PTY output both count as
+activity** (output throttled to one report per five seconds per PTY), a row's
+own `updated_at` is the floor for a Session the process has not heard from yet,
+and **fifteen minutes with neither** is read as a turn that ended without anyone
+being told. A live PTY makes that settle a `finished`; no live PTY makes it a
+`disconnected`, because a process that went away did not finish. `needs-input`
+is never swept — a Session waiting on a human may wait silently forever.
+
+The trade is knowingly paid: a harness that works in total silence for longer
+than the window gets a card that reads `finished` while it is still going.
+Nothing is killed, and the next `UserPromptSubmit` puts the row back on
+`running`. Before it, a lost `Stop` wedged the Session until a human edited the
+row by hand — while the Panel said the opposite.
 
 `Notification` is also intentionally narrowed to `permission_prompt`. Claude Code
 sends idle input reminders through the same hook event, so treating all
@@ -169,6 +195,44 @@ The harness pipes the hook payload (`hook_event_name`, `session_id`, `cwd`,
 `transcript_path`, …) on stdin; the command forwards it as the request body.
 `|| true` is load-bearing: a hook must never block or fail an operator's session.
 
+### Delivery, and what happens when there is none
+
+Fail-soft is not the same as silent, and until issue 243 this path was both. A
+`-m 3` POST against a Core whose event loop is also serving PTY fan-out, SQLite
+writes and file transfers is reachable under load, and `|| true` swallowed a
+timeout, a connection refused, a 401 and a 500 identically. Nothing on either
+side recorded the attempt, so a lost hook left no trace anywhere — and a lost
+terminal `Stop` wedged its Session on `running` with nothing to say why.
+
+Both ends now account for it:
+
+- The command adds `-f`, so a non-2xx answer is a failure rather than a silent
+  success, and `--retry 2 --retry-delay 1`, which retries what curl calls a
+  transient error — the timeout, above all. Three attempts bound the worst case
+  at about eleven seconds, well inside a harness's own hook timeout, and only on
+  the path where the Session's status is already wrong. `--retry-connrefused` is
+  deliberately absent: it would raise the curl version the command needs, and a
+  refused connection means the Core is down.
+- What still could not be delivered is appended to `$AC_HOOK_MISS_LOG`
+  (`<user-data-dir>/hook-misses.log`) as one tab-separated
+  `<iso8601> <taskId> <event> <curl exit>` line. Unset, the record goes to
+  `/dev/null` — a workspace opened by hand writes nowhere rather than failing.
+- The receiver counts the hooks it accepts and answers with that delivery
+  number, so an ack is a fact rather than an empty 200.
+- `HookDeliveryMonitor` drains the miss log into the Core's log with a running
+  total, starting at boot: a hook refused during a restart is exactly the drop
+  nobody would otherwise hear about.
+- OpenCode's plugin does the same in its own idiom — it checks `res.ok`, retries
+  once, and writes the same line.
+
+`-o /dev/null` rides along and is not cosmetic: Claude Code reads a hook's
+stdout as control JSON, so the receiver's answer had no business being printed
+there.
+
+The command still ends in `|| true`, and still means it: a delivered hook
+short-circuits the chain, a dropped one records itself first, and a record that
+cannot be written falls through to it.
+
 ## How a status change reaches the card
 
 1. The receiver hands the payload to `CoreHarnessStatus`.
@@ -200,8 +264,20 @@ Sessions whose process is gone:
   The Panel's own exit patch no longer fires for a Core-owned row: it was
   unconditional, so it would overwrite an `interrupted` Session with `finished`
   and raise a spurious `session:finished` besides.
-- **Boot sweep** — the Core's DB bootstrap stamps `disconnected` on rows left
-  `running` / `needs-input`, since no PTY of the previous run survived it.
+- **Boot sweep** — `core-session-sweep.ts` runs once per Core boot, before the
+  PTY core, the hook receiver or the core-link server can produce a Session of
+  this run. At that moment no PTY of this process exists, so every row still
+  claiming `running` / `needs-input` is an orphan of the previous one: a Core's
+  PTYs die with it, silently, with no exit callback and no `pty:exit`. Each is
+  written to `disconnected` through `CoreTaskWriter`, so the settle appends the
+  `task:updated` event a connected Panel re-renders from — a sweep nobody is
+  told about leaves the operator looking at the same wrong card.
+
+  `disconnected` rather than `finished` or `terminated`: it is the status the
+  Panel already uses for a process that went away without reporting, and it
+  claims nothing about how the work ended. The Panel has had this sweep for its
+  own rows all along; what it never had was scope over Core-owned ones, which is
+  every Session on a remote Core (issue 243).
 
 ## Terminal-input fallback
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,24 @@ lands, and `actana status` prints the Core's health, its endpoint, whether a
 pairing token is available, and — when one exists — whether a newer release
 does too.
 
+## Log lines worth grepping for
+
+A Core says something when a Session's status is decided by something other
+than the harness reporting it (issue 243). All of them are ordinary log lines —
+there is no counter endpoint to scrape:
+
+| Line | What it means |
+| --- | --- |
+| `hook-delivery.missed` | a hook's POST never got an ack; the line names the task, the event and curl's exit |
+| `hook-delivery.missed-total` | how many drops this Core has seen since boot — one a week is a flake, forty in an hour is a Core losing to its own load |
+| `session-sweep.settled` | rows a Core restart stranded, marked `disconnected` at boot |
+| `session-backstop.settled` | a Session settled because its turn went quiet and no `Stop` ever arrived |
+
+The drops are recorded by the hook itself into
+`<user-data-dir>/hook-misses.log` and drained into the log from there, so the
+ones that happened while the Core was down show up on its next boot. See
+[harness status detection](harness-status-detection.md#delivery-and-what-happens-when-there-is-none).
+
 There is no metrics endpoint and no tracing exporter. The Panel holds no
 task-shaped state to report on — each Core owns its own
 ([ADR 0004](adr/0004-core-owns-write-path.md)) — so the useful signal is the

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -1,0 +1,218 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapCoreDb } from "../core-db-bootstrap";
+import {
+  configureCoreMutationStore,
+  coreMutationStore,
+  disposeCoreMutationStore,
+} from "../core-mutation-store";
+import {
+  configureCoreQueryStore,
+  coreQueryStore,
+  disposeCoreQueryStore,
+  listActiveTasks,
+} from "../core-query-store";
+import {
+  appendEvent,
+  configureEventLogStore,
+  disposeEventLogStore,
+  getLastEventId,
+  readEventTail,
+} from "../event-log-store";
+import { CoreTaskWriter } from "../core-task-writer";
+import { CoreSessionBackstop } from "../core-session-backstop";
+import { clearSubagentActivity } from "@actana/shared/subagent-activity";
+
+// The backstop nobody has to arm (issue 243 part 2), against this Core's real
+// SQLite and event log.
+//
+// The case that matters is the one the drain backstop cannot reach: a turn
+// whose terminal `Stop` was the POST that dropped. Nothing was held, nothing
+// was armed, no subagent was tracked — the row simply says `running` with no
+// timer watching it. Every test below starts from exactly that row.
+
+const QUIET_MS = 15 * 60 * 1000;
+const MINUTE = 60 * 1000;
+
+describe("settling a turn whose end nobody reported", () => {
+  let userDataDir: string;
+  let writer: CoreTaskWriter;
+  let nowMs: number;
+  let livePtys: Set<string>;
+
+  const makeBackstop = () =>
+    new CoreSessionBackstop({
+      listActiveTasks,
+      writer,
+      hasLivePty: (taskId) => livePtys.has(taskId),
+      now: () => nowMs,
+      quietMs: QUIET_MS,
+    });
+
+  const insert = (taskId: string, status: string) => {
+    coreMutationStore.mutateTask({
+      op: "create",
+      taskId,
+      projectId: "p1",
+      title: taskId,
+      agent: "claude-code",
+      status,
+    });
+    livePtys.add(taskId);
+  };
+  const statusOf = (taskId: string) => coreQueryStore.getTask(taskId)?.status;
+  const kindsSince = (eventId: number) => readEventTail(eventId, 100).map((e) => e.kind);
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-session-backstop-"));
+    bootstrapCoreDb(userDataDir);
+    configureCoreMutationStore(userDataDir);
+    configureCoreQueryStore(userDataDir);
+    configureEventLogStore(userDataDir);
+    writer = new CoreTaskWriter({
+      mutationPort: coreMutationStore,
+      queryPort: coreQueryStore,
+      eventLog: { appendEvent, getLastEventId, readEventTail },
+    });
+    coreMutationStore.mutateProject({
+      op: "create",
+      projectId: "p1",
+      name: "Warehouse",
+      path: userDataDir,
+    });
+    nowMs = Date.now();
+    livePtys = new Set();
+  });
+
+  afterEach(() => {
+    clearSubagentActivity("t-1");
+    disposeCoreMutationStore();
+    disposeCoreQueryStore();
+    disposeEventLogStore();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("finishes a Session that has gone quiet, with nothing having armed it", () => {
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+    const before = getLastEventId();
+
+    // No hook was ever seen for this row, so no timer exists for it anywhere —
+    // which is precisely the state a lost `Stop` leaves behind.
+    nowMs += QUIET_MS + MINUTE;
+    expect(backstop.sweepOnce()).toEqual(["t-1"]);
+
+    expect(statusOf("t-1")).toBe("finished");
+    // The finish the operator never got: card, toast and notification all
+    // route on this event (ADR 0008).
+    expect(kindsSince(before)).toContain("session:finished");
+  });
+
+  it("leaves a turn alone while its harness is still talking", () => {
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+
+    // A long turn: hours of work, output all the way through. Every chunk of
+    // PTY output and every hook lands here.
+    for (let minute = 0; minute < 120; minute += 1) {
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1");
+      expect(backstop.sweepOnce()).toEqual([]);
+    }
+    expect(statusOf("t-1")).toBe("running");
+
+    // Then the turn ends and its `Stop` drops. Nothing else is coming.
+    nowMs += QUIET_MS + MINUTE;
+    expect(backstop.sweepOnce()).toEqual(["t-1"]);
+    expect(statusOf("t-1")).toBe("finished");
+  });
+
+  it("counts the row's own last write as the last thing heard from it", () => {
+    // A Session this process has heard nothing about since boot — the restart
+    // case — must not be settled for a silence that predates the Core.
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+
+    nowMs += QUIET_MS - MINUTE;
+    expect(backstop.sweepOnce()).toEqual([]);
+    nowMs += 2 * MINUTE;
+    expect(backstop.sweepOnce()).toEqual(["t-1"]);
+  });
+
+  it("never settles a Session that is waiting on a human", () => {
+    // `needs-input` may sit silent forever and still be true; a timer cannot
+    // make it truer, and finishing it would hide a question.
+    insert("t-1", "needs-input");
+    const backstop = makeBackstop();
+
+    nowMs += 10 * QUIET_MS;
+    expect(backstop.sweepOnce()).toEqual([]);
+    expect(statusOf("t-1")).toBe("needs-input");
+  });
+
+  it("calls a quiet Session with no PTY disconnected, not finished", () => {
+    // No live PTY means the process went away without its exit being
+    // recorded. That is not a finish, and it raises no finish notification.
+    insert("t-1", "running");
+    livePtys.delete("t-1");
+    const backstop = makeBackstop();
+    const before = getLastEventId();
+
+    nowMs += QUIET_MS + MINUTE;
+    expect(backstop.sweepOnce()).toEqual(["t-1"]);
+    expect(statusOf("t-1")).toBe("disconnected");
+    expect(kindsSince(before)).not.toContain("session:finished");
+  });
+
+  it("settles a row once, and the next sweep finds nothing to do", () => {
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+
+    nowMs += QUIET_MS + MINUTE;
+    expect(backstop.sweepOnce()).toEqual(["t-1"]);
+    const after = getLastEventId();
+
+    nowMs += QUIET_MS;
+    expect(backstop.sweepOnce()).toEqual([]);
+    expect(getLastEventId()).toBe(after);
+  });
+
+  it("settles every quiet Session, not just the first", () => {
+    insert("t-1", "running");
+    insert("t-2", "running");
+    insert("t-3", "running");
+    const backstop = makeBackstop();
+
+    nowMs += QUIET_MS + MINUTE;
+    backstop.noteActivity("t-2");
+    expect(backstop.sweepOnce().sort()).toEqual(["t-1", "t-3"]);
+    expect(statusOf("t-2")).toBe("running");
+  });
+
+  it("stops watching a Session whose PTY exit already settled it", () => {
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+    backstop.noteActivity("t-1");
+    backstop.forget("t-1");
+
+    // The exit path settles the row; the backstop must not then re-settle it.
+    coreMutationStore.mutateTask({ op: "update", taskId: "t-1", status: "terminated" });
+    nowMs += QUIET_MS + MINUTE;
+    expect(backstop.sweepOnce()).toEqual([]);
+    expect(statusOf("t-1")).toBe("terminated");
+  });
+
+  it("runs on a timer without holding the process open", () => {
+    insert("t-1", "running");
+    const backstop = makeBackstop();
+    backstop.start();
+    // Idempotent start, and a stop that can be called on a stopped instance —
+    // the shutdown path calls it unconditionally.
+    backstop.start();
+    backstop.stop();
+    backstop.stop();
+    expect(statusOf("t-1")).toBe("running");
+  });
+});

--- a/packages/core/src/__tests__/core-session-sweep.test.ts
+++ b/packages/core/src/__tests__/core-session-sweep.test.ts
@@ -1,0 +1,163 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapCoreDb } from "../core-db-bootstrap";
+import {
+  configureCoreMutationStore,
+  coreMutationStore,
+  disposeCoreMutationStore,
+} from "../core-mutation-store";
+import {
+  configureCoreQueryStore,
+  coreQueryStore,
+  disposeCoreQueryStore,
+  listActiveTasks,
+} from "../core-query-store";
+import {
+  appendEvent,
+  configureEventLogStore,
+  disposeEventLogStore,
+  getLastEventId,
+  readEventTail,
+} from "../event-log-store";
+import { CoreTaskWriter } from "../core-task-writer";
+import { sweepStrandedSessions } from "../core-session-sweep";
+
+// The boot sweep (issue 243 part 3), against this Core's real SQLite and real
+// event log — the two things a stranded row is wrong in.
+//
+// The scenario is a Core restart: rows left claiming `running` by PTYs that
+// died with the previous process, which no `onSessionExit` will ever fire for.
+// Everything here starts from rows written the way the Core writes them, and
+// asserts on what a Panel would actually see.
+
+describe("settling the Sessions a Core restart stranded", () => {
+  let userDataDir: string;
+  let writer: CoreTaskWriter;
+
+  const insert = (taskId: string, status: string, archived = false) => {
+    coreMutationStore.mutateTask({
+      op: "create",
+      taskId,
+      projectId: "p1",
+      title: taskId,
+      agent: "claude-code",
+      status,
+    });
+    if (archived) {
+      coreMutationStore.mutateTask({ op: "update", taskId, archived: true });
+    }
+  };
+  const statusOf = (taskId: string) => coreQueryStore.getTask(taskId)?.status;
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-session-sweep-"));
+    bootstrapCoreDb(userDataDir);
+    configureCoreMutationStore(userDataDir);
+    configureCoreQueryStore(userDataDir);
+    configureEventLogStore(userDataDir);
+    writer = new CoreTaskWriter({
+      mutationPort: coreMutationStore,
+      queryPort: coreQueryStore,
+      eventLog: { appendEvent, getLastEventId, readEventTail },
+    });
+    coreMutationStore.mutateProject({
+      op: "create",
+      projectId: "p1",
+      name: "Warehouse",
+      path: userDataDir,
+    });
+  });
+
+  afterEach(() => {
+    disposeCoreMutationStore();
+    disposeCoreQueryStore();
+    disposeEventLogStore();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("marks every row still claiming a live process as disconnected", () => {
+    insert("t-running", "running");
+    insert("t-waiting", "needs-input");
+
+    const settled = sweepStrandedSessions({ listActiveTasks, writer });
+
+    expect(settled.sort()).toEqual(["t-running", "t-waiting"]);
+    expect(statusOf("t-running")).toBe("disconnected");
+    expect(statusOf("t-waiting")).toBe("disconnected");
+  });
+
+  it("leaves a Session that already settled exactly as it settled", () => {
+    // The whole point of `disconnected` over `finished`: the sweep makes no
+    // claim about work whose end was actually reported.
+    insert("t-finished", "finished");
+    insert("t-interrupted", "interrupted");
+    insert("t-ready", "ready");
+
+    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(statusOf("t-finished")).toBe("finished");
+    expect(statusOf("t-interrupted")).toBe("interrupted");
+    expect(statusOf("t-ready")).toBe("ready");
+  });
+
+  it("sweeps an archived row too — it is the same stale row, one tab away", () => {
+    insert("t-archived", "running", true);
+    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual(["t-archived"]);
+    expect(statusOf("t-archived")).toBe("disconnected");
+  });
+
+  it("appends the event a connected Panel re-renders the card from", () => {
+    insert("t-running", "running");
+    const before = getLastEventId();
+
+    sweepStrandedSessions({ listActiveTasks, writer });
+
+    const appended = readEventTail(before, 100);
+    const updates = appended.filter((e) => e.kind === "task:updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].taskId).toBe("t-running");
+    // `disconnected` is not a finish, so no notification may ride out with it.
+    expect(appended.map((e) => e.kind)).not.toContain("session:finished");
+  });
+
+  it("is a no-op on the second boot, because the first one settled everything", () => {
+    insert("t-running", "running");
+    sweepStrandedSessions({ listActiveTasks, writer });
+    const after = getLastEventId();
+
+    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(getLastEventId()).toBe(after);
+  });
+
+  it("keeps sweeping when one row cannot be written", () => {
+    insert("t-a", "running");
+    insert("t-b", "running");
+    // A row that goes away between the read and the write — a Panel deleting
+    // a Session while this Core boots. It must cost that row, not the sweep.
+    const failing = new CoreTaskWriter({
+      mutationPort: {
+        mutateProject: coreMutationStore.mutateProject,
+        mutateTask: (mutation) => {
+          if (mutation.op === "update" && mutation.taskId === "t-a") {
+            throw new Error("row vanished");
+          }
+          return coreMutationStore.mutateTask(mutation);
+        },
+        listSessions: coreMutationStore.listSessions,
+      },
+      queryPort: coreQueryStore,
+      eventLog: { appendEvent, getLastEventId, readEventTail },
+    });
+
+    expect(sweepStrandedSessions({ listActiveTasks, writer: failing })).toEqual(["t-b"]);
+    expect(statusOf("t-b")).toBe("disconnected");
+    expect(statusOf("t-a")).toBe("running");
+  });
+
+  it("sweeps nothing, and says nothing, on a Core with no stranded rows", () => {
+    const before = getLastEventId();
+    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(getLastEventId()).toBe(before);
+  });
+});

--- a/packages/core/src/__tests__/harness-hook-delivery.test.ts
+++ b/packages/core/src/__tests__/harness-hook-delivery.test.ts
@@ -1,0 +1,226 @@
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HookDeliveryMonitor,
+  drainHookMisses,
+  hookMissLogPath,
+} from "../harness-hook-delivery";
+import { HOOK_MISS_LOG_ENV, hookCommand } from "../harness-hooks";
+import {
+  startHarnessHookReceiver,
+  type HarnessHookReceiver,
+} from "../harness-hook-receiver";
+
+// Hook delivery, both ends (issue 243 part 1).
+//
+// The failure this covers is the one with no evidence: a hook POST that never
+// landed, swallowed by `|| true`, leaving a Session wedged on `running` and
+// nothing anywhere to say why. So the assertions below start at the real shell
+// command a hook file carries, run it against a real receiver, and read the
+// file it writes when the Core does not ack.
+
+const hasSh = spawnSync("sh", ["-c", "exit 0"]).status === 0;
+const hasCurl = spawnSync("sh", ["-c", "command -v curl"]).status === 0;
+const shellAvailable = hasSh && hasCurl;
+
+describe("recording hooks this Core never acked", () => {
+  let dir: string;
+  let missLog: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-hook-delivery-"));
+    missLog = hookMissLogPath(dir);
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("reads a recorded miss and clears the file so it is reported once", () => {
+    fs.writeFileSync(
+      missLog,
+      "2026-08-17T10:54:51Z\tt-1\tStop\t28\n2026-08-17T10:55:02Z\tt-1\tSubagentStop\t7\n",
+    );
+
+    expect(drainHookMisses(missLog)).toEqual([
+      { at: "2026-08-17T10:54:51Z", taskId: "t-1", event: "Stop", code: "28" },
+      { at: "2026-08-17T10:55:02Z", taskId: "t-1", event: "SubagentStop", code: "7" },
+    ]);
+    // Drained means drained: a second pass must not re-report the same drops,
+    // or the running total stops meaning anything.
+    expect(drainHookMisses(missLog)).toEqual([]);
+    expect(fs.readFileSync(missLog, "utf8")).toBe("");
+  });
+
+  it("says nothing at all when no hook has been dropped", () => {
+    expect(drainHookMisses(missLog)).toEqual([]);
+    fs.writeFileSync(missLog, "");
+    expect(drainHookMisses(missLog)).toEqual([]);
+  });
+
+  it("drops a line it cannot read rather than guessing at it", () => {
+    fs.writeFileSync(missLog, "garbage\n\n2026-08-17T10:54:51Z\tt-1\tStop\t28\n");
+    expect(drainHookMisses(missLog)).toHaveLength(1);
+  });
+
+  it("keeps a running total, and reports what a dead Core's window recorded", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Written while this process was not running — the drops nobody could
+    // otherwise hear about, since the Core that would have logged them was the
+    // thing that was down.
+    fs.writeFileSync(missLog, "2026-08-17T10:54:51Z\tt-1\tStop\t7\n");
+
+    const monitor = new HookDeliveryMonitor({ missLogPath: missLog, intervalMs: 60_000 });
+    monitor.start();
+    expect(monitor.missCount()).toBe(1);
+
+    fs.appendFileSync(missLog, "2026-08-17T11:00:00Z\tt-2\tStop\t28\n");
+    monitor.drain();
+    expect(monitor.missCount()).toBe(2);
+    monitor.stop();
+
+    const logged = warn.mock.calls.map((call) => JSON.stringify(call)).join("\n");
+    expect(logged).toContain("hook-delivery.missed");
+    expect(logged).toContain("t-2");
+  });
+});
+
+describe("the hook command's half of the ack", () => {
+  it("checks the answer, retries a transient one, and still cannot fail a turn", () => {
+    const command = hookCommand("claude", "Stop");
+    // -f: without it curl exits 0 on a 401, a 404 and a 500 alike, so "the
+    // Core took it" was never something this command could know.
+    expect(command).toContain("-f");
+    expect(command).toContain("--retry 2");
+    // Whatever else it does, a hook may never take the operator's turn down.
+    expect(command).toContain("|| true");
+    // Claude Code reads hook stdout as control JSON; the receiver's answer has
+    // no business being printed there.
+    expect(command).toContain("-o /dev/null");
+  });
+
+  it("records what it could not deliver, and writes nowhere when unconfigured", () => {
+    const command = hookCommand("claude", "Stop");
+    expect(command).toContain(`$\{${HOOK_MISS_LOG_ENV}:-/dev/null}`);
+    // The record names the task and the event, which is what makes a drop
+    // attributable to the Session it wedged.
+    expect(command).toContain('"Stop"');
+    expect(command).toContain("$AC_HOOK_TASK_ID");
+  });
+});
+
+// The drop paths pay the command's own retry budget (three attempts, a second
+// between them), so they need more than vitest's default 5s.
+const DROP_PATH_TIMEOUT_MS = 40_000;
+
+describe("the two ends together, run as a hook really runs them", () => {
+  let dir: string;
+  let missLog: string;
+  let receiver: HarnessHookReceiver | null = null;
+  let seen: string[];
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-hook-delivery-e2e-"));
+    missLog = hookMissLogPath(dir);
+    seen = [];
+    receiver = await startHarnessHookReceiver((taskId, _payload, eventName) => {
+      seen.push(`${taskId}:${eventName}`);
+      // "t-gone" is a task this Core does not have — the 404 the pipeline
+      // answers when a hook names a row that was deleted.
+      return taskId === "t-gone"
+        ? { ok: false, body: { error: "task not found" } }
+        : { ok: true, body: { ok: true, status: "finished" } };
+    });
+  });
+  afterEach(() => {
+    receiver?.close();
+    receiver = null;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Run the hook the way a harness does — a real `sh`, a real `curl`, the
+  // payload on stdin — and never synchronously: the receiver under test lives
+  // in THIS event loop, so a blocking child would deadlock against the server
+  // that is supposed to answer it.
+  const runHook = (env: Record<string, string>): Promise<number> => {
+    const script = path.join(dir, "hook.sh");
+    fs.writeFileSync(script, hookCommand("claude", "Stop"));
+    return new Promise((resolve, reject) => {
+      const child = spawn("sh", [script], {
+        env: { ...process.env, ...env },
+        stdio: ["pipe", "ignore", "ignore"],
+      });
+      child.on("error", reject);
+      child.on("close", (code) => resolve(code ?? 0));
+      child.stdin.end(JSON.stringify({ hook_event_name: "Stop" }));
+    });
+  };
+
+  it.skipIf(!shellAvailable)("acks a delivered hook and records nothing", async () => {
+    await runHook({
+      AC_HOOK_URL: receiver!.url,
+      AC_HOOK_TOKEN: receiver!.token,
+      AC_HOOK_TASK_ID: "t-1",
+      AC_HOOK_MISS_LOG: missLog,
+    });
+
+    expect(seen).toEqual(["t-1:Stop"]);
+    expect(receiver!.acceptedCount()).toBe(1);
+    expect(drainHookMisses(missLog)).toEqual([]);
+  });
+
+  it.skipIf(!shellAvailable)("records the drop when the Core is not there", async () => {
+    // The Core is down (or its receiver's port moved with a restart) — the
+    // lost `Stop` this whole issue is about.
+    await runHook({
+      AC_HOOK_URL: "http://127.0.0.1:1",
+      AC_HOOK_TOKEN: "irrelevant",
+      AC_HOOK_TASK_ID: "t-wedged",
+      AC_HOOK_MISS_LOG: missLog,
+    });
+
+    const misses = drainHookMisses(missLog);
+    expect(misses).toHaveLength(1);
+    expect(misses[0]).toMatchObject({ taskId: "t-wedged", event: "Stop" });
+    expect(misses[0].at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(receiver!.acceptedCount()).toBe(0);
+  }, DROP_PATH_TIMEOUT_MS);
+
+  it.skipIf(!shellAvailable)("records a refusal too — a 401 is a lost hook, not a delivered one", async () => {
+    await runHook({
+      AC_HOOK_URL: receiver!.url,
+      AC_HOOK_TOKEN: "wrong-token",
+      AC_HOOK_TASK_ID: "t-1",
+      AC_HOOK_MISS_LOG: missLog,
+    });
+    expect(drainHookMisses(missLog)).toHaveLength(1);
+    expect(receiver!.acceptedCount()).toBe(0);
+
+    // …and a task this Core no longer has, which is the other answer the old
+    // `|| true` made indistinguishable from success.
+    await runHook({
+      AC_HOOK_URL: receiver!.url,
+      AC_HOOK_TOKEN: receiver!.token,
+      AC_HOOK_TASK_ID: "t-gone",
+      AC_HOOK_MISS_LOG: missLog,
+    });
+    expect(drainHookMisses(missLog)).toHaveLength(1);
+    expect(receiver!.acceptedCount()).toBe(0);
+  }, DROP_PATH_TIMEOUT_MS);
+
+  it.skipIf(!shellAvailable)("stays fail-soft with no miss log configured at all", async () => {
+    // A workspace opened by hand, or a Core that wired none: the command must
+    // still exit 0 and write nowhere.
+    const code = await runHook({
+      AC_HOOK_URL: "http://127.0.0.1:1",
+      AC_HOOK_TOKEN: "irrelevant",
+      AC_HOOK_TASK_ID: "t-1",
+      AC_HOOK_MISS_LOG: "",
+    });
+    expect(code).toBe(0);
+    expect(fs.existsSync(missLog)).toBe(false);
+  }, DROP_PATH_TIMEOUT_MS);
+});

--- a/packages/core/src/__tests__/harness-hooks.test.ts
+++ b/packages/core/src/__tests__/harness-hooks.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  HOOK_MISS_LOG_ENV,
   HOOK_TASK_ID_ENV,
   HOOK_TOKEN_ENV,
   HOOK_URL_ENV,
@@ -57,7 +58,21 @@ describe("installing a harness's lifecycle hooks (issue 84)", () => {
   });
 
   it("never blocks the operator's session when the receiver is down", () => {
+    // The chain still ends in `|| true`: a delivered hook short-circuits it, a
+    // dropped one records itself first, and a record that cannot be written
+    // falls through to it. Either way the command exits 0 (issue 243).
     expect(hookCommand("claude", "Stop")).toContain("|| true");
+  });
+
+  it("checks the Core's ack instead of swallowing every answer (issue 243)", () => {
+    const command = hookCommand("claude", "Stop");
+    // `-f` is what makes a 401/404/500 a failure rather than a silent success,
+    // and the retry is for the timeout a busy Core hands a `-m 3` POST.
+    expect(command).toContain("-f");
+    expect(command).toContain("--retry 2");
+    // The drop lands in a file the Core drains into its log — the trace this
+    // path had none of.
+    expect(command).toContain(`$\{${HOOK_MISS_LOG_ENV}:-/dev/null}`);
   });
 
   it("matches PreToolUse to AskUserQuestion but leaves PostToolUse open", () => {

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -84,6 +84,7 @@ import { CoreTaskWriter } from "./core-task-writer";
 import { CoreHarnessStatus } from "./core-harness-status";
 import { CoreTitleGenerator } from "./core-title-generator";
 import { startHarnessHookReceiver, type HarnessHookReceiver } from "./harness-hook-receiver";
+import { HookDeliveryMonitor, hookMissLogPath } from "./harness-hook-delivery";
 import { generateCertMaterial } from "./core-cert-material";
 import { verifyBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import {
@@ -200,11 +201,25 @@ async function startCore(): Promise<void> {
     console.error(`[core-entry] hook-receiver.start-failed: ${err}`);
   }
 
+  // The other end of the same conversation (issue 243). A hook that never got
+  // an ack records one line in this file; this folds those lines into the
+  // Core's log with a running total, starting with whatever was recorded while
+  // this process was not running — a restart is exactly when hooks are
+  // refused, and those are the drops nobody could otherwise hear about.
+  const hookDelivery = new HookDeliveryMonitor({ missLogPath: hookMissLogPath(userDataDir) });
+  hookDelivery.start();
+
   const deps: PtyCoreDeps = {
     userDataDir,
     appPath,
     getHookEnv: (): PtyHookEnv | null =>
-      hookReceiver ? { apiUrl: hookReceiver.url, token: hookReceiver.token } : null,
+      hookReceiver
+        ? {
+            apiUrl: hookReceiver.url,
+            token: hookReceiver.token,
+            missLogPath: hookMissLogPath(userDataDir),
+          }
+        : null,
     // Protect the core-link WS port so killLaunchProcesses never touches it —
     // and the hook receiver's, for the same reason: killing it would silently
     // strand every running Session's status.
@@ -476,6 +491,7 @@ async function startCore(): Promise<void> {
     core.killAll();
     server.close();
     hookReceiver?.close();
+    hookDelivery.stop();
     availabilityStore.stop();
     updateNotice?.stop();
     disposeEventLogStore();

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -72,6 +72,7 @@ import {
   configureCoreQueryStore,
   disposeCoreQueryStore,
   coreQueryStore,
+  listActiveTasks,
 } from "./core-query-store";
 import {
   configureCoreMutationStore,
@@ -85,6 +86,7 @@ import { CoreHarnessStatus } from "./core-harness-status";
 import { CoreTitleGenerator } from "./core-title-generator";
 import { startHarnessHookReceiver, type HarnessHookReceiver } from "./harness-hook-receiver";
 import { HookDeliveryMonitor, hookMissLogPath } from "./harness-hook-delivery";
+import { sweepStrandedSessions } from "./core-session-sweep";
 import { generateCertMaterial } from "./core-cert-material";
 import { verifyBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import {
@@ -182,6 +184,14 @@ async function startCore(): Promise<void> {
     queryPort: coreQueryStore,
     eventLog: { appendEvent, readEventTail, getLastEventId },
   });
+  // Boot reconciliation (issue 243). This Core's PTYs did not survive whatever
+  // ended the last process, so every row still claiming `running` /
+  // `needs-input` is an orphan of that run — no exit callback fired for any of
+  // them. Swept here: after the writer exists (each settle appends the event a
+  // Panel re-renders from) and before the PTY core, the hook receiver or the
+  // core-link server can produce a Session of THIS run that would be in scope.
+  sweepStrandedSessions({ listActiveTasks, writer: taskWriter });
+
   const titleGenerator = new CoreTitleGenerator({ writer: taskWriter });
   const harnessStatus = new CoreHarnessStatus({
     writer: taskWriter,

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -87,6 +87,7 @@ import { CoreTitleGenerator } from "./core-title-generator";
 import { startHarnessHookReceiver, type HarnessHookReceiver } from "./harness-hook-receiver";
 import { HookDeliveryMonitor, hookMissLogPath } from "./harness-hook-delivery";
 import { sweepStrandedSessions } from "./core-session-sweep";
+import { CoreSessionBackstop } from "./core-session-backstop";
 import { generateCertMaterial } from "./core-cert-material";
 import { verifyBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import {
@@ -202,11 +203,19 @@ async function startCore(): Promise<void> {
   // recorded at the top of harness-hook-receiver.ts. A receiver that cannot
   // start is not fatal: hooks go uninstalled, the Panel is told so, and its
   // terminal-input fallback carries the `running` signal instead.
+  // Assigned once the PTY core exists (it probes live PTYs); every producer of
+  // "this Session is still talking" reaches it through this binding.
+  let sessionBackstop: CoreSessionBackstop | null = null;
+
   let hookReceiver: HarnessHookReceiver | null = null;
   try {
-    hookReceiver = await startHarnessHookReceiver((taskId, payload) =>
-      harnessStatus.receiveHook(taskId, payload),
-    );
+    hookReceiver = await startHarnessHookReceiver((taskId, payload, eventNameFallback) => {
+      // A hook that landed is this Session talking, whatever it said — that is
+      // what keeps the quiet-Session backstop off a turn that is really
+      // running (issue 243).
+      sessionBackstop?.noteActivity(taskId);
+      return harnessStatus.receiveHook(taskId, payload, eventNameFallback);
+    });
   } catch (err) {
     console.error(`[core-entry] hook-receiver.start-failed: ${err}`);
   }
@@ -234,8 +243,15 @@ async function startCore(): Promise<void> {
     // and the hook receiver's, for the same reason: killing it would silently
     // strand every running Session's status.
     getProtectedPorts: () => [port, hookReceiver?.port],
-    onSessionExit: ({ taskId, exitCode }) => harnessStatus.sessionExited(taskId, exitCode),
+    onSessionExit: ({ taskId, exitCode }) => {
+      harnessStatus.sessionExited(taskId, exitCode);
+      sessionBackstop?.forget(taskId);
+    },
     onSessionOutputSignal: ({ taskId, signal }) => harnessStatus.outputSignal(taskId, signal),
+    // A harness that is working redraws its spinner into the PTY about once a
+    // second. Silence there, and no hooks either, is what the backstop below
+    // reads as "this turn ended and nobody said so" (issue 243).
+    onSessionOutputActivity: ({ taskId }) => sessionBackstop?.noteActivity(taskId),
   };
 
   // Eagerly install Claude Code's Shift+Enter keybinding flag for terminals
@@ -248,6 +264,19 @@ async function startCore(): Promise<void> {
   // Core's PTY core currently has a running PTY for it. Wired here so the
   // mutation store has no import-time dependency on `PtyCore`.
   setLivePtyProbe((taskId) => core.findByTask(taskId).ptyId);
+
+  // The unconditional half of issue 243. `armDeferredFinish` only ever fires
+  // for a Session whose hook ARRIVED; when the terminal `Stop` is the POST
+  // that dropped, nothing is armed at all. This one arms nothing: it asks the
+  // database once a minute which rows still claim to be working, and settles
+  // the ones that have gone quiet — no hook, no output — for long enough that
+  // the turn is provably over.
+  sessionBackstop = new CoreSessionBackstop({
+    listActiveTasks,
+    writer: taskWriter,
+    hasLivePty: (taskId) => Boolean(core.findByTask(taskId).ptyId),
+  });
+  sessionBackstop.start();
 
   // Issue 11: this Core probes its own PATH for every managed Harness and
   // publishes the resulting map as (a) a live snapshot readable via the
@@ -502,6 +531,7 @@ async function startCore(): Promise<void> {
     server.close();
     hookReceiver?.close();
     hookDelivery.stop();
+    sessionBackstop?.stop();
     availabilityStore.stop();
     updateNotice?.stop();
     disposeEventLogStore();

--- a/packages/core/src/core-query-store.ts
+++ b/packages/core/src/core-query-store.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import { makeOpenFailedThrottle } from "./log-throttle";
 import {
   countArchivedTasks,
+  queryActiveTasks,
   queryArchivedTasks,
   queryProjects,
   queryTask,
@@ -149,6 +150,30 @@ export const coreQueryStore: CoreQueryPort = {
     }
   },
 };
+
+/**
+ * Every task this Core's database still claims is working — `running` or
+ * `needs-input` (issue 243).
+ *
+ * Deliberately NOT a method on {@link CoreQueryPort}: that port is the surface
+ * the core-link server answers Panel frames from, and no frame asks this. The
+ * one caller is the Core's own boot sweep, in this process, so the read is a
+ * plain exported function against the same connection rather than a widening
+ * of a wire contract.
+ *
+ * Degrades to `[]` on an unavailable DB, like every read here — a Core that
+ * cannot read its rows sweeps nothing rather than crashing its own boot.
+ */
+export function listActiveTasks(): CoreLinkTaskSnapshot[] {
+  const conn = ensureConnection();
+  if (!conn) return [];
+  try {
+    return queryActiveTasks(conn as unknown as CoreQuerySqlite);
+  } catch (err) {
+    log.warn("core-query.list-active-tasks-failed", { error: String(err) });
+    return [];
+  }
+}
 
 /** Close the connection. Called on Core shutdown. */
 export function disposeCoreQueryStore(): void {

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -1,0 +1,182 @@
+// The backstop for a turn whose end nobody reported (issue 243, part 2).
+//
+// The drain backstop in `subagent-activity.ts` is armed by a hook that
+// ARRIVED: `armDeferredFinish` is reached from the subagent-lifecycle branch
+// and from the held-`Stop` branch, and both need a POST to have landed. So the
+// one case that most needs a backstop has none — when the terminal `Stop` is
+// itself the POST that dropped, nothing is armed, no timer is watching the
+// row, and it claims `running` for as long as the database exists.
+//
+// This is the unconditional one. It arms nothing and needs nothing armed: once
+// a minute it asks the database which rows still claim to be working, and
+// settles the ones that have gone quiet. A row nobody ever reported a hook for
+// is as much in scope as one that reported ten.
+//
+// ─── What "quiet" means, and why it is not just elapsed time ───
+//
+// A turn may legitimately run for hours, so "running for longer than N" is not
+// a signal — it is a way to finish live work. What separates a finished turn
+// from a long one is that a live harness never stops talking: every tool call
+// fires an unmatched `PostToolUse` (see `harness-hooks.ts`), and the harness's
+// own TUI redraws its spinner and elapsed-time counter into the PTY roughly
+// every second while it works. A Session that has emitted neither a hook nor a
+// byte of output for a quarter of an hour, while its row says `running`, is a
+// turn that ended without anyone being told.
+//
+// Both signals feed {@link CoreSessionBackstop.noteActivity}; the row's own
+// `updatedAt` is the floor for a Session this process has heard nothing about
+// yet (it was written when the row last changed), so a Core that just booted
+// does not settle a Session it has simply not met.
+//
+// The trade is stated plainly: a harness that works in total silence for
+// longer than the quiet window gets a card that says `finished` while it is
+// still going. Nothing is killed, no process is touched, and the next turn's
+// `UserPromptSubmit` puts the row back on `running`. Against that: before this
+// file, a lost `Stop` wedged a Session on `running` until a human edited the
+// row by hand — and the whole failure mode is that the Panel says otherwise.
+//
+// Only `running` is in scope. `needs-input` is a Session waiting on a human,
+// which is a state it is allowed to sit in indefinitely and silently; a card
+// that says the operator is being waited on is not made truer by a timer.
+
+import log from "./log";
+import {
+  clearSubagentActivity,
+  noteTaskFinished,
+} from "@actana/shared/subagent-activity";
+import type { CoreLinkTaskSnapshot } from "@actana/sdk/core-link-frames";
+import type { CoreTaskWriter } from "./core-task-writer";
+
+/**
+ * How long a `running` Session must go without a hook or a byte of output
+ * before this settles it.
+ *
+ * Fifteen minutes is chosen against the two failure directions rather than
+ * from taste. Below it sits every silence a live turn actually produces (a
+ * spinner tick is a second, a tool call ends in a `PostToolUse`), and above it
+ * sits nothing an operator would call responsive: a Session wedged for a
+ * quarter of an hour has already cost the Fleet view its meaning. It is also
+ * well under the two hours a lost `SubagentStop` costs today.
+ */
+const QUIET_SETTLE_MS = 15 * 60 * 1000;
+
+/** How often the sweep runs. Matches the deferred-finish recheck's cadence. */
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+/**
+ * Cap on remembered activity stamps — one per Session that has reported
+ * anything since boot. Bounded like every other per-task map in this path; the
+ * cost of dropping the oldest is that its row falls back to its `updatedAt`.
+ */
+const MAX_TRACKED_TASKS = 500;
+
+export type CoreSessionBackstopDeps = {
+  /** Every row this Core still claims is working. */
+  listActiveTasks: () => CoreLinkTaskSnapshot[];
+  /** The one seam a task row changes through, events included. */
+  writer: CoreTaskWriter;
+  /**
+   * Does this Core currently have a live PTY for the task? Optional; when it
+   * answers `false` the Session is settled as `disconnected` rather than
+   * `finished`, because a turn whose process is gone did not finish — that is
+   * the PTY-exit settle's answer, arriving late because its exit went
+   * unrecorded. Absent, every settle is a `finished`.
+   */
+  hasLivePty?: (taskId: string) => boolean;
+  /** Injected in tests. */
+  now?: () => number;
+  quietMs?: number;
+  intervalMs?: number;
+};
+
+/**
+ * The Core's quiet-Session backstop. One instance per Core process; the hook
+ * receiver and the PTY output path feed it, and it feeds the task writer.
+ */
+export class CoreSessionBackstop {
+  private readonly lastActivity = new Map<string, number>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly deps: CoreSessionBackstopDeps) {}
+
+  /**
+   * This Session just did something observable — a hook landed, or its PTY
+   * wrote output. Cheap on purpose: it is called from the PTY data path (the
+   * caller throttles) and from every accepted hook.
+   */
+  noteActivity(taskId: string): void {
+    if (!taskId) return;
+    // Re-insert so insertion order approximates recency for the cap below.
+    this.lastActivity.delete(taskId);
+    this.lastActivity.set(taskId, this.now());
+    while (this.lastActivity.size > MAX_TRACKED_TASKS) {
+      const oldest = this.lastActivity.keys().next().value;
+      if (oldest === undefined) break;
+      this.lastActivity.delete(oldest);
+    }
+  }
+
+  /** Forget a Session — its process is gone and something else settled it. */
+  forget(taskId: string): void {
+    this.lastActivity.delete(taskId);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.sweepOnce(), this.deps.intervalMs ?? SWEEP_INTERVAL_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /**
+   * Settle every `running` Session that has gone quiet, and return the ids
+   * that moved. Public so the boot path and the tests can drive it directly
+   * rather than waiting on a timer.
+   */
+  sweepOnce(): string[] {
+    const quietMs = this.deps.quietMs ?? QUIET_SETTLE_MS;
+    const now = this.now();
+    const settled: string[] = [];
+
+    for (const task of this.deps.listActiveTasks()) {
+      // `needs-input` is a Session waiting on a human, and may wait forever.
+      if (task.status !== "running") continue;
+      const lastHeard = Math.max(this.lastActivity.get(task.taskId) ?? 0, task.updatedAt);
+      if (now - lastHeard < quietMs) continue;
+      if (this.settle(task.taskId)) settled.push(task.taskId);
+    }
+    return settled;
+  }
+
+  private settle(taskId: string): boolean {
+    // A live PTY means the harness is there and simply stopped talking: the
+    // turn ended and its `Stop` never arrived. No PTY means the process went
+    // away without its exit being recorded, which is not a finish at all.
+    const alive = this.deps.hasLivePty ? this.deps.hasLivePty(taskId) : true;
+    const status = alive ? "finished" : "disconnected";
+    try {
+      const updated = this.deps.writer.mutate({ op: "update", taskId, status });
+      if (!updated) return false;
+      // The Session's subagents cannot outlive a turn we just called over, and
+      // a finish that this decided must be timestamped like any other — that
+      // is what tells a laggard subagent POST from resumed work.
+      clearSubagentActivity(taskId);
+      if (status === "finished") noteTaskFinished(taskId);
+      this.forget(taskId);
+      log.info("session-backstop.settled", { taskId, status });
+      return true;
+    } catch (err) {
+      log.warn("session-backstop.settle-failed", { taskId, status, error: String(err) });
+      return false;
+    }
+  }
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now();
+  }
+}

--- a/packages/core/src/core-session-sweep.ts
+++ b/packages/core/src/core-session-sweep.ts
@@ -1,0 +1,95 @@
+// The Core's boot reconciliation (issue 243, part 3).
+//
+// A Core's PTYs do not survive its process. Kill the daemon — a restart, a
+// crash, a container replaced — and every harness it was running dies with it:
+// no exit callback fires, no `pty:exit` is recorded, and `onSessionExit`, the
+// only unconditional settle this Core has, is never reached. The rows those
+// Sessions left behind keep claiming `running`, and on the code before this
+// file nothing ever came back for them. A live Core was found with twenty
+// `pty:spawn` events against four `pty:exit`s and a row that had claimed to be
+// working since eight hours before the daemon it belonged to even started.
+//
+// The Panel has had this sweep for its own rows since it had rows, and its
+// reasoning transfers word for word (`panel/src/server/services/tasks.ts`):
+//
+// > at that point no local PTYs exist, so any such status is an orphan of a
+// > previous run
+//
+// What did not transfer is the code: `sweepOrphanedActiveTasks` reads
+// `findActiveLocalTasks()`, which is local-scope rows only — and every Session
+// on a remote Core is Core-owned, so no Core-owned row was ever in scope for
+// any sweep anywhere. This is that sweep, on the side that owns the rows.
+//
+// Two properties make it safe to run unconditionally at boot:
+//
+//  - It runs BEFORE any PTY of this process can exist, so "the row claims a
+//    live process" and "the process is from a previous run" are the same
+//    statement. There is no live Session it could take down.
+//  - It writes through {@link CoreTaskWriter} like every other status change on
+//    this Core, so each swept row appends the `task:updated` event a connected
+//    Panel re-renders from and a reconnecting one replays off its cursor. A
+//    sweep nobody is told about would leave the operator looking at the same
+//    wrong card until they refreshed.
+//
+// `disconnected` is the status, not `finished` or `terminated`: it is what the
+// Panel already uses for exactly this — a Session whose process went away
+// without reporting — and it makes no claim about how the work ended, which is
+// the honest position. Nobody knows.
+
+import log from "./log";
+import type { CoreLinkTaskSnapshot } from "@actana/sdk/core-link-frames";
+import type { CoreTaskWriter } from "./core-task-writer";
+
+/** The status a stranded Session settles on. See the note above. */
+const STRANDED_STATUS = "disconnected";
+
+export type CoreSessionSweepDeps = {
+  /**
+   * Every row this Core still claims is working. `listActiveTasks` from
+   * `core-query-store.ts` in the daemon; an array in tests.
+   */
+  listActiveTasks: () => CoreLinkTaskSnapshot[];
+  /** The one seam a task row changes through, events included. */
+  writer: CoreTaskWriter;
+};
+
+/**
+ * Settle every Session this Core's database still claims is working, and
+ * return the ids that moved.
+ *
+ * Called once per boot. A row that vanishes between the read and the write
+ * (deleted by a Panel racing the boot) answers `null` from the writer and is
+ * simply not counted — a missing row needs no settling. A write that throws is
+ * logged and the sweep continues: one unwritable row must not leave the rest
+ * of the fleet's Sessions wedged.
+ */
+export function sweepStrandedSessions(deps: CoreSessionSweepDeps): string[] {
+  const stranded = deps.listActiveTasks();
+  if (stranded.length === 0) return [];
+
+  const settled: string[] = [];
+  for (const task of stranded) {
+    try {
+      const updated = deps.writer.mutate({
+        op: "update",
+        taskId: task.taskId,
+        status: STRANDED_STATUS,
+      });
+      if (updated) settled.push(task.taskId);
+    } catch (err) {
+      log.warn("session-sweep.settle-failed", {
+        taskId: task.taskId,
+        error: String(err),
+      });
+    }
+  }
+
+  if (settled.length > 0) {
+    log.info("session-sweep.settled", {
+      count: settled.length,
+      status: STRANDED_STATUS,
+      taskIds: settled,
+    });
+  }
+  return settled;
+}

--- a/packages/core/src/harness-hook-delivery.ts
+++ b/packages/core/src/harness-hook-delivery.ts
@@ -1,0 +1,183 @@
+// Whether a harness's hooks actually reached this Core — and what to do when
+// one did not (issue 243, part 1).
+//
+// Every status a Session card shows arrives as a fire-and-forget POST from a
+// hook's shell command. Before this module the command ended in `|| true`,
+// which swallowed a 3-second timeout, a connection refused, a 401 and a 500
+// identically and silently: a lost hook left no trace on either side, so the
+// wedged `running` row it produced had no explanation anywhere.
+//
+// Two halves fix that, and they meet in this file:
+//
+//  - **The ack.** The hook command now asks curl to fail on a non-2xx answer
+//    (`-f`) and to retry a transient one, so "the Core took it" is a fact the
+//    command can act on rather than an assumption. See `hookCommand` in
+//    `harness-hooks.ts` — the sh is there, next to the other per-family hook
+//    text, and the receiver's half is the `ack` counter it answers with.
+//  - **The miss log.** When the ack never comes, the command appends one line
+//    here instead of dropping the fact on the floor. The Core drains that file
+//    into its own log with a running total, so a dropped hook is visible as a
+//    log line on the machine it happened on.
+//
+// The file is the seam because the two ends cannot share memory: the writer is
+// a short-lived `sh` the harness spawned, and it may be writing while this Core
+// is down (a restart is exactly when hooks are refused). A file survives that,
+// and the drain at boot is what makes the misses from a dead Core's window
+// visible at all.
+//
+// Nothing here is on the hot path of a hook that SUCCEEDS: a delivered hook
+// never opens this file.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import log from "./log";
+
+/** How often the Core folds new misses into its log. */
+const DRAIN_INTERVAL_MS = 60_000;
+
+/**
+ * Stop reading a miss log bigger than this. A pathological loop (a harness
+ * re-firing a hook at a Core that is refusing every one) must not turn a
+ * diagnostic into a memory event; the count is still reported, the tail is
+ * dropped with the truncation.
+ */
+const MAX_MISS_LOG_BYTES = 1_000_000;
+
+/** How many individual misses one drain names before it summarizes. */
+const MAX_LOGGED_PER_DRAIN = 10;
+
+export type HookMiss = {
+  /** When the hook command gave up, as it stamped it (UTC, second-resolution). */
+  at: string;
+  taskId: string;
+  event: string;
+  /** curl's exit status — 28 is the timeout, 7 connection refused, 22 a 4xx/5xx. */
+  code: string;
+};
+
+/** Where a Core's hook commands record what they could not deliver. */
+export function hookMissLogPath(userDataDir: string): string {
+  return path.join(userDataDir, "hook-misses.log");
+}
+
+/**
+ * Read every miss recorded since the last drain and clear the file.
+ *
+ * Read-then-truncate, deliberately: the writers open with `>>` (O_APPEND), so
+ * the worst a concurrent write can cost is one line landing in the gap between
+ * the read and the truncate. Losing one diagnostic line is cheaper than a lock
+ * a `sh` one-liner would have to take — and a hook must never block on us.
+ *
+ * A missing file is not an error: it is the normal state of a Core whose hooks
+ * are all arriving.
+ */
+export function drainHookMisses(missLogPath: string): HookMiss[] {
+  let raw: string;
+  try {
+    const stat = fs.statSync(missLogPath);
+    if (stat.size === 0) return [];
+    if (stat.size > MAX_MISS_LOG_BYTES) {
+      raw = fs.readFileSync(missLogPath, "utf8").slice(0, MAX_MISS_LOG_BYTES);
+    } else {
+      raw = fs.readFileSync(missLogPath, "utf8");
+    }
+  } catch {
+    return [];
+  }
+  try {
+    fs.truncateSync(missLogPath, 0);
+  } catch (err) {
+    // Could not clear it, so every line would be re-reported on the next
+    // drain. Say so once and report nothing rather than loop on the same set.
+    log.warn("hook-delivery.miss-log-truncate-failed", { error: String(err) });
+    return [];
+  }
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseMiss)
+    .filter((miss): miss is HookMiss => miss !== null);
+}
+
+/**
+ * One recorded line, as `hookCommand` writes it:
+ * `<iso8601>\t<taskId>\t<event>\t<curl exit>`. A line this cannot read is
+ * dropped rather than guessed at — the file is written by a shell on a machine
+ * we do not control, and a mangled line is not worth a log entry of its own.
+ */
+function parseMiss(line: string): HookMiss | null {
+  const parts = line.split("\t");
+  if (parts.length < 4) return null;
+  const [at, taskId, event, code] = parts;
+  if (!taskId) return null;
+  return { at, taskId, event, code };
+}
+
+export type HookDeliveryMonitorDeps = {
+  /** The file `hookCommand` appends to. Usually {@link hookMissLogPath}. */
+  missLogPath: string;
+  /** Drain cadence. Only tests pass this. */
+  intervalMs?: number;
+};
+
+/**
+ * Folds the miss log into the Core's own log on a timer, with a running total.
+ *
+ * The total is what makes a rate legible: one miss in a week is a flake, forty
+ * in an hour is a Core whose event loop is losing to its own PTY fan-out —
+ * which is the failure this issue was filed about, and which no counter
+ * anywhere could previously show.
+ */
+export class HookDeliveryMonitor {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private total = 0;
+
+  constructor(private readonly deps: HookDeliveryMonitorDeps) {}
+
+  /**
+   * Drain once for whatever was recorded while this Core was down, then keep
+   * draining on the interval. The boot drain is the point: a hook refused
+   * during a restart is precisely the hook nobody would otherwise hear about.
+   */
+  start(): void {
+    if (this.timer) return;
+    this.drain();
+    this.timer = setInterval(() => this.drain(), this.deps.intervalMs ?? DRAIN_INTERVAL_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** Misses reported since this process started. */
+  missCount(): number {
+    return this.total;
+  }
+
+  /** Drain now; returns what it found. Exposed for the boot path and tests. */
+  drain(): HookMiss[] {
+    const misses = drainHookMisses(this.deps.missLogPath);
+    if (misses.length === 0) return misses;
+    this.total += misses.length;
+    for (const miss of misses.slice(0, MAX_LOGGED_PER_DRAIN)) {
+      log.warn("hook-delivery.missed", {
+        taskId: miss.taskId,
+        event: miss.event,
+        at: miss.at,
+        curlExit: miss.code,
+      });
+    }
+    log.warn("hook-delivery.missed-total", {
+      drained: misses.length,
+      total: this.total,
+      ...(misses.length > MAX_LOGGED_PER_DRAIN
+        ? { unlogged: misses.length - MAX_LOGGED_PER_DRAIN }
+        : {}),
+    });
+    return misses;
+  }
+}

--- a/packages/core/src/harness-hook-env.ts
+++ b/packages/core/src/harness-hook-env.ts
@@ -15,3 +15,12 @@
 export const HOOK_URL_ENV = "AC_HOOK_URL";
 export const HOOK_TOKEN_ENV = "AC_HOOK_TOKEN";
 export const HOOK_TASK_ID_ENV = "AC_HOOK_TASK_ID";
+/**
+ * Where a hook records a POST this Core never acked (issue 243). Unset — a
+ * Core that wired no miss log, an operator running the workspace by hand —
+ * means the record is written to `/dev/null` by the command's own default, so
+ * the hook stays fail-soft either way. It is a path, not a secret, but it
+ * still travels in the environment rather than in the file: the file must stay
+ * valid across a restart that puts the Core's data dir somewhere else.
+ */
+export const HOOK_MISS_LOG_ENV = "AC_HOOK_MISS_LOG";

--- a/packages/core/src/harness-hook-receiver.ts
+++ b/packages/core/src/harness-hook-receiver.ts
@@ -1,8 +1,8 @@
 // The Core's own hook receiver — where a harness running on this machine
 // reports what it is doing.
 //
-// Three decisions this file makes, recorded because the ticket left them open
-// (issue 84):
+// Four decisions this file makes, recorded because the tickets left them open
+// (issue 84, and (d) from issue 243):
 //
 // (a) **Transport: loopback HTTP, not a unix socket.** Every vendor's hook
 //     config takes a shell command and every vendor's documentation assumes
@@ -27,6 +27,13 @@
 //     as protected against its own port-kill path — and a guessable target.
 //     The chosen port is published to `getProtectedPorts` for the same reason
 //     the core-link port is.
+//
+// (d) **Every accepted hook is acked with a delivery number** (issue 243). The
+//     receiver counts what it has taken since boot and answers with that count,
+//     so the ack a hook command checks is a fact rather than an empty 200, and
+//     the Core's own log carries a monotonic sequence a reader can find a gap
+//     in. The client half — the retry, and the record of what never got an ack
+//     — is `harness-hooks.ts`'s command text and `harness-hook-delivery.ts`.
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { randomBytes, timingSafeEqual } from "node:crypto";
@@ -57,6 +64,8 @@ export type HarnessHookReceiver = {
   readonly url: string;
   readonly token: string;
   readonly port: number;
+  /** How many hooks this receiver has accepted since boot (issue 243). */
+  acceptedCount(): number;
   close(): void;
 };
 
@@ -118,6 +127,10 @@ export async function startHarnessHookReceiver(
   handler: HookReceiverHandler,
 ): Promise<HarnessHookReceiver> {
   const token = randomBytes(32).toString("hex");
+  // The delivery number this receiver acks with. Per boot, monotonic, and
+  // deliberately not per task: what it answers is "this Core is taking hooks,
+  // and this is the nth", which is the fact a lost POST cannot fake.
+  let accepted = 0;
 
   const server: Server = createServer((req, res) => {
     void (async () => {
@@ -170,9 +183,16 @@ export async function startHarnessHookReceiver(
         // The URL's event name is the fallback for a payload that carries
         // none — the hook writer knows which event it installed each entry
         // for, so a harness that omits it from the body is still routable.
-        const result = handler(taskId, payload, url.searchParams.get("hookEvent") ?? "");
-        res.writeHead(result.ok ? 200 : 404, { "content-type": "application/json" });
-        res.end(JSON.stringify(result.body));
+        const eventName = url.searchParams.get("hookEvent") ?? "";
+        const result = handler(taskId, payload, eventName);
+        if (!result.ok) {
+          res.writeHead(404, { "content-type": "application/json" });
+          res.end(JSON.stringify(result.body));
+          return;
+        }
+        accepted += 1;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ...result.body, ack: accepted }));
       } catch (err) {
         log.warn("hook-receiver.handler-failed", { error: String(err) });
         res.writeHead(500, { "content-type": "application/json" });
@@ -199,6 +219,7 @@ export async function startHarnessHookReceiver(
     url: `http://${LOCAL_HOOK_API_HOST}:${port}`,
     token,
     port,
+    acceptedCount: () => accepted,
     close: () => {
       try {
         server.close();

--- a/packages/core/src/harness-hooks-opencode.ts
+++ b/packages/core/src/harness-hooks-opencode.ts
@@ -37,7 +37,12 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { HOOK_TASK_ID_ENV, HOOK_TOKEN_ENV, HOOK_URL_ENV } from "./harness-hook-env";
+import {
+  HOOK_MISS_LOG_ENV,
+  HOOK_TASK_ID_ENV,
+  HOOK_TOKEN_ENV,
+  HOOK_URL_ENV,
+} from "./harness-hook-env";
 
 /** The comment that marks the file as this Core's to replace. */
 export const OPENCODE_PLUGIN_MARKER = "@actana-control-managed";
@@ -62,8 +67,10 @@ export function opencodePluginSource(slug: string): string {
 const HOOK_URL = process.env.${HOOK_URL_ENV};
 const HOOK_TOKEN = process.env.${HOOK_TOKEN_ENV};
 const HOOK_TASK_ID = process.env.${HOOK_TASK_ID_ENV};
+const MISS_LOG = process.env.${HOOK_MISS_LOG_ENV};
 const ENDPOINT = ${JSON.stringify(`/api/hooks/${slug}`)};
 const TIMEOUT_MS = 3000;
+const ATTEMPTS = 2;
 
 export const ActanaControl = async () => {
   // No environment means no Core listening for this session — a plugin file
@@ -82,6 +89,20 @@ export const ActanaControl = async () => {
   // Nothing awaits the chain — a hook must never hold up a turn.
   let queue = Promise.resolve();
 
+  // A hook nobody acked is a Session that may wedge on "running", so record
+  // it where the Core drains it into its log — the same tab-separated line the
+  // shell families' hook command writes. Best-effort in every direction: no
+  // path, no filesystem, or a failed write all mean the plugin simply does
+  // nothing, exactly as before.
+  const recordMiss = async (event, reason) => {
+    if (!MISS_LOG) return;
+    try {
+      const fs = await import("node:fs");
+      const at = new Date().toISOString().replace(/\\.\\d+Z$/, "Z");
+      fs.appendFileSync(MISS_LOG, at + "\\t" + HOOK_TASK_ID + "\\t" + event + "\\t" + reason + "\\n");
+    } catch {}
+  };
+
   const send = async (event, body) => {
     const url =
       HOOK_URL +
@@ -90,7 +111,7 @@ export const ActanaControl = async () => {
       encodeURIComponent(HOOK_TASK_ID) +
       "&hookEvent=" +
       encodeURIComponent(event);
-    await fetch(url, {
+    const res = await fetch(url, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -99,12 +120,32 @@ export const ActanaControl = async () => {
       body: JSON.stringify({ hook_event_name: event, ...body }),
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });
+    // The ack, checked. An unread 401 or 500 is a dropped hook wearing a 200's
+    // clothes, and it is what left a lost status invisible by construction.
+    if (!res.ok) throw new Error("http-" + res.status);
+    return res;
+  };
+
+  const deliver = async (event, body) => {
+    let lastReason = "unknown";
+    for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+      try {
+        await send(event, body);
+        return;
+      } catch (err) {
+        // A refused task (404) is settled, not transient — retrying it just
+        // spends another round trip to be told the same thing.
+        lastReason = String((err && err.message) || err).replace(/\\s+/g, " ");
+        if (lastReason === "http-404" || lastReason === "http-401") break;
+      }
+    }
+    await recordMiss(event, lastReason);
   };
 
   const post = (event, sessionID, extra) => {
     if (!sessionID || children.has(sessionID)) return;
     queue = queue.then(
-      () => send(event, { session_id: sessionID, ...extra }).catch(() => {}),
+      () => deliver(event, { session_id: sessionID, ...extra }).catch(() => {}),
       () => {},
     );
   };

--- a/packages/core/src/harness-hooks.ts
+++ b/packages/core/src/harness-hooks.ts
@@ -11,7 +11,7 @@
 // writer lives next door in `harness-hooks-opencode.ts` (issue 230); the row it
 // occupies in `HOOK_FAMILIES` is the same shape as the others'.
 //
-// Three rules the writers share:
+// Four rules the writers share:
 //
 //  - An operator's own hooks are preserved. Ours are tagged `_acManaged: true`
 //    so the next spawn replaces exactly what a previous spawn wrote and nothing
@@ -23,6 +23,9 @@
 //  - It is fail-soft (`|| true`). A hook that blocks or fails must never take
 //    the operator's session down with it; a missed hook costs a stale card,
 //    which the PTY-exit settle and the terminal-input fallback still catch.
+//  - Fail-soft is not the same as silent (issue 243). The command checks the
+//    Core's ack, retries a transient refusal, and records the ones it could
+//    not deliver — see `hookCommand` below.
 //
 // The registry is open by construction: a harness with no entry simply gets no
 // hooks, which is what tells the Panel to keep its terminal-input fallback
@@ -36,6 +39,7 @@ import {
 import { hookEndpointSlug } from "@actana/shared/mission-control-hook-env";
 import { ASK_USER_QUESTION_TOOL } from "@actana/shared/harness-questions";
 import {
+  HOOK_MISS_LOG_ENV,
   HOOK_TASK_ID_ENV,
   HOOK_TOKEN_ENV,
   HOOK_URL_ENV,
@@ -55,12 +59,18 @@ const MANAGED_FLAG = "_acManaged";
 const LEGACY_MANAGED_FLAG = "_mcManaged";
 
 /** Env var names the hook command reads. Set on the PTY by the spawn path. */
-export { HOOK_URL_ENV, HOOK_TOKEN_ENV, HOOK_TASK_ID_ENV } from "./harness-hook-env";
+export {
+  HOOK_URL_ENV,
+  HOOK_TOKEN_ENV,
+  HOOK_TASK_ID_ENV,
+  HOOK_MISS_LOG_ENV,
+} from "./harness-hook-env";
 
 /**
  * The shell command a managed hook entry runs: POST the payload the harness
  * pipes on stdin to this Core's loopback receiver, tagged with the task it
- * belongs to. Short timeout and `|| true` — see the fail-soft rule above.
+ * belongs to. Short timeout and a `|| true` at the end — see the fail-soft
+ * rule above.
  *
  * The event name rides the URL as well as the body. The writer knows which
  * event each entry is for, and naming it costs one query parameter: a payload
@@ -69,15 +79,48 @@ export { HOOK_URL_ENV, HOOK_TOKEN_ENV, HOOK_TASK_ID_ENV } from "./harness-hook-e
  * `ignored`, and every request identifies itself in a log or a `curl -v`
  * instead of being one of several indistinguishable opaque bodies. The body
  * still wins when it carries a name — the harness knows better than we do.
+ *
+ * The tail of the command is issue 243's ack, and every piece of it is there
+ * for a failure that really happened — a Session wedged on `running` because
+ * its terminal `Stop` was the POST that dropped:
+ *
+ *  - `-f` makes a non-2xx answer a failure. Without it curl exits 0 on a 401,
+ *    a 404 and a 500 alike, so "the Core took it" was never a fact this
+ *    command could act on.
+ *  - `--retry 2 --retry-delay 1` retries what curl calls a transient error —
+ *    a timeout above all, which is exactly what a Core busy serving PTY
+ *    fan-out and SQLite writes hands a `-m 3` POST. Three attempts bound the
+ *    worst case at about eleven seconds, well inside a harness's own hook
+ *    timeout, and only on the path where the Session's status is already
+ *    broken. `--retry-connrefused` is deliberately NOT here: it would raise
+ *    the curl version this command needs, and a refused connection means the
+ *    Core is down, which a second attempt a second later does not fix.
+ *  - The `printf` records what could not be delivered — one tab-separated
+ *    line per lost hook, drained into the Core's log by
+ *    `harness-hook-delivery.ts`. The path defaults to `/dev/null`, so a
+ *    workspace opened by hand (or by a Core that wired no miss log) writes
+ *    nowhere rather than failing.
+ *  - `|| true` still ends the chain, and still means the same thing: when the
+ *    POST succeeds the chain short-circuits, when it fails the record is
+ *    written, and when the record cannot be written the command still exits 0.
+ *    A hook may never fail an operator's turn.
+ *
+ * `-o /dev/null` is new too, and not cosmetic: Claude Code reads a hook's
+ * stdout as control JSON, so the receiver's answer had no business being
+ * printed there.
  */
 export function hookCommand(slug: string, event: string): string {
   return (
-    `sh -c 'curl -sS -m 3 -X POST ` +
+    `sh -c 'curl -sS -f -m 3 --retry 2 --retry-delay 1 -o /dev/null -X POST ` +
     `-H "Authorization: Bearer $${HOOK_TOKEN_ENV}" ` +
     `-H "Content-Type: application/json" ` +
     `--data-binary @- ` +
     `"$${HOOK_URL_ENV}/api/hooks/${slug}` +
-    `?taskId=$${HOOK_TASK_ID_ENV}&hookEvent=${encodeURIComponent(event)}" || true'`
+    `?taskId=$${HOOK_TASK_ID_ENV}&hookEvent=${encodeURIComponent(event)}"; ` +
+    `s=$?; [ "$s" = 0 ] || ` +
+    `printf "%s\\t%s\\t%s\\t%s\\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" ` +
+    `"$${HOOK_TASK_ID_ENV}" "${event}" "$s" ` +
+    `>> "$\{${HOOK_MISS_LOG_ENV}:-/dev/null}" || true'`
   );
 }
 

--- a/packages/core/src/pty-manager.ts
+++ b/packages/core/src/pty-manager.ts
@@ -160,6 +160,13 @@ const ptys = new Map<string, Pty>();
 const RING_LIMIT_BYTES = 1_000_000;
 
 /**
+ * How often a talking PTY reports that it is talking. The consumer only asks
+ * "was there anything in the last quarter of an hour", so a five-second floor
+ * loses nothing and keeps a chatty harness from calling out per chunk.
+ */
+const OUTPUT_ACTIVITY_THROTTLE_MS = 5_000;
+
+/**
  * Dependencies the PTY core needs from its host process.
  */
 export type PtyCoreDeps = {
@@ -189,6 +196,14 @@ export type PtyCoreDeps = {
     taskId: string;
     signal: "interrupted" | "hooks-need-review";
   }) => void;
+  /**
+   * This Session's harness is still talking (issue 243). Not a status and not
+   * a signal — just the fact that bytes arrived, which is what tells a turn
+   * that is genuinely running from one that ended without saying so. Throttled
+   * to at most one call per {@link OUTPUT_ACTIVITY_THROTTLE_MS} per PTY, so a
+   * harness redrawing its spinner does not cost a callback per chunk.
+   */
+  onSessionOutputActivity?: (info: { taskId: string }) => void;
 };
 
 /** Event emitted by the Core for a PTY — `data` (output) or `exit`. */
@@ -664,10 +679,20 @@ export class PtyCore {
     // reports once. Re-armed as soon as it is no longer being shown.
     let interruptReported = false;
     let hookReviewReported = false;
+    // Last time this PTY's output was reported as activity (issue 243).
+    let activityReportedAt = 0;
     const watchOutput = plan.mode === "agent" && !opts.shell && !opts.shellSession;
     proc.onData((data: string) => {
       releaseSpawnHold();
       if (watchOutput) {
+        if (p.taskId && Date.now() - activityReportedAt > OUTPUT_ACTIVITY_THROTTLE_MS) {
+          activityReportedAt = Date.now();
+          try {
+            this.deps.onSessionOutputActivity?.({ taskId: p.taskId });
+          } catch (err) {
+            log.warn("pty.output-activity.failed", { error: String(err) });
+          }
+        }
         const interrupted = hasClaudeInterruptPrompt(data);
         if (interrupted && !interruptReported) {
           interruptReported = true;

--- a/packages/core/src/pty-manager.ts
+++ b/packages/core/src/pty-manager.ts
@@ -26,6 +26,7 @@ import {
 } from "@actana/shared/pty-spawn-policy";
 import { type PtyHookEnv } from "./pty-hook-env";
 import {
+  HOOK_MISS_LOG_ENV,
   HOOK_TASK_ID_ENV,
   HOOK_TOKEN_ENV,
   HOOK_URL_ENV,
@@ -560,6 +561,10 @@ export class PtyCore {
           env[HOOK_URL_ENV] = hookEnv.apiUrl;
           env[HOOK_TOKEN_ENV] = hookEnv.token;
           env[HOOK_TASK_ID_ENV] = opts.taskId;
+          // Where this Session's hooks record a POST the Core never acked
+          // (issue 243). Absent, the command writes to /dev/null and the hook
+          // is as fail-soft as it always was — just as invisible when it drops.
+          if (hookEnv.missLogPath) env[HOOK_MISS_LOG_ENV] = hookEnv.missLogPath;
         }
       }
     }

--- a/packages/shared/src/__tests__/core-query.test.ts
+++ b/packages/shared/src/__tests__/core-query.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import Database from "better-sqlite3";
 import {
   countArchivedTasks,
+  queryActiveTasks,
   queryArchivedTasks,
   queryProjects,
   queryTasks,
@@ -285,6 +286,43 @@ describe("queryArchivedTasks", () => {
 
   it("returns empty when the tasks table does not exist", () => {
     expect(queryArchivedTasks(asQuery(new Database(":memory:")))).toEqual([]);
+  });
+});
+
+describe("queryActiveTasks (the Core's boot sweep read, issue 243)", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = openDb();
+  });
+
+  it("returns only the rows that still claim a live harness process", () => {
+    insertTask(db, { taskId: "t-running", projectId: "p1", status: "running" });
+    insertTask(db, { taskId: "t-waiting", projectId: "p1", status: "needs-input" });
+    insertTask(db, { taskId: "t-ready", projectId: "p1", status: "ready" });
+    insertTask(db, { taskId: "t-done", projectId: "p1", status: "finished" });
+    insertTask(db, { taskId: "t-gone", projectId: "p1", status: "disconnected" });
+
+    expect(queryActiveTasks(asQuery(db)).map((t) => t.taskId).sort()).toEqual([
+      "t-running",
+      "t-waiting",
+    ]);
+  });
+
+  it("includes archived rows — an archived Session claiming to work is just as wrong", () => {
+    insertTask(db, { taskId: "t-archived", projectId: "p1", status: "running", archived: true });
+    expect(queryActiveTasks(asQuery(db)).map((t) => t.taskId)).toEqual(["t-archived"]);
+  });
+
+  it("spans every project: a dead process did not die for one Project only", () => {
+    insertTask(db, { taskId: "t-a", projectId: "p1", status: "running" });
+    insertTask(db, { taskId: "t-b", projectId: "p2", status: "needs-input" });
+    expect(queryActiveTasks(asQuery(db))).toHaveLength(2);
+  });
+
+  it("returns empty when the tasks table does not exist", () => {
+    const empty = new Database(":memory:");
+    expect(queryActiveTasks(asQuery(empty))).toEqual([]);
+    empty.close();
   });
 });
 

--- a/packages/shared/src/core-query.ts
+++ b/packages/shared/src/core-query.ts
@@ -173,6 +173,41 @@ function listTasksWhereArchived(
 }
 
 /**
+ * Every task on this Core whose status still claims a live harness process —
+ * `running` or `needs-input` (issue 243).
+ *
+ * The Core's boot sweep is the only caller, and the query is shaped for it in
+ * two ways the listing helpers are not:
+ *
+ *  - **Archived rows are included.** The other listings answer a browse, where
+ *    an archived row is out of scope by definition. This one answers "what
+ *    does this database still claim is running?", and an archived Session that
+ *    claims to be working is exactly as wrong as an active one — it is the same
+ *    stale row, one tab further away from the operator who could notice it.
+ *  - **No project filter.** A process that did not survive the Core's restart
+ *    did not survive it for one Project only.
+ *
+ * Returns an empty array when the table is absent, like every helper here.
+ */
+export function queryActiveTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSnapshot[] {
+  let rows: TaskRow[];
+  try {
+    rows = sqlite
+      .prepare(
+        `SELECT id, project_id, title, title_manually_set, claude_session_id, agent, status,
+                pinned, archived, icon, updated_at
+         FROM tasks
+         WHERE status IN ('running', 'needs-input')
+         ORDER BY updated_at DESC`,
+      )
+      .all() as TaskRow[];
+  } catch {
+    return [];
+  }
+  return rows.map(taskRowToSnapshot);
+}
+
+/**
  * How many archived tasks this Core holds, optionally scoped to one project.
  *
  * The Panel needs this number continuously — it gates the Archived tab, labels

--- a/packages/shared/src/mission-control-hook-env.ts
+++ b/packages/shared/src/mission-control-hook-env.ts
@@ -3,6 +3,12 @@ import { isValidTcpPort } from "./tcp-port";
 export type PtyHookEnv = {
   apiUrl: string;
   token: string;
+  /**
+   * Where a hook records a POST the Core never acked (issue 243). Optional: a
+   * host that wires no miss log still installs working hooks, and the command
+   * they run falls back to `/dev/null` rather than failing.
+   */
+  missLogPath?: string;
 };
 
 /** Hostname a Core uses to reach its own loopback Actana Control API. */


### PR DESCRIPTION
## Summary

Three independent ways a Core-owned Session gets left on `running` after its work is over, and no backstop that catches
the important one. This closes all three, and they only work as a set — the sweep answers a restart, the backstop
answers a lost `Stop`, and the ack is what makes either of them explicable after the fact.

- **The hook ack.** A hook's POST ended in `|| true`, which swallowed a timeout, a connection refused, a 401 and a 500
  identically, so a lost hook left no trace on either side. The command now fails on a non-2xx answer (`-f`), retries a
  transient one (`--retry 2 --retry-delay 1` — the timeout a busy Core hands a `-m 3` POST), and appends what it still
  could not deliver to `$AC_HOOK_MISS_LOG`. The receiver counts the hooks it accepts and answers with that delivery
  number. `HookDeliveryMonitor` drains the miss log into the Core's log with a running total, starting at boot — a hook
  refused during a restart is exactly the drop nobody could otherwise hear about. OpenCode's plugin does the same in its
  own idiom.
- **The unconditional backstop.** `armDeferredFinish` is only reached from branches that need a hook to have *arrived*,
  so when the terminal `Stop` is itself the POST that drops, nothing is armed at all. `CoreSessionBackstop` arms nothing
  and needs nothing armed: once a minute it asks the database which rows still claim to be working and settles the ones
  that have gone quiet. Quiet is the load-bearing word — a working harness fires a `PostToolUse` per tool call and
  redraws its spinner into the PTY about once a second, so hooks *and* PTY output count as activity, the row's own
  `updatedAt` is the floor, and fifteen minutes with neither is a turn that ended without anyone being told.
- **The boot reconciliation sweep.** A Core's PTYs die with it — no exit callback, no `pty:exit`, no settle — and
  nothing swept at startup. The Panel has had this sweep for its own rows all along; what it never had was scope over
  Core-owned ones, which is every Session on a remote Core. `sweepStrandedSessions` runs once per boot, before any PTY
  of this process can exist, and writes `disconnected` through `CoreTaskWriter` so each settle appends the
  `task:updated` event a connected Panel re-renders from.

`disconnected` rather than `finished` for the sweep: it is what the Panel already uses for a process that went away
without reporting, and it claims nothing about how the work ended.

### The one trade, stated plainly

A harness that works in *total* silence — no hook, no byte of output — for longer than fifteen minutes gets a card
reading `finished` while it is still going. Nothing is killed, no process is touched, and the next turn's
`UserPromptSubmit` puts the row back on `running`. Weighed against a lost `Stop` wedging a Session until a human edits
the row by hand, while the Panel says the opposite.

## Related issues

Closes #243

Scope boundaries kept deliberately: `pty-core-link-server.ts` is untouched (#187 owns its restructuring), the core-link
send path's live-event cursor advance is untouched (#244), and the Panel's `session-drive-register.ts` / `router.ts` are
untouched (#242).

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## How was this tested?

New tests, all against the Core's real SQLite, real event log and real loopback receiver rather than hand-built frames:

- `harness-hook-delivery.test.ts` (10) — drains and clears the miss log, keeps a running total across a boot, and runs
  the **actual generated hook command** through a real `sh` + `curl` against a real receiver: a delivered hook acks and
  records nothing; a Core that is not there, a wrong bearer and a task the Core does not have each leave exactly one
  recorded line; and with no miss log configured the command still exits 0 and writes nowhere.
- `core-session-backstop.test.ts` (9) — finishes a quiet Session that nothing armed (and raises the `session:finished`
  event the operator never got), leaves a two-hour turn alone while it keeps talking, never touches `needs-input`,
  calls a quiet Session with no live PTY `disconnected` rather than `finished`, and settles each row exactly once.
- `core-session-sweep.test.ts` (7) — sweeps `running` / `needs-input` including archived rows, leaves settled rows
  exactly as they settled, appends `task:updated` without a spurious `session:finished`, is a no-op on the second boot,
  and keeps going when one row cannot be written.
- `core-query.test.ts` (+4) — the boot sweep's read: only rows claiming a live process, archived included, every
  project.
- `harness-hooks.test.ts` (+1, 1 updated) — the fail-soft assertion now says what it means, next to the new ack.

Suites run locally on this branch: `@actana/core` 1166 passed, `@actana/shared` 184, `@actana/sdk` 236, `@actana/cli`
421, `@actana/panel` 1405 (2 timeouts under load that pass in isolation — `terminals-in-browser` and `panel-link`,
neither touched here). `pnpm typecheck` and `pnpm lint` clean (warnings pre-existing). The root `scripts` suite has one
pre-existing environment failure on this machine (`core-launcher` picks up a real `/opt/actana` install).

Not covered by a test: the throttled PTY-output activity callback in `pty-manager.ts`, whose only test route would be
spawning a real PTY — the module's existing tests are unit-level over its pure helpers.

## Checklist

- [x] Conventional Commits on every commit, not just the title
- [x] Docs updated (`docs/harness-status-detection.md`, `docs/observability.md`)
- [x] No new dependencies
