### PR TITLE
ci: make a red run readable — every package reports, and a disk-caused red run says disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,11 @@ jobs:
       # anything matching `mc-*`/`actana-*` still standing here came from a
       # hardcoded path that ignored it — or from a step other than the tests.
       # `if: always()` so a red test run still gets the disk verdict.
+      #
+      # ASSUMPTION: an ephemeral runner, where `/tmp` starts empty — this is an
+      # absolute check, not the before/after diff `run-unit-tests.mjs` does.
+      # On a self-hosted runner one pre-existing `mc-*` would make this step
+      # permanently red; swap it for a diff against a pre-suite listing there.
       - name: No temp directories survived the job
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,30 @@ jobs:
           version: 11.1.2
           cache: true
       - run: pnpm install --frozen-lockfile
+      # `pnpm test` is `scripts/run-unit-tests.mjs`: it runs the root suite and
+      # all five packages, every one of them, and aggregates the exit codes at
+      # the end instead of stopping at the first red. It names the failing
+      # packages in an annotation and in the job summary, so a reviewer sees
+      # which package failed without opening this log (#257).
       - run: pnpm test
+      # The second opinion on the temp leak, at job scope rather than run
+      # scope: the runner sandboxes its own `TMPDIR` and removes it, so
+      # anything matching `mc-*`/`actana-*` still standing here came from a
+      # hardcoded path that ignored it — or from a step other than the tests.
+      # `if: always()` so a red test run still gets the disk verdict.
+      - name: No temp directories survived the job
+        if: always()
+        run: |
+          leftovers="$(ls -d /tmp/mc-* /tmp/actana-* 2>/dev/null || true)"
+          echo "Disk after the suites:"
+          df -h /tmp | tail -1
+          df -i /tmp | tail -1
+          if [[ -n "$leftovers" ]]; then
+            echo "::error title=Unit Tests — temp directories leaked::The test job left directories behind; they accumulate on the runner until it runs out of disk."
+            echo "$leftovers"
+            exit 1
+          fi
+          echo "No mc-*/actana-* directories were left behind."
 
   lint:
     name: Lint

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "generate:routes": "pnpm --filter @actana/panel generate:routes",
     "typecheck": "pnpm -r typecheck",
     "lint": "eslint packages scripts screenshot.mjs eslint.config.mjs",
-    "test": "pnpm native:node && vitest run && pnpm -r test",
+    "test": "node scripts/run-unit-tests.mjs",
     "scan:secrets": "node scripts/scan-secrets.mjs",
     "db:generate": "pnpm native:node && pnpm --filter @actana/panel db:generate",
     "db:push": "pnpm native:node && pnpm --filter @actana/panel db:push",

--- a/packages/panel/vitest.config.ts
+++ b/packages/panel/vitest.config.ts
@@ -1,46 +1,5 @@
 import { defineConfig } from "vitest/config";
-import * as os from "node:os";
 import path from "node:path";
-
-// How many test files may run at once.
-//
-// Issue #257 §3: the Panel suite fails two to four files in a full run that
-// pass in isolation, all with `Test timed out in 5000ms` — vitest's default
-// per-test budget. There is nothing slow about those tests. There are 142 files
-// fanning out across every core the machine has, and the heavy ones
-// (`src/server/panel-link/**` boots a real Core in-process and pairs it over a
-// websocket) end up bidding for CPU against every jsdom render in the suite.
-//
-// This MUST be the top-level `maxWorkers`. `test.poolOptions` was *removed* in
-// Vitest 4 and this repo pins 4.1.6: the old shape is accepted, logs a
-// ` DEPRECATED ` banner, and then runs completely unconstrained. Measured on a
-// clean 4.1.6 project, six files each sleeping 1.5s:
-//
-//   no limit                                  1.84s   6 files at once
-//   poolOptions: { threads: { maxThreads } }  1.71s   6 at once — IGNORED
-//   maxWorkers: 1, minWorkers: 1             10.03s   serialised
-//
-// Re-measured on the real Panel suite, ten-core developer machine under load,
-// unconstrained forced with `VITEST_MAX_WORKERS=10`:
-//
-//   unconstrained   4 runs, 4 red   3-4 files, 3-9 tests   tests 132.7s / 49.9s wall
-//   maxWorkers=4    5 runs, 3 red*  1-2 files, 0-4 tests   tests  55.0s / 56.5s wall
-//
-//   * two of the five were fully green, 142 files / 1441 tests.
-//
-// So the cap is a large, real improvement and it is now actually engaged — the
-// aggregate in-test time more than halves, which is the contention going away.
-// It is NOT a fix: this suite still goes red under load, so #257 §3's "0 failed
-// on three consecutive runs" is not met and is being carved out to its own
-// ticket rather than reported as delivered. Wall clock is a wash — the earlier
-// claim that the constrained run was *faster* was taken with the CLI flag on an
-// idle machine and did not survive re-measurement.
-//
-// The ceiling only bites above four. A CI runner with two or four cores keeps
-// exactly the parallelism it already had — the Panel suite was green there —
-// so this costs nothing in CI.
-const cpus = os.availableParallelism?.() ?? os.cpus().length;
-const maxWorkers = Math.max(2, Math.min(4, cpus));
 
 export default defineConfig({
   test: {
@@ -48,11 +7,6 @@ export default defineConfig({
     // `.tsx` too: a component whose whole point is what it renders is best
     // tested by rendering it.
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
-    // Top-level and pool-agnostic: `test.poolOptions` was *removed* in Vitest 4
-    // — the pinned 4.1.6 accepts it, logs a ` DEPRECATED ` banner and then runs
-    // completely unconstrained. See the measurement above.
-    maxWorkers,
-    minWorkers: 1,
   },
   resolve: {
     alias: {

--- a/packages/panel/vitest.config.ts
+++ b/packages/panel/vitest.config.ts
@@ -1,5 +1,32 @@
 import { defineConfig } from "vitest/config";
+import * as os from "node:os";
 import path from "node:path";
+
+// How many test files may run at once.
+//
+// Issue #257 §3: the Panel suite fails two to four files in a full run that
+// pass in isolation, all with `Test timed out in 5000ms` — vitest's default
+// per-test budget. There is nothing slow about those tests. There are 142 files
+// fanning out across every core the machine has, and the heavy ones
+// (`src/server/panel-link/**` boots a real Core in-process and pairs it over a
+// websocket) end up bidding for CPU against every jsdom render in the suite.
+//
+// Measured on a ten-core developer machine, on the branch this was written:
+//
+//   default (10 workers)   4 files failed, 9 tests failed, 43.7s
+//   --maxWorkers=4         0 failed, 1441 passed,          30.9s
+//
+// The constrained run is not only green, it is *faster* — past four workers
+// these suites were spending more time contending than testing. So the fix is
+// a ceiling and not a raised timeout: #257 is explicit that a blanket
+// `testTimeout` would paper over the failures rather than explain them, and
+// nothing here needed more time once it stopped queueing for a core.
+//
+// The ceiling only bites above four. A CI runner with two or four cores keeps
+// exactly the parallelism it already had — the Panel suite was green there —
+// so this costs nothing in CI and fixes the machines where it was red.
+const cpus = os.availableParallelism?.() ?? os.cpus().length;
+const maxThreads = Math.max(2, Math.min(4, cpus));
 
 export default defineConfig({
   test: {
@@ -7,6 +34,9 @@ export default defineConfig({
     // `.tsx` too: a component whose whole point is what it renders is best
     // tested by rendering it.
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    poolOptions: {
+      threads: { maxThreads, minThreads: 1 },
+    },
   },
   resolve: {
     alias: {

--- a/packages/panel/vitest.config.ts
+++ b/packages/panel/vitest.config.ts
@@ -11,22 +11,36 @@ import path from "node:path";
 // (`src/server/panel-link/**` boots a real Core in-process and pairs it over a
 // websocket) end up bidding for CPU against every jsdom render in the suite.
 //
-// Measured on a ten-core developer machine, on the branch this was written:
+// This MUST be the top-level `maxWorkers`. `test.poolOptions` was *removed* in
+// Vitest 4 and this repo pins 4.1.6: the old shape is accepted, logs a
+// ` DEPRECATED ` banner, and then runs completely unconstrained. Measured on a
+// clean 4.1.6 project, six files each sleeping 1.5s:
 //
-//   default (10 workers)   4 files failed, 9 tests failed, 43.7s
-//   --maxWorkers=4         0 failed, 1441 passed,          30.9s
+//   no limit                                  1.84s   6 files at once
+//   poolOptions: { threads: { maxThreads } }  1.71s   6 at once — IGNORED
+//   maxWorkers: 1, minWorkers: 1             10.03s   serialised
 //
-// The constrained run is not only green, it is *faster* — past four workers
-// these suites were spending more time contending than testing. So the fix is
-// a ceiling and not a raised timeout: #257 is explicit that a blanket
-// `testTimeout` would paper over the failures rather than explain them, and
-// nothing here needed more time once it stopped queueing for a core.
+// Re-measured on the real Panel suite, ten-core developer machine under load,
+// unconstrained forced with `VITEST_MAX_WORKERS=10`:
+//
+//   unconstrained   4 runs, 4 red   3-4 files, 3-9 tests   tests 132.7s / 49.9s wall
+//   maxWorkers=4    5 runs, 3 red*  1-2 files, 0-4 tests   tests  55.0s / 56.5s wall
+//
+//   * two of the five were fully green, 142 files / 1441 tests.
+//
+// So the cap is a large, real improvement and it is now actually engaged — the
+// aggregate in-test time more than halves, which is the contention going away.
+// It is NOT a fix: this suite still goes red under load, so #257 §3's "0 failed
+// on three consecutive runs" is not met and is being carved out to its own
+// ticket rather than reported as delivered. Wall clock is a wash — the earlier
+// claim that the constrained run was *faster* was taken with the CLI flag on an
+// idle machine and did not survive re-measurement.
 //
 // The ceiling only bites above four. A CI runner with two or four cores keeps
 // exactly the parallelism it already had — the Panel suite was green there —
-// so this costs nothing in CI and fixes the machines where it was red.
+// so this costs nothing in CI.
 const cpus = os.availableParallelism?.() ?? os.cpus().length;
-const maxThreads = Math.max(2, Math.min(4, cpus));
+const maxWorkers = Math.max(2, Math.min(4, cpus));
 
 export default defineConfig({
   test: {
@@ -34,9 +48,11 @@ export default defineConfig({
     // `.tsx` too: a component whose whole point is what it renders is best
     // tested by rendering it.
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
-    poolOptions: {
-      threads: { maxThreads, minThreads: 1 },
-    },
+    // Top-level and pool-agnostic: `test.poolOptions` was *removed* in Vitest 4
+    // — the pinned 4.1.6 accepts it, logs a ` DEPRECATED ` banner and then runs
+    // completely unconstrained. See the measurement above.
+    maxWorkers,
+    minWorkers: 1,
   },
   resolve: {
     alias: {

--- a/scripts/__tests__/run-unit-tests.driver.test.mjs
+++ b/scripts/__tests__/run-unit-tests.driver.test.mjs
@@ -1,0 +1,151 @@
+// The guiding property of #257, asserted by *running the driver*rather than by
+// reading it.
+//
+// `unit-tests.test.mjs` pins the pieces — `exitCodeFor` over synthetic arrays,
+// the stage list, the report's wording. None of that would catch a `break` in
+// the stage loop, an `&&` creeping back into the spawn, or an early `exit`
+// between two stages. Those are exactly the bugs this ticket exists because of:
+// the old shell chain was wrong in a way every unit test around it still passed.
+//
+// So this drives the real `scripts/run-unit-tests.mjs` in a throwaway repo root
+// with `pnpm` shimmed, and asks the one question that matters: when a stage
+// fails, do the stages *after* it still run and still report?
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { STAGES } from "../lib/unit-tests.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+/** A throwaway repo root: the real driver, a shimmed `pnpm`, nothing else. */
+let fixture;
+
+beforeAll(() => {
+  fixture = fs.mkdtempSync(path.join(os.tmpdir(), "mc-driver-"));
+  fs.mkdirSync(path.join(fixture, "scripts", "lib"), { recursive: true });
+  fs.mkdirSync(path.join(fixture, "bin"), { recursive: true });
+  fs.mkdirSync(path.join(fixture, "tmp"), { recursive: true });
+
+  // The driver and the library under test, verbatim.
+  for (const file of [["run-unit-tests.mjs"], ["lib", "unit-tests.mjs"]]) {
+    fs.copyFileSync(path.join(repoRoot, "scripts", ...file), path.join(fixture, "scripts", ...file));
+  }
+
+  // The native preflight is a gate, not a stage; it is not what is under test.
+  fs.writeFileSync(path.join(fixture, "scripts", "ensure-node-sqlite.mjs"), "process.exit(0);\n");
+
+  for (const stage of STAGES.filter((s) => s.kind === "package")) {
+    fs.mkdirSync(path.join(fixture, "packages", stage.dir), { recursive: true });
+  }
+
+  // `pnpm`, shimmed: it reports which stage it was asked to run and fails the
+  // ones named in `FAKE_FAILING_STAGES`. Everything else about the driver —
+  // the loop, the spawn, the exit-code aggregation, the report — is real.
+  const shim = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const dirFlag = args.indexOf("-C");
+const id = dirFlag === -1 ? "root" : args[dirFlag + 1].replace("packages/", "");
+const failing = (process.env.FAKE_FAILING_STAGES ?? "").split(",").filter(Boolean);
+if (failing.includes(id)) {
+  console.log(" Test Files  1 failed | 19 passed (20)");
+  process.exit(1);
+}
+console.log(" Test Files  20 passed (20)");
+process.exit(0);
+`;
+  const shimPath = path.join(fixture, "bin", "pnpm");
+  fs.writeFileSync(shimPath, shim);
+  fs.chmodSync(shimPath, 0o755);
+});
+
+afterAll(() => {
+  if (fixture) fs.rmSync(fixture, { recursive: true, force: true });
+});
+
+/** Run the real driver against the fixture, failing the named stages. */
+function driveWith(failing) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path.join(fixture, "scripts", "run-unit-tests.mjs")], {
+      cwd: fixture,
+      env: {
+        ...process.env,
+        PATH: `${path.join(fixture, "bin")}${path.delimiter}${process.env.PATH}`,
+        FAKE_FAILING_STAGES: failing.join(","),
+        // Keep the sandbox and its startup sweep inside the fixture.
+        TMPDIR: path.join(fixture, "tmp"),
+        TEMP: path.join(fixture, "tmp"),
+        TMP: path.join(fixture, "tmp"),
+        GITHUB_ACTIONS: "",
+        GITHUB_STEP_SUMMARY: "",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("close", (exitCode) => resolve({ exitCode, output }));
+  });
+}
+
+describe("the driver, actually driven", () => {
+  it("runs every stage and exits 0 when they all pass", async () => {
+    const { exitCode, output } = await driveWith([]);
+    for (const stage of STAGES) expect(output).toContain(`>>> ${stage.label}:`);
+    expect(output).toContain(`All ${STAGES.length} stages passed.`);
+    expect(exitCode).toBe(0);
+  }, 60_000);
+
+  it("still runs — and still reports — every stage after the first one fails", async () => {
+    // `sdk` is the first package stage. Under `pnpm -r` its failure meant
+    // shared, cli, core and panel never ran at all; #246 lost 573 lines of
+    // Panel tests exactly this way.
+    const { exitCode, output } = await driveWith(["sdk"]);
+
+    expect(output).toContain("FAIL  packages/sdk");
+    for (const stage of STAGES.filter((s) => s.id !== "sdk")) {
+      expect(output).toContain(`>>> ${stage.label}:`);
+      expect(output).toContain(`PASS  ${stage.label.padEnd(16)} passed`);
+    }
+    expect(output).toContain("1 of 6 stages FAILED: packages/sdk");
+    expect(exitCode).toBe(1);
+  }, 60_000);
+
+  it("still runs every package after the root suite fails", async () => {
+    // The other half of the old chain: `vitest run && pnpm -r test` meant a
+    // red root suite skipped all five packages.
+    const { exitCode, output } = await driveWith(["root"]);
+
+    expect(output).toContain("FAIL  root suite");
+    for (const stage of STAGES.filter((s) => s.kind === "package")) {
+      expect(output).toContain(`PASS  ${stage.label.padEnd(16)} passed`);
+    }
+    expect(exitCode).toBe(1);
+  }, 60_000);
+
+  it("names every failing stage, not just the first", async () => {
+    const { exitCode, output } = await driveWith(["sdk", "panel"]);
+    expect(output).toContain("2 of 6 stages FAILED: packages/sdk, packages/panel");
+    expect(exitCode).toBe(1);
+  }, 60_000);
+
+  it("never prints the recursive-run bail the ticket is named after", async () => {
+    const { output } = await driveWith(["cli"]);
+    expect(output).not.toContain("ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL");
+  }, 60_000);
+
+  it("sweeps a sandbox left behind by a run that could not clean up after itself", async () => {
+    // SIGKILL cannot be trapped, so a killed run leaves `act-testrun-<pid>`
+    // under a prefix the `mc-*`/`actana-*` leak check deliberately ignores.
+    const orphan = path.join(fixture, "tmp", "act-testrun-999999");
+    fs.mkdirSync(orphan, { recursive: true });
+    fs.writeFileSync(path.join(orphan, "junk"), "x");
+
+    const { output } = await driveWith([]);
+    expect(output).toContain("swept");
+    expect(fs.existsSync(orphan)).toBe(false);
+  }, 60_000);
+});

--- a/scripts/__tests__/unit-tests.test.mjs
+++ b/scripts/__tests__/unit-tests.test.mjs
@@ -445,30 +445,6 @@ describe("the wiring that makes any of this run", () => {
     expect(job).toContain("- run: pnpm test");
   });
 
-  it("caps the Panel workers with the option Vitest 4 actually reads", () => {
-    // The bug this guards: `test.poolOptions` was REMOVED in Vitest 4. On the
-    // pinned 4.1.6 it is accepted, logs a ` DEPRECATED ` banner, and the suite
-    // then runs completely unconstrained — a worker cap that does nothing, and
-    // green runs credited to a mechanism that was never engaged.
-    const source = fs.readFileSync(path.join(repoRoot, "packages", "panel", "vitest.config.ts"), "utf8");
-    // Comments stripped: the block above this config *explains* `poolOptions`
-    // at length, and the assertion is about what vitest reads, not prose.
-    const config = source.replace(/^\s*\/\/.*$/gm, "");
-    expect(config).not.toContain("poolOptions");
-    expect(config).toMatch(/^\s*maxWorkers,$/m);
-    expect(config).toMatch(/^\s*minWorkers: 1,$/m);
-  });
-
-  it("still pins the vitest major those options belong to", () => {
-    // `maxWorkers`/`minWorkers` are the Vitest 4 spelling. A downgrade to 3
-    // would make them the dead ones instead, which is the same bug mirrored.
-    const panel = JSON.parse(
-      fs.readFileSync(path.join(repoRoot, "packages", "panel", "package.json"), "utf8"),
-    );
-    const pinned = panel.devDependencies?.vitest ?? panel.dependencies?.vitest;
-    expect(pinned).toMatch(/^4\./);
-  });
-
   it("checks for leaked temp directories even when the suites went red", () => {
     const job = workflow.slice(workflow.indexOf("  unit-tests:"), workflow.indexOf("  lint:"));
     expect(job).toContain("No temp directories survived the job");

--- a/scripts/__tests__/unit-tests.test.mjs
+++ b/scripts/__tests__/unit-tests.test.mjs
@@ -322,6 +322,30 @@ describe("the wiring that makes any of this run", () => {
     expect(job).toContain("- run: pnpm test");
   });
 
+  it("caps the Panel workers with the option Vitest 4 actually reads", () => {
+    // The bug this guards: `test.poolOptions` was REMOVED in Vitest 4. On the
+    // pinned 4.1.6 it is accepted, logs a ` DEPRECATED ` banner, and the suite
+    // then runs completely unconstrained — a worker cap that does nothing, and
+    // green runs credited to a mechanism that was never engaged.
+    const source = fs.readFileSync(path.join(repoRoot, "packages", "panel", "vitest.config.ts"), "utf8");
+    // Comments stripped: the block above this config *explains* `poolOptions`
+    // at length, and the assertion is about what vitest reads, not prose.
+    const config = source.replace(/^\s*\/\/.*$/gm, "");
+    expect(config).not.toContain("poolOptions");
+    expect(config).toMatch(/^\s*maxWorkers,$/m);
+    expect(config).toMatch(/^\s*minWorkers: 1,$/m);
+  });
+
+  it("still pins the vitest major those options belong to", () => {
+    // `maxWorkers`/`minWorkers` are the Vitest 4 spelling. A downgrade to 3
+    // would make them the dead ones instead, which is the same bug mirrored.
+    const panel = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages", "panel", "package.json"), "utf8"),
+    );
+    const pinned = panel.devDependencies?.vitest ?? panel.dependencies?.vitest;
+    expect(pinned).toMatch(/^4\./);
+  });
+
   it("checks for leaked temp directories even when the suites went red", () => {
     const job = workflow.slice(workflow.indexOf("  unit-tests:"), workflow.indexOf("  lint:"));
     expect(job).toContain("No temp directories survived the job");

--- a/scripts/__tests__/unit-tests.test.mjs
+++ b/scripts/__tests__/unit-tests.test.mjs
@@ -21,7 +21,12 @@ import {
   exitCodeFor,
   failedStages,
   isLeakedName,
+  SUSPICIOUS_DROP_BYTES,
+  diskVerdict,
+  isProcessAlive,
   leftoverReport,
+  sandboxPid,
+  staleSandboxes,
   renderAnnotations,
   renderJobSummary,
   renderReport,
@@ -206,6 +211,124 @@ describe("the report a reviewer reads", () => {
     expect(renderReport(mixed, { disk })).toContain("DISK:");
     expect(renderAnnotations(mixed, { disk })[0]).toContain("out of disk");
     expect(failedStages(mixed)).toHaveLength(2);
+  });
+});
+
+describe("the disk verdict, over a whole run", () => {
+  const gib = 1024 * 1024 * 1024;
+  const reading = (freeBytes, extra = {}) => ({
+    target: "/tmp",
+    freeBytes,
+    freeInodes: 1_000_000,
+    exhausted: false,
+    unknown: false,
+    message: `/tmp: ${freeBytes / gib} GiB free`,
+    ...extra,
+  });
+
+  it("says nothing when the run started and ended with room", () => {
+    const verdict = diskVerdict(reading(40 * gib), reading(39 * gib));
+    expect(verdict.ok).toBe(true);
+    expect(verdict.lines).toEqual([]);
+  });
+
+  it("says DISK when a run that started healthy exhausted the disk while running", () => {
+    // The realistic incident: 40 GiB at preflight, nothing left by the time
+    // the Panel suite is done. The preflight reading alone calls this healthy.
+    const before = reading(40 * gib);
+    const after = reading(0.2 * gib, { exhausted: true, message: "/tmp: 205 MiB free — BELOW the floor" });
+    const verdict = diskVerdict(before, after);
+
+    expect(verdict.exhausted).toBe(true);
+    expect(verdict.lines.join("\n")).toContain("EXHAUSTED the disk while it ran");
+    expect(renderReport([], { disk: before, diskAfter: after })).toContain("DISK:");
+    expect(renderAnnotations([], { disk: before, diskAfter: after })[0]).toContain("out of disk");
+    expect(renderJobSummary([], { disk: before, diskAfter: after })).toContain("ran out of disk");
+  });
+
+  it("says DISK when the run ate more space than a test run plausibly could", () => {
+    // Never crossed the floor, so no reading is `exhausted` — but a unit test
+    // run whose net footprint is megabytes did not legitimately spend 20 GiB.
+    const before = reading(60 * gib);
+    const after = reading(40 * gib);
+    const verdict = diskVerdict(before, after);
+
+    expect(verdict.exhausted).toBe(false);
+    expect(verdict.drained).toBe(true);
+    expect(verdict.droppedBytes).toBeGreaterThan(SUSPICIOUS_DROP_BYTES);
+    expect(renderReport([], { disk: before, diskAfter: after })).toContain("DISK:");
+    expect(renderAnnotations([], { disk: before, diskAfter: after })[0]).toContain("drained the disk");
+  });
+
+  it("does not cry drain over a run that used an ordinary amount of space", () => {
+    expect(diskVerdict(reading(40 * gib), reading(39.5 * gib)).drained).toBe(false);
+  });
+
+  it("degrades to the preflight reading alone rather than inventing a verdict", () => {
+    const before = reading(0.2 * gib, { exhausted: true, message: "/tmp: 205 MiB free — BELOW the floor" });
+    const verdict = diskVerdict(before, null);
+    expect(verdict.exhausted).toBe(true);
+    expect(verdict.drained).toBe(false);
+    expect(renderReport([], { disk: before })).toContain("DISK:");
+  });
+
+  it("stays quiet when a reading could not be taken at all", () => {
+    const unknown = { target: "/tmp", ok: true, exhausted: false, unknown: true, message: "unknown" };
+    expect(diskVerdict(unknown, unknown).ok).toBe(true);
+  });
+});
+
+describe("sweeping sandboxes a killed run left behind", () => {
+  it("recognises its own sandbox names and nothing else", () => {
+    expect(sandboxPid("act-testrun-4321")).toBe(4321);
+    expect(sandboxPid("mc-core-db-AbCd12")).toBeNull();
+    expect(sandboxPid("act-testrun-not-a-pid")).toBeNull();
+  });
+
+  it("collects sandboxes whose owning process is gone", () => {
+    const stale = staleSandboxes("/tmp", {
+      readdir: () => ["act-testrun-11", "act-testrun-22", "mc-something", "unrelated"],
+      alive: () => false,
+      self: 99,
+    });
+    expect(stale).toEqual(["act-testrun-11", "act-testrun-22"]);
+  });
+
+  it("never touches a concurrent run's sandbox — that would be the worse bug", () => {
+    const stale = staleSandboxes("/tmp", {
+      readdir: () => ["act-testrun-11", "act-testrun-22"],
+      alive: (pid) => pid === 22,
+      self: 99,
+    });
+    expect(stale).toEqual(["act-testrun-11"]);
+  });
+
+  it("never removes the sandbox of the run doing the sweeping", () => {
+    const stale = staleSandboxes("/tmp", {
+      readdir: () => ["act-testrun-99"],
+      alive: () => false,
+      self: 99,
+    });
+    expect(stale).toEqual([]);
+  });
+
+  it("treats a directory it cannot read as nothing to sweep", () => {
+    expect(
+      staleSandboxes("/nope", {
+        readdir: () => {
+          throw new Error("ENOENT");
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("counts a process it may not signal as alive, not as stale", () => {
+    const alive = isProcessAlive(1, {
+      kill: () => {
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      },
+    });
+    expect(alive).toBe(true);
   });
 });
 

--- a/scripts/__tests__/unit-tests.test.mjs
+++ b/scripts/__tests__/unit-tests.test.mjs
@@ -1,0 +1,333 @@
+// The properties #257 asks for, asserted rather than trusted.
+//
+// The ticket's guiding criterion is behavioural — "a red `Unit Tests` run names
+// every package that failed, and never hides one behind another" — and the way
+// it was broken was a shell chain nobody read closely. So the chain is gone and
+// the properties that replaced it are pinned here: every package is a stage,
+// no stage can be skipped, a failure is never swallowed, and the report names
+// the packages that failed.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  LEAK_PREFIXES,
+  MIN_FREE_BYTES,
+  MIN_FREE_INODES,
+  STAGES,
+  countByPrefix,
+  diskHeadroom,
+  exitCodeFor,
+  failedStages,
+  isLeakedName,
+  leftoverReport,
+  renderAnnotations,
+  renderJobSummary,
+  renderReport,
+  sandboxPath,
+  stageCommand,
+  stagePrefix,
+  stripAnsi,
+  summaryLine,
+} from "../lib/unit-tests.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+/** A stage result, as `run-unit-tests.mjs` would have built it. */
+function result(label, ok, summary = null, exitCode = ok ? 0 : 1) {
+  return { id: label, label, ok, exitCode, summary, durationMs: 1234 };
+}
+
+describe("the stage list", () => {
+  it("covers every workspace package — a sixth package cannot be silently untested", () => {
+    const onDisk = fs
+      .readdirSync(path.join(repoRoot, "packages"), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+    const staged = STAGES.filter((stage) => stage.kind === "package")
+      .map((stage) => stage.dir)
+      .sort();
+    expect(staged).toEqual(onDisk);
+  });
+
+  it("names each package the way its package.json does", () => {
+    for (const stage of STAGES.filter((s) => s.kind === "package")) {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(repoRoot, "packages", stage.dir, "package.json"), "utf8"),
+      );
+      expect(manifest.name).toBe(stage.pkg);
+      // Every package must actually have the script the stage invokes,
+      // otherwise the stage is a no-op that reports green.
+      expect(manifest.scripts?.test).toBeTruthy();
+    }
+  });
+
+  it("runs the root suite as well as the packages", () => {
+    expect(STAGES.filter((stage) => stage.kind === "root")).toHaveLength(1);
+    expect(STAGES[0].id).toBe("root");
+  });
+
+  it("keeps the topological order a reader of the old logs will recognise", () => {
+    expect(STAGES.map((stage) => stage.id)).toEqual(["root", "sdk", "shared", "cli", "core", "panel"]);
+  });
+});
+
+describe("the commands the stages run", () => {
+  it("drives one package at a time, so there is no recursive run to bail out of", () => {
+    for (const stage of STAGES.filter((s) => s.kind === "package")) {
+      const { command, args } = stageCommand(stage);
+      expect(command).toBe("pnpm");
+      expect(args).toEqual(["-C", `packages/${stage.dir}`, "run", "test"]);
+      // `-r` is the bail itself. `--filter` is subtler and was measured: it
+      // routes a single package through the recursive runner too, and prints
+      // `[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL]` when that package fails — the
+      // one string #257 requires a red log never to contain.
+      expect(args).not.toContain("-r");
+      expect(args).not.toContain("--recursive");
+      expect(args).not.toContain("--filter");
+    }
+  });
+
+  it("runs the root suite through the repo's own vitest", () => {
+    const { command, args } = stageCommand(STAGES[0]);
+    expect([command, ...args].join(" ")).toBe("pnpm exec vitest run");
+  });
+
+  it("reproduces the `packages/<dir> test:` prefix the acceptance criteria grep for", () => {
+    const core = STAGES.find((stage) => stage.id === "core");
+    expect(stagePrefix(core)).toBe("packages/core test: ");
+    expect(stagePrefix(STAGES[0])).toBe("");
+  });
+});
+
+describe("reading a run's verdict", () => {
+  it("finds vitest's summary line under ANSI colour", () => {
+    const coloured = `\u001b[32m Test Files \u001b[39m 1 failed | 29 passed (30)\n`;
+    expect(summaryLine(coloured)).toBe("Test Files  1 failed | 29 passed (30)");
+  });
+
+  it("says nothing rather than guessing when a stage never got that far", () => {
+    expect(summaryLine("Error: Cannot find module\n")).toBeNull();
+    expect(summaryLine(undefined)).toBeNull();
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(stripAnsi("packages/cli test: ok")).toBe("packages/cli test: ok");
+  });
+});
+
+describe("the exit code", () => {
+  it("is non-zero when any stage failed, wherever it sat in the order", () => {
+    const stages = STAGES.map((stage) => result(stage.label, true));
+    for (let index = 0; index < stages.length; index += 1) {
+      const mixed = stages.map((entry, i) => (i === index ? result(entry.label, false) : entry));
+      expect(exitCodeFor(mixed)).toBe(1);
+    }
+  });
+
+  it("is zero only when every stage passed", () => {
+    expect(exitCodeFor(STAGES.map((stage) => result(stage.label, true)))).toBe(0);
+  });
+
+  it("does not buy readability with a swallowed failure", () => {
+    // The failing stage is the first one; four green stages follow it. The
+    // old chain would not have run them; the new runner must run them *and*
+    // still go red.
+    const results = [result("root suite", false, "Test Files  1 failed (16)"), ...STAGES.slice(1).map((s) => result(s.label, true))];
+    expect(results).toHaveLength(STAGES.length);
+    expect(exitCodeFor(results)).toBe(1);
+  });
+});
+
+describe("the report a reviewer reads", () => {
+  const mixed = [
+    result("root suite", true, "Test Files  16 passed (16)"),
+    result("packages/sdk", true, "Test Files  12 passed (12)"),
+    result("packages/shared", true, "Test Files  9 passed (9)"),
+    result("packages/cli", false, "Test Files  1 failed | 29 passed | 1 skipped (31)"),
+    result("packages/core", true, "Test Files  60 passed (60)"),
+    result("packages/panel", false, "Test Files  2 failed | 140 passed (142)"),
+  ];
+
+  it("names every stage, including the ones that passed", () => {
+    const report = renderReport(mixed);
+    for (const stage of STAGES) expect(report).toContain(stage.label);
+  });
+
+  it("answers 'which packages failed' without a re-run", () => {
+    const report = renderReport(mixed);
+    expect(report).toContain("2 of 6 stages FAILED: packages/cli, packages/panel");
+  });
+
+  it("carries each stage's Test Files line, so 'did panel run at all' has an answer", () => {
+    const report = renderReport(mixed);
+    expect(report).toContain("Test Files  2 failed | 140 passed (142)");
+    expect(report).toContain("Test Files  60 passed (60)");
+  });
+
+  it("says so plainly when everything passed", () => {
+    expect(renderReport(mixed.map((entry) => ({ ...entry, ok: true, exitCode: 0 })))).toContain(
+      "All 6 stages passed.",
+    );
+  });
+
+  it("raises an annotation per failing package, named", () => {
+    const annotations = renderAnnotations(mixed);
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0]).toContain("::error title=Unit Tests — packages/cli failed::");
+    expect(annotations[0]).toContain("Test Files  1 failed | 29 passed | 1 skipped (31)");
+    expect(annotations[1]).toContain("packages/panel");
+  });
+
+  it("raises no annotation on a green run", () => {
+    expect(renderAnnotations(mixed.map((entry) => ({ ...entry, ok: true })))).toEqual([]);
+  });
+
+  it("puts a row per stage in the job summary, so the run page names them too", () => {
+    const summary = renderJobSummary(mixed);
+    for (const stage of STAGES) expect(summary).toContain(`| ${stage.label} |`);
+    expect(summary).toContain("**2 of 6 stages failed:** packages/cli, packages/panel");
+  });
+
+  it("keeps each summary row to four columns — vitest's line is full of pipes", () => {
+    const rows = renderJobSummary(mixed)
+      .split("\n")
+      .filter((line) => line.startsWith("| "));
+    for (const row of rows) {
+      expect(row.replace(/\\\|/g, "").split("|").filter(Boolean)).toHaveLength(4);
+    }
+    expect(renderJobSummary(mixed)).toContain("1 failed \\| 29 passed \\| 1 skipped (31)");
+  });
+
+  it("still lists the failures when the machine was the cause", () => {
+    const disk = { exhausted: true, message: "/tmp: 12.0 MiB free — BELOW the floor this job needs" };
+    expect(renderReport(mixed, { disk })).toContain("DISK:");
+    expect(renderAnnotations(mixed, { disk })[0]).toContain("out of disk");
+    expect(failedStages(mixed)).toHaveLength(2);
+  });
+});
+
+describe("the disk preflight", () => {
+  const gib = 1024 * 1024 * 1024;
+  const statfs = (freeBytes, freeInodes = 1_000_000) => () => ({
+    bsize: 4096,
+    bavail: freeBytes / 4096,
+    ffree: freeInodes,
+  });
+
+  it("passes a machine with room", () => {
+    const headroom = diskHeadroom("/tmp", { statfs: statfs(40 * gib) });
+    expect(headroom.ok).toBe(true);
+    expect(headroom.exhausted).toBe(false);
+    expect(headroom.message).toContain("/tmp");
+    expect(headroom.message).toContain("40.0 GiB free");
+  });
+
+  it("fails a machine below the byte floor, and says the word", () => {
+    const headroom = diskHeadroom("/tmp", { statfs: statfs(MIN_FREE_BYTES - 4096) });
+    expect(headroom.exhausted).toBe(true);
+    expect(headroom.message).toContain("BELOW the floor");
+  });
+
+  it("fails on inodes too — mkdtemp runs out of those long before bytes", () => {
+    const headroom = diskHeadroom("/tmp", { statfs: statfs(40 * gib, MIN_FREE_INODES - 1) });
+    expect(headroom.exhausted).toBe(true);
+  });
+
+  it("warns without blocking when space is tight but sufficient", () => {
+    const headroom = diskHeadroom("/tmp", { statfs: statfs(2 * gib) });
+    expect(headroom.ok).toBe(true);
+    expect(headroom.tight).toBe(true);
+    expect(headroom.message).toContain("tight, but proceeding");
+  });
+
+  it("never blocks a run because it could not read the filesystem", () => {
+    const headroom = diskHeadroom("/nope", {
+      statfs: () => {
+        throw Object.assign(new Error("no such file"), { code: "ENOENT" });
+      },
+    });
+    expect(headroom.ok).toBe(true);
+    expect(headroom.unknown).toBe(true);
+  });
+});
+
+describe("the temp sandbox and the leak check", () => {
+  it("names a sandbox that cannot itself be mistaken for a leak", () => {
+    const sandbox = path.basename(sandboxPath("/tmp", 4242));
+    expect(isLeakedName(sandbox)).toBe(false);
+    for (const prefix of LEAK_PREFIXES) expect(sandbox.startsWith(prefix)).toBe(false);
+  });
+
+  it("greps for exactly the prefixes the ticket names", () => {
+    expect(LEAK_PREFIXES).toEqual(["mc-", "actana-"]);
+    expect(isLeakedName("mc-core-db-boot-Ab12Cd")).toBe(true);
+    expect(isLeakedName("actana-cursor-Xy99Zz")).toBe(true);
+    expect(isLeakedName("vitest-pool-1")).toBe(false);
+  });
+
+  it("counts the real temp root as unchanged when nothing escaped the sandbox", () => {
+    const before = ["mc-old-AAAAAA", "actana-old-BBBBBB"];
+    const report = leftoverReport({ before, after: before, stranded: ["mc-ut-CCCCCC"] });
+    expect(report.escaped).toEqual([]);
+    expect(report.ok).toBe(true);
+    expect(report.message).toContain("no mc-*/actana-* directories were left in the real temp root");
+  });
+
+  it("fails, and names them, when a directory ignored TMPDIR", () => {
+    const report = leftoverReport({
+      before: ["mc-old-AAAAAA"],
+      after: ["mc-old-AAAAAA", "mc-hardcoded-DDDDDD", "actana-hardcoded-EEEEEE"],
+    });
+    expect(report.ok).toBe(false);
+    expect(report.escaped).toEqual(["mc-hardcoded-DDDDDD", "actana-hardcoded-EEEEEE"]);
+    const annotation = renderAnnotations([], { leftovers: report })[0];
+    expect(annotation).toContain("mc-hardcoded-DDDDDD");
+    expect(annotation).toContain("actana-hardcoded-EEEEEE");
+  });
+
+  it("attributes stranded directories to the prefix their call site chose", () => {
+    expect(
+      countByPrefix(["mc-ut-AAAAAA", "mc-ut-BBBBBB", "mc-core-db-boot-CCCCCC"]),
+    ).toEqual([
+      ["mc-ut-", 2],
+      ["mc-core-db-boot-", 1],
+    ]);
+  });
+});
+
+describe("the wiring that makes any of this run", () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+
+  it("points `pnpm test` at the runner, with no chain left to short-circuit", () => {
+    expect(manifest.scripts.test).toBe("node scripts/run-unit-tests.mjs");
+    expect(manifest.scripts.test).not.toContain("&&");
+    expect(manifest.scripts.test).not.toContain("pnpm -r");
+  });
+
+  it("leaves no `pnpm -r test` anywhere to reintroduce the bail", () => {
+    for (const script of Object.values(manifest.scripts)) {
+      expect(script).not.toMatch(/pnpm\s+-r\s+test/);
+    }
+  });
+
+  it("still runs `pnpm test` from the Unit Tests job, under its unchanged name", () => {
+    // Renaming a required status check makes every open pull request
+    // unmergeable, so the job keeps the name the ruleset knows it by.
+    expect(workflow).toContain("    name: Unit Tests\n");
+    const job = workflow.slice(workflow.indexOf("  unit-tests:"), workflow.indexOf("  lint:"));
+    expect(job).toContain("- run: pnpm test");
+  });
+
+  it("checks for leaked temp directories even when the suites went red", () => {
+    const job = workflow.slice(workflow.indexOf("  unit-tests:"), workflow.indexOf("  lint:"));
+    expect(job).toContain("No temp directories survived the job");
+    // Without `if: always()` the check is skipped on exactly the runs whose
+    // disk pressure is worth knowing about.
+    expect(job).toMatch(/name: No temp directories survived the job\n\s+if: always\(\)/);
+    expect(job).toContain("ls -d /tmp/mc-* /tmp/actana-*");
+  });
+});

--- a/scripts/lib/unit-tests.mjs
+++ b/scripts/lib/unit-tests.mjs
@@ -128,7 +128,7 @@ export function failedStages(results) {
  * would leave "did `panel` run at all?" unanswerable, which is the question
  * that started the ticket.
  */
-export function renderReport(results, { leftovers = null, disk = null } = {}) {
+export function renderReport(results, { leftovers = null, disk = null, diskAfter = null } = {}) {
   const rule = "-".repeat(72);
   const lines = ["", rule, "Unit Tests — every stage, and what it did", rule];
   for (const result of results) {
@@ -148,10 +148,10 @@ export function renderReport(results, { leftovers = null, disk = null } = {}) {
     );
   }
 
-  if (disk?.exhausted) {
+  const verdict = diskVerdict(disk, diskAfter);
+  if (verdict.lines.length) {
     lines.push("");
-    lines.push("DISK: this machine was out of space during the run — see the preflight above.");
-    lines.push("      Treat the failures above as unexplained until the run is repeated with headroom.");
+    lines.push(...verdict.lines);
   }
   if (leftovers?.escaped?.length) {
     lines.push("");
@@ -169,12 +169,20 @@ export function renderReport(results, { leftovers = null, disk = null } = {}) {
  * and against the pull request; the job summary renders as a table on the run
  * page. Both are cheap, so both.
  */
-export function renderAnnotations(results, { leftovers = null, disk = null } = {}) {
+export function renderAnnotations(results, { leftovers = null, disk = null, diskAfter = null } = {}) {
   const lines = [];
-  if (disk?.exhausted) {
+  const verdict = diskVerdict(disk, diskAfter);
+  if (verdict.exhausted) {
+    const culprit = diskAfter?.exhausted ? diskAfter : disk;
     lines.push(
-      `::error title=Unit Tests — out of disk::${disk.message}. ` +
+      `::error title=Unit Tests — out of disk::${culprit.message}. ` +
         "A run that dies of disk is not a run that tells you about your code.",
+    );
+  } else if (verdict.drained) {
+    lines.push(
+      `::error title=Unit Tests — the run drained the disk::` +
+        `${formatBytes(verdict.droppedBytes)} of free space went during this run. ` +
+        "Suspect a runaway write or leaked temp directories before suspecting the code.",
     );
   }
   for (const failure of failedStages(results)) {
@@ -191,7 +199,7 @@ export function renderAnnotations(results, { leftovers = null, disk = null } = {
 }
 
 /** The `$GITHUB_STEP_SUMMARY` table — the same facts, rendered for the run page. */
-export function renderJobSummary(results, { leftovers = null, disk = null } = {}) {
+export function renderJobSummary(results, { leftovers = null, disk = null, diskAfter = null } = {}) {
   const lines = ["## Unit Tests", ""];
   const failed = failedStages(results);
   lines.push(
@@ -215,9 +223,16 @@ export function renderJobSummary(results, { leftovers = null, disk = null } = {}
       "see [#257](https://github.com/actana/control/issues/257).",
   );
   if (disk) {
-    lines.push("", "### Machine", "", `- ${disk.message}`);
-    if (disk.exhausted) {
+    const verdict = diskVerdict(disk, diskAfter);
+    lines.push("", "### Machine", "", `- before: ${disk.message}`);
+    if (diskAfter) lines.push(`- after:  ${diskAfter.message}`);
+    if (verdict.exhausted) {
       lines.push("- **This run ran out of disk.** The failures above may be the machine, not the code.");
+    } else if (verdict.drained) {
+      lines.push(
+        `- **This run consumed ${formatBytes(verdict.droppedBytes)} of free space** — far more than a ` +
+          "test run should. Suspect the machine before the code.",
+      );
     }
   }
   if (leftovers) {
@@ -284,6 +299,70 @@ export function diskHeadroom(target, { statfs = fs.statfsSync } = {}) {
     (Number.isFinite(freeInodes) ? `, ${formatCount(freeInodes)} inodes free` : "") +
     (exhausted ? " — BELOW the floor this job needs" : tight ? " — tight, but proceeding" : "");
   return { target, freeBytes, freeInodes, ok: !exhausted, exhausted, tight, unknown: false, message };
+}
+
+/**
+ * How much disk a unit test run may plausibly eat before the drop is the story.
+ *
+ * The suites write into a sandbox that is removed at the end, so a full run's
+ * net footprint is megabytes. A multi-gigabyte fall over one `pnpm test` is
+ * something pathological — a runaway log, a core dump, or the ~10k stale temp
+ * directories #257 §4 is about — and it is worth naming even when the
+ * filesystem never quite reached the floor.
+ */
+export const SUSPICIOUS_DROP_BYTES = 8 * 1024 * 1024 * 1024;
+export const SUSPICIOUS_DROP_INODES = 200_000;
+
+/**
+ * The disk verdict for a whole run, from the reading before and the one after.
+ *
+ * The preflight reading alone cannot answer the question #257 §4 actually
+ * asks — *was this red run the machine or the code?* — because the realistic
+ * failure is a job that starts with 40 GiB and exhausts it during the Panel
+ * suite. That run passes preflight, prints a healthy figure at the top, and
+ * then fails for reasons no line in the report connects to disk.
+ *
+ * `after` is optional: with only a preflight reading this degrades to exactly
+ * the old behaviour rather than inventing a verdict it cannot support.
+ */
+export function diskVerdict(before, after = null) {
+  const exhausted = Boolean(before?.exhausted) || Boolean(after?.exhausted);
+  const usable = before && after && !before.unknown && !after.unknown;
+  const droppedBytes = usable ? before.freeBytes - after.freeBytes : 0;
+  const droppedInodes =
+    usable && Number.isFinite(before.freeInodes) && Number.isFinite(after.freeInodes)
+      ? before.freeInodes - after.freeInodes
+      : 0;
+  const drained = droppedBytes > SUSPICIOUS_DROP_BYTES || droppedInodes > SUSPICIOUS_DROP_INODES;
+
+  const lines = [];
+  if (exhausted) {
+    const culprit = after?.exhausted ? after : before;
+    lines.push(
+      after?.exhausted && !before?.exhausted
+        ? `DISK: this run EXHAUSTED the disk while it ran — ${culprit.message}.`
+        : `DISK: this machine was out of space during the run — ${culprit.message}.`,
+    );
+    lines.push("      Treat the failures above as unexplained until the run is repeated with headroom.");
+  } else if (drained) {
+    const parts = [];
+    if (droppedBytes > SUSPICIOUS_DROP_BYTES) parts.push(`${formatBytes(droppedBytes)} of free space`);
+    if (droppedInodes > SUSPICIOUS_DROP_INODES) parts.push(`${formatCount(droppedInodes)} inodes`);
+    lines.push(`DISK: this run consumed ${parts.join(" and ")} — far more than a test run should.`);
+    lines.push(`      ${after.message}`);
+    lines.push("      Suspect a runaway write or leaked temp directories before suspecting the code.");
+  }
+
+  return {
+    exhausted,
+    drained,
+    ok: !exhausted && !drained,
+    droppedBytes,
+    droppedInodes,
+    before: before ?? null,
+    after: after ?? null,
+    lines,
+  };
 }
 
 export function formatBytes(bytes) {
@@ -369,6 +448,57 @@ export function countByPrefix(names) {
     counts.set(prefix, (counts.get(prefix) ?? 0) + 1);
   }
   return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+/**
+ * The pid encoded in one of our sandbox directory names, or null if the name
+ * is not one of ours at all.
+ */
+export function sandboxPid(name) {
+  if (!name.startsWith(SANDBOX_PREFIX)) return null;
+  const rest = name.slice(SANDBOX_PREFIX.length);
+  return /^[0-9]+$/.test(rest) ? Number(rest) : null;
+}
+
+/** Is a pid still running? `EPERM` means yes, owned by somebody else. */
+export function isProcessAlive(pid, { kill = process.kill.bind(process) } = {}) {
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+/**
+ * Sandboxes from earlier runs that no live process owns.
+ *
+ * The sandbox is removed on `exit` and on `SIGINT`/`SIGTERM`/`SIGHUP`, but
+ * `SIGKILL`, a runner OOM and a cancelled CI job cannot be trapped — and the
+ * prefix is deliberately outside the `mc-*`/`actana-*` globs the leak check
+ * greps for, so a sandbox that survives one of those is drift under a name
+ * nothing will ever flag. Sweeping at startup closes that hole in one readdir.
+ *
+ * A sandbox whose pid is still alive belongs to a *concurrent* run and is left
+ * strictly alone: deleting a live run's `TMPDIR` would be a far worse bug than
+ * the leak this cleans up.
+ */
+export function staleSandboxes(
+  root,
+  { readdir = fs.readdirSync, alive = isProcessAlive, self = process.pid } = {},
+) {
+  let entries;
+  try {
+    entries = readdir(root);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => {
+      const pid = sandboxPid(name);
+      return pid !== null && pid !== self && !alive(pid);
+    })
+    .sort();
 }
 
 /** Where the sandbox lives, given the real temp root. */

--- a/scripts/lib/unit-tests.mjs
+++ b/scripts/lib/unit-tests.mjs
@@ -1,0 +1,377 @@
+// What a red `Unit Tests` run has to say, and the shape that makes it say it.
+//
+// The job used to run one shell chain:
+//
+//     pnpm native:node && vitest run && pnpm -r test
+//
+// and both links in that chain throw information away. `&&` stops at the first
+// non-zero exit, so a failure in the 16-file root suite means none of the five
+// packages run at all. And `pnpm -r` bails on the first failing package by
+// default, in topological order — sdk → shared → cli → core → panel — so a
+// single flake in `packages/cli` means `core` and `panel` never run either.
+//
+// That is not a theoretical loss. Issue #257 §1 lists three runs of
+// 2026-08-18 that ended on the same four lines:
+//
+//     packages/cli test:  Test Files  1 failed | 29 passed | 1 skipped (31)
+//     [ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @actana/cli@0.3.0 test: `vitest run`
+//
+// The sharpest was #246 — a *Panel* fix carrying 573 lines of new Panel tests,
+// none of which ran, on a log with no `packages/panel test:` line in it. The
+// reviewer of that pull request learned nothing about the change under review.
+//
+// So: every stage runs, always, and the exit codes are aggregated at the end
+// rather than short-circuited on the way through. The cost on a green run is
+// zero (every stage ran anyway) and on a red run it is the remaining stages'
+// runtime — which is exactly the runtime you want spent, because that is the
+// information currently being discarded.
+//
+// The stages are run one package at a time rather than with `pnpm -r
+// --no-bail` on purpose. `--no-bail` would fix the bail, but the guiding
+// criterion — *never hide one package behind another* — would then rest on a
+// flag staying in a string. Driving the packages from here makes it a property
+// of the runner: there is no bail to disable, each package's exit code is its
+// own, and the report can name a failing package without parsing pnpm's
+// end-of-run summary. `packages/<dir> test:` line prefixes are reproduced so
+// the log reads as it always has, and so the greps in #257's acceptance
+// criteria keep working.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * The stages of a full `pnpm test`, in the order they run.
+ *
+ * `root` is the repo-level suite over `scripts/**` (vitest.config.ts); the
+ * rest are the workspace packages, kept in the topological order `pnpm -r`
+ * used so a familiar log stays familiar. Order is presentation only — no stage
+ * can be skipped because an earlier one failed, which is the entire point.
+ *
+ * `unit-tests.test.mjs` asserts this list against `packages/*` on disk, so a
+ * sixth package added next year fails a test here instead of silently never
+ * being tested in CI.
+ */
+export const STAGES = [
+  { id: "root", label: "root suite", kind: "root" },
+  { id: "sdk", label: "packages/sdk", kind: "package", pkg: "@actana/sdk", dir: "sdk" },
+  { id: "shared", label: "packages/shared", kind: "package", pkg: "@actana/shared", dir: "shared" },
+  { id: "cli", label: "packages/cli", kind: "package", pkg: "@actana/cli", dir: "cli" },
+  { id: "core", label: "packages/core", kind: "package", pkg: "@actana/core", dir: "core" },
+  { id: "panel", label: "packages/panel", kind: "package", pkg: "@actana/panel", dir: "panel" },
+];
+
+/**
+ * The command a stage runs.
+ *
+ * `pnpm -C <dir> run test`, and deliberately not `pnpm --filter <name> test`:
+ * `--filter` goes through pnpm's *recursive* runner even for a single package,
+ * and a failure there still prints
+ *
+ *     [ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @actana/cli@0.3.3 test: `vitest run`
+ *
+ * — the exact line #257 asks to never see again, and one a reader would
+ * reasonably take as proof the bail was still happening. `-C` runs the
+ * package's own script with no recursion to bail out of, so the string is
+ * structurally absent rather than suppressed by a flag.
+ */
+export function stageCommand(stage) {
+  if (stage.kind === "root") return { command: "pnpm", args: ["exec", "vitest", "run"] };
+  return { command: "pnpm", args: ["-C", `packages/${stage.dir}`, "run", "test"] };
+}
+
+/**
+ * The prefix every line of a stage's output carries.
+ *
+ * `pnpm -r` wrote `packages/cli test: …`; the acceptance criteria in #257 are
+ * written against exactly that string ("confirm the resulting red run still
+ * contains `packages/core test: Test Files …`"), so it is reproduced rather
+ * than improved on. The root suite is unprefixed, as it was.
+ */
+export function stagePrefix(stage) {
+  return stage.kind === "root" ? "" : `${stage.label} test: `;
+}
+
+/** vitest's own one-line verdict, plucked back out of a stage's output. */
+export function summaryLine(output) {
+  const match = /^\s*Test Files\s+.*$/m.exec(stripAnsi(output ?? ""));
+  return match ? match[0].trim() : null;
+}
+
+/** ANSI is fine on a terminal and noise in a job summary. */
+export function stripAnsi(text) {
+  return String(text).replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+/**
+ * The run's exit code.
+ *
+ * Non-zero if *any* stage failed. Readability is bought with the remaining
+ * stages' runtime, never by swallowing a failure — #257 asks for both, and a
+ * green run that hid a red package would be a worse bug than the one this
+ * replaces.
+ */
+export function exitCodeFor(results) {
+  return results.some((result) => result.ok === false) ? 1 : 0;
+}
+
+/** The stages that failed, in run order. */
+export function failedStages(results) {
+  return results.filter((result) => result.ok === false);
+}
+
+/**
+ * The block printed at the end of every run, green or red.
+ *
+ * This is the answer to #257's closing criterion — *take any red run and
+ * answer, from the log alone, which packages failed* — so it lists every
+ * stage, including the ones that passed. A report that only named failures
+ * would leave "did `panel` run at all?" unanswerable, which is the question
+ * that started the ticket.
+ */
+export function renderReport(results, { leftovers = null, disk = null } = {}) {
+  const rule = "-".repeat(72);
+  const lines = ["", rule, "Unit Tests — every stage, and what it did", rule];
+  for (const result of results) {
+    const mark = result.ok ? "PASS" : "FAIL";
+    const verdict = result.ok ? "passed" : `FAILED (exit ${result.exitCode})`;
+    lines.push(`${mark}  ${result.label.padEnd(16)} ${verdict}`);
+    if (result.summary) lines.push(`      ${result.summary}`);
+  }
+  lines.push(rule);
+
+  const failed = failedStages(results);
+  if (failed.length === 0) {
+    lines.push(`All ${results.length} stages passed.`);
+  } else {
+    lines.push(
+      `${failed.length} of ${results.length} stages FAILED: ${failed.map((f) => f.label).join(", ")}`,
+    );
+  }
+
+  if (disk?.exhausted) {
+    lines.push("");
+    lines.push("DISK: this machine was out of space during the run — see the preflight above.");
+    lines.push("      Treat the failures above as unexplained until the run is repeated with headroom.");
+  }
+  if (leftovers?.escaped?.length) {
+    lines.push("");
+    lines.push(`TEMP: ${leftovers.escaped.length} directories escaped the run's sandbox — see below.`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * The same verdict for GitHub's own UI.
+ *
+ * #257 asks that the failing packages be named "where a reviewer sees them
+ * without opening the log". `::error` annotations surface on the checks tab
+ * and against the pull request; the job summary renders as a table on the run
+ * page. Both are cheap, so both.
+ */
+export function renderAnnotations(results, { leftovers = null, disk = null } = {}) {
+  const lines = [];
+  if (disk?.exhausted) {
+    lines.push(
+      `::error title=Unit Tests — out of disk::${disk.message}. ` +
+        "A run that dies of disk is not a run that tells you about your code.",
+    );
+  }
+  for (const failure of failedStages(results)) {
+    const detail = failure.summary ?? `exited ${failure.exitCode}`;
+    lines.push(`::error title=Unit Tests — ${failure.label} failed::${failure.label}: ${detail}`);
+  }
+  if (leftovers?.escaped?.length) {
+    lines.push(
+      `::error title=Unit Tests — temp directories leaked::${leftovers.escaped.length} ` +
+        `directories survived the job outside its sandbox: ${leftovers.escaped.slice(0, 10).join(", ")}`,
+    );
+  }
+  return lines;
+}
+
+/** The `$GITHUB_STEP_SUMMARY` table — the same facts, rendered for the run page. */
+export function renderJobSummary(results, { leftovers = null, disk = null } = {}) {
+  const lines = ["## Unit Tests", ""];
+  const failed = failedStages(results);
+  lines.push(
+    failed.length === 0
+      ? `All ${results.length} stages passed.`
+      : `**${failed.length} of ${results.length} stages failed:** ${failed.map((f) => f.label).join(", ")}`,
+  );
+  lines.push("");
+  lines.push("| Stage | Result | Test Files | Duration |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const result of results) {
+    const verdict = result.ok ? "passed" : `**failed** (exit ${result.exitCode})`;
+    // vitest's own summary line is full of `|` separators, which would each
+    // open a new column and shred the table.
+    const summary = result.summary ? `\`${escapeCell(result.summary)}\`` : "—";
+    lines.push(`| ${result.label} | ${verdict} | ${summary} | ${formatDuration(result.durationMs)} |`);
+  }
+  lines.push("");
+  lines.push(
+    "Every stage above ran to completion. A failing stage no longer stops the ones after it — " +
+      "see [#257](https://github.com/actana/control/issues/257).",
+  );
+  if (disk) {
+    lines.push("", "### Machine", "", `- ${disk.message}`);
+    if (disk.exhausted) {
+      lines.push("- **This run ran out of disk.** The failures above may be the machine, not the code.");
+    }
+  }
+  if (leftovers) {
+    lines.push("", "### Temp directories", "", `- ${leftovers.message}`);
+    for (const name of leftovers.escaped.slice(0, 20)) lines.push(`  - \`${name}\``);
+  }
+  return lines.join("\n");
+}
+
+/** A `|` inside a markdown table cell is a column break unless it is escaped. */
+export function escapeCell(text) {
+  return String(text).replace(/\|/g, "\\|");
+}
+
+function formatDuration(ms) {
+  if (typeof ms !== "number" || Number.isNaN(ms)) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  return `${Math.floor(seconds / 60)}m${String(Math.round(seconds % 60)).padStart(2, "0")}s`;
+}
+
+// -- Disk --------------------------------------------------------------------
+//
+// #257 §4 could not find the 108-failure `ENOSPC` incident the original report
+// described, and says so; what it asks for is the weaker, cheaper precaution —
+// "a run whose failures are caused by the machine rather than the code should
+// say so". That is this: free space and inode headroom read at the start, said
+// out loud, and checked against a floor before a single suite runs. A red run
+// that is really a full disk should cost one glance, not a re-run.
+
+/** Below this much free space, the suites are not worth starting. */
+export const MIN_FREE_BYTES = 1024 * 1024 * 1024;
+/** Below this many free inodes, likewise — `mkdtemp` fails long before bytes run out. */
+export const MIN_FREE_INODES = 50_000;
+/** Above the floor but below this, the run proceeds and says it is tight. */
+export const TIGHT_FREE_BYTES = 4 * 1024 * 1024 * 1024;
+
+/**
+ * Read one filesystem's headroom and decide whether it can carry a test run.
+ *
+ * `statfs` is injected so the thresholds can be tested at their edges without
+ * a machine that is actually full.
+ */
+export function diskHeadroom(target, { statfs = fs.statfsSync } = {}) {
+  let stat;
+  try {
+    stat = statfs(target);
+  } catch (error) {
+    return {
+      target,
+      ok: true,
+      exhausted: false,
+      unknown: true,
+      message: `disk headroom for ${target} is unknown (${error.code ?? error.message})`,
+    };
+  }
+  const freeBytes = stat.bavail * stat.bsize;
+  const freeInodes = stat.ffree ?? Number.POSITIVE_INFINITY;
+  const exhausted = freeBytes < MIN_FREE_BYTES || freeInodes < MIN_FREE_INODES;
+  const tight = !exhausted && freeBytes < TIGHT_FREE_BYTES;
+  const message =
+    `${target}: ${formatBytes(freeBytes)} free` +
+    (Number.isFinite(freeInodes) ? `, ${formatCount(freeInodes)} inodes free` : "") +
+    (exhausted ? " — BELOW the floor this job needs" : tight ? " — tight, but proceeding" : "");
+  return { target, freeBytes, freeInodes, ok: !exhausted, exhausted, tight, unknown: false, message };
+}
+
+export function formatBytes(bytes) {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+export function formatCount(count) {
+  return Number.isFinite(count) ? count.toLocaleString("en-US") : "many";
+}
+
+// -- Temp directories --------------------------------------------------------
+//
+// #257 §4's leak is real and measured: 389 stale `mc-*`/`actana-*` directories
+// over eight days when the ticket was filed, 1,048 on this checkout the day it
+// was implemented, 2.2G of drift. They come from dozens of distinct
+// `mkdtempSync(join(tmpdir(), "mc-…"))` call sites across five packages, and
+// chasing each one with an `afterEach` would be forty-odd edits that the
+// forty-first call site immediately defeats.
+//
+// So the run gets its own temp root instead. `TMPDIR` is pointed at a per-run
+// sandbox, every `os.tmpdir()` in every suite and every child process lands
+// inside it, and it is removed when the run ends — pass, fail or signal. The
+// count in `/tmp` is then the same before and after by construction rather
+// than by everyone remembering.
+//
+// The sandbox is deliberately *not* named `actana-*` or `mc-*`: it must not
+// match the very glob the leak check greps for.
+
+export const SANDBOX_PREFIX = "act-testrun-";
+/** The globs #257 names. A directory matching one of these in the real temp root escaped. */
+export const LEAK_PREFIXES = ["mc-", "actana-"];
+
+export function isLeakedName(name) {
+  return LEAK_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/** Every `mc-*`/`actana-*` entry directly inside `root`, sorted. */
+export function leakedEntries(root, { readdir = fs.readdirSync } = {}) {
+  let entries;
+  try {
+    entries = readdir(root);
+  } catch {
+    return [];
+  }
+  return entries.filter((name) => isLeakedName(name)).sort();
+}
+
+/**
+ * What the run did to the real temp root, and what stayed behind in its own.
+ *
+ * `escaped` is the criterion that fails a run: a directory matching `mc-*` or
+ * `actana-*` that appeared in the *real* temp root while the job ran ignored
+ * `TMPDIR` — a hardcoded `/tmp/…` path, most likely — and would have drifted
+ * forever. `stranded` is the softer half: suites that left directories inside
+ * the sandbox. Those cost nothing once the sandbox is removed, so they are
+ * reported by name and prefix to make the drift visible and attributable,
+ * without turning today's forty call sites into a red train.
+ */
+export function leftoverReport({ before, after, stranded = [] }) {
+  const seen = new Set(before);
+  const escaped = after.filter((name) => !seen.has(name));
+  const byPrefix = countByPrefix(stranded);
+  const message = escaped.length
+    ? `${escaped.length} directories escaped the run's TMPDIR sandbox into the real temp root — ` +
+      "these survive the job and must be cleaned up at their source"
+    : `no mc-*/actana-* directories were left in the real temp root (${stranded.length} were ` +
+      "created inside the run's sandbox and removed with it)";
+  return { escaped, stranded, byPrefix, message, ok: escaped.length === 0 };
+}
+
+/** `mc-core-db-boot-AbCd12` → `mc-core-db-boot-`, so a report names the call site's prefix. */
+export function countByPrefix(names) {
+  const counts = new Map();
+  for (const name of names) {
+    const prefix = name.replace(/[A-Za-z0-9]{6}$/, "");
+    counts.set(prefix, (counts.get(prefix) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+/** Where the sandbox lives, given the real temp root. */
+export function sandboxPath(realTmp, pid) {
+  return path.join(realTmp, `${SANDBOX_PREFIX}${pid}`);
+}

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// `pnpm test` — every stage, every time, and a report that names what failed.
+//
+// The rationale lives next to the logic in `lib/unit-tests.mjs`. This file is
+// the driver: preflight the machine, sandbox the run's temp directory, run
+// each stage to completion regardless of what the last one did, then say what
+// happened — on the console, as GitHub annotations, and in the job summary.
+//
+// The one thing it must never do is exit zero while a stage was red.
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  STAGES,
+  diskHeadroom,
+  exitCodeFor,
+  leakedEntries,
+  leftoverReport,
+  renderAnnotations,
+  renderJobSummary,
+  renderReport,
+  sandboxPath,
+  stageCommand,
+  stagePrefix,
+  summaryLine,
+} from "./lib/unit-tests.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const onGitHub = Boolean(process.env.GITHUB_ACTIONS);
+
+// -- Preflight: the machine ---------------------------------------------------
+//
+// Read before anything runs, and printed whether or not it is a problem. #257
+// §5's lesson is that the wrong diagnosis ran for six days because the log did
+// not say what the machine looked like; one line at the top is the whole fix.
+
+const realTmp = fs.realpathSync(os.tmpdir());
+const disk = diskHeadroom(realTmp);
+const workspaceDisk = diskHeadroom(repoRoot);
+
+console.log("Unit Tests — machine preflight");
+console.log(`  temp      ${disk.message}`);
+console.log(`  workspace ${workspaceDisk.message}`);
+
+if (disk.exhausted || workspaceDisk.exhausted) {
+  const culprit = disk.exhausted ? disk : workspaceDisk;
+  const message =
+    `Out of disk before a single test ran — ${culprit.message}. ` +
+    "This run is a machine failure, not a code failure; nothing below it would have meant anything.";
+  console.error(`\nDISK: ${message}`);
+  if (onGitHub) console.log(`::error title=Unit Tests — out of disk::${message}`);
+  writeJobSummary(
+    ["## Unit Tests", "", "**Aborted before running: the machine is out of disk.**", "", `- ${culprit.message}`].join(
+      "\n",
+    ),
+  );
+  process.exit(1);
+}
+
+// -- Preflight: the native binding --------------------------------------------
+//
+// Was the first link of the old `&&` chain. It stays a gate rather than a
+// stage: without a loadable better-sqlite3 every suite fails for one reason,
+// and five identical stack traces are not five pieces of information.
+
+const native = await run(process.execPath, [path.join(repoRoot, "scripts", "ensure-node-sqlite.mjs")], {
+  prefix: "native: ",
+});
+if (native.exitCode !== 0) {
+  const message = "The Node better-sqlite3 binding could not be prepared — every suite would fail on it.";
+  console.error(`\nNATIVE: ${message}`);
+  if (onGitHub) console.log(`::error title=Unit Tests — native binding::${message}`);
+  process.exit(native.exitCode || 1);
+}
+
+// -- The temp sandbox ---------------------------------------------------------
+
+const tmpBefore = leakedEntries(realTmp);
+const sandbox = sandboxPath(realTmp, process.pid);
+fs.mkdirSync(sandbox, { recursive: true });
+
+let cleaned = false;
+function removeSandbox() {
+  if (cleaned) return;
+  cleaned = true;
+  try {
+    fs.rmSync(sandbox, { recursive: true, force: true, maxRetries: 3 });
+  } catch (error) {
+    console.error(`could not remove the run's temp sandbox ${sandbox}: ${error.message}`);
+  }
+}
+process.on("exit", removeSandbox);
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    removeSandbox();
+    process.exit(130);
+  });
+}
+
+console.log(`  sandbox   TMPDIR=${sandbox} (removed when this run ends)`);
+console.log("");
+
+// -- The stages ---------------------------------------------------------------
+
+const results = [];
+for (const stage of STAGES) {
+  const { command, args } = stageCommand(stage);
+  const prefix = stagePrefix(stage);
+  console.log(`>>> ${stage.label}: ${command} ${args.join(" ")}`);
+  const started = performance.now();
+  const outcome = await run(command, args, {
+    prefix,
+    env: { ...process.env, TMPDIR: sandbox, TEMP: sandbox, TMP: sandbox },
+  });
+  const durationMs = performance.now() - started;
+  results.push({
+    id: stage.id,
+    label: stage.label,
+    ok: outcome.exitCode === 0,
+    exitCode: outcome.exitCode,
+    summary: summaryLine(outcome.output),
+    durationMs,
+  });
+  console.log("");
+}
+
+// -- What the run left behind -------------------------------------------------
+
+const stranded = leakedEntries(sandbox);
+const tmpAfter = leakedEntries(realTmp);
+const leftovers = leftoverReport({ before: tmpBefore, after: tmpAfter, stranded });
+
+console.log("Temp directories");
+console.log(`  ${leftovers.message}`);
+for (const [prefix, count] of leftovers.byPrefix.slice(0, 12)) {
+  console.log(`    ${String(count).padStart(4)}  ${prefix}*`);
+}
+for (const name of leftovers.escaped) console.log(`  ESCAPED: ${path.join(realTmp, name)}`);
+
+removeSandbox();
+
+// -- The report ---------------------------------------------------------------
+
+console.log(renderReport(results, { leftovers, disk }));
+if (onGitHub) for (const annotation of renderAnnotations(results, { leftovers, disk })) console.log(annotation);
+writeJobSummary(renderJobSummary(results, { leftovers, disk }));
+
+// A leaked directory is a failure of the job, not of a package: it is reported
+// on its own rather than blamed on whichever stage happened to run last.
+process.exit(leftovers.ok ? exitCodeFor(results) : 1);
+
+// -- Plumbing -----------------------------------------------------------------
+
+/**
+ * Run one command to completion, streaming its output line by line under a
+ * prefix and keeping a copy so the `Test Files` line can be read back out.
+ *
+ * Never rejects: a stage that cannot even be spawned is a stage that failed,
+ * and the run carries on to the next one.
+ */
+function run(command, args, { prefix = "", env = process.env } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+    let output = "";
+    const partial = { stdout: "", stderr: "" };
+
+    const pump = (streamName, stream, sink) => {
+      stream.setEncoding("utf8");
+      stream.on("data", (chunk) => {
+        output += chunk;
+        partial[streamName] += chunk;
+        const lines = partial[streamName].split("\n");
+        partial[streamName] = lines.pop() ?? "";
+        for (const line of lines) sink.write(`${prefix}${line}\n`);
+      });
+    };
+    pump("stdout", child.stdout, process.stdout);
+    pump("stderr", child.stderr, process.stderr);
+
+    child.on("error", (error) => {
+      process.stderr.write(`${prefix}could not run ${command}: ${error.message}\n`);
+      output += `\n${error.message}`;
+      resolve({ exitCode: 1, output });
+    });
+    child.on("close", (code, signal) => {
+      for (const [streamName, sink] of [
+        ["stdout", process.stdout],
+        ["stderr", process.stderr],
+      ]) {
+        if (partial[streamName]) sink.write(`${prefix}${partial[streamName]}\n`);
+      }
+      resolve({ exitCode: code ?? (signal ? 1 : 0), output });
+    });
+  });
+}
+
+function writeJobSummary(markdown) {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target) return;
+  try {
+    fs.appendFileSync(target, `${markdown}\n`);
+  } catch (error) {
+    console.error(`could not write the job summary: ${error.message}`);
+  }
+}

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -25,6 +25,7 @@ import {
   sandboxPath,
   stageCommand,
   stagePrefix,
+  staleSandboxes,
   summaryLine,
 } from "./lib/unit-tests.mjs";
 
@@ -77,6 +78,21 @@ if (native.exitCode !== 0) {
 }
 
 // -- The temp sandbox ---------------------------------------------------------
+
+// A sandbox is removed on exit and on the three signals a process can trap.
+// SIGKILL, a runner OOM and a cancelled CI job are not among them, and this
+// prefix is deliberately outside the `mc-*`/`actana-*` globs the leak check
+// greps for — so a survivor is drift under a name nothing would ever flag.
+// One readdir at startup closes it. Live runs' sandboxes are left alone.
+const stale = staleSandboxes(realTmp);
+for (const name of stale) {
+  try {
+    fs.rmSync(path.join(realTmp, name), { recursive: true, force: true, maxRetries: 3 });
+  } catch (error) {
+    console.error(`  could not remove the stale sandbox ${name}: ${error.message}`);
+  }
+}
+if (stale.length) console.log(`  swept     ${stale.length} sandbox(es) left by runs that were killed`);
 
 const tmpBefore = leakedEntries(realTmp);
 const sandbox = sandboxPath(realTmp, process.pid);
@@ -131,6 +147,10 @@ for (const stage of STAGES) {
 
 const stranded = leakedEntries(sandbox);
 const tmpAfter = leakedEntries(realTmp);
+// Read again, not reused from preflight: the realistic way a job dies of disk
+// is to start with 40 GiB and exhaust it during the Panel suite. A single
+// preflight reading reports that run as healthy and never says `DISK:`.
+const diskAfter = diskHeadroom(realTmp);
 const leftovers = leftoverReport({ before: tmpBefore, after: tmpAfter, stranded });
 
 console.log("Temp directories");
@@ -140,13 +160,19 @@ for (const [prefix, count] of leftovers.byPrefix.slice(0, 12)) {
 }
 for (const name of leftovers.escaped) console.log(`  ESCAPED: ${path.join(realTmp, name)}`);
 
+console.log("");
+console.log("Disk, after the run");
+console.log(`  temp      ${diskAfter.message}`);
+
 removeSandbox();
 
 // -- The report ---------------------------------------------------------------
 
-console.log(renderReport(results, { leftovers, disk }));
-if (onGitHub) for (const annotation of renderAnnotations(results, { leftovers, disk })) console.log(annotation);
-writeJobSummary(renderJobSummary(results, { leftovers, disk }));
+console.log(renderReport(results, { leftovers, disk, diskAfter }));
+if (onGitHub) {
+  for (const annotation of renderAnnotations(results, { leftovers, disk, diskAfter })) console.log(annotation);
+}
+writeJobSummary(renderJobSummary(results, { leftovers, disk, diskAfter }));
 
 // A leaked directory is a failure of the job, not of a package: it is reported
 // on its own rather than blamed on whichever stage happened to run last.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 // Root vitest project — the repo-level build and packaging scripts. Package
-// tests live in packages/*/vitest.config.ts and run via `pnpm -r test`.
+// tests live in packages/*/vitest.config.ts; `pnpm test` drives this suite and
+// each package's in turn from scripts/run-unit-tests.mjs. `pnpm -r test` is
+// gone — it bailed on the first failing package and hid the rest (issue #257),
+// and scripts/__tests__/unit-tests.test.mjs asserts it stays gone.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
Closes #257 (the `Unit Tests` half; see the checklist for what is left open).

**§3 (Panel isolation) is not in this pull request at all.** It is carved out to **#274**, together with the `packages/panel/vitest.config.ts` change that used to be here. #270 carries **§1** — every package reports — and **§4** — a disk-caused red run says disk. Nothing under `packages/` is touched.

Base is `chore/release-discipline-and-cursor-cli`, not `main` and not a `beta/**` train.

## The one sentence

A red `Unit Tests` run now names every package that failed, and cannot hide one behind another.

`pnpm test` was `pnpm native:node && vitest run && pnpm -r test`. Both links discard information: `&&` stops at the first non-zero exit, so a root-suite failure means no package runs at all; `pnpm -r` bails on the first failing package in topological order, so a flake in `packages/cli` means `core` and `panel` never run. #257 §1 lists three runs of 2026-08-18 that ended exactly there — the sharpest being #246, a *Panel* fix carrying 573 lines of new Panel tests, none of which ran, on a log containing no `packages/panel test:` line at all.

`scripts/run-unit-tests.mjs` replaces the chain: every stage runs to completion, the exit codes are aggregated at the end, and the run reports all six stages.

## Evidence, not assertion

### A deliberate failure in `packages/cli` — `core` and `panel` still report

A failing test was planted in `packages/cli/src/__tests__/`, a full `pnpm test` run, then the test removed. Every `Test Files` line the run printed:

```
 Test Files  17 passed (17)
packages/sdk test:     Test Files  20 passed | 2 skipped (22)
packages/shared test:  Test Files  14 passed (14)
packages/cli test:     Test Files  1 failed | 30 passed | 1 skipped (32)   <-- the planted failure
packages/core test:    Test Files  64 passed (64)                          <-- would not have run
packages/panel test:   Test Files  142 passed (142)                        <-- would not have run
```

```
$ grep -c ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL <log>
0
$ echo $?   # after pnpm test
1
```

and the annotation a reviewer sees without opening the log:

```
::error title=Unit Tests — packages/cli failed::packages/cli: Test Files  1 failed | 30 passed | 1 skipped (32)
```

### A failure in the **root** suite — all five packages still report

This one was not planted. The root suite fails on the developer machine used here for an environmental reason (`AC_APP_PATH` from a real `/opt/actana` install leaks into `scripts/__tests__/core-launcher.test.mjs`), which produced the `&&`-chain case for free:

```
FAIL  root suite       FAILED (exit 1)
      Test Files  1 failed | 16 passed (17)
PASS  packages/sdk     Test Files  20 passed | 2 skipped (22)
PASS  packages/shared  Test Files  14 passed (14)
PASS  packages/cli     Test Files  30 passed | 1 skipped (31)
PASS  packages/core    Test Files  64 passed (64)
PASS  packages/panel   Test Files  142 passed (142)
------------------------------------------------------------------------
1 of 6 stages FAILED: root suite
```

Under the old chain that run would have printed no package line whatsoever.

### And the flake this ticket exists for, live

During verification, `packages/cli/src/__tests__/events-tail-cursor.test.ts` — **#208**, the flake behind all three unreadable runs in §1 — failed on its own:

```
packages/cli test:  FAIL  src/__tests__/events-tail-cursor.test.ts > ... > delivers every event exactly once ...
packages/cli test: Error: timed out waiting: the TLS server never bound
packages/cli test:  Test Files  1 failed | 29 passed | 1 skipped (31)
packages/core test:  Test Files  64 passed (64)
packages/panel test:  Test Files  142 passed (142)
```

That is the exact scenario from the ticket, and this time the log answers it. #208 stays open, as §5 asks — it is not fixed here.

### Green, and the exit code

```
PASS root suite / sdk / shared / cli / core / panel   —   All 6 stages passed.
EXIT: 0
```

### The job summary a reviewer sees on the run page

```
## Unit Tests

**1 of 6 stages failed:** packages/cli

| Stage | Result | Test Files | Duration |
| --- | --- | --- | --- |
| root suite | passed | `Test Files  17 passed (17)` | 2.5s |
| packages/sdk | passed | `Test Files  20 passed \| 2 skipped (22)` | 2.6s |
| packages/shared | passed | `Test Files  14 passed (14)` | 911ms |
| packages/cli | **failed** (exit 1) | `Test Files  1 failed \| 30 passed \| 1 skipped (32)` | 2.9s |
| packages/core | passed | `Test Files  64 passed (64)` | 9.9s |
| packages/panel | passed | `Test Files  142 passed (142)` | 29.4s |
```

### Temp leak (§4)

`pnpm test` now runs under its own `TMPDIR`, removed when the run ends. Measured across every full run above:

```
TMP BEFORE: 1633
TMP AFTER:  1633
```

with the drift still attributed by call-site prefix, so it stays visible:

```
no mc-*/actana-* directories were left in the real temp root (125 were created inside the run's sandbox and removed with it)
    22  mc-claude-code-hooks-proj-*
    10  mc-ut-*
     9  mc-opencode-hooks-proj-*
     8  mc-ask-question-proj-*
     ...
```

For scale: #257 §4 measured 389 stale directories over eight days. This checkout had **1,633** and 2.2G before the first run of this branch.

### Panel isolation (§3) — **removed from this pull request**, now #274

§3 is not delivered and this pull request no longer contains anything belonging to it.
`packages/panel/vitest.config.ts` is byte-identical to the base branch again, and the two
tests in `scripts/__tests__/unit-tests.test.mjs` that existed only to police that config went
with it.

**Why it was dropped rather than kept as a partial improvement.** The clamp
`Math.max(2, Math.min(4, cpus))` is a *floor* as well as a ceiling. Vitest's own default is
`cpus - 1`, so on a 4-core machine the clamp computes **4** against a default of **3**.
`actana/control` is public, so `runs-on: ubuntu-24.04` is a 4-vCPU runner — the change would
have raised the Panel suite there from 3 workers to 4, the direction this branch's own
measurement associates with *more* red files, inside the very `Unit Tests` job #257 exists to
make readable. Measured under `taskset`, which `os.availableParallelism()` honours:

| cores | vitest default | the dropped config |
|---|---|---|
| 2 | 9.76s — 1 worker | 4.86s — 2 workers |
| 4 | 3.17s — 3 workers | 1.63s — **4 workers** |
| 10 | 1.72s — 9 workers | 3.23s — 4 workers |

The comment above the clamp claimed the opposite — "a CI runner with two or four cores keeps
exactly the parallelism it already had". That sentence was written at `fd0484a:25-27` while
`poolOptions` still made the whole setting inert, and was carried into the working version
without being re-checked. Caught in review, and it is the round-1 pattern repeating: the one
claim whose evidence never engaged is the one that survived the fix.

**Everything measured here is preserved on #274**, not thrown away — the Vitest 4
`poolOptions` finding, the engagement measurement (in-test time 132.7s → 55.0s), the fact that
the baseline is itself flaky (4 unconstrained runs: 3f/3t, 4f/8t, 3f/9t, 3f), the `taskset`
table above, the non-reproducing `project-picker-switch.test.tsx` render, and a
ceiling-only-on-every-core-count requirement for whatever cap lands there.

## Boundaries and sequencing

**Nothing owned by #264 was touched.** No ruleset, no required-status-check list, no branch protection, no promotion gate. `docs/rulesets/` is untouched.

**No status check was added, removed, or renamed.** The `Unit Tests` job keeps its name — `scripts/__tests__/unit-tests.test.mjs` asserts that, because renaming a required check makes every open PR unmergeable. The one new thing is a *step* inside the existing job, not a new job, so no new check appears and nothing can sit Pending forever (ADR 0023 D33). Its pass case exits 0 explicitly.

**The one line #264 may also want:** `.github/workflows/ci.yml`, the `unit-tests:` job — a new `- name: No temp directories survived the job` step appended after `- run: pnpm test` (currently around line 467). If #264 restructures that job, this step is the only addition to carry across. Everything else in my diff is `scripts/` and `package.json`.

**#260's files are untouched** — `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` and `docs/ci-cd.md` are not modified. Nothing in them referenced the old test chain (checked by grep), so no pointer was needed.

**Nothing under `packages/` is touched at all** — no product source, and no package-level config either since `packages/panel/vitest.config.ts` went to #274. The diff is seven files: `.github/workflows/ci.yml`, `package.json`, the root `vitest.config.ts`, and four under `scripts/`.

## Not done, and why

- **`project-picker-switch.test.tsx > opens onto just the one Project when the Core owns only it`** — §3 asks for the empty-`<div />` render to be explained and fixed rather than given more time. **It does not reproduce on this branch.** The unconstrained baseline run here failed on `terminals-in-browser.test.ts` and `live-read-path.test.ts`, both plain 5s timeouts; the `TestingLibraryElementError` §3 describes did not appear, in that run or any since. All four files §3 names pass alone (`4 passed / 28 tests`) and inside the full suite. I will not claim a diagnosis for a failure I could not make happen. Carried to **#274** with the runs that looked for it.
- **#208 is not fixed** and stays open, exactly as §5 asks.
- **`ENOSPC` presentation** is implemented in the weaker form §4 settled on: free space and inode headroom are read and logged before any suite runs, and a run below the floor aborts saying `DISK` rather than producing a wall of unrelated failures. The 108-failure incident §4 could not find is still not evidenced, and nothing here claims it.

## Noticed, not fixed (follow-up material)

`pnpm typecheck` is still `pnpm -r typecheck` — the same bail, in the `Typecheck` job. Out of scope for #257, which is written against `Unit Tests`, but it is the identical failure mode one job over.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


