### PR TITLE
docs: record why the release is unsigned, and repoint the citations that said so

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -232,8 +232,12 @@ the digest claim is about the container images only.
 container images are unsigned: no Apple notarization, no Windows Authenticode —
 there is no Windows artifact to sign — and no detached GPG or Sigstore signature
 over a tarball or an image manifest. `release.yml` carries no signing secret at
-all; the only credentials on the release path are `github.token` for the assets
-and the Docker Hub PAT for the mirror.
+all — its one signing-adjacent capability, `id-token: write` on the `npm` job,
+is keyless OIDC rather than a key. Three credentials sit on the release path
+and none of them signs anything: `github.token` for the Release assets, the
+`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` PAT for the images, and `NPM_TOKEN`
+for the packages. The last two are each mandatory, gated by their own `resolve`
+step that fails the release before anything is built when they are unset.
 
 Integrity is **the published checksums**, and both paths that put a Core on a
 machine verify them. `install.sh` fetches `SHA256SUMS` *before* the tarball, and

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -226,6 +226,63 @@ guarantee](#the-digest-guarantee-where-it-starts-and-where-it-stops). The Core
 tarballs are not: they are built by the release, from the promoted commit, and
 the digest claim is about the container images only.
 
+### Integrity is published checksums, not signatures
+
+**Nothing a release ships is code-signed.** The three Core tarballs and both
+container images are unsigned: no Apple notarization, no Windows Authenticode —
+there is no Windows artifact to sign — and no detached GPG or Sigstore signature
+over a tarball or an image manifest. `release.yml` carries no signing secret at
+all; the only credentials on the release path are `github.token` for the assets
+and the Docker Hub PAT for the mirror.
+
+Integrity is **the published checksums**, and both paths that put a Core on a
+machine verify them. `install.sh` fetches `SHA256SUMS` *before* the tarball, and
+`actana update` does the same for an in-place upgrade
+([`actana-update.ts`](../packages/core/src/actana-update.ts)); each compares the
+SHA-256 it computed against the release's own line and refuses to install on a
+mismatch. What that proves is bounded, and both call sites say so in a comment:
+the tarball is the one the release's checksum file describes. The checksums came
+over the same channel as the bytes, so this catches corruption and truncation —
+not a release channel someone else controls. That is the gap a signature would
+close, and it is open.
+
+One release surface is attested, and it is not a counter-example: the npm
+packages are published with `--provenance`, so `@actana/sdk` and `@actana/cli`
+carry a SLSA provenance attestation that the release reads back off the registry
+before it succeeds ([npm](#npm)). Provenance attests *where a package was
+built*. It is not a signature over a released binary, and it covers neither the
+tarballs nor the images.
+
+**Why unsigned is safe for the way this ships.** The distribution path is
+`curl | bash`, and `curl` — like `wget` — does not set the
+`com.apple.quarantine` extended attribute. Nothing arriving by that path is ever
+quarantined, so **Gatekeeper never intervenes**, and there is no dialog for
+notarization to buy off. This is a claim about the *transport*, not about the
+bytes: revisit it the moment a browser-download distribution is added, because a
+browser does set the attribute. That case is already the operator's, not the
+installer's — [`../INSTALL.md`](../INSTALL.md) documents `xattr -dr
+com.apple.quarantine` as the escape hatch for a tarball fetched in Safari or
+Chrome.
+
+**The corollary, which already cost one review cycle: do not add `xattr -dr
+com.apple.quarantine` to `actana setup`.** It is a recursive attribute strip run
+on every install to undo a state the install path cannot produce. On the paths
+`actana setup` actually runs on there is nothing to clear, so it buys nothing;
+on any other path it silently clears quarantine on files that legitimately carry
+it, turning a Gatekeeper decision into something the installer made on the
+operator's behalf without saying so. The strip stays where it is, in `INSTALL.md`,
+run by hand by the person who knows they used a browser.
+
+This is the current posture, not a permanent refusal.
+[ADR 0010](adr/0010-panel-becomes-a-self-hosted-web-service.md) voided the
+Panel's desktop signing story and deferred the question to Harness distribution
+planning; this section is that answer, and
+[#24](https://github.com/actana/control/issues/24) — sign the release, publish
+an SBOM and provenance — is where it changes. Until that lands, treat every
+statement above as load-bearing rather than incidental: `install.sh`'s checksum
+comment points here, and the macOS prerelease checklist's Gatekeeper box assumes
+it.
+
 ## The tag ladder
 
 Five published tag classes, each answering exactly one question ([ADR

--- a/docs/core-macos-prerelease-checklist.md
+++ b/docs/core-macos-prerelease-checklist.md
@@ -24,9 +24,11 @@ rather than a job. A GitHub runner is destroyed rather than restarted, and a
 LaunchAgent is by definition tied to a login session, so "does the Core come
 back after a reboot?" and "does it come back after a logout?" can only be
 answered on a real Mac. Gatekeeper is the same kind of question: the tarball
-ships unsigned and un-notarized (out of scope — see
-[#55](https://github.com/actana/control/issues/55)), and whether macOS lets an
-operator run it is not something a headless runner experiences.
+ships unsigned and un-notarized, deliberately and for a reason that is written
+down — see [Integrity is published checksums, not
+signatures](ci-cd.md#integrity-is-published-checksums-not-signatures) — and
+whether macOS lets an operator run it is not something a headless runner
+experiences.
 
 The `tarball-macos` leg does the part a runner *can* do: it builds the
 `mac-arm64` tarball on an Apple-silicon runner and boots it through its own

--- a/install.sh
+++ b/install.sh
@@ -323,7 +323,8 @@ main() {
   # What this proves: the tarball is the one the release's own checksum file
   # describes. Both came over the same channel, so it catches corruption and
   # truncation, not a release channel someone else controls — the project
-  # publishes no signatures (spec: "No code signing").
+  # publishes no signatures. Why that is safe, and what would change it:
+  # docs/ci-cd.md, "Integrity is published checksums, not signatures".
   say "Checksum verified against the release's $SHASUMS_ASSET."
 
   tar -xzf "$tarball" -C "$work_dir" || die "could not unpack $asset"


### PR DESCRIPTION
Closes #55. Part of #23, ADR 0016 clause **D46** (K3).

Promotes the last home of the "no code signing" decision out of
`.scratch/harness-installer/spec.md` — a file #58 deletes — and repoints the two
documentation citations that name it.

## What changed

- **`docs/ci-cd.md`** — a new `### Integrity is published checksums, not signatures`
  under `## The release artifacts`: what is and is not signed, what the checksums
  prove and what they do not, why unsigned is safe for a `curl | bash` transport,
  the `xattr` corollary, and the cross-link to #24.
- **`install.sh`** — the checksum comment cited `spec: "No code signing"`; it now
  cites `docs/ci-cd.md` and the section by name. **Comment only** — no installer
  behaviour changes, and `sh -n install.sh` is clean.
- **`docs/core-macos-prerelease-checklist.md`** — its Gatekeeper note deferred to
  #55, which this PR closes. Left alone it would have pointed at a closed issue
  instead of at the reason, so it now links the section.

No source file and no workflow is touched.

## Accuracy: what I checked before writing it

The ticket's framing was checked against what the release actually produces
today, not against the spec being deleted, and it needed one correction.

- **`.github/workflows/release.yml`** — the assets are three tarballs plus
  `SHA256SUMS` (asserted at an explicit count check), composed and re-verified
  with `sha256sum -c`. No signing secret on the path: `github.token` for the
  assets, the Docker Hub PAT for the mirror.
- **`.github/workflows/container-image.yml`** — the images are built with plain
  `docker build` and stitched with `docker buildx imagetools create`. Not
  `buildx build`, so there is no BuildKit provenance or SBOM attestation on them
  either.
- **The correction.** The npm job publishes `@actana/sdk` and `@actana/cli` with
  `--provenance` and reads the SLSA attestation back off the registry before the
  release succeeds. A flat "nothing in this project is signed" — which is how the
  old spec line reads — is contradicted by the release itself. The section states
  the npm exception explicitly and bounds it: provenance attests where a package
  was built, not the tarballs and not the images.
- **`grep -rn 'cosign|notariz|codesign|authenticode'`** across the repo — no
  signing tooling anywhere outside prose about the deleted Electron app.
- **Both verifiers.** `install.sh` fetches `SHA256SUMS` before the tarball and
  dies on mismatch; `packages/core/src/actana-update.ts:123` does the same for
  `actana update`. The section's "verified by both" claim is from those two call
  sites, not from the spec.
- **`docs/adr/0010`** — deferred signing to "Harness distribution planning". This
  section is that answer, and it says so.

## Links: which ones, and how

Every relative link in both changed files was resolved against the worktree with
a script (path exists; `#anchor` present as a heading), not eyeballed:

| Link | Checked how |
| --- | --- |
| `../INSTALL.md` | file exists; read §"Gatekeeper, and downloading the tarball in a browser" — it is the `xattr` escape hatch the section defers to |
| `../packages/core/src/actana-update.ts` | file exists; read the checksum branch that backs the claim |
| `adr/0010-panel-becomes-a-self-hosted-web-service.md` | file exists; read the deferral sentence |
| `#npm` (in-page) | heading `### npm` present → slug resolves |
| `ci-cd.md#integrity-is-published-checksums-not-signatures` (from the checklist) | target file exists **and** the new heading's slug matches |
| #24, #55, #58 | `gh api repos/actana/control/issues/N` — #24 confirmed **open** and titled "Supply chain: sign the release, publish an SBOM and provenance" |

All 35 relative links in the two files resolve, and all 7 in-page anchors in
`docs/ci-cd.md` resolve.

## One deliberate deviation, and one thing left undone

**The path is `docs/ci-cd.md`, not `docs/contribute/ci-cd.md`.** The ticket and
D46 both name `contribute/`. That directory does not exist yet — ADR 0016 line 71
already says `docs/ci-cd.md` is "G3's destination, until #59 moves it to
`docs/contribute/`", and the G3 row carries the same parenthetical. Writing the
ticket's literal path would have shipped exactly the dead link this change exists
to remove, so it is written and cited at the path that exists today and moves
with the tree under #59. **No ADR amendment is needed** — 0016 already anticipates
this.

**`packages/core/src/actana-update.ts:137` carries the identical dangling
citation** (`spec: "No code signing"`) and is **deliberately untouched**: it is
source, and this PR is documentation. It is one of the ten references #58
repoints. Flagging it so it is not lost.

## Boundaries

Nothing here touches ADR 0007's domain correction (#56) or `repo-template/`
(#57). Base is `chore/improvement-sweep`, not `main` and not a beta branch.
Draft, and staying draft.
