### PR TITLE
fix(panel): reconcile pane events with tab interest in the Session drive register

### DIFF
--- a/packages/panel/src/components/views/TerminalPane.tsx
+++ b/packages/panel/src/components/views/TerminalPane.tsx
@@ -562,6 +562,13 @@ export function TerminalPane({
   // claim on the **Session lock**: this never leaves the Panel, and the lock is
   // an explicit gesture on the core-link (D6). First-come, so the second tab to
   // open the same Session follows the first rather than fighting it.
+  //
+  // Per pane on purpose, and counted per tab underneath (issue 186): a second
+  // pane of this tab on the same Session announces nothing — the tab's interest
+  // is already held, and re-asserting it would move the keyboard off whichever
+  // pane the operator was typing in — and this cleanup gives the Session back
+  // only when it is the last pane to go. What the mount/unmount pair says here
+  // is what this pane holds; what the tab holds is the sum of them.
   useEffect(() => {
     const coreId = descriptor.coreId;
     if (!coreId) return;

--- a/packages/panel/src/lib/__tests__/panel-link-client.test.ts
+++ b/packages/panel/src/lib/__tests__/panel-link-client.test.ts
@@ -685,3 +685,131 @@ describe("panel link · watching", () => {
     link.close();
   });
 });
+
+describe("panel link · a tab's panes on one Session", () => {
+  // The service keys drive interest per tab and the browser opens panes, so
+  // this is the seam where the two are reconciled (issue 186). One tab may hold
+  // two panes on one Session — a split view, the same Session opened twice —
+  // and what the service is told has to be the *tab's* standing, once.
+
+  it("announces a Session once however many panes this tab opens on it", () => {
+    const link = client();
+    const socket = live();
+
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1");
+
+    // Not a saving of bytes. A second `watch` re-asserts interest the service
+    // already holds, and re-asserting moves this tab to the tail of that
+    // Session's queue: the keyboard leaves the pane the operator is looking at,
+    // with no gesture of theirs to explain it.
+    expect(socket.drives("core_a")).toEqual([{ taskId: "task_1", want: "watch" }]);
+    link.close();
+  });
+
+  it("announces each Session in its own right", () => {
+    const link = client();
+    const socket = live();
+
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_2");
+
+    expect(socket.drives("core_a")).toEqual([
+      { taskId: "task_1", want: "watch" },
+      { taskId: "task_2", want: "watch" },
+    ]);
+    link.close();
+  });
+
+  it("still asks for the keyboard in a pane on a Session it already watches", () => {
+    const link = client();
+    const socket = live();
+
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1", { take: true });
+
+    // `take` is the operator's gesture, not a pane arriving. Deduping it would
+    // be a button that does nothing in the one case it exists for.
+    expect(socket.drives("core_a")).toEqual([
+      { taskId: "task_1", want: "watch" },
+      { taskId: "task_1", want: "take" },
+    ]);
+    link.close();
+  });
+
+  it("gives a Session back only when the last pane on it closes", () => {
+    const link = client();
+    const socket = live();
+
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1");
+
+    expect(link.releaseSessionDrive("core_a", "task_1")).toBe(false);
+    // The tab still has the Session on screen. A `drop` here would have the
+    // service hand the drive to another tab while this one keeps a writable
+    // pane and keeps typing — two writers, and nothing on screen to say so.
+    expect(socket.drives("core_a")).toEqual([{ taskId: "task_1", want: "watch" }]);
+
+    expect(link.releaseSessionDrive("core_a", "task_1")).toBe(true);
+    expect(socket.drives("core_a")).toEqual([
+      { taskId: "task_1", want: "watch" },
+      { taskId: "task_1", want: "drop" },
+    ]);
+    link.close();
+  });
+
+  it("counts panes, not gestures: a take does not keep the Session held", () => {
+    const link = client();
+    const socket = live();
+
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1", { take: true });
+
+    expect(link.releaseSessionDrive("core_a", "task_1")).toBe(true);
+    expect(socket.drives("core_a").at(-1)).toEqual({ taskId: "task_1", want: "drop" });
+    link.close();
+  });
+
+  it("says nothing for a Session this tab has no pane on", () => {
+    const link = client();
+    const socket = live();
+
+    expect(link.releaseSessionDrive("core_a", "task_1")).toBe(false);
+
+    expect(socket.drives("core_a")).toEqual([]);
+    link.close();
+  });
+
+  it("re-announces a twice-held Session once on a reconnect", () => {
+    const link = client();
+    const first = live();
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1");
+
+    first.drop();
+    vi.advanceTimersByTime(20);
+    const second = live();
+
+    // What the new socket is owed is the tab's interest, which is one Session
+    // whatever it is showing it in. Re-announcing it per pane on every flap is
+    // the duplicate `watch` again, with a reconnect for a trigger.
+    expect(second.drives("core_a")).toEqual([{ taskId: "task_1", want: "watch" }]);
+    link.close();
+  });
+
+  it("re-announces nothing once every pane on the Session has gone", () => {
+    const link = client();
+    const first = live();
+    link.driveSession("core_a", "task_1");
+    link.driveSession("core_a", "task_1");
+    link.releaseSessionDrive("core_a", "task_1");
+    link.releaseSessionDrive("core_a", "task_1");
+
+    first.drop();
+    vi.advanceTimersByTime(20);
+    const second = live();
+
+    expect(second.drives("core_a")).toEqual([]);
+    link.close();
+  });
+});

--- a/packages/panel/src/lib/__tests__/session-write-store.test.ts
+++ b/packages/panel/src/lib/__tests__/session-write-store.test.ts
@@ -22,6 +22,10 @@ type Handlers = {
 function fakeBridge() {
   const handlers: Handlers = {};
   const drives: Array<{ taskId: string; take: boolean }> = [];
+  // The pane count the real link client keeps, and the answer the store asks it
+  // for (issue 186). A fake that said "last pane" to every release would pass a
+  // test the product fails, so this one counts.
+  const panes = new Map<string, number>();
   const bridge = {
     onSessionLock: (cb: NonNullable<Handlers["lock"]>) => {
       handlers.lock = cb;
@@ -33,9 +37,17 @@ function fakeBridge() {
     },
     driveSession: (_coreId: string, taskId: string, opts?: { take?: boolean }) => {
       drives.push({ taskId, take: opts?.take === true });
+      if (opts?.take !== true) panes.set(taskId, (panes.get(taskId) ?? 0) + 1);
     },
     releaseSessionDrive: (_coreId: string, taskId: string) => {
       drives.push({ taskId, take: false });
+      const open = panes.get(taskId) ?? 0;
+      if (open > 1) {
+        panes.set(taskId, open - 1);
+        return false;
+      }
+      panes.delete(taskId);
+      return true;
     },
   } as unknown as PanelBridge;
   __setPanelBridgeForTests(bridge);
@@ -156,6 +168,37 @@ describe("the drive gestures", () => {
       { taskId: TASK, take: false },
       { taskId: TASK, take: true },
     ]);
+  });
+
+  it("keeps the tab's answer while a second pane on the Session is still open", () => {
+    const { handlers } = fakeBridge();
+
+    // Two panes in this tab, one Session — a split view, or the same Session
+    // opened twice. The drive is the *tab's*, so both panes read one answer.
+    watchSessionDrive(CORE, TASK);
+    watchSessionDrive(CORE, TASK);
+    handlers.drive?.({ coreId: CORE, taskId: TASK, driving: true, reason: "watch" });
+
+    releaseSessionDrive(CORE, TASK);
+
+    // The tab still has the Session on screen and the service still has it
+    // driving. Reading `none` here is what let the surviving pane keep a
+    // writable surface after the drive had gone somewhere else — issue 186's
+    // silent dual write, seen from the browser.
+    expect(readSessionWriteState(CORE, TASK).drive).toBe("driving");
+    expect(readSessionWriteState(CORE, TASK).access.writable).toBe(true);
+  });
+
+  it("clears the tab's answer when the last pane on the Session closes", () => {
+    const { handlers } = fakeBridge();
+
+    watchSessionDrive(CORE, TASK);
+    watchSessionDrive(CORE, TASK);
+    handlers.drive?.({ coreId: CORE, taskId: TASK, driving: true, reason: "watch" });
+    releaseSessionDrive(CORE, TASK);
+    releaseSessionDrive(CORE, TASK);
+
+    expect(readSessionWriteState(CORE, TASK).drive).toBe("none");
   });
 
   it("does nothing for a pane with no Core to address", () => {

--- a/packages/panel/src/lib/panel-bridge.ts
+++ b/packages/panel/src/lib/panel-bridge.ts
@@ -135,10 +135,18 @@ export type PanelBridge = {
    * Panel does. `take` is the operator asking for the keyboard here, which moves
    * it off whichever tab of this Panel had it — a Panel-local handover that
    * costs nobody their Session and crosses no wire.
+   *
+   * Counted over this tab's panes, so a second pane on the same Session says
+   * nothing on the wire (issue 186). `take` is exempt: it is a gesture, not a
+   * pane.
    */
   driveSession(coreId: string, taskId: string, opts?: { take?: boolean }): void;
-  /** This tab's pane on a Session has gone. */
-  releaseSessionDrive(coreId: string, taskId: string): void;
+  /**
+   * One of this tab's panes on a Session has gone. Returns whether it was the
+   * last one — whether the tab gave the Session back, or still has it on screen
+   * in another pane (issue 186).
+   */
+  releaseSessionDrive(coreId: string, taskId: string): boolean;
   /** The Session lock as the service's link to that Core sees it, pushed on change. */
   onSessionLock(
     cb: (msg: { coreId: string; taskId: string; lock: PanelSessionLock }) => void,

--- a/packages/panel/src/lib/panel-link-client.ts
+++ b/packages/panel/src/lib/panel-link-client.ts
@@ -168,15 +168,30 @@ export class PanelLinkClient {
     }) => void
   >();
   /**
-   * The Sessions this tab has a pane open on, as `coreId` → `taskId`s.
+   * The Sessions this tab has a pane open on, as `coreId` → `taskId` → **how
+   * many panes** (issue 186).
    *
    * Held for the same reason the PTY claims above are: the service gives a
    * tab's drives back when its socket dies, so a reconnect that re-sent only
    * the subscriptions would come back with every pane on this tab following a
-   * Session nobody drives. The set is the tab's, and it is re-announced on
-   * every open.
+   * Session nobody drives. The interest is the tab's, and it is re-announced on
+   * every open — once per Session, not once per pane.
+   *
+   * **A count rather than a set, because a tab is not a pane.** The service
+   * keys interest per tab — one client id, one entry, whatever that tab has on
+   * screen (issue 242) — while the browser opens and closes panes, and a tab
+   * may well hold two panes on one Session. With a set, the two granularities
+   * disagreed in both directions: the second pane's `watch` re-announced
+   * interest the tab already held, and the first pane to close dropped it out
+   * from under the one still open. This is the seam where pane events are
+   * aggregated into the tab-level fact the service is told, so exactly one
+   * `watch` goes out for the first pane and exactly one `drop` for the last.
+   *
+   * It counts *panes*, not gestures: {@link driveSession} with `take` is the
+   * operator moving their keyboard to a pane that is already on screen and
+   * already counted, so it announces without counting.
    */
-  private readonly drivenSessions = new Map<string, Set<string>>();
+  private readonly drivenSessions = new Map<string, Map<string, number>>();
 
   constructor(opts: PanelLinkOptions = {}) {
     this.createSocket = opts.createSocket ?? defaultCreateSocket;
@@ -320,23 +335,60 @@ export class PanelLinkClient {
    * `take: true` is the operator asking for the keyboard here, which moves it
    * off whichever tab of this Panel had it. Without it a pane takes the drive
    * only if no other tab is driving that Session.
+   *
+   * **Reference-counted over this tab's panes** (issue 186), exactly as
+   * {@link watch} is over a Core's subscribers. A second pane on a Session this
+   * tab has already announced sends nothing: the service holds the tab's
+   * interest already, and re-announcing it would move this tab to the back of
+   * that Session's queue — the keyboard leaving the pane the operator is
+   * looking at, with no gesture of theirs to explain it.
+   *
+   * `take` is the exception and announces every time, because it is not a pane
+   * arriving: it is the operator asking for the keyboard *here*, and it has to
+   * reach the service whether or not this tab is already watching — that is the
+   * whole of the gesture when another tab holds the drive.
    */
   driveSession(coreId: string, taskId: string, opts: { take?: boolean } = {}): void {
+    const take = opts.take === true;
+    if (take) {
+      this.write({ t: "drive", coreId, taskId, want: "take" });
+      return;
+    }
     let driven = this.drivenSessions.get(coreId);
     if (!driven) {
-      driven = new Set();
+      driven = new Map();
       this.drivenSessions.set(coreId, driven);
     }
-    driven.add(taskId);
-    this.write({ t: "drive", coreId, taskId, want: opts.take === true ? "take" : "watch" });
+    const panes = driven.get(taskId) ?? 0;
+    driven.set(taskId, panes + 1);
+    // Only the first pane announces. The rest are this tab's own business.
+    if (panes > 0) return;
+    this.write({ t: "drive", coreId, taskId, want: "watch" });
   }
 
-  /** This tab's pane on a Session is gone; it drives nothing there. Idempotent. */
-  releaseSessionDrive(coreId: string, taskId: string): void {
+  /**
+   * One of this tab's panes on a Session has gone. Idempotent.
+   *
+   * Returns whether that was the **last** pane — whether the tab actually gave
+   * the Session back (issue 186). Until it is, this tab still has the Session
+   * on screen and still holds its interest, and a caller that reset its own
+   * copy of the answer on the first pane to close would have the surviving pane
+   * believing nobody arbitrates a Session the service still has this tab
+   * driving. The one place the pane count is kept is here; callers ask it
+   * rather than keeping a second one that can disagree.
+   */
+  releaseSessionDrive(coreId: string, taskId: string): boolean {
     const driven = this.drivenSessions.get(coreId);
-    if (!driven?.delete(taskId)) return;
+    const panes = driven?.get(taskId) ?? 0;
+    if (!driven || panes === 0) return false;
+    if (panes > 1) {
+      driven.set(taskId, panes - 1);
+      return false;
+    }
+    driven.delete(taskId);
     if (driven.size === 0) this.drivenSessions.delete(coreId);
     this.write({ t: "drive", coreId, taskId, want: "drop" });
+    return true;
   }
 
   /**
@@ -623,7 +675,7 @@ export class PanelLinkClient {
    */
   private resendSessionDrives(): void {
     for (const [coreId, taskIds] of this.drivenSessions) {
-      for (const taskId of taskIds) {
+      for (const taskId of taskIds.keys()) {
         this.rawSend(encodePanelLinkFrame({ t: "drive", coreId, taskId, want: "watch" }));
       }
     }

--- a/packages/panel/src/lib/session-write-store.ts
+++ b/packages/panel/src/lib/session-write-store.ts
@@ -140,10 +140,22 @@ export function takeSessionDrive(coreId: string | null | undefined, taskId: stri
   getPanelBridge()?.driveSession(coreId, taskId, { take: true });
 }
 
-/** This tab's pane on a Session has gone. */
+/**
+ * One of this tab's panes on a Session has gone.
+ *
+ * The local answer is reset only when it was the **last** pane (issue 186).
+ * This entry is keyed by Session and shared by every pane rendering it, and the
+ * drive it holds is the tab's standing, not the pane's — so clearing it because
+ * one of two panes closed would tell the surviving pane that nobody arbitrates
+ * a Session this tab is still watching. `none` reads as writable, which is the
+ * silent half of a dual write: a pane typing on a drive it no longer holds,
+ * with no read-only state on screen to say so.
+ */
 export function releaseSessionDrive(coreId: string | null | undefined, taskId: string): void {
   if (!coreId) return;
-  getPanelBridge()?.releaseSessionDrive(coreId, taskId);
+  // The pane count lives in the link client, which is the one thing that also
+  // has to re-announce this tab's interest on a reconnect. Asked, not mirrored.
+  if (getPanelBridge()?.releaseSessionDrive(coreId, taskId) !== true) return;
   const k = key(coreId, taskId);
   const current = entries.get(k);
   if (!current) return;

--- a/packages/panel/src/server/panel-link/router.ts
+++ b/packages/panel/src/server/panel-link/router.ts
@@ -372,6 +372,12 @@ export class PanelLinkRouter {
    * @internal — a tab wants (or gives back) the keyboard for one Session, among
    * this Panel's own tabs. Never the Session lock; see the module comment.
    *
+   * One frame per tab per Session, whatever that tab has on screen: the browser
+   * counts its own panes and sends the first pane's `watch` and the last pane's
+   * `drop` (issue 186). Panes have no name here and are not meant to — what this
+   * router arbitrates is tabs, and a `drop` is therefore read as "that tab is
+   * done with this Session", not "one of its panes closed".
+   *
    * Gated on `multiConnection` like everything else in issue 147: against a
    * Core that evicts every client but one, two tabs both writing is what the
    * Panel does today, and the promise for such a Core is today's behaviour

--- a/packages/panel/src/server/panel-link/session-drive-register.ts
+++ b/packages/panel/src/server/panel-link/session-drive-register.ts
@@ -35,6 +35,30 @@
 // The id is not authority and nothing verifies it, exactly as D9 says of its
 // own: it decides which of one Operator's tabs holds a keyboard, and the
 // gesture it arbitrates is unconditional for any tab that asks for it outright.
+//
+// **A tab is not a pane, and the aggregating happens in the browser** (issue
+// 186). One tab may hold two panes on one Session, so pane-level opens and
+// closes cannot be interest-level ones: the second pane's `watch` re-asserted
+// interest the tab already held and sent it to the back of this queue with no
+// operator gesture behind it, and the first pane to close released the whole
+// tab's interest while the other pane kept a writable surface — the register
+// handing the Session to some other tab while this one went on typing into it.
+// Both are gone, and they are gone at the seam that knows what a pane is: the
+// panel-link client counts this tab's panes per Session and announces the first
+// and releases the last, so one `watch` and one `drop` reach here per tab per
+// Session. Nothing in this file could have done it — panes have no name on the
+// wire, and inventing one would put the browser's layout in the service.
+//
+// That leaves the ordering question #242 parked here — whether re-asserting
+// interest a tab already holds should keep its place in the queue — answered
+// deliberately rather than by omission: **it still goes to the tail**, and this
+// ticket removed the re-assertions nobody asked for instead of making
+// re-assertion free. The one that remains is a reconnect re-announcing this
+// tab's interest, and tail is the rule #242 settled for exactly that case: two
+// tabs on one Session, a flap can move the keyboard, the tab holding it says so
+// on screen, and taking it back is one click. Making a re-assert
+// position-preserving would quietly become a grace period holding a keyboard
+// for a tab that may never come back.
 
 /**
  * The tab identity this register arbitrates between: a panel-link client id,
@@ -91,9 +115,13 @@ export class SessionDriveRegister {
    * — the sole watcher of a Session stays its driver across its own reload,
    * which is the whole of issue 242 — but it does move that tab to the tail
    * behind any other tab still watching. That is the first-come rule applied
-   * evenly, and the same end state a reload reaches today; whether re-asserting
-   * existing interest should preserve its position is issue 186's question, and
-   * this ticket deliberately leaves it there.
+   * evenly, and the same end state a reload reaches today.
+   *
+   * It stays that way (issue 186). What a re-assert costs is a place in the
+   * queue, and the fix for a cost nobody asked for is to stop asking: a tab's
+   * panes are counted in the browser and only the first announces, so the
+   * re-asserts left are the ones a reconnect owes this register — where tail is
+   * the rule #242 chose on purpose. See the module comment.
    */
   want(
     taskId: string,
@@ -110,8 +138,15 @@ export class SessionDriveRegister {
   }
 
   /**
-   * This tab has stopped watching this Session — its pane closed, or its whole
-   * socket went away. The drive falls to the next tab still watching.
+   * This tab has stopped watching this Session — its **last** pane on it closed,
+   * or its whole socket went away. The drive falls to the next tab still
+   * watching.
+   *
+   * Last, not any: a tab with a second pane still open has not stopped watching
+   * anything, and a `drop` on its behalf would hand the Session on while it
+   * still had it on screen and writable (issue 186). Which pane was the last one
+   * is a question only the browser can answer, and it does — see the module
+   * comment.
    */
   release(taskId: string, clientId: DriveClientId): DriveChange {
     const watchers = this.interest.get(taskId);


### PR DESCRIPTION
## Summary

The Panel's Session drive register keys interest **per tab** — one client id, one
entry, whatever that tab has on screen — while the browser opened and closed
panes and sent a frame for each. A tab can hold two panes on one Session, and
there the two granularities disagreed in both directions (#186).

This reconciles them at the only layer that knows what a pane is: the panel-link
client now reference-counts this tab's panes per Session, exactly as it already
does for a Core's watchers. The first pane announces `watch`, the last pane
sends `drop`, and a reconnect re-announces the tab's interest once rather than
once per pane. `take` is exempt and always announces — it is the operator asking
for the keyboard here, not a pane arriving.

The register and router are unchanged in behaviour. They gain the sentence that
says what they arbitrate (tabs, never panes), and #242's parked ordering
question is answered rather than left: interest still goes to the tail on a
re-assert, and this ticket removed the re-assertions nobody asked for instead of
making re-assertion free.

**Stacked on `fix/session-and-event-reliability`**, not the train: it builds on
`e2fee65` (#242's client-id keying), which is where "the same tab" is defined.
Base is deliberately the feature branch; `Train rules` accepts it, and the whole
CI matrix is green on this head.

## Related issues

Closes #186
Builds on #242 · underlying model #140 · found in review of #184

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## The two failures, and where each is now caught

**1. Duplicate `watch` moved the keyboard to the back of the queue.** A second
pane on the same Session re-asserted interest the register already held; nothing
new was registered, but the send re-entered the queue at the tail. Now the
second pane sends nothing — `panel link · a tab's panes on one Session >
announces a Session once however many panes this tab opens on it`.

**2. Closing one of two panes dropped the tab's interest — silent dual write.**
The first pane's `drop` released the whole tab's interest with no refcount to
say the other pane still held it, so the register handed the Session on while
the surviving pane kept a writable surface and kept typing. Now the `drop` waits
for the last pane, and the browser's own copy of the answer waits with it —
`gives a Session back only when the last pane on it closes`, and `keeps the
tab's answer while a second pane on the Session is still open`.

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [x] Manually verified (describe steps below)

- 9 new tests: 7 in `panel-link-client.test.ts` (the pane count, `take`'s
  exemption, and what a reconnect re-announces), 2 in
  `session-write-store.test.ts` (the shared per-Session answer across two panes).
  The store's fake bridge now counts panes like the real client, so it cannot
  pass a test the product fails.
- Verified red before the change: 5 of the 9 fail on `e2fee65` without it. The
  rest are regression guards that hold either way.
- `packages/panel`: 1441 tests, all green in isolation. Two in
  `live-read-path.test.ts` time out under the full local run and pass on their
  own — a known local flake on this machine, unrelated to this branch.
- `pnpm -r typecheck` clean; eslint clean on every changed file.
- `pnpm panel:e2e` green end to end, including the file-drop leg (2048 MiB
  across a Panel capped at a 256 MB heap, RSS +76 MiB).
- Every commit passes `commitlint` against this repo's own config, not just the
  title.

## Screenshots / recordings

Not applicable — no visual change. What changes is what a pane *stays*: writable
when this tab still holds the Session in another pane, and unmoved when a second
pane opens on it.

## Checklist

- [x] This PR targets the **open train** by way of the branch it is stacked on —
      base is `fix/session-and-event-reliability`, not `main`, and `Train rules`
      passes
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix works, and all tests pass locally
- [x] I updated documentation (the register's and router's own module docs) where relevant
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (#242 landed as `e2fee65`) — and this PR is a draft
