### PR TITLE
docs(adr): correct the update host domain in ADR 0007 and drop the docs/specs pointers

### DIFF
--- a/docs/adr/0007-scope-narrowing-and-rebrand.md
+++ b/docs/adr/0007-scope-narrowing-and-rebrand.md
@@ -18,12 +18,12 @@ The motivations are (1) *result parity* — see ADR 0006 on skills; the same pri
 
 ## Consequences
 
-- Nine removal specs land as separate PRs (Whisper, Pet + multiplayer, Screenshot, Recall/Memory, Bundled skills, IDE-adjacent, Convenience, plus cross-core notifications add and the rebrand). See `docs/specs/`.
+- Nine removal specs land as separate PRs (Whisper, Pet + multiplayer, Screenshot, Recall/Memory, Bundled skills, IDE-adjacent, Convenience, plus cross-core notifications add and the rebrand).
 - The rebrand spec (09) is expanded to cover the npm scope (`@agentsystemlabs` → `@qcentic`), package name (`mission-control` → `actana-control`), update host (`agentsystem.dev` → `control.actana.ai`), and agent bridge dep (`@agentsystemlabs/mission-control-agent` → `@qcentic/actana-control-agent`).
 - The `MC_*` env-var prefix used between the Panel and the agent bridge is a wire contract; because we now own both sides, renaming it to `AC_*` lands together with the package rename as a single break. Confirmed 2026-07-30. Detailed in spec 09.
 - One consolidated forward-only migration drops every table and `app_settings` field belonging to a removed feature. No feature flags. See ADR 0006 for skill-install specifics.
 - `package.json` (`name`, `productName`, `build.appId`, `build.publish`), the window title, deep-link scheme, and all user-facing strings switch to Actana Control. `README.md`, `PRODUCT.md`, `SPEC.md`, `CHANGELOG.md`, and `CONTEXT.md` are updated; `docs/upstream/*` is updated to reflect that many upstream-divergence axes now become NON-EXISTENT (Panel-side) because the entire feature area is gone.
-- `electron/update-manager.ts` is disabled: no periodic checks, no update dialog. The module remains as a stub with a TODO pointing at the `control.actano.ai` follow-up so re-enabling later is a small change rather than a rebuild.
+- `electron/update-manager.ts` is disabled: no periodic checks, no update dialog. The module remains as a stub with a TODO pointing at the `control.actana.ai` follow-up so re-enabling later is a small change rather than a rebuild.
 - macOS entitlements lose the microphone usage description (came with Whisper). Any other capability that was declared for a removed feature is stripped in the same pass.
 - The harness registry stays extensible for new harnesses (`opencode`, `pi`, `hermes`) even though the current skill-install table shape goes away — see the domain model.
 - Legacy references to *Mission Control* survive only in `docs/upstream/` porting notes (where they are the correct historical name).

--- a/docs/adr/0009-remove-managed-sandbox.md
+++ b/docs/adr/0009-remove-managed-sandbox.md
@@ -16,7 +16,7 @@ The detached-core Harness is the strict superset. It owns the Session (PTY, even
 
 ## Consequences
 
-- Removal spec 10 (`docs/specs/10-remove-sandbox.md`) lands as a single PR alongside the other scope-narrowing specs. Total removal count rises from nine to ten.
+- Removal spec 10 lands as a single PR alongside the other scope-narrowing specs. Total removal count rises from nine to ten.
 - The `sandboxes` table and every `scopeId` / `sandboxId` column dropped in one forward-only migration. No data-migration path — existing sandbox-scoped projects are gone with their sandbox (fresh-fork, no users to preserve).
 - `@agentsystemlabs/mission-control-agent` npm dependency is removed. Rebrand spec 09's "publish `@qcentic/actana-control-agent` before rebrand can land" prerequisite is **dissolved** — the package no longer needs to exist because nothing in Actana Control installs an agent on a VM anymore. Spec 09 is updated to strike the agent-bridge rename from its checklist.
 - Electron IPC surface shrinks by ~48 channels (`sandbox:*`, `remoteVm:*`, `remotePty:*`, `remoteFs:*`, `remoteGit:*`). Preload contract, `electron-contract.ts` shared types, and `ipc-channels.ts` all shrink correspondingly.

--- a/docs/specs/09-rebrand-and-auto-update.md
+++ b/docs/specs/09-rebrand-and-auto-update.md
@@ -7,7 +7,7 @@ package metadata, Electron builder config, main-process constants, all
 user-facing strings under `src/`, and the top-level docs. In the same
 cutover, disable the auto-update path (periodic check, background download,
 update dialog) without deleting `electron/update-manager.ts` — the module
-stays in place as a stub so re-enabling against `control.actano.ai` is a
+stays in place as a stub so re-enabling against `control.actana.ai` is a
 diff, not a rebuild. Hard forward-only: no dual naming, no compatibility
 shims, no data-dir migration.
 
@@ -23,7 +23,7 @@ Root file: `/Users/mehdiroshanfekr/Projects/opensource/mission-control-updated/p
 | `build.productName` | `"MissionControl"` | `"Actana Control"` |
 | `build.mac.extendInfo.NSMicrophoneUsageDescription` | `"Mission Control uses the microphone…"` | remove entirely — mic entitlement/whisper are being deleted per ADR 0007 (spec 01 Whisper removal) |
 | `build.mac.extendInfo.NSScreenCaptureUsageDescription` | `"Mission Control captures a screen region…"` | remove entirely — screenshot capture is being deleted per ADR 0007 |
-| `build.publish[0].url` | `"https://agentsystem.dev/downloads/mission-control/auto-update"` | replace the entire `build.publish` array with `"publish": null` (disables generic-provider publishing entirely). Do not point at `control.actano.ai` yet — see Open Questions. |
+| `build.publish[0].url` | `"https://agentsystem.dev/downloads/mission-control/auto-update"` | replace the entire `build.publish` array with `"publish": null` (disables generic-provider publishing entirely). Do not point at `control.actana.ai` yet — see Open Questions. |
 | `build.win.artifactName` | `"${productName}-${version}-Setup.${ext}"` | keep — resolves via `productName`; will produce `Actana Control-<ver>-Setup.exe` after productName change |
 
 No `author` or `publisher` field is currently set — leave absent (or add
@@ -179,7 +179,7 @@ every entry point.
 1. Prepend a top-of-file comment block:
    ```
    // Auto-update is DISABLED for the initial Actana Control cutover.
-   // Re-enable when control.actano.ai (spelling TBC — see docs/specs/09) is
+   // Re-enable when control.actana.ai (spelling TBC — see docs/specs/09) is
    // live and the generic-provider artifacts (latest-mac.yml, latest.yml,
    // latest-linux.yml, *.blockmap, *.zip) are being served. Re-enabling is:
    //   1. Restore `build.publish` in package.json with the new URL.


### PR DESCRIPTION
Closes #56. Part of #23. Base is `chore/improvement-sweep`.

ADR 0007 said the disabled update-manager stub points at `control.actano.ai`.
The only thing in the repo that resolved that typo was spec 09's Open Questions
(*"`actana.ai` is authoritative"*), and `docs/specs/` is slated for deletion — so
deleting it first would have left a live ADR carrying a wrong domain with nothing
to correct it. This fixes the domain and, per the ticket, also strikes the two ADR
pointers into `docs/specs/`.

## Every occurrence of the misspelling in the repo

`grep -rn -i actano .` over the whole worktree (excluding `.git/` and
`node_modules/`) — **12 hits in 4 files, all under `docs/`. Zero hits outside
`docs/`**: no source file, config, workflow, test fixture, or `package.json`
contains it.

### Changed (4)

| File:line | Text | Why changed |
| --- | --- | --- |
| `docs/adr/0007-scope-narrowing-and-rebrand.md:26` | `control.actano.ai` | The ticket's target. A live ADR consequence stating the update host. |
| `docs/specs/09-rebrand-and-auto-update.md:10` | `control.actano.ai` | Same domain, prose. |
| `docs/specs/09-rebrand-and-auto-update.md:26` | `control.actano.ai` | Same domain, prose in the `package.json` table's *note* column (not a value — the value in that row is `"publish": null`). |
| `docs/specs/09-rebrand-and-auto-update.md:182` | `control.actano.ai` | Same domain, inside a fenced block quoting a prospective comment for `electron/update-manager.ts`. Flagging the judgement call: it is a code block, but it is prose-in-a-comment, the file no longer exists (Electron left with ADR 0010), and nothing reads it. Say the word and I will revert this one line. |

### Found and deliberately NOT changed (8)

**A proposed bundle identifier, out of the ticket's reach (3 hits).** The string
`ai.actano.control`, offered as a candidate `build.appId`. It is *not* a live
value: there is no `appId` anywhere in this repo — no `build` block in
`package.json`, no `electron/`, no `build/` — only a proposal in a spec for the
packaging config that ADR 0010 removed. It is left alone for two reasons that do
not depend on that:

- It does not contain the string `actano.ai`, so AC1 never reached it; and D46/K4
  is narrower still — *"fix `actano.ai` in ADR 0007"*, one domain, one file.
- Both files carrying it are deleted wholesale by #58, which takes all 12
  `docs/specs/` and all 13 `docs/tickets/` files.

| File:line | Text |
| --- | --- |
| `docs/specs/09-rebrand-and-auto-update.md:22` | `build.appId` → `"ai.actano.control"` |
| `docs/tickets/09-rebrand-and-auto-update.md:95` | `build.appId`: → `"ai.actano.control"` |
| `docs/tickets/09-rebrand-and-auto-update.md:111` | acceptance criterion: `codesign -dv` matches `ai.actano.control` |

> Worth a follow-up ticket: spec 09's own Open Questions section already resolves
> this to `ai.actana.control` (line 381), so the spec contradicts itself and the
> ticket file inherits the wrong side. Left as-is here on purpose.

**Records of the misspelling — erasing them destroys their meaning (2 hits).**

| File:line | Text | Why not changed |
| --- | --- | --- |
| `docs/adr/0016-the-0-1-0-shape.md:191` | D46/K4: *"(`actana.ai` is authoritative; fix `actano.ai` in ADR 0007)"* | This clause **commissions this PR**. Rewriting it yields "fix `actana.ai` in ADR 0007", which is self-contradictory, and ADR 0016 is a locked decision record — #56 does not ask for D46 to be amended. |
| `docs/specs/09-rebrand-and-auto-update.md:381` | *"(Prior confusion between `actano.ai` and `actana.ai` … is resolved: `actana.ai` is authoritative.)"* | The sentence exists to record which spelling won. Removing the loser removes the sentence's point. |

**Not the domain at all — an open legal-entity question (3 hits).** `"Actano"` as
a possible company/publisher string, distinct from `actano.ai`. Resolving the
entity name is the operator's call, not this ticket's.

| File:line | Text | Why not changed |
| --- | --- | --- |
| `docs/specs/09-rebrand-and-auto-update.md:30` | `"author": "Actano"` if the operator wants a signed-installer publisher | A proposed `package.json` author string, not the domain — and, like `build.appId`, a proposal in a spec #58 deletes rather than a value anything reads. |
| `docs/specs/09-rebrand-and-auto-update.md:391` | whether it's `"Actana"`, `"Actano"`, or a legal-entity name | Explicitly still open in the spec's own Open Questions. |
| `docs/specs/09-rebrand-and-auto-update.md:415` | an "Actana/Actano-owned" Apple Developer Team ID | Same open entity question, in the code-signing paragraph. |

## The other two acceptance criteria

- **ADR 0007's `docs/specs/` pointer struck.** The "Nine removal specs land as
  separate PRs (…)" bullet loses its trailing "See `docs/specs/`." sentence. It
  still names all nine specs, so it stands on its own.
- **ADR 0009's `docs/specs/10-remove-sandbox.md` path rewritten out.** Now reads
  "Removal spec 10 lands as a single PR …" — the spec keeps its identifier,
  loses the path. Checked: no other ADR cites a `docs/specs/` path.

## Boundaries

Nothing here touches #55's territory (the no-code-signing paragraph, `install.sh`
links in the contributing docs) or #57's (moving `repo-template/` out of the
clone). ADR 0016 D46 mentions both — another reason it was left alone. Docs only,
no code, no tests, no config.

