### PR TITLE
test(cli): settle the tip hunt before the live pushes in events-tail-cursor

### DIFF
--- a/packages/cli/src/__tests__/events-tail-cursor.test.ts
+++ b/packages/cli/src/__tests__/events-tail-cursor.test.ts
@@ -137,13 +137,48 @@ describe("actana events tail, across a Core restart", () => {
     log.push("session:finished");
 
     const firstRun: string[] = [];
-    const first = fixture.run(["events", "tail", "--json", "--limit", "2"], {
+    const notices: string[] = [];
+    const first = fixture.run(["events", "tail", "--json", "--limit", "2", "--verbose"], {
       connect: connectCore,
       onOut: (line) => firstRun.push(line),
+      onErr: (line) => notices.push(line),
     });
-    await waitFor(() => log.tailReads >= 1, "the first tail never subscribed");
+
+    // Wait for the tip hunt to have *finished*, not merely to have started.
+    //
+    // This is the flake in #208, and it is a race rather than a slow runner:
+    // one `subscribe` is not where a first run settles. With three events
+    // already in the log the Core answers the first one with a full tail and an
+    // `eventsReplayed` that is only a receipt, so the run asks again from #3 and
+    // waits for a second marker to close an *empty* tail (`event-tip.ts`). The
+    // old wait here was `log.tailReads >= 1` — satisfied by the *first* of those
+    // reads. The two events below then had a window, one round trip wide, in
+    // which to land before the second `readEventTail` ran: appended inside it
+    // they are history, counted by the tip tracker and deliberately never
+    // printed, so `--limit 2` is never reached and the run follows a Core that
+    // has nothing left to say. That is a hang, not an overrun — which is why CI
+    // saw 61.7s against a 60s budget three times over, and why the file passes
+    // in 1.2s whenever the race is won.
+    //
+    // The notice below is the run stating that it has found the end of the log
+    // and switched printing on — the condition these two pushes actually need,
+    // published on stderr by the command itself, and the same signal the
+    // history-longer-than-a-tail test waits for. Reaching it takes a round trip
+    // more under load and none of the assertions less.
+    const endOfLog = (): string | undefined =>
+      notices.find((line) => line.includes("the Core's log ends at #"));
+    await waitFor(() => endOfLog() !== undefined, "the first tail never found the end of the log");
+    // #3, and stated: the run walked the whole history and stopped at its end.
+    // A tip settled anywhere else is the failure the pushes below were racing —
+    // now an assertion about the cursor rather than a timeout with no evidence.
+    expect(
+      endOfLog(),
+      "the first tail settled somewhere other than the end of the history",
+    ).toContain("the Core's log ends at #3;");
     // Nothing from the tail above may be printed: with no stored cursor, a tail
     // starts at the end of the log the way `tail -f` does.
+    expect(firstRun, "history was printed while the end of the log was being found").toEqual([]);
+
     log.push("task:question");
     log.push("pty:exit");
 


### PR DESCRIPTION
## Summary

`events-tail-cursor.test.ts > resumes where the last run stopped, and does not replay it` times out in CI
under runner load (#208). It is a **race in the test's synchronisation, not a budget problem** — the run
hangs forever and vitest's 60s deadline is what stops it. The fix waits for the condition the test's own
pushes depend on, and adds two assertions rather than removing any.

### The race

A first `events tail` has no stored cursor, so it starts at the end of the log the way `tail -f` does —
and the end of the log has to be *found*, because the Core publishes it only through the replay
(`event-tip.ts`). With three events of history:

1. `subscribe(0)` → the Core sends #1–#3 and an `eventsReplayed` that is a **receipt for what it sent**,
   not a statement of the tip.
2. The run therefore asks again — `subscribe(3)` — and only a marker closing an **empty** tail means "this
   is the end". Until then, printing stays off and every delivered event is counted as history.

The old wait was `await waitFor(() => log.tailReads >= 1, "the first tail never subscribed")` — satisfied by
the **first** of those two reads. The two events the test then appends had a window, one round trip wide, in
which to land inside the *second* tail. Appended there they are history: the tip tracker counts them, the
command deliberately prints neither, `--limit 2` is never reached, and the run follows a Core with nothing
left to say. Forever.

### Why the evidence in the issue reads as load but is a hang

The issue reasoned that 61.7s / 61.7s / 63.1s against a 60s budget looked like an overrun rather than a
deadlock, since "a deadlock would sit at the deadline every time". A hang here sits at the deadline too —
60s plus teardown of a real `wss://` Core and a temp dir is exactly 61–63s. The tell is the other direction:
**the whole file passes in 1.2s** when the race is won, so there is no 60s of work to overrun.

Measured on this branch (5 rounds, instrumented `readEventTail`):

| | read #1 | old wait released | read #2 | margin |
|---|---|---|---|---|
| round 0 | 6.6ms | 11.5ms | 7.6ms | −3.9ms |
| round 1 | 4.2ms | 10.7ms | 5.1ms | −5.6ms |
| round 2 | 3.9ms | 10.1ms | 5.4ms | −4.7ms |
| round 3 | 2.7ms | 9.7ms | 3.4ms | −6.3ms |
| round 4 | 2.7ms | 11.0ms | 3.1ms | −7.9ms |

The second read lands 0.4–1.5ms after the first; the old wait released on the 10ms poll tick behind it. The
test was passing on **4–8ms of scheduler jitter** — which is why it fails on a loaded runner and only there,
why re-runs go green, and why the four recorded strikes are spread across unrelated branches.

### The fix

Wait for the run to say it has found the end of the log — `the Core's log ends at #N`, on stderr under
`--verbose`. That is the same signal the sibling test (`prints none of a history longer than the Core
replays in one tail`) already waits for, and it is the exact precondition the two pushes need: once it is
emitted, `printing` is on and nothing can be swallowed as history.

**Nothing is weakened.** The 60s budget stays, and every assertion is unchanged — `[4, 5]` from the first
run, the on-disk cursor at `5`, `[6]` and only `[6]` from the second. Two assertions are **added**:

- the tip settled at `#3` **exactly** — the run walked the whole history and stopped at its end, which is
  what makes the `[4, 5]` below it mean anything;
- nothing was printed while the end of the log was being found.

A lost race now fails **in 12ms**, naming the tip it settled on (`expected '…ends at #5…' to contain
'…ends at #3;'`), instead of burning 60s to report only that time ran out.

### On #244's semantics

The ordering #244 landed — the live-event cursor advancing only *behind* a send that landed, `subscribe`'s
replay moving its cursor on the same evidence — is what this test exists to guard, and it is untouched here.
No production code changes; `packages/core/src/__tests__/core-link-event-cursor-advance.test.ts` (4 tests)
and the rest of `packages/core` (1170 tests) are green on this branch.

### Worth flagging: one red cli test hides core and panel entirely

CI's **Unit Tests** job runs `pnpm test` → `pnpm native:node && vitest run && pnpm -r test`. `pnpm -r` bails
on the first failing package, and the workspace's topological order puts `cli` second:

```
$ pnpm -r --workspace-concurrency=1 exec pwd
packages/sdk
packages/cli      ← this flake aborts the run here
packages/shared
packages/core
packages/panel
```

So this one hung test does not merely add a red check — it **suppresses every `core`, `shared` and `panel`
result behind it**. A PR that touches only the Core or the Panel can go red with the failure sitting in a
package it never touched and with no report at all from the packages it did. That is part of why #208 has
been expensive out of proportion to its size, and it is worth separating in triage: the flake is fixed here,
the bail ordering is not (a `--no-bail` on the recursive run, or splitting the job per package, would be its
own change).

## Related issues

Closes #208
Refs #244

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue) — test-only
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [ ] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [x] Manually verified (described below)

Local, on this branch (`env -u AC_*` to keep this machine's Core out of the runs):

- `packages/cli/src/__tests__/events-tail-cursor.test.ts` — **15 consecutive clean runs**, 4/4 each.
- Under load — 30 busy loops on 10 cores — **5/5 green**, file time inflated to 4.7–12.8s (of a 60s budget).
- The **pre-fix** file under that same load: **4 failures in 6 runs**, each `Test timed out in 60000ms`,
  file durations 65.9–68.3s — the CI signature, reproduced locally.
- Deterministic proof of the mechanism: forcing the two events into the tip hunt's second tail leaves the
  pre-fix run printing `[]` and never resolving; the fixed test catches that state in 12ms with a sentence.
- `packages/cli` 421 passed / 3 skipped · `packages/core` 1170 passed · `packages/sdk` 236 passed / 5 skipped
  · `packages/shared` 184 passed · root `vitest run` 474 passed · `tsc --noEmit` and `eslint` clean.
- `packages/panel`: 1429/1431 in a full local run; the handful that fail vary run to run and **all pass in
  isolation** (a known local full-run timeout artefact — this diff touches no panel file).

## Checklist

- [ ] This PR targets the open train (`beta/x.y.z`), not `main` — **deliberately not**: it targets
  `fix/session-and-event-reliability`, the integration branch #244 landed on, since the flake is about
  exactly those semantics.
- [x] My PR title and every commit in the branch follow Conventional Commits (verified with the repo's own
  `commitlint.config.mjs`), and the branch name follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed — the wait carries the whole argument
- [x] I added tests proving my fix works, and all tests pass locally
- [ ] I updated documentation (README, docs/, changelog entry) where relevant — n/a, test-only
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (#245 is on the base branch); this PR is a draft

---

**CI on this branch:** all 17 checks green on the first attempt, Unit Tests included (2m3s) — run
32137677337. Five train/publish jobs skipped as expected on a non-train PR.
