### PR TITLE
chore(release): promote 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actana-control",
-  "version": "0.3.1",
-  "description": "Actana Control \u2014 self-hosted Panel service for driving AI coding agents across many Cores.",
+  "version": "0.3.2",
+  "description": "Actana Control — self-hosted Panel service for driving AI coding agents across many Cores.",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actana-control",
   "version": "0.3.2",
-  "description": "Actana Control — self-hosted Panel service for driving AI coding agents across many Cores.",
+  "description": "Actana Control \u2014 self-hosted Panel service for driving AI coding agents across many Cores.",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@actana/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Actana Control CLI — the `actana` command's client half: the blob registry that names Cores, and the client nouns built on @actana/sdk.",
   "license": "MIT",
   "type": "module",
-  "keywords": ["actana", "cli", "agent", "terminal", "core-link"],
+  "keywords": [
+    "actana",
+    "cli",
+    "agent",
+    "terminal",
+    "core-link"
+  ],
   "homepage": "https://github.com/actana/control/tree/main/packages/cli#readme",
   "bugs": "https://github.com/actana/control/issues",
   "repository": {
@@ -15,7 +21,10 @@
   "engines": {
     "node": ">=22"
   },
-  "files": ["dist", "bin"],
+  "files": [
+    "dist",
+    "bin"
+  ],
   "bin": {
     "actana": "bin/actana.mjs"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,13 +4,7 @@
   "description": "Actana Control CLI — the `actana` command's client half: the blob registry that names Cores, and the client nouns built on @actana/sdk.",
   "license": "MIT",
   "type": "module",
-  "keywords": [
-    "actana",
-    "cli",
-    "agent",
-    "terminal",
-    "core-link"
-  ],
+  "keywords": ["actana", "cli", "agent", "terminal", "core-link"],
   "homepage": "https://github.com/actana/control/tree/main/packages/cli#readme",
   "bugs": "https://github.com/actana/control/issues",
   "repository": {
@@ -21,10 +15,7 @@
   "engines": {
     "node": ">=22"
   },
-  "files": [
-    "dist",
-    "bin"
-  ],
+  "files": ["dist", "bin"],
   "bin": {
     "actana": "bin/actana.mjs"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actana/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Actana Control Core — standalone Node daemon: PTY manager + core-link WebSocket server.",
   "license": "MIT",
   "private": true,

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actana/panel",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Actana Control Panel — service + UI (TanStack Start SSR server and the browser app).",
   "license": "MIT",
   "private": true,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,13 +4,7 @@
   "description": "Actana Control SDK — the Core client and the core-link wire protocol it speaks: frame schema, protocol version, codec, transport.",
   "license": "MIT",
   "type": "module",
-  "keywords": [
-    "actana",
-    "core-link",
-    "sdk",
-    "agent",
-    "terminal"
-  ],
+  "keywords": ["actana", "core-link", "sdk", "agent", "terminal"],
   "homepage": "https://github.com/actana/control/tree/main/packages/sdk#readme",
   "bugs": "https://github.com/actana/control/issues",
   "repository": {
@@ -21,9 +15,7 @@
   "engines": {
     "node": ">=22"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@actana/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Actana Control SDK — the Core client and the core-link wire protocol it speaks: frame schema, protocol version, codec, transport.",
   "license": "MIT",
   "type": "module",
-  "keywords": ["actana", "core-link", "sdk", "agent", "terminal"],
+  "keywords": [
+    "actana",
+    "core-link",
+    "sdk",
+    "agent",
+    "terminal"
+  ],
   "homepage": "https://github.com/actana/control/tree/main/packages/sdk#readme",
   "bugs": "https://github.com/actana/control/issues",
   "repository": {
@@ -15,7 +21,9 @@
   "engines": {
     "node": ">=22"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actana/shared",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Actana Control shared internals — mutation/query contracts, registration-blob codec, event log. The core-link frames live in @actana/sdk.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Promotion gate for 0.3.2. Do not merge this pull request by hand. promote.yml performs the fast-forward; a UI merge or squash creates a new commit whose SHA breaks the ADR 0023 D16 revision-label assertion, which is what made 0.3.1 unreleasable.