### PR TITLE
fix: make cursor-cli drivable — right binary, auto mode delivered or refused, trust dialog recognised, turn-start said

### DIFF
--- a/docs/adr/0026-prompt-delivery-is-a-core-responsibility.md
+++ b/docs/adr/0026-prompt-delivery-is-a-core-responsibility.md
@@ -60,3 +60,47 @@ The fix is not a fourth number. It is that **the Core watches the harness and re
 - **A prompt that a harness swallowed is now re-typed rather than reported delivered** (D3a, D6a), and the two new log lines say which is happening: `pty.prompt-delivery.waiting-for-composer` while the Core holds, `pty.prompt-delivery.prompt-swallowed` when a write left no echo. A Session that used to start empty and silent now starts late and correct.
 - **The opencode boot is in the suite as bytes, not as a description.** `packages/core/src/__tests__/fixtures/opencode-1.18.18-{boot,composer}.txt` are a live PTY capture, and the delivery test replays them at their captured timings — the 4.4 s hole included. Its boot was measured at between 3.4 s and 6.9 s across runs on one machine, which is the clearest possible argument that no constant was ever going to answer this.
 - **A prompt can now be deliberately not delivered** (D5, D8). That is a new outcome with a new failure mode: a Session that starts, shows a dialog, and sits there. It is the intended trade, it is logged, and it leaves a running harness rather than an exited one.
+
+## Amendment — issue 177 (2026-08-19)
+
+Two changes, both within this record rather than against it.
+
+**D7's folder-trust entry now also covers `cursor-cli`.** D7's argument for
+scoping was that a dialog spec is a transcription of a named harness's screen,
+and applying one vendor's transcription to another means pressing a digit into a
+layout nobody has looked at. That argument holds for the bypass-permissions
+entry, which is scoped to `claude-code` still: `Bypass Permissions mode` is
+Claude Code's phrase and the screen behind it is Claude Code's screen.
+
+It does not hold for folder-trust, because that entry contains no transcription
+to carry across. What it asserts is that "trust" plus a workspace noun plus a
+question mark means a trust prompt is up, that an option meaning yes is the one
+to take, and that an option meaning no is the one to refuse. The number of
+options, their labels and **which digit the affirmative one carries** are read
+off the screen in front of it by `readDialogOptions` — this module has never
+hard-coded a key, which is precisely what [issue
+177](https://github.com/actana/control/issues/177) warns a careless partial
+match would do. The nouns were widened (`workspace`, `project`, `repo`) for the
+same reason: they make the entry less dependent on one vendor's wording, not
+more. D5 is unchanged and is what makes the widening safe — a screen whose menu
+does not parse yields no answer, and no answer means no keystroke.
+
+The honest caveat: cursor-agent's trust screen has not been observed by anyone
+who wrote the entry. If it does not match, the outcome is what it is today —
+unrecognised — with the change below making that visible.
+
+**Abandoned delivery now moves the Session to `needs-input`.** D5 and D8 are
+deliberate that the Core types nothing into a dialog it cannot read and gives
+up with the dialog still on screen. The last Consequence above named the cost of
+that — *"a Session that starts, shows a dialog, and sits there"* — and until now
+the giving-up was a `pty.prompt-delivery.abandoned` log line on the Core and
+nothing else. No client reads that log, so every client saw a Session at its
+pre-turn status and no way to tell it from a hang.
+
+The Core now reports it as an output signal (`dialog-unanswered`,
+`pty-manager.ts` → `CoreHarnessStatus.outputSignal`), which maps to
+`needs-input` — the same route Codex's `hooks-need-review` already takes, and
+for the same reason: a harness waiting on a human is what `needs-input` means.
+Nothing about the decision changed, only whether anybody is told. `needs-input`
+is a settled status, so an SDK `waitForIdle` on an abandoned Session now returns
+instead of waiting for a report that was never going to come.

--- a/docs/adr/0026-prompt-delivery-is-a-core-responsibility.md
+++ b/docs/adr/0026-prompt-delivery-is-a-core-responsibility.md
@@ -85,9 +85,26 @@ same reason: they make the entry less dependent on one vendor's wording, not
 more. D5 is unchanged and is what makes the widening safe — a screen whose menu
 does not parse yields no answer, and no answer means no keystroke.
 
-The honest caveat: cursor-agent's trust screen has not been observed by anyone
-who wrote the entry. If it does not match, the outcome is what it is today —
-unrecognised — with the change below making that visible.
+**What the entry achieves, precisely: recognition, not an answer.**
+cursor-agent's trust screen has since been observed on a machine that has the
+harness installed, and is committed as bytes at
+`packages/core/src/__tests__/fixtures/cursor-agent-2026.08.11-folder-trust.txt`.
+The nouns catch it. The menu is **letter-keyed** — `[a] Trust this workspace` /
+`[q] Quit` — and `readDialogOptions` reads digits, so it returns an empty list,
+`chooseDialogOption` returns null, and a cursor-cli delivery that meets this
+screen always abandons. The row makes the dialog *recognised*; answering it
+needs a menu reader this module does not have, which is
+[issue 273](https://github.com/actana/control/issues/273). The win is real and
+it is the change below: before the row, the prompt and a carriage return were
+typed into the trust dialog and the delivery reported `delivered`.
+
+**Recognition is not a net under a harness the table has never heard of, and
+this record previously said it was.** An *unrecognised* dialog does not abandon:
+`onQuiet` finds no dialog, emits `settled`, calls `writePrompt`, and the prompt
+goes into whatever is on screen. The `needs-input` outcome exists **only because
+a pattern matched**. D7 stands on the matching, not on a downstream backstop —
+whoever adds the fifth harness must not read this amendment as "matching is
+optional, the net catches it either way."
 
 **Abandoned delivery now moves the Session to `needs-input`.** D5 and D8 are
 deliberate that the Core types nothing into a dialog it cannot read and gives

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -296,6 +296,30 @@ The narrower question matters: Cursor and Codex both take our hooks file and
 report a turn's *end*, so "hooks were installed" would suppress the fallback and
 leave their Sessions on `ready` for the whole first turn.
 
+### The CLI has no equivalent, and says so
+
+`hooksReportTurnStart` reaches every client, not just the Panel: the SDK carries
+it off the `spawned` frame onto `CoreSession.reportsTurnStart`, and the `actana`
+CLI reports it on `session start` / `session resume` as both a stderr note and a
+`--json` field.
+
+It is a statement rather than a fallback, and that is deliberate. The Panel can
+watch the keystrokes going into its pane because it owns the pane; `actana
+session start` hands the prompt to the Core and hangs up (#129 D6), so there are
+no keystrokes here to watch, and a client that wrote `running` on its own would
+be reporting a status the Core never decided. What it can do is stop a quiet
+`session ls` from reading as a dead harness:
+
+```
+$ actana session start web "refactor the picker" --harness cursor-cli
+Started cursor-cli in web — session task_x, pty pty_x.
+Note: cursor-cli does not report the start of a turn, so this session will not
+show as running until it stops. `--wait` and `session logs` are unaffected.
+```
+
+Both named affordances do still work, because turn *end* is reported: `--wait`
+is `CoreSession.waitForIdle`, and `session logs` reads the Core's replay ring.
+
 ## Title generation
 
 Runs on the Core, for Core-owned rows. Task metadata is Core-owned, the harness

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -126,6 +126,10 @@ export function fakeStartedSession(overrides: Partial<StartedSession> = {}): Sta
     ptyId: "pty_1",
     harness: "claude-code",
     command: "claude",
+    // Claude Code is the one harness that reports a turn's start, so the
+    // default fake is the quiet case — a test asking about the caveat has to
+    // say `reportsTurnStart: false` and mean it.
+    reportsTurnStart: true,
     projectId: "proj_1",
     project: "web",
     wait: async () => ({ status: "finished", exited: false }),

--- a/packages/cli/src/__tests__/cursor-cli-drivable.test.ts
+++ b/packages/cli/src/__tests__/cursor-cli-drivable.test.ts
@@ -1,0 +1,199 @@
+// cursor-cli, driven from this client, against the machine that has to accept
+// it (issue 177 findings 1 and 2).
+//
+// The issue was filed against a client that lived outside this repository, and
+// its first two findings were both the same mistake in two columns of one
+// table: the client sent the harness *id* where the Core wanted the canonical
+// *binary*, and it set the auto-mode spawn *option* without ever putting the
+// matching *flag* in the command. `cursor-cli` is where both bit, and it is
+// the only harness where either could — its id and its binary differ
+// (`cursor-cli` vs `cursor-agent`), and its flag is `--force` where the
+// template the client was built from said `--dangerously-skip-permissions`.
+// `codex` and `opencode` survived on a coincidence, which is what kept it
+// hidden.
+//
+// The client half now lives here, in `packages/cli` and the SDK under it, so
+// the findings are testable rather than describable. Every assertion below
+// runs the command this client would actually send through `resolveSpawnPlan`
+// — the same function `packages/core` calls before spawning anything — so a
+// pass means the Core would have accepted it, not that two files in this
+// repository agree with each other.
+//
+// Importing `@actana/shared` from a test is the arrangement `tsconfig.json`,
+// `vitest.config.ts` and `no-local-escape.test.ts` already describe: test-only,
+// never from a shipped module.
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  resolveSpawnPlan,
+  SpawnPolicyError,
+  type SpawnPolicyDeps,
+  type SpawnRequest,
+} from "@actana/shared/pty-spawn-policy";
+import {
+  HARNESS_LAUNCH_COMMANDS,
+  harnessAutoModeFlag,
+  harnessLaunchCommand,
+} from "@actana/sdk/core-session.ts";
+import { KNOWN_HARNESSES } from "../session-gateway.ts";
+import { makeCliFixture, type CliFixture } from "./cli-harness.ts";
+import { EXIT_OK } from "../exit-codes.ts";
+import type { CoreLinkPtySpawnHarness } from "@actana/sdk/core-link-frames.ts";
+
+const PROJECT_ROOT = "/home/core/projects/web";
+
+function policyDeps(): SpawnPolicyDeps {
+  return {
+    cwdExists: () => true,
+    realpath: (p) => p,
+    projectRoots: () => [PROJECT_ROOT],
+    resolveCommand: (name) => `/usr/local/bin/${name}`,
+    resolveShell: () => ({
+      shell: "/bin/zsh",
+      shellArgs: (cmd) => (cmd ? ["-l", "-c", cmd] : ["-l"]),
+    }),
+  };
+}
+
+/** The spawn this client would send for `harness`, put to the Core's policy. */
+function planFor(harness: CoreLinkPtySpawnHarness, autoMode: boolean) {
+  return resolveSpawnPlan(
+    {
+      taskId: "t1",
+      cwd: PROJECT_ROOT,
+      command: harnessLaunchCommand(harness, autoMode),
+      agent: harness,
+      ...(autoMode ? { dangerouslySkipPermissions: true } : {}),
+    } as SpawnRequest,
+    policyDeps(),
+  );
+}
+
+describe("finding 1 — argv[0] is the canonical binary, never the harness id", () => {
+  it("sends cursor-agent for cursor-cli, which is the whole of the original crash", () => {
+    // `core-client: pty:spawn rejected (command-not-on-allowlist)`, verbatim
+    // from the issue. The command starting with the id is what produced it.
+    expect(HARNESS_LAUNCH_COMMANDS["cursor-cli"].split(" ")[0]).toBe("cursor-agent");
+    expect(harnessLaunchCommand("cursor-cli", false).startsWith("cursor-cli")).toBe(false);
+  });
+
+  it("resolves a plan for every harness, so nothing rides on id === binary", () => {
+    // The point of sweeping all four rather than testing cursor-cli alone:
+    // codex and opencode passed the old client too, by coincidence. A table
+    // that is right for the reason rather than by luck is right for all of
+    // them.
+    for (const harness of KNOWN_HARNESSES) {
+      const plan = planFor(harness, false);
+      expect(plan.mode, `${harness} was not accepted as an agent spawn`).toBe("agent");
+    }
+  });
+
+  it("puts the binary the Core resolved on the plan, per harness", () => {
+    const binaries: Record<CoreLinkPtySpawnHarness, string> = {
+      "claude-code": "/usr/local/bin/claude",
+      codex: "/usr/local/bin/codex",
+      "cursor-cli": "/usr/local/bin/cursor-agent",
+      opencode: "/usr/local/bin/opencode",
+    };
+    for (const harness of KNOWN_HARNESSES) {
+      const plan = planFor(harness, false);
+      if (plan.mode !== "agent") throw new Error("wrong mode");
+      expect(plan.binary).toBe(binaries[harness]);
+    }
+  });
+});
+
+describe("finding 2 — auto mode reaches the harness, or the spawn is refused", () => {
+  it("puts each harness's own flag in the command, and cursor-cli's is --force", () => {
+    expect(harnessAutoModeFlag("cursor-cli")).toBe("--force");
+    expect(harnessLaunchCommand("cursor-cli", true)).toBe("cursor-agent --force");
+    expect(harnessLaunchCommand("claude-code", true)).toContain(
+      "--dangerously-skip-permissions",
+    );
+    expect(harnessLaunchCommand("codex", true)).toContain("--yolo");
+    // OpenCode ships no such flag. `null` is the fact, not a gap.
+    expect(harnessAutoModeFlag("opencode")).toBeNull();
+    expect(harnessLaunchCommand("opencode", true)).toBe("opencode");
+  });
+
+  it("is accepted by the Core for every harness, auto mode on", () => {
+    for (const harness of KNOWN_HARNESSES) {
+      const plan = planFor(harness, true);
+      expect(plan.mode, `${harness} auto-mode launch was refused`).toBe("agent");
+    }
+  });
+
+  it("carries the flag into argv rather than only into the option", () => {
+    for (const harness of KNOWN_HARNESSES) {
+      const flag = harnessAutoModeFlag(harness);
+      if (flag === null) continue;
+      const plan = planFor(harness, true);
+      if (plan.mode !== "agent") throw new Error("wrong mode");
+      expect(plan.argv, `${harness} auto mode never reached argv`).toContain(flag);
+    }
+  });
+
+  it("refuses the option with no flag — the silent pass this issue closed", () => {
+    // The pre-177 behaviour, reproduced deliberately: set the option, send the
+    // command a client that only knew Claude Code would have built. The Core
+    // used to accept this and launch an interactive cursor-agent.
+    let thrown: unknown;
+    try {
+      resolveSpawnPlan(
+        {
+          taskId: "t1",
+          cwd: PROJECT_ROOT,
+          command: "cursor-agent",
+          agent: "cursor-cli",
+          dangerouslySkipPermissions: true,
+        } as SpawnRequest,
+        policyDeps(),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SpawnPolicyError);
+    expect((thrown as SpawnPolicyError).code).toBe("auto-mode-flag-missing");
+  });
+
+  it("still refuses the flag with no option, in the direction that always worked", () => {
+    expect(() =>
+      resolveSpawnPlan(
+        {
+          taskId: "t1",
+          cwd: PROJECT_ROOT,
+          command: "cursor-agent --force",
+          agent: "cursor-cli",
+        } as SpawnRequest,
+        policyDeps(),
+      ),
+    ).toThrow(SpawnPolicyError);
+  });
+});
+
+describe("--model is never dropped silently (issue 177, ticket #211)", () => {
+  // The acceptance criterion asks for one of two things, not for the flag:
+  // `--model` reaches every harness that supports it, or it is rejected loudly
+  // where it is not passed. This build does the second — the flag is not
+  // carried at all, and #211 is where carrying it lands. What must never
+  // happen in between is the third thing: accepted, and then quietly not sent.
+  let fixture: CliFixture | null = null;
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = null;
+  });
+
+  it("is refused as an unknown flag rather than accepted and ignored", async () => {
+    fixture = makeCliFixture();
+    const run = await fixture.run([
+      "session",
+      "start",
+      "web",
+      "go",
+      "--model",
+      "composer-2.5",
+    ]);
+    expect(run.code).not.toBe(EXIT_OK);
+    expect(run.err.join("\n")).toContain("unknown flag --model");
+  });
+});

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -179,6 +179,60 @@ describe("actana session start", () => {
     expect(run.err.join("\n")).toContain("Started claude-code in web");
   });
 
+  // ─── The turn-start asymmetry (issue 177 finding 4) ────────────────────
+  //
+  // Over the CLI a cursor-cli Session is statusless from prompt to stop:
+  // cursor-agent takes the Core's `.cursor/hooks.json` and never fires
+  // `beforeSubmitPrompt`, so nothing moves the row to `running`. The Panel
+  // compensates by watching the keystrokes going into its pane; `start` hands
+  // the prompt over and hangs up, so it has no keystrokes to watch. What it
+  // can do is say so, which is the half of the acceptance criterion a CLI can
+  // honestly meet.
+
+  it("says plainly when nothing will report the start of a turn", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--harness", "cursor-cli"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({ harness: "cursor-cli", reportsTurnStart: false }),
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    const err = run.err.join("\n");
+    expect(err).toContain("does not report the start of a turn");
+    expect(err).toContain("cursor-cli");
+    // Named so an operator does not read the caveat as "this session is
+    // broken" — the two things that still work are the two they would reach
+    // for next.
+    expect(err).toContain("--wait");
+    expect(err).toContain("session logs");
+    // Still just the id on stdout: a caveat is not output a script captures.
+    expect(run.out).toEqual(["task_1"]);
+  });
+
+  it("says nothing about turn starts for a harness that reports them", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go"], {
+      sessions: fakeSessionGateway({
+        start: async () => fakeStartedSession({ reportsTurnStart: true }),
+      }),
+    });
+    expect(run.err.join("\n")).not.toContain("does not report the start of a turn");
+  });
+
+  it("carries the answer as a --json field, not only as prose", async () => {
+    // A script deciding whether a quiet status means "still working" or "never
+    // started" cannot parse a sentence off stderr.
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--json"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({ harness: "cursor-cli", reportsTurnStart: false }),
+      }),
+    });
+    expect(JSON.parse(run.out.join("\n"))).toMatchObject({ reportsTurnStart: false });
+  });
+
   it("hands the prompt over as typed, and never a carriage return with it", async () => {
     await withRegisteredCore();
     let seen: Record<string, unknown> | null = null;

--- a/packages/cli/src/harness-resume.ts
+++ b/packages/cli/src/harness-resume.ts
@@ -14,6 +14,7 @@
 // spawn with the Core's own message on it — not a command trimmed here on a
 // guess about a machine this process is not on.
 
+import { harnessAutoModeFlag } from "@actana/sdk/core-session.ts";
 import type { CoreLinkPtySpawnHarness } from "@actana/sdk/core-link-frames.ts";
 
 /**
@@ -34,26 +35,39 @@ import type { CoreLinkPtySpawnHarness } from "@actana/sdk/core-link-frames.ts";
  *                                    `ses`
  *
  * `dangerouslySkipPermissions` appends that harness's spelling of "do not stop
- * to ask me", which the Core accepts **only** on a spawn that also set the
- * matching option — the CLI sends both or neither (see `session-gateway.ts`).
- * OpenCode has no such flag and gets none, which is not an omission: a flag
- * invented here would be rejected by the allow-list rather than honoured.
+ * to ask me", and it is **read from {@link harnessAutoModeFlag} rather than
+ * spelled again here** (issue 177 finding 2). It used to be a fourth switch
+ * over the same four harnesses, which is one more transcription of a vendor
+ * fact than can be kept in step — and the direction it drifts in is the silent
+ * one: a wrong flag is a rejected spawn, a *missing* flag used to be an
+ * interactive harness a caller thought was unattended.
+ *
+ * The Core now checks the gesture both ways: the flag is accepted only on a
+ * spawn that set the option, and since issue 177 the option is refused on a
+ * command that lacks the flag. The CLI sends both or neither (see
+ * `session-gateway.ts`). OpenCode has no such flag and gets none, which is not
+ * an omission — it is the one harness whose auto-mode cell is genuinely empty,
+ * and the Core reads it the same way.
  */
 export function harnessResumeCommand(
   harness: CoreLinkPtySpawnHarness,
   sessionId: string,
   opts: { dangerouslySkipPermissions?: boolean } = {},
 ): string {
-  const skip = opts.dangerouslySkipPermissions === true;
+  // One table for the flag, whatever the shape of the command it hangs off.
+  // `null` here is both "auto mode was not asked for" and "this harness has
+  // none" — two different facts with the same consequence for the command.
+  const autoMode =
+    opts.dangerouslySkipPermissions === true ? harnessAutoModeFlag(harness) : null;
   switch (harness) {
     case "claude-code":
-      return join(["claude", "--resume", sessionId], skip ? "--dangerously-skip-permissions" : null);
+      return join(["claude", "--resume", sessionId], autoMode);
     case "codex":
-      return join(["codex", "resume", sessionId, "--enable", "hooks"], skip ? "--yolo" : null);
+      return join(["codex", "resume", sessionId, "--enable", "hooks"], autoMode);
     case "cursor-cli":
-      return join(["cursor-agent", "--resume", sessionId], skip ? "--force" : null);
+      return join(["cursor-agent", "--resume", sessionId], autoMode);
     case "opencode":
-      return join(["opencode", "--session", sessionId], null);
+      return join(["opencode", "--session", sessionId], autoMode);
   }
 }
 

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -274,6 +274,11 @@ async function reportStartedSession(
     const where = session.project ?? session.projectId;
     deps.err(`Started ${session.harness} in ${where} — session ${session.taskId}, pty ${session.ptyId}.`);
     deps.verbose(`command: ${session.command}`);
+    // Issue 177 finding 4, said out loud rather than left to be discovered.
+    // Not `verbose`: an operator who has to know this is precisely one who has
+    // not passed `-v`, and the line they would otherwise read is a `session
+    // ls` that has not moved.
+    if (!session.reportsTurnStart) deps.err(noTurnStartLine(session.harness));
 
     if (!args.wait) {
       // The one-shot default (#129 D6). The id is the whole of stdout, so it can
@@ -663,6 +668,27 @@ async function readText(
   return { text: words.join(" ") };
 }
 
+/**
+ * What a caller is told when nothing will report this Session's turn starting.
+ *
+ * The Panel answers the same gap with a terminal-input fallback — it watches
+ * the keystrokes going into the pane and calls an Enter the start of a turn.
+ * A CLI has no equivalent: `start` hands the prompt to the Core and hangs up
+ * (#129 D6), so there is no keystroke stream here to watch and inventing a
+ * `running` this side never observed would be a status the Core did not say.
+ *
+ * So the asymmetry is printed instead. The sentence names what still works,
+ * because the failure this prevents is an operator reading a stalled `session
+ * ls` as a stalled harness and killing a Session that was working.
+ */
+function noTurnStartLine(harness: string): string {
+  return (
+    `Note: ${harness} does not report the start of a turn, so this session ` +
+    `will not show as running until it stops. \`--wait\` and \`session logs\` ` +
+    `are unaffected.`
+  );
+}
+
 /** The identity fields `start` and `resume` report, in both output modes. */
 function startedFields(session: StartedSession): Record<string, unknown> {
   return {
@@ -670,6 +696,10 @@ function startedFields(session: StartedSession): Record<string, unknown> {
     ptyId: session.ptyId,
     harness: session.harness,
     command: session.command,
+    // In `--json` too, and unconditionally: a script deciding whether a quiet
+    // status means "still working" or "never started" needs the answer as a
+    // field, not as a sentence on stderr it would have to parse.
+    reportsTurnStart: session.reportsTurnStart,
     projectId: session.projectId,
     project: session.project,
   };

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -147,6 +147,23 @@ export type StartedSession = {
   harness: CoreLinkPtySpawnHarness;
   /** The command the Core was asked to run, after defaulting. */
   command: string;
+  /**
+   * Will anything move this Session to `running` when a turn begins?
+   *
+   * The Core's answer for this Session, off the spawn (issue 84, issue 177
+   * finding 4) — not a property of the harness family, because it depends on
+   * which hooks actually landed on that machine and on whether the vendor
+   * fires them. `false` for `cursor-cli` today: the Core writes
+   * `.cursor/hooks.json` and cursor-agent never fires `beforeSubmitPrompt`.
+   *
+   * The CLI's job with it is to say so. `--wait` still works — turn *end* is
+   * reported, which is what `waitForIdle` waits for — but everything between
+   * the prompt and the stop is invisible, so a `session ls` run against a
+   * working cursor Session shows the status it had before the turn began. An
+   * operator told that is reading a quiet table correctly; one who is not has
+   * no way to tell it from a harness that never started.
+   */
+  reportsTurnStart: boolean;
   projectId: string;
   /** The Project's name, when the start resolved one. */
   project: string | null;
@@ -463,6 +480,7 @@ function wrap(session: CoreSession, projectId: string, project: string | null): 
     ptyId: session.ptyId,
     harness: session.harness,
     command: session.command,
+    reportsTurnStart: session.reportsTurnStart,
     projectId,
     project,
     wait: async (opts) => {

--- a/packages/core/src/__tests__/fixtures/cursor-agent-2026.08.11-folder-trust.txt
+++ b/packages/core/src/__tests__/fixtures/cursor-agent-2026.08.11-folder-trust.txt
@@ -1,0 +1,6 @@
+│  ⚠  Workspace Trust Required                                  │
+│  Cursor Agent can execute code and access files in this dir…  │
+│  Do you trust the contents of this directory?                 │
+│  ▶ [a] Trust this workspace                                   │
+│    [q] Quit                                                   │
+│  Use arrow keys to navigate, Enter to select, or press the …  │

--- a/packages/core/src/__tests__/harness-prompt-delivery.test.ts
+++ b/packages/core/src/__tests__/harness-prompt-delivery.test.ts
@@ -465,17 +465,76 @@ describe("chooseDialogOption", () => {
 });
 
 describe("dialogsForHarness", () => {
-  it("keeps Claude Code's dialogs to Claude Code", () => {
-    // Both specs are transcriptions of Claude Code's own screens. Applying
-    // them to a harness nobody has observed would mean pressing a digit into
-    // another vendor's layout on the strength of the word "trust".
+  it("keeps Claude Code's bypass-permissions screen to Claude Code", () => {
+    // That spec is a transcription of Claude Code's own warning screen, down
+    // to the phrase `Bypass Permissions mode`. Applying it to a harness nobody
+    // has observed would mean pressing a digit into another vendor's layout.
     expect(dialogsForHarness("claude-code").map((d) => d.id)).toEqual([
       "folder-trust",
       "bypass-permissions",
     ]);
     expect(dialogsForHarness("codex")).toEqual([]);
-    expect(dialogsForHarness("cursor-cli")).toEqual([]);
     expect(dialogsForHarness("opencode")).toEqual([]);
+  });
+
+  it("gives cursor-cli the folder-trust spec, and only that one (issue 177)", () => {
+    // Finding 3: cursor-agent's trust prompt was never answered because the
+    // matcher was scoped to a harness it is not. The entry it gets carries no
+    // Claude-specific wording and, crucially, no Claude-specific *key* — the
+    // digit comes off the menu on screen.
+    expect(dialogsForHarness("cursor-cli").map((d) => d.id)).toEqual(["folder-trust"]);
+  });
+});
+
+describe("cursor-agent's trust prompt (issue 177 finding 3)", () => {
+  const specs = dialogsForHarness("cursor-cli");
+
+  it("recognises a trust prompt worded differently from Claude Code's", () => {
+    // Not a transcription of a screen anybody has observed — the point of the
+    // assertion is that the matcher does not depend on one. `workspace` is a
+    // noun Claude Code never uses, and the option order is reversed relative
+    // to Claude's so a hard-coded `1` would be wrong here.
+    const screen = [
+      "Do you trust the files in this workspace?",
+      "",
+      "  1. No, exit",
+      "❯ 2. Yes, I trust this workspace",
+      "",
+    ].join("\n");
+
+    const match = matchBlockingDialog(screen, specs);
+    expect(match?.spec.id).toBe("folder-trust");
+    // The digit is read, not assumed. This is the exact failure the issue
+    // warned a careless partial match would introduce.
+    expect(match?.answer?.number).toBe(2);
+    expect(match?.answer?.label).toContain("Yes");
+  });
+
+  it("answers nothing when the menu cannot be read", () => {
+    // D5 unchanged: something is in the way and there is no confident way
+    // past it, so `answer` is null and the caller must type nothing. That
+    // path now ends in a `needs-input` Session rather than in silence.
+    const screen = "Do you trust the files in this workspace?\n\n  [y/N]\n";
+    const match = matchBlockingDialog(screen, specs);
+    expect(match?.spec.id).toBe("folder-trust");
+    expect(match?.answer).toBeNull();
+  });
+
+  it("does not fire on prose that merely contains the word trust", () => {
+    const screen = "I do not trust this test to be meaningful without a menu.\n";
+    expect(matchBlockingDialog(screen, specs)).toBeNull();
+  });
+
+  it("does not hand cursor-cli Claude Code's bypass-permissions screen", () => {
+    const screen = [
+      "Bypass Permissions mode",
+      "Do you want to proceed?",
+      "  1. No, exit",
+      "  2. Yes, I accept",
+    ].join("\n");
+    // Nothing in the cursor-cli spec list matches it — that screen is Claude
+    // Code's and stays Claude Code's.
+    expect(matchBlockingDialog(screen, specs)?.spec.id).not.toBe("bypass-permissions");
   });
 });
 

--- a/packages/core/src/__tests__/harness-prompt-delivery.test.ts
+++ b/packages/core/src/__tests__/harness-prompt-delivery.test.ts
@@ -193,6 +193,36 @@ const REAL_COMPOSER = readFileSync(
 );
 
 /**
+ * cursor-agent 2026.08.11-e8db854's Workspace Trust screen, in a fresh
+ * untrusted directory.
+ *
+ * **Provenance:** this is not a capture taken on this branch's machine —
+ * cursor-agent is not installed there. It is the screen pasted into the
+ * review of PR #272 by a reviewer who does have it installed and who took it
+ * off a live PTY; the two lines ending `…` are elided in that paste, and it
+ * carries no escape sequences because it arrived as text rather than as
+ * bytes. It is committed anyway, because the one thing it settles it settles
+ * conclusively and no amount of wording-independence in {@link
+ * BLOCKING_DIALOGS} could have settled it: **the menu is letter-keyed.**
+ *
+ * `[a] Trust this workspace` / `[q] Quit` is a menu {@link readDialogOptions}
+ * cannot read, because `OPTION_LINE` requires a digit followed by `.` or `)`.
+ * So the entry that gives cursor-cli `folder-trust` makes the dialog
+ * *recognised* — which is what routes it to the abandon path and a
+ * `needs-input` Session instead of a prompt typed into a trust dialog — and it
+ * does not make it *answerable*. Reading letter keys is issue #273.
+ *
+ * The synthesised numbered menu in the test above this one proves the digit
+ * path works and is worth keeping; what it cannot do is stand in for this,
+ * because it encodes an assumption about cursor-agent that this screen
+ * contradicts.
+ */
+const CURSOR_TRUST_DIALOG = readFileSync(
+  path.resolve(__dirname, "fixtures/cursor-agent-2026.08.11-folder-trust.txt"),
+  "utf8",
+);
+
+/**
  * OpenCode 1.18.18's boot, up to the point where issue 229's prompt was lost —
  * captured byte-for-byte from a live PTY (only the project path substituted).
  *
@@ -523,6 +553,37 @@ describe("cursor-agent's trust prompt (issue 177 finding 3)", () => {
   it("does not fire on prose that merely contains the word trust", () => {
     const screen = "I do not trust this test to be meaningful without a menu.\n";
     expect(matchBlockingDialog(screen, specs)).toBeNull();
+  });
+
+  it("recognises the real trust screen and answers nothing on it", () => {
+    // The fixture, not a synthesis. `matchBlockingDialog` fires — the widened
+    // nouns catch `workspace` and `directory` — and `readDialogOptions` comes
+    // back empty, because the menu offers `[a]` and `[q]` rather than `1.` and
+    // `2.`. That combination is the whole of what this entry buys cursor-cli
+    // today: the dialog is seen, so delivery abandons and the Session reports
+    // `needs-input`; the dialog is not answered, and cannot be until
+    // `readDialogOptions` learns letter keys (issue #273).
+    const match = matchBlockingDialog(CURSOR_TRUST_DIALOG, specs);
+    expect(match?.spec.id).toBe("folder-trust");
+    expect(readDialogOptions(CURSOR_TRUST_DIALOG)).toEqual([]);
+    expect(match?.answer).toBeNull();
+  });
+
+  it("replays the real screen into an abandoned delivery, writing nothing", () => {
+    // What the entry is actually worth, end to end, on bytes rather than on a
+    // description of them. Before this PR the same screen produced `settled` →
+    // `delivered` and typed the prompt and a carriage return into the trust
+    // dialog while reporting success; a `needs-input` Session is the honest
+    // outcome and this is the test that holds the line at it.
+    const h = startDelivery("refactor the picker", { harness: "cursor-cli" });
+    h.delivery.onOutput(CURSOR_TRUST_DIALOG);
+    h.clock.advance(PROFILE.maxWaitMs * 2);
+
+    expect(h.writes).toEqual([]);
+    expect(h.delivery.currentPhase).toBe("abandoned");
+    expect(h.events).toContainEqual({ phase: "dialog-unreadable", dialog: "folder-trust" });
+    expect(h.events.at(-1)).toEqual({ phase: "abandoned", reason: "blocked by folder-trust" });
+    expect(h.events.some((e) => e.phase === "delivered")).toBe(false);
   });
 
   it("does not hand cursor-cli Claude Code's bypass-permissions screen", () => {

--- a/packages/core/src/__tests__/harness-status-detection.test.ts
+++ b/packages/core/src/__tests__/harness-status-detection.test.ts
@@ -196,6 +196,20 @@ describe("harness status detection on the Core (issue 84)", () => {
     expect(rowStatus()).toBe("terminated");
   });
 
+  it("reports a Session parked on a dialog nobody answered as needs-input", async () => {
+    // Issue 177 finding 3. Prompt delivery abandons rather than guessing (ADR
+    // 0026 D5), and until now that decision was a log line on the Core: the
+    // row stayed where it was and every client saw a Session that looked hung.
+    // It is not hung — it is waiting on a human, which `needs-input` is the
+    // word for, and which is a settled status so an SDK `waitForIdle` stops.
+    const status = new CoreHarnessStatus({ writer });
+    await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
+    expect(rowStatus()).toBe("running");
+
+    status.outputSignal(TASK_ID, "dialog-unanswered");
+    expect(rowStatus()).toBe("needs-input");
+  });
+
   it("names an unnamed Session on the Core's own row, unpinned for a later rename", async () => {
     await postHook({
       hook_event_name: "UserPromptSubmit",

--- a/packages/core/src/__tests__/pty-spawn-policy.test.ts
+++ b/packages/core/src/__tests__/pty-spawn-policy.test.ts
@@ -299,6 +299,98 @@ describe("resolveSpawnPlan — agent allow-list", () => {
     }
   });
 
+  // ─── The other direction (issue 177 finding 2) ──────────────────────────
+  //
+  // The check used to run one way only: a flag without the option was
+  // rejected, an option without the flag passed. So a caller that set
+  // `dangerouslySkipPermissions` and built its command string from a
+  // Claude-shaped template got a spawn the Core accepted and an *interactive*
+  // harness — and nothing anywhere said auto mode had been asked for and not
+  // delivered. cursor-cli is where it bit, because cursor-cli is the harness
+  // whose flag nobody had transcribed; the defect is per-harness and so is the
+  // coverage below.
+
+  it("rejects auto mode asked for without the harness's flag, for every harness that has one", () => {
+    const cases: Array<{ agent: string; command: string }> = [
+      { agent: "claude-code", command: "claude" },
+      {
+        agent: "claude-code",
+        command: "claude --resume 00000000-0000-4000-8000-000000000000",
+      },
+      { agent: "codex", command: "codex --enable hooks" },
+      // The subcommand form too: `resume <id>` is stripped before the flags
+      // are checked, so a resumed Codex must not slip through on its shape.
+      {
+        agent: "codex",
+        command: "codex resume 019d7a0f-432a-7fa1-a821-b7841f983967 --enable hooks",
+      },
+      // The exact spawn from the issue's reproduction, minus the flag the
+      // client never added.
+      { agent: "cursor-cli", command: "cursor-agent" },
+      {
+        agent: "cursor-cli",
+        command: "cursor-agent --resume 00000000-0000-4000-8000-000000000000",
+      },
+    ];
+
+    for (const { agent, command } of cases) {
+      expectRejected(
+        spawnReq({ agent, command, dangerouslySkipPermissions: true }),
+        depsFor(),
+        "auto-mode-flag-missing",
+      );
+    }
+  });
+
+  it("names the missing flag in the message, because adding it is the caller's next move", () => {
+    let thrown: unknown;
+    try {
+      resolveSpawnPlan(
+        spawnReq({
+          agent: "cursor-cli",
+          command: "cursor-agent",
+          dangerouslySkipPermissions: true,
+        }),
+        depsFor(),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(String(thrown)).toContain("--force");
+  });
+
+  it("still launches OpenCode with the option set — it has no flag to be missing", () => {
+    // Not an exemption written into the check: `HARNESS_AUTO_MODE_FLAGS` holds
+    // null for opencode, and null means "this CLI ships no unattended mode".
+    // Refusing the launch would break a harness over a flag no version of it
+    // has ever had.
+    const plan = resolveSpawnPlan(
+      spawnReq({
+        agent: "opencode",
+        command: "opencode",
+        dangerouslySkipPermissions: true,
+      }),
+      depsFor(),
+    );
+    if (plan.mode !== "agent") throw new Error("wrong mode");
+    expect(plan.binary).toBe("/usr/local/bin/opencode");
+    expect(plan.argv).toEqual([]);
+  });
+
+  it("leaves a plain launch with no option and no flag alone", () => {
+    // The negative control on the negative control: closing one direction must
+    // not make "no auto mode anywhere" into an error.
+    for (const { agent, command } of [
+      { agent: "claude-code", command: "claude" },
+      { agent: "codex", command: "codex --enable hooks" },
+      { agent: "cursor-cli", command: "cursor-agent" },
+      { agent: "opencode", command: "opencode" },
+    ]) {
+      const plan = resolveSpawnPlan(spawnReq({ agent, command }), depsFor());
+      expect(plan.mode).toBe("agent");
+    }
+  });
+
   it("rejects unexpected positional args after allowed agent flags", () => {
     expectRejected(
       spawnReq({ agent: "codex", command: "codex --enable hooks exec bad" }),

--- a/packages/core/src/core-harness-status.ts
+++ b/packages/core/src/core-harness-status.ts
@@ -99,8 +99,18 @@ export class CoreHarnessStatus {
    * until the operator reviews them with `/hooks`. That is precisely the
    * moment the hooks cannot report, so the Session would sit on `running`
    * while it is in fact waiting on a human. `needs-input` says so.
+   *
+   * `dialog-unanswered` — prompt delivery gave up because a dialog was in the
+   * way that the Core could not read (ADR 0026 D5, issue 177 finding 3). The
+   * same shape as the one above and the same answer: a harness parked on a
+   * question nothing is going to answer for it is waiting on a human, and
+   * saying `needs-input` is the difference between a client showing a dialog
+   * to attend to and a client showing a Session that appears to have hung.
    */
-  outputSignal(taskId: string, signal: "interrupted" | "hooks-need-review"): void {
+  outputSignal(
+    taskId: string,
+    signal: "interrupted" | "hooks-need-review" | "dialog-unanswered",
+  ): void {
     if (!taskId) return;
     this.receiveHook(taskId, {
       hook_event_name:

--- a/packages/core/src/harness-prompt-delivery.ts
+++ b/packages/core/src/harness-prompt-delivery.ts
@@ -277,12 +277,28 @@ export type BlockingDialogMatch = {
  * Claude's option order and arbitrary for anyone else's"* — and a key this
  * module never hard-codes is a key it cannot get arbitrarily wrong.
  *
- * **What is not verified:** cursor-agent's trust screen has not been observed
- * by anyone who wrote this entry, and the patterns below are deliberately
- * wording-independent *because* of that rather than in spite of it. If they do
- * not match, the outcome is exactly today's — the dialog is not recognised —
- * with the abandon path above now making it visible. What they cannot produce
- * is a wrong keystroke.
+ * **What that buys cursor-cli, exactly.** Its trust screen has since been
+ * observed and is committed as
+ * `__tests__/fixtures/cursor-agent-2026.08.11-folder-trust.txt`. The nouns
+ * catch it — `workspace`, `directory`, question mark — so the dialog is
+ * *recognised*. It is not *answered*, and cannot be: cursor-agent's menu is
+ * letter-keyed (`[a] Trust this workspace` / `[q] Quit`), `OPTION_LINE`
+ * below requires a digit, so {@link readDialogOptions} returns an empty list
+ * and {@link chooseDialogOption} returns null. Every cursor-cli delivery that
+ * meets this screen abandons. That is the whole of the win and it is still a
+ * real one — before it, the prompt and a carriage return went into the trust
+ * dialog and the delivery reported success. Teaching the reader letter keys is
+ * issue 273; until it lands, "recognised" is the honest word for this row.
+ *
+ * **What recognition is not: a net under harnesses this table has never
+ * heard of.** An *unrecognised* dialog does not abandon. `onQuiet` finds no
+ * dialog, emits `settled`, and calls `writePrompt` — the prompt is typed into
+ * whatever is on screen, which is precisely what cursor-agent's trust screen
+ * got before it had a row here. The `needs-input` outcome exists **only
+ * because a pattern here matched**. Anyone adding a fifth harness should read that as: matching is
+ * the whole job; nothing downstream catches a dialog this table missed. What
+ * a wording-independent pattern buys is a match that cannot produce a *wrong
+ * keystroke*, not a match that is optional.
  */
 export const BLOCKING_DIALOGS: readonly BlockingDialogSpec[] = [
   {

--- a/packages/core/src/harness-prompt-delivery.ts
+++ b/packages/core/src/harness-prompt-delivery.ts
@@ -244,27 +244,62 @@ export type BlockingDialogMatch = {
  * The dialogs the Core knows how to get past.
  *
  * Both entries are the same shape and the same danger: the highlighted default
- * is the destructive one. Claude Code's folder-trust prompt defaults to
+ * is the destructive one, so nothing here is answered by pressing Enter. Claude Code's folder-trust prompt defaults to
  * declining and *exiting*, and its bypass-permissions warning — the screen a
  * session launched with `--dangerously-skip-permissions` lands on — does the
  * same. Auto mode on its own survives, because nothing types into it; a prompt
  * on its own survives, because there is no dialog in the way. The two together
  * were what died, and this table is why they no longer do.
  *
- * Both are scoped to `claude-code`, because both are transcriptions of *that*
- * harness's screens: the wording, the option labels and the fact that the
- * highlighted default exits were all read off Claude Code and nothing else.
- * Applying them to a harness nobody has observed would mean pressing a digit
- * into a menu on the strength of another vendor's layout, which is the guess
- * D5 exists to refuse. A harness with no entry here still gets the quiet gap,
- * the separate carriage return and the length-scaled pause; what it does not
- * get is Claude Code's answers to questions it was never asked.
+ * The bypass-permissions entry is scoped to `claude-code`, because it is a
+ * transcription of *that* harness's screen: the wording, the option labels and
+ * the fact that the highlighted default exits were all read off Claude Code
+ * and nothing else. Applying it to a harness nobody has observed would mean
+ * pressing a digit into a menu on the strength of another vendor's layout,
+ * which is the guess D5 exists to refuse. A harness with no entry here still
+ * gets the quiet gap, the separate carriage return and the length-scaled
+ * pause; what it does not get is Claude Code's answers to questions it was
+ * never asked.
+ *
+ * Folder-trust now covers `cursor-cli` as well (issue 177 finding 3), and the
+ * reason it can is that **nothing about Claude Code's menu is carried across
+ * with it**. What the entry supplies is three things that are true of any
+ * folder-trust prompt in any wording: that the word "trust" and a workspace
+ * noun and a question mark together mean one is up, that an option meaning
+ * "go ahead" is the one to take, and that an option meaning "no" is the one to
+ * never take. Everything harness-specific — how many options there are, what
+ * they are called, and *which digit* the affirmative one carries — is read off
+ * the screen in front of it by {@link readDialogOptions}, and if it cannot be
+ * read then {@link chooseDialogOption} returns null and D5 applies unchanged:
+ * nothing is typed, delivery is abandoned, and the Session is reported
+ * `needs-input` rather than left looking like a hang. The issue is explicit
+ * about the failure mode to avoid here — *"the key sent is `1`, correct for
+ * Claude's option order and arbitrary for anyone else's"* — and a key this
+ * module never hard-codes is a key it cannot get arbitrarily wrong.
+ *
+ * **What is not verified:** cursor-agent's trust screen has not been observed
+ * by anyone who wrote this entry, and the patterns below are deliberately
+ * wording-independent *because* of that rather than in spite of it. If they do
+ * not match, the outcome is exactly today's — the dialog is not recognised —
+ * with the abandon path above now making it visible. What they cannot produce
+ * is a wrong keystroke.
  */
 export const BLOCKING_DIALOGS: readonly BlockingDialogSpec[] = [
   {
     id: "folder-trust",
-    harnesses: ["claude-code"],
-    match: [/\btrust\b/i, /\b(folder|directory|files)\b/i, /\?/],
+    harnesses: ["claude-code", "cursor-cli"],
+    // `workspace|project|repo` join the nouns because they are what a vendor
+    // other than Anthropic is as likely to call the same thing. Widening the
+    // *nouns* rather than dropping the `trust` anchor keeps the pairing that
+    // makes this a dialog rather than prose: a paragraph containing the word
+    // "trust" still does not match without a question mark and a workspace
+    // noun, and even a full match answers nothing unless the menu below it
+    // offers exactly one "yes" and at least one "no".
+    match: [
+      /\btrust\b/i,
+      /\b(folder|directory|files|workspace|project|repo(?:sitory)?)\b/i,
+      /\?/,
+    ],
     affirmative: /\b(yes|proceed|trust|allow)\b/i,
     refuse: /\b(no|exit|quit|cancel|deny)\b/i,
   },

--- a/packages/core/src/pty-manager.ts
+++ b/packages/core/src/pty-manager.ts
@@ -146,7 +146,7 @@ export function hasCodexHookReviewPrompt(text: string): boolean {
 function reportOutputSignal(
   deps: PtyCoreDeps,
   taskId: string,
-  signal: "interrupted" | "hooks-need-review",
+  signal: "interrupted" | "hooks-need-review" | "dialog-unanswered",
 ): void {
   if (!taskId) return;
   try {
@@ -191,10 +191,21 @@ export type PtyCoreDeps = {
    * newly-installed hooks until the operator reviews them with `/hooks` — the
    * one moment its hooks provably cannot report. Both are read off the PTY
    * stream; each fires once per occurrence, not once per chunk.
+   *
+   * `dialog-unanswered` is the third and comes from prompt delivery rather
+   * than from a pattern in the bytes (issue 177 finding 3): the Core gave up
+   * on delivering the starting prompt because a dialog was in its way that it
+   * could not answer. ADR 0026 D5 is deliberate that it types nothing in that
+   * case — a session parked on a visible dialog is one keystroke from an
+   * operator being fine, and one that answered wrongly is gone — but until now
+   * the giving-up was a log line on the Core and nothing else. The Session sat
+   * at its pre-turn status, and to every client that is indistinguishable from
+   * a hang. It is not a hang: it is a harness waiting on a human, which is
+   * what `needs-input` means.
    */
   onSessionOutputSignal?: (info: {
     taskId: string;
-    signal: "interrupted" | "hooks-need-review";
+    signal: "interrupted" | "hooks-need-review" | "dialog-unanswered";
   }) => void;
   /**
    * This Session's harness is still talking (issue 243). Not a status and not
@@ -667,6 +678,15 @@ export class PtyCore {
               }
             },
             onEvent: ({ phase, ...detail }) => {
+              // Delivery gave up with something still on screen. Say so as a
+              // status and not only in the log (issue 177 finding 3): every
+              // client reads the Session's status, and none of them reads this
+              // process's log. `needs-input` is what it is — a harness waiting
+              // on a human — and it is a settled status, so an SDK
+              // `waitForIdle` stops waiting instead of waiting forever.
+              if (phase === "abandoned" && p.taskId) {
+                reportOutputSignal(this.deps, p.taskId, "dialog-unanswered");
+              }
               // A dialog's label is harness output, so it goes through the same
               // cleaner every other borrowed string in this file does.
               const safe = Object.fromEntries(

--- a/packages/sdk/src/__tests__/core-client.test.ts
+++ b/packages/sdk/src/__tests__/core-client.test.ts
@@ -151,7 +151,9 @@ describe("CoreClient", () => {
       c.replay("pty-1", 3),
     ]);
 
-    expect(spawned).toEqual({ ptyId: "pty-1" });
+    // `hooksReportTurnStart` rides on every spawn answer now (issue 177
+    // finding 4); this rig's Core omits it, and absent reads as false.
+    expect(spawned).toEqual({ ptyId: "pty-1", hooksReportTurnStart: false });
     expect(found).toEqual({ ptyId: "pty-1" });
     expect(replayed).toEqual({ data: "scrollback", nextSeq: 7, from: undefined });
     // Three questions, three distinct ids, and the Core answered each with the

--- a/packages/sdk/src/__tests__/core-link-mtls.test.ts
+++ b/packages/sdk/src/__tests__/core-link-mtls.test.ts
@@ -172,7 +172,7 @@ describe("Core client over mTLS", () => {
     expect(client.isAuthenticated()).toBe(true);
     await expect(
       client.spawn({ taskId: "t1", cwd: "/tmp", command: "claude", agent: "claude-code" }),
-    ).resolves.toEqual({ ptyId: "pty-1" });
+    ).resolves.toEqual({ ptyId: "pty-1", hooksReportTurnStart: false });
   }, 20_000);
 
   it("never authenticates without the pinned client cert — the handshake fails first", async () => {

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -244,6 +244,43 @@ describe("CoreSession.start", () => {
     );
   });
 
+  // ─── The turn-start signal (issue 177 finding 4) ──────────────────────
+  //
+  // The Core already answered this on `spawned` and the SDK threw it away, so
+  // an automation had no way to learn that its cursor-cli Session would sit at
+  // its pre-turn status for the whole of a turn that was genuinely running.
+
+  it("carries the Core's turn-start answer onto the Session", async () => {
+    rig = startRig({
+      spawn: (async () => ({ ptyId: "pty-1", hooksReportTurnStart: true })) as PtyCore["spawn"],
+    });
+    session = await startSession(rig);
+
+    expect(session.reportsTurnStart).toBe(true);
+  });
+
+  it("reports no turn-start when the Core says a harness does not report one", async () => {
+    // cursor-cli's answer today: the Core writes `.cursor/hooks.json` and
+    // cursor-agent never fires `beforeSubmitPrompt`.
+    rig = startRig({
+      spawn: (async () => ({ ptyId: "pty-1", hooksReportTurnStart: false })) as PtyCore["spawn"],
+    });
+    session = await startSession(rig, { harness: "cursor-cli" });
+
+    expect(session.reportsTurnStart).toBe(false);
+  });
+
+  it("reads a Core that answers nothing at all as no turn-start", async () => {
+    // The safe direction on an older Core: a redundant caveat, never a Session
+    // that silently looks idle for its whole life.
+    rig = startRig({
+      spawn: (async () => ({ ptyId: "pty-1" })) as unknown as PtyCore["spawn"],
+    });
+    session = await startSession(rig);
+
+    expect(session.reportsTurnStart).toBe(false);
+  });
+
   it("starts a Session with no prompt when none was given", async () => {
     rig = startRig();
     session = await startSession(rig, { prompt: undefined });

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -1085,8 +1085,33 @@ export class CoreClient {
 
   // ─── Typed frame methods ───────────────────────────────────────────────────
 
-  spawn(opts: CoreLinkPtySpawnOptions): Promise<{ ptyId: string }> {
-    return this.rpc({ type: "spawn", reqId: "", opts }) as Promise<{ ptyId: string }>;
+  /**
+   * Start a PTY on the Core and hand back its id and one fact about it.
+   *
+   * `hooksReportTurnStart` is the Core's answer for *this* Session: will a
+   * lifecycle hook announce the START of a turn, or only its end (issue 84,
+   * issue 177 finding 4)? It is narrower than "hooks were installed" —
+   * cursor-agent takes the hooks file and never fires `beforeSubmitPrompt`,
+   * and Codex will not run newly-installed hooks until the operator reviews
+   * them — so a Session can report a turn's end and never its start, which
+   * looks exactly like an idle Session to anything watching status.
+   *
+   * A Core too old to answer omits the field, and absent reads as `false`: a
+   * client that says "no turn-start signal here" about a Core that would have
+   * given one is a redundant sentence, and the other way round is a Session
+   * that silently looks idle for its whole life.
+   */
+  async spawn(
+    opts: CoreLinkPtySpawnOptions,
+  ): Promise<{ ptyId: string; hooksReportTurnStart: boolean }> {
+    const answer = (await this.rpc({ type: "spawn", reqId: "", opts })) as {
+      ptyId: string;
+      hooksReportTurnStart?: boolean;
+    };
+    return {
+      ptyId: answer.ptyId,
+      hooksReportTurnStart: answer.hooksReportTurnStart === true,
+    };
   }
 
   write(ptyId: string, data: string): Promise<boolean> {
@@ -1373,7 +1398,15 @@ export type CoreExecResult = {
 export function unwrapResponse(msg: CoreLinkResponseFrame): unknown {
   switch (msg.type) {
     case "spawned":
-      return { ptyId: msg.ptyId };
+      // `hooksReportTurnStart` comes through here rather than being dropped
+      // (issue 177 finding 4): it is the Core's only statement that this
+      // Session will report a turn's *start*, and a client that never sees it
+      // cannot tell a running cursor-cli Session from an idle one. Absent on
+      // an older Core, which reads as false.
+      return {
+        ptyId: msg.ptyId,
+        hooksReportTurnStart: msg.hooksReportTurnStart === true,
+      };
     case "spawnError":
       throw new Error(msg.message);
     case "writeResult":

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -82,19 +82,43 @@ export const HARNESS_LAUNCH_COMMANDS: Readonly<Record<CoreLinkPtySpawnHarness, s
 
 /**
  * Each harness's spelling of "do not stop to ask me", appended to the default
- * command when {@link CoreSessionOptions.dangerouslySkipPermissions} is set.
+ * command when {@link CoreSessionStartOptions.dangerouslySkipPermissions} is
+ * set.
  *
  * The option and the flag are two halves of one gesture and the Core checks
- * both: the flag is allow-listed only for a spawn that also set the option, so
- * setting one without the other is a rejected spawn rather than a quiet
- * downgrade. OpenCode has no such flag, and gets none.
+ * both **directions** of it (issue 177 finding 2): a flag with no option is a
+ * rejected spawn, and since that issue an option with no flag is one too. It
+ * used to be neither — the Core accepted the mismatch, launched an interactive
+ * harness, and let a caller that believed itself unattended sit on a permission
+ * prompt nobody was watching. So this table is not a convenience: it is the
+ * only thing standing between `dangerouslySkipPermissions: true` and a refused
+ * spawn, for every caller that does not pass its own `command`.
+ *
+ * OpenCode has no such flag, and `null` says so. That is a fact about the
+ * vendor's CLI rather than a gap here, and the Core reads it the same way — it
+ * is the one harness where the option is allowed to arrive with no flag behind
+ * it, because there is no flag to send.
+ *
+ * Exported because it is the answer to "what does auto mode look like for this
+ * harness", and a caller building its own command needs the same cell of the
+ * same table. Two transcriptions of a vendor fact is one more than can be kept
+ * in step; finding 1 of the same issue was that mistake in the binary column.
  */
-const HARNESS_SKIP_PERMISSION_FLAGS: Readonly<Record<CoreLinkPtySpawnHarness, string | null>> = {
+export const HARNESS_SKIP_PERMISSION_FLAGS: Readonly<
+  Record<CoreLinkPtySpawnHarness, string | null>
+> = {
   "claude-code": "--dangerously-skip-permissions",
   codex: "--yolo",
   "cursor-cli": "--force",
   opencode: null,
 };
+
+/** The flag that puts `harness` in auto mode, or null where it ships none. */
+export function harnessAutoModeFlag(
+  harness: CoreLinkPtySpawnHarness,
+): string | null {
+  return HARNESS_SKIP_PERMISSION_FLAGS[harness];
+}
 
 /**
  * The statuses that mean the harness has stopped and is waiting on a human.
@@ -255,6 +279,31 @@ export class CoreSession {
   readonly harness: CoreLinkPtySpawnHarness;
   /** The command the Core was asked to start, after defaulting. */
   readonly command: string;
+  /**
+   * Will anything move this Session to `running` when a turn begins (issue 84,
+   * issue 177 finding 4)?
+   *
+   * The Core's answer for this Session and not a property of the harness
+   * family: it depends on which hooks actually landed on that machine and on
+   * whether the vendor fires them. `false` today for `cursor-cli` — the Core
+   * writes `.cursor/hooks.json` and cursor-agent never fires
+   * `beforeSubmitPrompt` — and for `codex` until an operator reviews the newly
+   * installed hooks with `/hooks`. Both still report a turn's *end*.
+   *
+   * What that means for a caller: {@link waitForIdle} is unaffected, because it
+   * waits for a settled status and turn *end* is reported. What is missing is
+   * everything in between. A Session with `reportsTurnStart === false` will sit
+   * at its pre-turn status for the whole of a turn that is genuinely running,
+   * which is indistinguishable from a Session that never started — so a caller
+   * that shows progress, or that treats "not running" as "stuck", has to read
+   * this and say so rather than infer activity from a status that will not
+   * move. The Panel's answer is a terminal-input fallback; the `actana` CLI's
+   * is to print the asymmetry.
+   *
+   * `false` on a Core too old to answer, which is the safe direction: a
+   * redundant caveat, never a silently statusless Session.
+   */
+  readonly reportsTurnStart: boolean;
 
   private readonly client: CoreClient;
   private readonly terminal: TerminalScreen;
@@ -290,6 +339,7 @@ export class CoreSession {
     ptyId: string;
     harness: CoreLinkPtySpawnHarness;
     command: string;
+    reportsTurnStart: boolean;
     terminal: TerminalScreen;
   }) {
     this.client = opts.client;
@@ -297,6 +347,7 @@ export class CoreSession {
     this.ptyId = opts.ptyId;
     this.harness = opts.harness;
     this.command = opts.command;
+    this.reportsTurnStart = opts.reportsTurnStart;
     this.terminal = opts.terminal;
   }
 
@@ -330,7 +381,9 @@ export class CoreSession {
     }
     const cols = opts.cols ?? DEFAULT_COLS;
     const rows = opts.rows ?? DEFAULT_ROWS;
-    const command = opts.command ?? defaultLaunchCommand(opts.harness, opts.dangerouslySkipPermissions === true);
+    const command =
+      opts.command ??
+      harnessLaunchCommand(opts.harness, opts.dangerouslySkipPermissions === true);
 
     // The event log first: a subscribe sent after the spawn could miss the
     // status change of a harness that answered before this side asked.
@@ -384,7 +437,7 @@ export class CoreSession {
       session.onCoreEvent(event);
     });
 
-    let spawned: { ptyId: string };
+    let spawned: { ptyId: string; hooksReportTurnStart: boolean };
     try {
       spawned = await client.spawn({
         taskId,
@@ -419,6 +472,7 @@ export class CoreSession {
       ptyId: spawned.ptyId,
       harness: opts.harness,
       command,
+      reportsTurnStart: spawned.hooksReportTurnStart,
       terminal,
     });
     session.unsubscribes.push(stopData, stopExit, stopEvents);
@@ -749,8 +803,24 @@ export class CoreSession {
   }
 }
 
-/** The launch command for a harness nobody named one for. */
-function defaultLaunchCommand(
+/**
+ * The launch command a Session gets when its caller named none — the whole of
+ * it, auto-mode flag included.
+ *
+ * Exported because it is the one answer to "what will `start` actually run",
+ * and issue 177 is what happens when that question has two answers. Both
+ * halves of the command come out of the same tables the Core validates against
+ * ({@link HARNESS_LAUNCH_COMMANDS} for the binary, which is `cursor-agent` and
+ * not `cursor-cli`; {@link HARNESS_SKIP_PERMISSION_FLAGS} for the flag), so a
+ * test can put this straight through the Core's `resolveSpawnPlan` and find
+ * out rather than reason about it.
+ *
+ * `skipPermissions` is the caller's request, not a promise about the result:
+ * OpenCode has no such flag and so gets none, which the Core accepts, and
+ * every other harness gets the one it spells auto mode with, which the Core
+ * now *requires* whenever the option is set.
+ */
+export function harnessLaunchCommand(
   harness: CoreLinkPtySpawnHarness,
   skipPermissions: boolean,
 ): string {

--- a/packages/shared/src/__tests__/harness-cli-config.test.ts
+++ b/packages/shared/src/__tests__/harness-cli-config.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  HARNESS_AUTO_MODE_FLAGS,
   HARNESS_CLI_CONFIG,
   HARNESS_SPAWN_COMMANDS,
+  assertAutoModeFlagsSync,
   assertHarnessCliRegistrySync,
+  autoModeFlagForHarness,
   pathLookupCandidates,
   resolveHarnessCliInstallCommand,
   resolveHarnessCliUpdateCommands,
 } from "../harness-cli-config";
-import { HARNESS_REGISTRY } from "../harnesses";
+import {
+  HARNESS_REGISTRY,
+  harnessSkipPermissionsFlag,
+  harnessSupportsSkipPermissions,
+} from "../harnesses";
 
 describe("Harness config", () => {
   it("stays in sync with HARNESS_REGISTRY command names", () => {
@@ -18,6 +25,66 @@ describe("Harness config", () => {
     for (const [agent, config] of Object.entries(HARNESS_CLI_CONFIG)) {
       expect(HARNESS_SPAWN_COMMANDS[agent as keyof typeof HARNESS_SPAWN_COMMANDS]).toBe(config.command);
     }
+  });
+
+  // ─── Auto mode is one fact (issue 177 finding 2) ────────────────────────
+  //
+  // Finding 1 was a table that agreed with the Core about three harnesses out
+  // of four, in the binary column. The flag column had the same shape and a
+  // worse failure: a wrong flag is a rejected spawn, a missing one used to be
+  // an interactive harness a caller believed was unattended.
+
+  it("names each harness's auto-mode flag, and OpenCode's absence of one", () => {
+    expect(HARNESS_AUTO_MODE_FLAGS["claude-code"]).toBe("--dangerously-skip-permissions");
+    expect(HARNESS_AUTO_MODE_FLAGS.codex).toBe("--yolo");
+    // The flag the client never sent, which is the whole of finding 2.
+    expect(HARNESS_AUTO_MODE_FLAGS["cursor-cli"]).toBe("--force");
+    // `null` is a fact about the vendor's CLI, not an unfilled cell.
+    expect(HARNESS_AUTO_MODE_FLAGS.opencode).toBeNull();
+  });
+
+  it("derives that table from the config rather than restating it", () => {
+    for (const [agent, config] of Object.entries(HARNESS_CLI_CONFIG)) {
+      expect(autoModeFlagForHarness(agent as keyof typeof HARNESS_AUTO_MODE_FLAGS)).toBe(
+        config.autoModeFlag ?? null,
+      );
+    }
+  });
+
+  it("keeps HARNESS_REGISTRY's flag and its support boolean on the same fact", () => {
+    expect(() =>
+      assertAutoModeFlagsSync(
+        Object.fromEntries(
+          Object.entries(HARNESS_REGISTRY).map(([agent, meta]) => [
+            agent,
+            meta.skipPermissionsFlag ?? null,
+          ]),
+        ) as Record<keyof typeof HARNESS_REGISTRY, string | null>,
+      ),
+    ).not.toThrow();
+
+    for (const agent of Object.keys(HARNESS_REGISTRY) as Array<
+      keyof typeof HARNESS_REGISTRY
+    >) {
+      // "Supports auto mode" can only mean "has a flag for it". A `true` next
+      // to a missing flag is the mismatch the Core now refuses at spawn.
+      expect(harnessSupportsSkipPermissions(agent)).toBe(
+        harnessSkipPermissionsFlag(agent) !== null,
+      );
+    }
+  });
+
+  it("throws on drift rather than letting a second table quietly disagree", () => {
+    expect(() =>
+      assertAutoModeFlagsSync({
+        "claude-code": "--dangerously-skip-permissions",
+        codex: "--yolo",
+        // The bug, written out: a table that thinks cursor-cli spells auto
+        // mode the way Claude Code does.
+        "cursor-cli": "--dangerously-skip-permissions",
+        opencode: null,
+      }),
+    ).toThrow(/cursor-cli/);
   });
 
   it("resolves Cursor CLI via agent alias candidates", () => {

--- a/packages/shared/src/harness-cli-config.ts
+++ b/packages/shared/src/harness-cli-config.ts
@@ -56,6 +56,19 @@ export type HarnessCliConfig = {
   installCommand: HarnessCliInstallCommand;
   /** Extra directories under the user home dir to prepend on PATH when they exist. */
   homePathSuffixes?: HarnessCliPathSuffixes;
+  /**
+   * This CLI's own spelling of "do not stop to ask me" — the flag that turns a
+   * launch into an unattended one (issue 177 finding 2).
+   *
+   * Absent means the vendor ships no such flag, which is a different fact from
+   * "we have not filled this in": OpenCode has none, so a caller asking for
+   * auto mode there is asking for something that does not exist rather than
+   * something that was dropped. Every other consumer of this idea — the spawn
+   * policy's allow-list, the Panel's launch builder, the SDK's default command
+   * — reads it from here, because four transcriptions of one vendor fact is
+   * four chances to disagree about it.
+   */
+  autoModeFlag?: string;
 };
 
 export const MANAGED_HARNESSES = HARNESSES;
@@ -81,6 +94,7 @@ export const HARNESS_CLI_CONFIG = {
       default: "curl -fsSL https://claude.ai/install.sh | bash",
       win32: "irm https://claude.ai/install.ps1 | iex",
     },
+    autoModeFlag: "--dangerously-skip-permissions",
   }),
   codex: withResolveAs({
     agent: "codex",
@@ -95,6 +109,7 @@ export const HARNESS_CLI_CONFIG = {
       darwin: ["npm install -g @openai/codex@latest", "brew upgrade codex"],
     },
     installCommand: "npm install -g @openai/codex@latest",
+    autoModeFlag: "--yolo",
   }),
   "cursor-cli": withResolveAs({
     agent: "cursor-cli",
@@ -112,6 +127,7 @@ export const HARNESS_CLI_CONFIG = {
       default: "curl https://cursor.com/install -fsS | bash",
       win32: "irm 'https://cursor.com/install?win32=true' | iex",
     },
+    autoModeFlag: "--force",
   }),
   opencode: withResolveAs({
     agent: "opencode",
@@ -272,6 +288,46 @@ export function resolveHarnessCliUpdateCommands(
 export const HARNESS_SPAWN_COMMANDS = Object.fromEntries(
   MANAGED_HARNESSES.map((agent) => [agent, HARNESS_CLI_CONFIG[agent].command]),
 ) as Readonly<Record<Harness, string>>;
+
+/**
+ * Each harness's auto-mode flag, or `null` where the vendor ships none.
+ *
+ * The one home for {@link HarnessCliConfig.autoModeFlag}, derived rather than
+ * re-typed so a new harness cannot arrive with the table half-filled. `null` is
+ * load-bearing everywhere this is read: it means "this CLI has no unattended
+ * mode", not "nobody has looked it up yet", and it is why OpenCode is neither
+ * given a flag nor refused a launch.
+ */
+export const HARNESS_AUTO_MODE_FLAGS = Object.fromEntries(
+  MANAGED_HARNESSES.map((agent) => [agent, HARNESS_CLI_CONFIG[agent].autoModeFlag ?? null]),
+) as Readonly<Record<Harness, string | null>>;
+
+/** The flag that puts `agent` in auto mode, or null where it has none. */
+export function autoModeFlagForHarness(agent: Harness): string | null {
+  return HARNESS_AUTO_MODE_FLAGS[agent];
+}
+
+/**
+ * Throw when a registry's auto-mode flags have drifted from this table.
+ *
+ * The sibling of {@link assertSpawnCommandsSync}, for the second half of a
+ * launch command. Issue 177 finding 1 was the binary half of exactly this drift
+ * — a table that agreed with the Core about three harnesses out of four — and
+ * the flag half is worse, because it fails silently rather than at spawn.
+ */
+export function assertAutoModeFlagsSync(
+  autoModeFlags: Record<Harness, string | null | undefined>,
+): void {
+  for (const agent of MANAGED_HARNESSES) {
+    const expected = HARNESS_AUTO_MODE_FLAGS[agent];
+    const actual = autoModeFlags[agent] ?? null;
+    if (actual !== expected) {
+      throw new Error(
+        `Auto-mode flag drift for ${agent}: registry=${actual}, config=${expected}`,
+      );
+    }
+  }
+}
 
 export function assertHarnessCliRegistrySync(registry: Record<Harness, { command: string }>): void {
   for (const agent of MANAGED_HARNESSES) {

--- a/packages/shared/src/harnesses.ts
+++ b/packages/shared/src/harnesses.ts
@@ -1,5 +1,5 @@
 import type { Harness } from "./domain";
-import { HARNESS_CLI_CONFIG } from "./harness-cli-config";
+import { HARNESS_AUTO_MODE_FLAGS, HARNESS_CLI_CONFIG } from "./harness-cli-config";
 
 export type HarnessRegistryEntry = {
   label: string;
@@ -10,6 +10,12 @@ export type HarnessRegistryEntry = {
   uiVisible: boolean;
   disabled?: boolean;
   supportsSkipPermissions: boolean;
+  /**
+   * Read from {@link HARNESS_AUTO_MODE_FLAGS}, never typed out here.
+   *
+   * Issue 177 finding 2 was one table disagreeing with another about which
+   * flag a harness spells auto mode with; the fix is that there is one table.
+   */
   skipPermissionsFlag?: string;
   startCommand: (opts?: { skipPermissions?: boolean }) => string;
   titleInvocation?: (input: string) => { cmd: string; args: string[] };
@@ -24,7 +30,7 @@ export const HARNESS_REGISTRY: Record<Harness, HarnessRegistryEntry> = {
     command: HARNESS_CLI_CONFIG["claude-code"].command,
     uiVisible: true,
     supportsSkipPermissions: true,
-    skipPermissionsFlag: "--dangerously-skip-permissions",
+    skipPermissionsFlag: HARNESS_AUTO_MODE_FLAGS["claude-code"] ?? undefined,
     startCommand: () => "claude",
     titleInvocation: (input) => ({ cmd: "claude", args: ["-p", input] }),
   },
@@ -36,7 +42,7 @@ export const HARNESS_REGISTRY: Record<Harness, HarnessRegistryEntry> = {
     command: HARNESS_CLI_CONFIG.codex.command,
     uiVisible: true,
     supportsSkipPermissions: true,
-    skipPermissionsFlag: "--yolo",
+    skipPermissionsFlag: HARNESS_AUTO_MODE_FLAGS["codex"] ?? undefined,
     startCommand: (opts) =>
       opts?.skipPermissions
         ? "codex --enable hooks --yolo"
@@ -51,7 +57,7 @@ export const HARNESS_REGISTRY: Record<Harness, HarnessRegistryEntry> = {
     command: HARNESS_CLI_CONFIG["cursor-cli"].command,
     uiVisible: true,
     supportsSkipPermissions: true,
-    skipPermissionsFlag: "--force",
+    skipPermissionsFlag: HARNESS_AUTO_MODE_FLAGS["cursor-cli"] ?? undefined,
     startCommand: (opts) => (opts?.skipPermissions ? "cursor-agent --force" : "cursor-agent"),
     titleInvocation: (input) => ({ cmd: "cursor-agent", args: ["-p", input] }),
   },
@@ -72,8 +78,27 @@ export const UI_HARNESSES = Object.entries(HARNESS_REGISTRY)
   .filter(([, meta]) => meta.uiVisible)
   .map(([id]) => id as Harness);
 
+/**
+ * Does this Harness have an auto mode at all?
+ *
+ * Answered by whether the vendor ships a flag for it, which is the only thing
+ * the question can mean. Reading the registry's own boolean instead would let
+ * a `true` sit next to a missing flag — the launch builder would put nothing
+ * in the command, the spawn descriptor would still declare the intent, and the
+ * mismatch would be the one issue 177 finding 2 describes.
+ */
 export const harnessSupportsSkipPermissions = (agent: Harness) =>
-  HARNESS_REGISTRY[agent].supportsSkipPermissions;
+  HARNESS_AUTO_MODE_FLAGS[agent] !== null;
+
+/**
+ * The flag this Harness spells auto mode with, or null where it has none.
+ *
+ * The registry's re-export of {@link HARNESS_AUTO_MODE_FLAGS}, for callers
+ * already holding a registry entry. Same cell, same table — see issue 177
+ * finding 2 for what the alternative cost.
+ */
+export const harnessSkipPermissionsFlag = (agent: Harness): string | null =>
+  HARNESS_AUTO_MODE_FLAGS[agent];
 
 /**
  * Does a session launched for this Harness carry its skip-permissions flag?

--- a/packages/shared/src/pty-spawn-policy.ts
+++ b/packages/shared/src/pty-spawn-policy.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { HARNESS_SPAWN_COMMANDS } from "./harness-cli-config";
+import { HARNESS_AUTO_MODE_FLAGS, HARNESS_SPAWN_COMMANDS } from "./harness-cli-config";
 import { isAiModelId } from "./ai-runtime-defaults";
 import type { Harness } from "./domain";
 import { buildCmdScriptCommand, isWindowsCommandScript } from "./windows-cmd";
@@ -176,43 +176,84 @@ export type SpawnPolicyErrorCode =
   | "shell-with-agent"
   | "shell-meta-in-args"
   | "agent-arg-not-allowed"
+  | "auto-mode-flag-missing"
   | "empty-command";
 
 const SHELL_META = /[`$();&|<>"'\\\n\r\t*?{}[\]~#!]/;
 
 type HarnessArgRule = {
   value: false | { allowed?: readonly string[] };
+  /**
+   * This flag IS the harness's auto-mode flag, so it travels with the
+   * `dangerouslySkipPermissions` spawn option — in **both** directions. See
+   * {@link validateHarnessArgv}.
+   */
   requiresDangerouslySkipPermissions?: boolean;
   /** When set, string arg values must start with this prefix (OpenCode session ids). */
   valuePrefix?: string;
 };
 
-const HARNESS_ARG_RULES: Readonly<Record<HarnessSpawn, Readonly<Record<string, HarnessArgRule>>>> = {
+/**
+ * Everything a harness may be launched with **except** its auto-mode flag.
+ *
+ * That one flag is not written here on purpose (issue 177 finding 2). It used
+ * to be, once per harness, which made this table the fourth transcription of a
+ * vendor fact the registry already held — and the id/binary coincidence that
+ * hid finding 1 for so long was the same shape of mistake one column over.
+ * {@link withAutoModeFlags} splices it in from
+ * {@link HARNESS_AUTO_MODE_FLAGS}, so a harness whose flag changes changes it
+ * in one place and a harness that has none (OpenCode) grows no entry at all.
+ */
+const HARNESS_ARG_RULES_BASE: Readonly<
+  Record<HarnessSpawn, Readonly<Record<string, HarnessArgRule>>>
+> = {
   "claude-code": {
     "--bare": { value: false },
     "--session-id": { value: {} },
     "--resume": { value: {} },
     "--model": { value: {} },
-    "--dangerously-skip-permissions": {
-      value: false,
-      requiresDangerouslySkipPermissions: true,
-    },
   },
   codex: {
     "--model": { value: {} },
     "--enable": { value: { allowed: ["hooks"] } },
-    "--yolo": { value: false, requiresDangerouslySkipPermissions: true },
   },
   "cursor-cli": {
     "--resume": { value: {} },
     "--model": { value: {} },
-    "--force": { value: false, requiresDangerouslySkipPermissions: true },
   },
   opencode: {
     "--model": { value: {} },
     "--session": { value: {}, valuePrefix: "ses" },
   },
 };
+
+function withAutoModeFlags(
+  base: Readonly<Record<HarnessSpawn, Readonly<Record<string, HarnessArgRule>>>>,
+): Readonly<Record<HarnessSpawn, Readonly<Record<string, HarnessArgRule>>>> {
+  return Object.fromEntries(
+    Object.entries(base).map(([agent, rules]) => {
+      const flag = HARNESS_AUTO_MODE_FLAGS[agent as HarnessSpawn];
+      if (flag === null) return [agent, rules];
+      return [
+        agent,
+        { ...rules, [flag]: { value: false, requiresDangerouslySkipPermissions: true } },
+      ];
+    }),
+  ) as Readonly<Record<HarnessSpawn, Readonly<Record<string, HarnessArgRule>>>>;
+}
+
+const HARNESS_ARG_RULES = withAutoModeFlags(HARNESS_ARG_RULES_BASE);
+
+/**
+ * The flag that puts `agent` into auto mode, or null where the vendor ships
+ * none.
+ *
+ * Re-exported from the harness registry so a caller building a spawn command
+ * and the policy validating it are reading the same cell of the same table.
+ */
+export function autoModeFlagForSpawn(agent: HarnessSpawn): string | null {
+  return HARNESS_AUTO_MODE_FLAGS[agent];
+}
 
 function windowsCmdExe(deps: SpawnPolicyDeps): string {
   const root = deps.windowsSystemRoot?.() ?? process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
@@ -287,12 +328,43 @@ function validateCodexArgv(
   validateHarnessArgv("codex", argv, opts);
 }
 
+/**
+ * Check one harness's argv against its allow-list, in **both** directions of
+ * the auto-mode gesture.
+ *
+ * The option (`dangerouslySkipPermissions`) and the flag (`--force`, `--yolo`,
+ * `--dangerously-skip-permissions`) are two halves of one request, and until
+ * issue 177 only one half was checked: a flag with no option was rejected, an
+ * option with no flag passed. That asymmetry is what made finding 2 invisible.
+ * A caller that set the option and built its command string from a
+ * Claude-shaped template got a Core that accepted the spawn, launched an
+ * *interactive* cursor-agent, and reported nothing unusual — the session then
+ * parked on a permission prompt that the caller, believing itself unattended,
+ * was not watching for. A rejected spawn says so in one line at the point of
+ * the mistake.
+ *
+ * The one harness this cannot be asked of is OpenCode, which ships no such
+ * flag: {@link HARNESS_AUTO_MODE_FLAGS} holds `null` for it, and asking for
+ * auto mode there is asking for something that does not exist rather than
+ * something that was dropped on the way. Refusing that launch would break the
+ * harness over a flag no version of it has ever had, so the option is allowed
+ * to be a no-op there and *only* there — which is a fact of the table, not a
+ * special case in this function.
+ *
+ * `argv` here is the flags only. `validateCodexArgv` strips the `resume <id>`
+ * subcommand before calling in, and the auto-mode flag is a flag either way, so
+ * a resumed Codex session is checked exactly like a fresh one.
+ */
 function validateHarnessArgv(
   agent: HarnessSpawn,
   argv: string[],
   opts: { dangerouslySkipPermissions: boolean },
 ): void {
   const rules = HARNESS_ARG_RULES[agent];
+  // Collected as the loop consumes argv rather than scanned for afterwards: a
+  // flag token and a flag-shaped *value* are different things, and only the
+  // loop knows which is which.
+  let sawAutoModeFlag = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]!;
     const rule = rules[arg];
@@ -302,11 +374,14 @@ function validateHarnessArgv(
         `pty:spawn rejected unsupported ${agent} argument`,
       );
     }
-    if (rule.requiresDangerouslySkipPermissions && !opts.dangerouslySkipPermissions) {
-      throw new SpawnPolicyError(
-        "agent-arg-not-allowed",
-        `pty:spawn rejected unsupported ${agent} argument`,
-      );
+    if (rule.requiresDangerouslySkipPermissions) {
+      if (!opts.dangerouslySkipPermissions) {
+        throw new SpawnPolicyError(
+          "agent-arg-not-allowed",
+          `pty:spawn rejected unsupported ${agent} argument`,
+        );
+      }
+      sawAutoModeFlag = true;
     }
     if (rule.value === false) continue;
 
@@ -324,6 +399,18 @@ function validateHarnessArgv(
       );
     }
     i += 1;
+  }
+
+  // The other direction, and the reason this function exists in the shape it
+  // does. The message names the flag because the caller's next move is to add
+  // it, and a code that only said "not allowed" would send them looking at the
+  // args they *did* send.
+  const autoModeFlag = HARNESS_AUTO_MODE_FLAGS[agent];
+  if (opts.dangerouslySkipPermissions && autoModeFlag !== null && !sawAutoModeFlag) {
+    throw new SpawnPolicyError(
+      "auto-mode-flag-missing",
+      `pty:spawn asked for ${agent} auto mode without ${autoModeFlag} in the command`,
+    );
   }
 }
 


### PR DESCRIPTION
Closes the four failure points in #177 that this repository can close, plus the
enabling defect under finding 2 that the issue calls out as *"squarely
`actana/control`'s"*.

## The issue is out of date in one place, and this PR translates it

#177 splits the work into a "client" half in `experiment/src/commands/session.ts`
— *"out of this repo, unversioned scratch tooling"* — and a "repo" half in
`packages/shared` and `packages/panel`. That split no longer exists. `experiment/`
was retired on 2026-08-19 and its successor is `packages/cli` in this repository,
published as `@actana/cli`. **Findings 1, 2, 3 and 5 are therefore all in scope
here**, and none of them is left unfixed on the grounds that the issue assigned
them elsewhere.

Findings 1, 2 (client half) and 5 turned out to have landed already with the CLI
and SDK extraction, exactly as the issue's own follow-up comment records. This PR
does not re-fix them — it **proves** them, against the Core's own spawn policy,
in `packages/cli/src/__tests__/cursor-cli-drivable.test.ts`. See the verification
table below for which claims are run and which are read.

## What changed, by finding

### 1 — argv[0] is the canonical binary, never the harness id

Already true (`HARNESS_LAUNCH_COMMANDS["cursor-cli"] === "cursor-agent"`), and now
tested. The new suite pushes the command this client would actually send through
`resolveSpawnPlan` — the same function `packages/core` calls before spawning —
for **every** harness rather than for cursor-cli alone, because codex and
opencode passed the old client by the id/binary coincidence and a table that is
right only by luck is a table that will drift.

### 2 — auto mode reaches the harness, or the spawn is refused

The client half was already right. The repo-side enabling defect was not:
`validateHarnessArgv` checked the gesture in one direction only, so a flag with
no option was rejected and **an option with no flag passed silently**. The Core
launched an interactive cursor-agent while the caller believed the session was
unattended.

`packages/shared/src/pty-spawn-policy.ts` now rejects that with a new
`auto-mode-flag-missing` code whose message names the missing flag. OpenCode
still launches with the option set — it ships no auto-mode flag at all, which is
a `null` in the table rather than a carve-out in the check.

The flag also gets one home. `HARNESS_AUTO_MODE_FLAGS` is derived from
`HARNESS_CLI_CONFIG`; `HARNESS_ARG_RULES`, `HARNESS_REGISTRY` and the CLI's
`harnessResumeCommand` now read it instead of restating it. That was four
transcriptions of one vendor fact — the same drift finding 1 was, one column
over — with `assertAutoModeFlagsSync` to catch a fifth.

### 3 — the trust dialog is now *recognised*, and that is all it is

**Restated after review.** An earlier version of this section, and of commit
`e9eceae`'s subject, said the dialog is *answered*. Against the real harness it
is not. The reviewer has `cursor-agent 2026.08.11-e8db854` installed, captured
its trust screen off a live PTY in a fresh untrusted directory and put it
through this branch:

```
│  ⚠  Workspace Trust Required                                  │
│  Cursor Agent can execute code and access files in this dir…  │
│  Do you trust the contents of this directory?                 │
│  ▶ [a] Trust this workspace                                   │
│    [q] Quit                                                   │
│  Use arrow keys to navigate, Enter to select, or press the …  │
```

The menu is **letter-keyed**. `OPTION_LINE` requires a digit followed by `.` or
`)`, so `readDialogOptions` returns `[]`, `chooseDialogOption` returns `null`,
and `answer` is always null on this screen. The `folder-trust` row cannot answer
the dialog it was added for. **Answering it needs a menu reader this module does
not have, which is now [#273](https://github.com/actana/control/issues/273)** —
filed, not implied as done, and not implemented here.

What the row *does* buy is the whole of the criterion's second branch, and it is
real. `matchBlockingDialog` fires on that screen — the widened nouns catch
`workspace` and `directory` — so delivery takes the abandon path instead of the
delivery path. Replayed on the same captured bytes:

| | events | writes into the PTY |
| --- | --- | --- |
| before this PR | `settled` → `delivered` | the prompt, then `"\r"` — typed straight into the trust dialog, reported as a successful delivery |
| this branch | `dialog-unreadable` → `abandoned` | **none** |

A silently-wrong `delivered` became an honest `needs-input`. D5 is honoured and
no arbitrary key is pressed — the issue's *"the key sent is `1`, correct for
Claude's option order and arbitrary for anyone else's"* is avoided by never
hard-coding a key at all. The nouns widen to `workspace`, `project`, `repo` for
the same reason, and ADR 0026 D5 is what makes widening safe: a menu that does
not parse yields no answer, and no answer means no keystroke.

**The screen is now a fixture.** `packages/core/src/__tests__/fixtures/cursor-agent-2026.08.11-folder-trust.txt`,
as bytes, next to the opencode and Claude Code captures. **Its provenance is the
review of this PR, not a run on the branch author's machine** — cursor-agent is
not installed there, which is exactly how the wrong claim survived to review.
Two tests hold it: `answer` is null at the reader, and the whole delivery
replays to `dialog-unreadable` → `abandoned` with no writes and no `delivered`.
The synthesised numbered menu stays, because it proves the digit path works, but
it encoded an assumption about cursor-agent that the real screen contradicts.

**Two records corrected.** The module's "what is not verified" note and ADR
0026's issue 177 amendment both said an unmatched dialog gets today's outcome
"with the abandon path now making it visible". That is false, and load-bearing
for D7: an **unrecognised** dialog never reaches the abandon path — `onQuiet`
finds no dialog, emits `settled`, calls `writePrompt`, and the prompt is typed
into whatever is on screen. The `needs-input` net exists **only because a
pattern matched**. Whoever adds the fifth harness would have read the old
sentence as "matching is optional, the net catches it either way."

The **bypass-permissions** entry stays scoped to `claude-code`. `Bypass
Permissions mode` is Claude Code's phrase and that screen is Claude Code's screen.

Under it, the safety net itself. D5 says the Core types nothing into a dialog it
cannot read and abandons delivery; that decision was a
`pty.prompt-delivery.abandoned` log line on the Core and **nothing else**, so
every client saw a Session at its pre-turn status with no way to tell it from a
hang. It is now an output signal mapping to `needs-input` — the same route
Codex's hook-review prompt already takes. Nothing about the decision changed,
only whether anybody is told. `needs-input` is a settled status, so an SDK
`waitForIdle` on an abandoned Session returns instead of waiting forever.

### 4 — no turn-start signal

The Core already answers `hooksReportTurnStart` on `spawned`, and the SDK was
**dropping it in `unwrapResponse`**. It now reaches `CoreSession.reportsTurnStart`
and, through the gateway, `actana session start` / `session resume`:

```
$ actana session start web "refactor the picker" --harness cursor-cli
Started cursor-cli in web — session task_x, pty pty_x.
Note: cursor-cli does not report the start of a turn, so this session will not
show as running until it stops. `--wait` and `session logs` are unaffected.
```

A statement rather than a fallback, deliberately. The Panel can watch keystrokes
because it owns the pane; `session start` hands the prompt over and hangs up
(#129 D6), so there are none here to watch, and writing `running` on its own
would be a status the Core never decided. `--json` carries `reportsTurnStart` as
a field, because a script deciding whether a quiet status means "still working"
or "never started" cannot parse a sentence off stderr.

### 5 — resume is no longer claude-code-only

Already true; `harnessResumeCommand` covers all four and the existing suite runs
each through `resolveSpawnPlan`. Changed here only to stop spelling the auto-mode
flags itself.

## Verified vs. read

**cursor-agent is not installed on this machine.** Nothing below claims a live
cursor-agent run, and the two rows that would need one say so.

| Finding | How | What was actually run |
| --- | --- | --- |
| 1 — wrong binary | **Run** | `cursor-cli-drivable.test.ts` puts `harnessLaunchCommand(h, …)` through the Core's real `resolveSpawnPlan` for all four harnesses and asserts the resolved binary per harness. A command starting with the id fails it. |
| 2 — option with no flag | **Run** | `pty-spawn-policy.test.ts` — six spawns across all three flag-bearing harnesses, fresh and resumed, each rejected `auto-mode-flag-missing`; opencode still resolves; the message names `--force`. Plus the negative control that a plain launch is untouched. |
| 2 — flag delivered | **Run** | Same suite: the flag is asserted **in `plan.argv`**, not just in the string, for every harness that has one. |
| 3 — matcher recognises the prompt | **Run against cursor-agent's real screen** | `matchBlockingDialog` fires on the committed fixture, `readDialogOptions` returns `[]`, `answer` is `null`, and the whole delivery replays to `dialog-unreadable` → `abandoned` with no writes. Recognised, **not answered** — the menu is letter-keyed and the reader takes digits (#273). The screen came from this PR's review, on a machine with cursor-agent installed; it was not captured here. The synthesised reversed-order menu is still run alongside it and still returns option `2`. |
| 3 — unanswered dialog is not a hang | **Run at the status layer, read at the wiring** | `CoreHarnessStatus.outputSignal(task, "dialog-unanswered")` is run and asserted to move a `running` row to `needs-input`. The one line in `pty-manager.ts` that calls it on `phase === "abandoned"` is **read, not run** — it lives inside `PtyCore.spawn`'s delivery callback and there is no PTY-spawning delivery test to hang it off. It is typechecked and one branch long. |
| 4 — turn-start reaches a client | **Run** | SDK: three cases over a real `PtyCoreLinkServer` (Core says yes / no / says nothing). CLI: the note appears for a harness that reports none, does **not** appear for one that does, and rides in `--json`. |
| 5 — resume | **Run** | Pre-existing `harness-resume.test.ts` sweeps all four harnesses through `resolveSpawnPlan`, auto mode on and off. |
| `--model` never dropped silently | **Run** | `actana session start web go --model composer-2.5` → `actana: unknown flag --model.`, exit 2. Both as a test and by hand against the built binary. |

Test counts, per package, run explicitly rather than through `pnpm -r` (which
bails on the first failing package, and `packages/cli` sorts before
`packages/core`):

| Package | Before | After |
| --- | --- | --- |
| `@actana/shared` | 184 passed | **188 passed** |
| `@actana/sdk` | 250 passed, 5 skipped | **253 passed**, 5 skipped |
| `@actana/cli` | 456 passed, 3 skipped | **468 passed**, 3 skipped |
| `@actana/core` | 1200 passed | **1212 passed** |
| `@actana/panel` | 1429 passed, **10 failed** | **1439 passed**, 0 failed on a clean run |

`typecheck` is clean in all five packages; `pnpm lint` reports 0 errors.

The panel numbers are flake under a full local run, not a regression: the same
suite failed on the **base commit before any change here** (10 tests across 3
files). On this branch the first panel run went 2 failed / 1437 passed and an
immediate re-run of the identical tree went **142 files, 1439 passed, 0
failed** — including
`packages/panel/src/lib/__tests__/session-skip-permissions.test.ts`, the suite
the review named as the one that would notice the
`harnessSupportsSkipPermissions` change. No panel source file is touched by this
PR.

## Decisions the review asked me to confirm

**`harnessSupportsSkipPermissions` answering from the flag table is intended.**
`packages/shared/src/harnesses.ts:89-90` now returns
`HARNESS_AUTO_MODE_FLAGS[agent] !== null` rather than the registry's own
`supportsSkipPermissions` boolean. Deliberate: "does this harness have an auto
mode" can only honestly mean "does the vendor ship a flag for it", and the
alternative is precisely the shape of finding 2 — a `true` sitting next to a
missing flag, the launch builder putting nothing in the command, and the spawn
descriptor still declaring the intent. Reading the flag makes that
unrepresentable. Identical for all four harnesses today, and
`session-skip-permissions.test.ts` is green, so the Panel is unaffected.

The consequence the review names is accepted and is the point: the registry's
`supportsSkipPermissions` field is now **decorative**, and a future `true` next
to an absent flag is ignored rather than honoured. The field is left in place
because it is part of the registry's published shape; retiring it is a
follow-up, not this PR.

**Criterion 8 is met for the flag, and qualified for the command.** The
auto-mode *flag* now has exactly one home (`HARNESS_CLI_CONFIG.autoModeFlag`).
The launch *command* still lives in two tables — shared's
`HARNESS_SPAWN_COMMANDS` and the SDK's `HARNESS_LAUNCH_COMMANDS` — because the
SDK must not import `@actana/shared` (ADR 0025 D4). That predates this PR and is
not fixed by it; what changes is that `cursor-cli-drivable.test.ts` cross-checks
the SDK's table against the Core's real spawn policy, so drift now fails a test
instead of a spawn.

## Ticket boundaries

- **#232** owns the prompt-delivery readiness wait for cursor-cli and is **not**
  implemented here. It lands in `HARNESS_READINESS` / `readinessFor` in
  `packages/core/src/harness-prompt-delivery.ts`, which this PR leaves entirely
  alone — `opencode` is still its only entry. This PR touches the *other* table
  in that module, `BLOCKING_DIALOGS` / `dialogsForHarness`, which is a separate
  concern: answering a dialog that is in the way versus waiting for a composer
  to appear. #232 can add a `cursor-cli` entry to `HARNESS_READINESS` without
  colliding with anything here.
- **#266** landed on this branch at `90cf562`. Its changes to
  `packages/shared/src/pty-spawn-policy.ts` (the `shell-session` mode and the
  `core exec` note) are intact; `packages/cli/src/core-resolution.ts`,
  `packages/cli/src/__tests__/no-local-escape.test.ts` and
  `packages/sdk/src/core-link-frames.ts` are untouched.
- **#273** owns teaching `readDialogOptions` letter keys, filed off this PR's
  review and **not** implemented here. Until it lands, cursor-agent's trust
  dialog is recognised and abandoned rather than answered. It also gates #232
  end to end: a cursor session in an untrusted directory abandons before
  readiness is ever reached.
- **#211** owns `--model`. Not implemented; the criterion is met on its "rejected
  loudly" branch and there is now a test pinning that it is never silently
  dropped in the meantime.
- `.github/workflows/ci.yml`, `docs/rulesets/`, `AGENTS.md`, `CLAUDE.md` and
  `docs/ci-cd.md` belong to #257, #264 and #260 and are not touched.

Refs #177

