### PR TITLE
fix(core): keep a separator where sanitizeInitialInput drops a line break

### DIFF
--- a/packages/core/src/__tests__/pty-manager.test.ts
+++ b/packages/core/src/__tests__/pty-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { disposePty, planLaunchPortKillTargets } from "../pty-manager";
+import { disposePty, planLaunchPortKillTargets, sanitizeInitialInput } from "../pty-manager";
 
 describe("planLaunchPortKillTargets", () => {
   it("marks Mission Control runtime ports as protected", () => {
@@ -45,5 +45,81 @@ describe("disposePty", () => {
         },
       } as never),
     ).not.toThrow();
+  });
+});
+
+describe("sanitizeInitialInput", () => {
+  // Issue #193: a line break is a C0 byte, so it failed the `code >= 32` test
+  // and was dropped like any other control byte — and `.join("")` left nothing
+  // in its place, welding the word before the break onto the word after it
+  // ("the diff" + "then open" => "diffthen"). Every programmatic starting
+  // prompt (Ship / Sync / Create-PR) is sanitised here, so these cases pin the
+  // separator semantics rather than leaving them to the next reader.
+  it("keeps a separator where a line break was", () => {
+    expect(sanitizeInitialInput("review the diff\nthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+  });
+
+  it("drops a leading or trailing line break without leaving stray whitespace", () => {
+    expect(sanitizeInitialInput("review the diff\n")).toBe("review the diff");
+    expect(sanitizeInitialInput("\nreview the diff")).toBe("review the diff");
+    expect(sanitizeInitialInput("\nreview the diff\n")).toBe("review the diff");
+  });
+
+  it("collapses a run of line breaks to a single separator", () => {
+    expect(sanitizeInitialInput("first paragraph\n\n\nsecond paragraph")).toBe(
+      "first paragraph second paragraph",
+    );
+  });
+
+  it("treats carriage returns like line feeds, CRLF included", () => {
+    expect(sanitizeInitialInput("review the diff\r\nthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+    expect(sanitizeInitialInput("review the diff\rthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+    expect(sanitizeInitialInput("review the diff\n\rthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+  });
+
+  it("returns undefined for a prompt that is only line breaks", () => {
+    expect(sanitizeInitialInput("\n")).toBeUndefined();
+    expect(sanitizeInitialInput("\n\n\n")).toBeUndefined();
+    expect(sanitizeInitialInput("\r\n\r\n")).toBeUndefined();
+  });
+
+  it("returns undefined when there is nothing to send", () => {
+    expect(sanitizeInitialInput(undefined)).toBeUndefined();
+    expect(sanitizeInitialInput("")).toBeUndefined();
+    expect(sanitizeInitialInput("   ")).toBeUndefined();
+  });
+
+  it("still refuses to pass keybinding control bytes through to the TUI", () => {
+    // The filter's original purpose stands: a caller must not be able to drive
+    // the harness TUI from a starting prompt. A non-whitespace C0/DEL byte was
+    // never text, so it is removed with no separator in its place.
+    expect(sanitizeInitialInput("esc\x1b[Ainjected")).toBe("esc[Ainjected");
+    expect(sanitizeInitialInput("ctrl\x03c")).toBe("ctrlc");
+    expect(sanitizeInitialInput("del\x7fbyte")).toBe("delbyte");
+  });
+
+  it("separates words joined by a tab or a form feed", () => {
+    expect(sanitizeInitialInput("review the diff\tthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+    expect(sanitizeInitialInput("review the diff\vthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+    expect(sanitizeInitialInput("review the diff\fthen open a PR")).toBe(
+      "review the diff then open a PR",
+    );
+  });
+
+  it("leaves ordinary text, its spacing and its non-ASCII alone", () => {
+    expect(sanitizeInitialInput("  ship it — please  ")).toBe("ship it — please");
+    expect(sanitizeInitialInput("two  spaces stay")).toBe("two  spaces stay");
   });
 });

--- a/packages/core/src/pty-manager.ts
+++ b/packages/core/src/pty-manager.ts
@@ -254,12 +254,22 @@ function appendBuffer(p: Pty, data: string): number {
   return seq;
 }
 
+// The C0 bytes that are whitespace in the source text: tab, line feed,
+// vertical tab, form feed, carriage return. They cannot be written through
+// verbatim — a bare CR/LF submits the prompt early — but they *separate* the
+// words either side of them, so a run of them collapses to one space instead
+// of vanishing (issue #193). Dropping them outright welded the last word of a
+// line onto the first word of the next: "review the diff\nthen open a PR"
+// arrived as "review the diffthen open a PR".
+const WHITESPACE_CONTROL_RUN = /[\t\n\v\f\r]+/g;
+
 // A programmatic starting prompt (Ship / Sync / Create-PR) is written to the
-// agent's stdin like the user typing. Drop C0/DEL control bytes so a caller
-// can't drive TUI keybindings; the submit CR is added separately.
-function sanitizeInitialInput(text: string | undefined): string | undefined {
+// agent's stdin like the user typing. Whitespace control bytes become a single
+// space; every other C0/DEL byte is dropped with nothing in its place, so a
+// caller can't drive TUI keybindings. The submit CR is added separately.
+export function sanitizeInitialInput(text: string | undefined): string | undefined {
   if (!text) return undefined;
-  const clean = Array.from(text)
+  const clean = Array.from(text.replace(WHITESPACE_CONTROL_RUN, " "))
     .filter((ch) => {
       const code = ch.charCodeAt(0);
       return code >= 32 && code !== 127;


### PR DESCRIPTION
Closes #193.

## The bug

`sanitizeInitialInput()` strips C0/DEL bytes from a programmatic starting
prompt and rejoins the survivors with `.join("")`. A line break is `0x0A`, so
it failed the `code >= 32` test and was dropped like any other control byte —
with nothing left in its place. The word ending one line was welded onto the
word opening the next:

```
review the diff
then open a PR
```

reached the agent as `review the diffthen open a PR`, with `diff` and `then`
fused into one token. Every programmatic starting prompt (Ship / Sync /
Create-PR) is sanitised through this one function, so any multi-line prompt
was delivered mangled.

## The fix

Whitespace control bytes — tab, LF, VT, FF, CR — now collapse to a single
space before the C0/DEL filter runs. They still cannot pass through verbatim
(a bare CR/LF would submit the prompt early), but they *separate* the words
either side of them, so they leave a separator behind rather than vanishing.

Every other C0/DEL byte is still removed with nothing in its place — those are
keybinding attempts, never text — so the filter's original purpose is
unchanged. A *run* of whitespace controls collapses to one space, so CRLF and
blank lines do not pad the prompt, and the existing `.trim()` keeps a leading
or trailing break from leaving stray whitespace.

The change is small, but every harness start prompt goes through it, so the
behaviour is pinned rather than left to the next reader.

## Tests

`sanitizeInitialInput` is exported for the suite the way `disposePty` and
`planLaunchPortKillTargets` already are. New cases in
`packages/core/src/__tests__/pty-manager.test.ts`:

- a line break keeps a separator (the issue's own example)
- a leading or trailing line break leaves no stray whitespace
- a run of repeated newlines collapses to one separator
- carriage returns, `\r\n` and `\n\r` behave like line feeds
- a prompt that is only newlines returns `undefined`
- nothing to send (`undefined`, empty, all-spaces) returns `undefined`
- tab and form feed separate too
- ESC / `\x03` / DEL are still removed **without** a separator
- ordinary text, its internal double spaces and its non-ASCII are untouched

## Verification

- `vitest run --root packages/core` — 63 files, 1179 tests, all green
- `tsc --noEmit` on `packages/core` — clean
- `eslint` on both changed files — no new problems (3 pre-existing warnings in
  `pty-manager.ts`, all on untouched lines)
- `commitlint --from origin/chore/improvement-sweep --to HEAD` — 0 problems

The root suite's `scripts/__tests__/core-launcher.test.mjs` fails on this
machine only, because a real `/opt/actana` install is present; it is unrelated
to this change and fails the same way on the base commit.

## Scope

Base is `chore/improvement-sweep` (the 0.3.2 improvement batch, cut from
`beta/0.3.1`), **not** `main` and not a beta branch. Touches only
`packages/core/src/pty-manager.ts` and its test — no overlap with #224
(`CoreFilesErrorCode` in the SDK) or #202 (release skill documentation).

Draft on purpose.
