### PR TITLE
feat(shared): pairing primitives — code generation and the pairing-session model (#281)

### DIFF
--- a/packages/shared/src/__tests__/pairing-code.test.ts
+++ b/packages/shared/src/__tests__/pairing-code.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  PAIRING_CODE_ALPHABET,
+  PAIRING_CODE_GROUP_SIZE,
+  PAIRING_CODE_LENGTH,
+  formatPairingCode,
+  generatePairingCode,
+  normalisePairingCode,
+  type CsprngPort,
+} from "../pairing-code";
+
+// The pairing code is the one thing a human carries between the Core and the
+// client (#280): eight characters from an alphabet with no ambiguous glyphs,
+// drawn from a CSPRNG with no modulo bias, printed `XXXX-XXXX`. The port makes
+// the draw assertable without stubbing `node:crypto`.
+
+/** A port that hands out a scripted byte sequence, one batch at a time. */
+function scriptedCsprng(bytes: number[]): CsprngPort & { calls: number[] } {
+  const queue = [...bytes];
+  const calls: number[] = [];
+  return {
+    calls,
+    bytes(n) {
+      calls.push(n);
+      return Uint8Array.from(queue.splice(0, n));
+    },
+  };
+}
+
+describe("pairing code", () => {
+  describe("alphabet", () => {
+    it("excludes the five ambiguous characters", () => {
+      for (const ch of ["0", "O", "1", "I", "L"]) {
+        expect(PAIRING_CODE_ALPHABET).not.toContain(ch);
+      }
+    });
+
+    it("is 31 unique upper-case alphanumerics", () => {
+      expect(PAIRING_CODE_ALPHABET).toHaveLength(31);
+      expect(new Set(PAIRING_CODE_ALPHABET).size).toBe(31);
+      expect(PAIRING_CODE_ALPHABET).toMatch(/^[A-Z2-9]+$/);
+    });
+  });
+
+  describe("generatePairingCode", () => {
+    it("draws 8 characters grouped XXXX-XXXX", () => {
+      const code = generatePairingCode();
+      expect(code).toMatch(/^[A-HJ-KM-NP-Z2-9]{4}-[A-HJ-KM-NP-Z2-9]{4}$/);
+      expect(code.replace("-", "")).toHaveLength(PAIRING_CODE_LENGTH);
+      expect(code[PAIRING_CODE_GROUP_SIZE]).toBe("-");
+    });
+
+    it("draws only from the alphabet, over many codes", () => {
+      for (let i = 0; i < 200; i += 1) {
+        for (const ch of generatePairingCode().replace("-", "")) {
+          expect(PAIRING_CODE_ALPHABET).toContain(ch);
+        }
+      }
+    });
+
+    it("maps accepted bytes through the alphabet in order", () => {
+      const csprng = scriptedCsprng([0, 1, 2, 30, 31, 32, 61, 62]);
+      expect(generatePairingCode(csprng)).toBe("ABC9-AB9A");
+    });
+
+    it("asks for exactly the bytes it still needs", () => {
+      const csprng = scriptedCsprng([0, 1, 2, 3, 4, 5, 6, 7]);
+      generatePairingCode(csprng);
+      expect(csprng.calls).toEqual([PAIRING_CODE_LENGTH]);
+    });
+
+    it("rejects and redraws the biased bytes instead of folding them", () => {
+      // 248-255 are the byte values with no partner in the last cycle of 31.
+      // Folding them with `%` would over-weight A-H; the draw must skip them
+      // and come back for more bytes.
+      const rejected = [248, 249, 250, 251, 252, 253, 254, 255];
+      const csprng = scriptedCsprng([...rejected, 0, 1, 2, 3, 4, 5, 6, 7]);
+      expect(generatePairingCode(csprng)).toBe("ABCD-EFGH");
+      expect(csprng.calls).toEqual([8, 8]);
+    });
+
+    it("keeps a partially drawn code and asks only for the remainder", () => {
+      const csprng = scriptedCsprng([0, 1, 2, 255, 3, 4, 5, 6, 7]);
+      expect(generatePairingCode(csprng)).toBe("ABCD-EFGH");
+      expect(csprng.calls).toEqual([8, 1]);
+    });
+
+    it("has no modulo bias: every accepted byte value is equally weighted", () => {
+      // The whole accepted range, one character each. If the ceiling were wrong
+      // — 256 instead of 248 — some characters would appear 9 times and others
+      // 8, which is exactly the head start the rejection exists to remove.
+      const accepted = Array.from({ length: 248 }, (_, b) => b);
+      const csprng = scriptedCsprng(accepted);
+      const counts = new Map<string, number>();
+      for (let i = 0; i < accepted.length / PAIRING_CODE_LENGTH; i += 1) {
+        for (const ch of generatePairingCode(csprng).replace("-", "")) {
+          counts.set(ch, (counts.get(ch) ?? 0) + 1);
+        }
+      }
+      expect(counts.size).toBe(PAIRING_CODE_ALPHABET.length);
+      expect([...counts.values()]).toEqual(Array(PAIRING_CODE_ALPHABET.length).fill(8));
+    });
+
+    it("throws rather than spinning when the port yields nothing", () => {
+      expect(() => generatePairingCode(scriptedCsprng([]))).toThrow(/no bytes/);
+    });
+  });
+
+  describe("normalisePairingCode", () => {
+    it("accepts the canonical form unchanged", () => {
+      expect(normalisePairingCode("ABCD-EFGH")).toBe("ABCD-EFGH");
+    });
+
+    it("accepts the code without the hyphen", () => {
+      expect(normalisePairingCode("ABCDEFGH")).toBe("ABCD-EFGH");
+    });
+
+    it("accepts mixed case", () => {
+      expect(normalisePairingCode("aBcD-eFgH")).toBe("ABCD-EFGH");
+      expect(normalisePairingCode("abcdefgh")).toBe("ABCD-EFGH");
+    });
+
+    it("accepts whitespace from a paste or a spoken grouping", () => {
+      expect(normalisePairingCode("  ABCD EFGH \n")).toBe("ABCD-EFGH");
+    });
+
+    it("round-trips a generated code", () => {
+      const code = generatePairingCode();
+      expect(normalisePairingCode(code)).toBe(code);
+      expect(normalisePairingCode(code.replace("-", "").toLowerCase())).toBe(code);
+    });
+
+    it("rejects the excluded characters rather than guessing at them", () => {
+      for (const ch of ["0", "O", "1", "I", "L"]) {
+        expect(normalisePairingCode(`ABCDEFG${ch}`)).toBeNull();
+      }
+    });
+
+    it("rejects the wrong length and other junk", () => {
+      expect(normalisePairingCode("ABCDEFG")).toBeNull();
+      expect(normalisePairingCode("ABCDEFGHJ")).toBeNull();
+      expect(normalisePairingCode("")).toBeNull();
+      expect(normalisePairingCode("ABCD-EF!H")).toBeNull();
+    });
+  });
+
+  describe("formatPairingCode", () => {
+    it("groups a raw draw", () => {
+      expect(formatPairingCode("ABCDEFGH")).toBe("ABCD-EFGH");
+    });
+  });
+});

--- a/packages/shared/src/__tests__/pairing-session.test.ts
+++ b/packages/shared/src/__tests__/pairing-session.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  PAIRING_ATTEMPT_CAP,
+  PAIRING_SESSION_TTL_MS,
+  canRedeem,
+  consumePairingSession,
+  createPairingSession,
+  isConsumed,
+  isDead,
+  isExpired,
+  recordWrongAttempt,
+  type PairingSession,
+} from "../pairing-session";
+
+// Three separate defences (#280): a TTL, a cap of five wrong attempts, and
+// single use. Every transition here is pure and takes `now` from the caller,
+// so a session can be walked past its expiry without fake timers.
+
+const MINT = 1_700_000_000_000;
+
+function session(overrides: Partial<PairingSession> = {}): PairingSession {
+  return {
+    ...createPairingSession({
+      id: "pair_abc",
+      label: "mehdi-laptop",
+      codeHash: "sha256:deadbeef",
+      now: MINT,
+    }),
+    ...overrides,
+  };
+}
+
+describe("pairing session", () => {
+  describe("createPairingSession", () => {
+    it("expires five minutes after the mint by default", () => {
+      expect(PAIRING_SESSION_TTL_MS).toBe(5 * 60 * 1000);
+      expect(session().expiresAt).toBe(MINT + PAIRING_SESSION_TTL_MS);
+      expect(session().createdAt).toBe(MINT);
+    });
+
+    it("honours an explicit TTL and attempt cap", () => {
+      const s = createPairingSession({
+        id: "pair_abc",
+        label: "l",
+        codeHash: "h",
+        now: MINT,
+        ttlMs: 60_000,
+        attemptCap: 2,
+      });
+      expect(s.expiresAt).toBe(MINT + 60_000);
+      expect(s.attemptCap).toBe(2);
+    });
+
+    it("starts pending: no attempts, not consumed", () => {
+      const s = session();
+      expect(s.attempts).toBe(0);
+      expect(s.attemptCap).toBe(PAIRING_ATTEMPT_CAP);
+      expect(s.consumedAt).toBeNull();
+      expect(isConsumed(s)).toBe(false);
+      expect(isDead(s)).toBe(false);
+    });
+
+    it("defaults the three future-proofing fields to null", () => {
+      const s = session();
+      expect(s.created_by).toBeNull();
+      expect(s.tenant_id).toBeNull();
+      expect(s.auth_method).toBeNull();
+    });
+  });
+
+  describe("isExpired", () => {
+    it("is live before the boundary", () => {
+      expect(isExpired(session(), session().expiresAt - 1)).toBe(false);
+    });
+
+    it("is live exactly at the boundary, as the bearer is", () => {
+      expect(isExpired(session(), session().expiresAt)).toBe(false);
+    });
+
+    it("is expired one millisecond past the boundary", () => {
+      expect(isExpired(session(), session().expiresAt + 1)).toBe(true);
+    });
+
+    it("refuses redemption once expired", () => {
+      const s = session();
+      expect(canRedeem(s, s.expiresAt)).toEqual({ ok: true });
+      expect(canRedeem(s, s.expiresAt + 1)).toEqual({ ok: false, reason: "expired" });
+    });
+  });
+
+  describe("recordWrongAttempt", () => {
+    it("dies at exactly the fifth wrong code, not the fourth", () => {
+      let s = session();
+      for (let i = 1; i < PAIRING_ATTEMPT_CAP; i += 1) {
+        s = recordWrongAttempt(s);
+        expect(s.attempts).toBe(i);
+        expect(isDead(s)).toBe(false);
+        expect(canRedeem(s, MINT)).toEqual({ ok: true });
+      }
+      s = recordWrongAttempt(s);
+      expect(s.attempts).toBe(PAIRING_ATTEMPT_CAP);
+      expect(isDead(s)).toBe(true);
+      expect(canRedeem(s, MINT)).toEqual({ ok: false, reason: "attempts-exhausted" });
+    });
+
+    it("does not mutate the session it was given", () => {
+      const s = session();
+      recordWrongAttempt(s);
+      expect(s.attempts).toBe(0);
+    });
+
+    it("stops the counter at the cap", () => {
+      let s = session();
+      for (let i = 0; i < PAIRING_ATTEMPT_CAP + 3; i += 1) s = recordWrongAttempt(s);
+      expect(s.attempts).toBe(PAIRING_ATTEMPT_CAP);
+    });
+
+    it("keeps the session's own cap when it was minted with one", () => {
+      let s = session({ attemptCap: 2 });
+      s = recordWrongAttempt(s);
+      expect(isDead(s)).toBe(false);
+      s = recordWrongAttempt(s);
+      expect(isDead(s)).toBe(true);
+    });
+  });
+
+  describe("consumePairingSession", () => {
+    it("stamps the consumption and leaves the input alone", () => {
+      const s = session();
+      const result = consumePairingSession(s, MINT + 1_000);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.session.consumedAt).toBe(MINT + 1_000);
+        expect(isConsumed(result.session)).toBe(true);
+      }
+      expect(s.consumedAt).toBeNull();
+    });
+
+    it("refuses a second consume", () => {
+      const first = consumePairingSession(session(), MINT + 1_000);
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(consumePairingSession(first.session, MINT + 2_000)).toEqual({
+        ok: false,
+        reason: "already-consumed",
+      });
+    });
+
+    it("refuses an expired session", () => {
+      const s = session();
+      expect(consumePairingSession(s, s.expiresAt + 1)).toEqual({
+        ok: false,
+        reason: "expired",
+      });
+    });
+
+    it("refuses a session that hit the attempt cap", () => {
+      let s = session();
+      for (let i = 0; i < PAIRING_ATTEMPT_CAP; i += 1) s = recordWrongAttempt(s);
+      expect(consumePairingSession(s, MINT)).toEqual({
+        ok: false,
+        reason: "attempts-exhausted",
+      });
+    });
+
+    it("reports consumption ahead of expiry, so a replay reads as a replay", () => {
+      const first = consumePairingSession(session(), MINT);
+      if (!first.ok) throw new Error("expected the first consume to succeed");
+      expect(consumePairingSession(first.session, first.session.expiresAt + 1)).toEqual({
+        ok: false,
+        reason: "already-consumed",
+      });
+    });
+  });
+});

--- a/packages/shared/src/pairing-code.ts
+++ b/packages/shared/src/pairing-code.ts
@@ -1,0 +1,124 @@
+// The one-time pairing code an operator reads out loud (#280, #281).
+//
+// `actana pair new` mints one of these on the Core and a human carries it to
+// the client — that hand-carry is the only manual step left in enrollment, so
+// the code is shaped for a voice call and a keyboard, not for a URL. Hence the
+// two decisions below.
+//
+// **The alphabet drops `0`, `O`, `1`, `I` and `L`.** They are the characters a
+// human transcribes wrong, and there is nobody downstream to forgive a typo:
+// a wrong character burns one of five attempts on a session that dies at the
+// cap. Dropping them costs ~3 bits over the eight characters (31^8 ≈ 2^39.6
+// against 36^8 ≈ 2^41.3) and buys a code that survives being spoken.
+//
+// **The draw rejects biased bytes rather than folding them with `%`.** A
+// pairing code is a pre-auth secret guarding CSR signing, so the draw has to
+// be uniform over the alphabet: `randomBytes(1)[0] % 31` would make the first
+// eight letters ~14% likelier than the rest, which is a measurable head start
+// for anyone spraying codes at the endpoint.
+//
+// This file is self-contained (no `~/` imports) and reaches `node:crypto`
+// through an injectable port, the same arrangement as the HMAC port in
+// `core-link-bearer.ts`: the Core mints codes, tests assert the draw, and
+// neither has to stub a global to do it.
+//
+// These are internals, not wire types. `packages/shared` is private and stays
+// private ([ADR 0025][adr] D4); the SDK declares its own shapes for whatever
+// crosses the socket, as `packages/sdk/src/core-registration-blob.ts` argues
+// at length.
+//
+// [adr]: ../../../docs/adr/0025-the-protocol-ships-with-the-client.md
+
+import { randomBytes } from "node:crypto";
+
+/**
+ * The code alphabet: A–Z and 2–9, less `0`, `O`, `1`, `I` and `L`. 31
+ * characters. Exported because the Core's operator output and the client's
+ * input hint both describe it to a human, and two descriptions of one alphabet
+ * drift apart.
+ */
+export const PAIRING_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+/** Characters drawn per code, before grouping. */
+export const PAIRING_CODE_LENGTH = 8;
+
+/** Characters per printed group — the code reads as `XXXX-XXXX`. */
+export const PAIRING_CODE_GROUP_SIZE = 4;
+
+/**
+ * Byte values at or above this are thrown away instead of being folded into
+ * the alphabet. 256 is not a multiple of 31, so the top 8 byte values (248–255)
+ * have no partner in the last cycle and would over-weight `A`–`H`. Discarding
+ * them leaves 248 values covering the 31 characters exactly 8 times each, which
+ * is what makes the `%` below unbiased rather than merely convenient.
+ */
+const UNBIASED_BYTE_CEILING = 256 - (256 % PAIRING_CODE_ALPHABET.length);
+
+/**
+ * CSPRNG port. The default draws from `node:crypto.randomBytes`, which is
+ * available everywhere this module is imported (the Core mints, the CLI prints,
+ * tests assert). Bytes rather than integers on purpose: the rejection above is
+ * the property under test, so it lives here in code a test can drive, not
+ * behind `randomInt` where a fake would have to be trusted to be uniform.
+ */
+export interface CsprngPort {
+  /** Fill `n` cryptographically random bytes. Never returns fewer than one. */
+  bytes(n: number): Uint8Array;
+}
+
+const defaultCsprng: CsprngPort = {
+  bytes: (n) => randomBytes(n),
+};
+
+/** Group a raw 8-character draw for printing: `ABCDEFGH` -> `ABCD-EFGH`. */
+export function formatPairingCode(raw: string): string {
+  return `${raw.slice(0, PAIRING_CODE_GROUP_SIZE)}-${raw.slice(PAIRING_CODE_GROUP_SIZE)}`;
+}
+
+/**
+ * Mint a pairing code, formatted `XXXX-XXXX`.
+ *
+ * Draws in batches sized to what is still missing, so a run with no rejections
+ * costs one call to the port and the common case is a single `randomBytes(8)`.
+ */
+export function generatePairingCode(csprng: CsprngPort = defaultCsprng): string {
+  const drawn: string[] = [];
+  while (drawn.length < PAIRING_CODE_LENGTH) {
+    const batch = csprng.bytes(PAIRING_CODE_LENGTH - drawn.length);
+    // A port that yields nothing would spin this loop forever. Fail loudly
+    // instead: a starved CSPRNG is a broken one, and a pairing code minted from
+    // a broken CSPRNG is worse than no pairing code.
+    if (batch.length === 0) throw new Error("CSPRNG port returned no bytes");
+    for (const byte of batch) {
+      if (byte >= UNBIASED_BYTE_CEILING) continue;
+      drawn.push(PAIRING_CODE_ALPHABET[byte % PAIRING_CODE_ALPHABET.length]);
+      if (drawn.length === PAIRING_CODE_LENGTH) break;
+    }
+  }
+  return formatPairingCode(drawn.join(""));
+}
+
+/**
+ * Canonicalise a code a human typed, or return `null` if it cannot be one.
+ *
+ * Accepts the hyphen or no hyphen, any case, and stray whitespace from a paste
+ * — everything a phone call and a text field produce between the operator's
+ * screen and the client's prompt. The canonical form is the printed one
+ * (`XXXX-XXXX`, upper case), so `normalisePairingCode(generatePairingCode())`
+ * is the code itself and a comparison never has to know which side it came
+ * from.
+ *
+ * Out-of-alphabet characters are rejected rather than folded: the excluded
+ * five have no unambiguous partner to fold *to* — `0` and `O` are both absent
+ * — so a `0` here is a transcription error, and quietly guessing at which
+ * character was meant would spend the caller's attempt on a code they never
+ * heard.
+ */
+export function normalisePairingCode(input: string): string | null {
+  const stripped = input.replace(/[\s-]/g, "").toUpperCase();
+  if (stripped.length !== PAIRING_CODE_LENGTH) return null;
+  for (const ch of stripped) {
+    if (!PAIRING_CODE_ALPHABET.includes(ch)) return null;
+  }
+  return formatPairingCode(stripped);
+}

--- a/packages/shared/src/pairing-session.ts
+++ b/packages/shared/src/pairing-session.ts
@@ -1,0 +1,184 @@
+// The pending pairing session — what the Core holds between `actana pair new`
+// and the client redeeming the code (#280, #281).
+//
+// Everything here is a pure function over a plain object. The session is
+// minted, expired, attempted against and consumed by the Core, which owns the
+// clock, the store and the audit log; this module owns only the rules, so it
+// takes `now` as an argument in the manner of `verifyBearer`'s injectable
+// clock in `core-link-bearer.ts`. Nothing here reads a socket, a disk or a
+// clock it was not handed, and no test needs fake timers to walk a session
+// past its expiry.
+//
+// The three defences the design fixes on (#280 "Security properties") are
+// deliberately separate: a **TTL** bounds how long a code is worth stealing, a
+// **cap of five wrong attempts** bounds guessing within one session, and
+// **single use** stops a redeemed code being replayed. Each has its own field
+// and its own transition below, so a change to one cannot silently weaken
+// another. Rate limiting on the endpoint is the fourth defence and is *not*
+// here — it is per-caller, not per-session, and belongs to the server that can
+// see callers.
+//
+// These are internals, not wire types: `packages/shared` is private and stays
+// private ([ADR 0025][adr] D4). The redemption request and response are the
+// SDK's to declare, for the reason written out at the top of
+// `packages/sdk/src/core-registration-blob.ts`.
+//
+// [adr]: ../../../docs/adr/0025-the-protocol-ships-with-the-client.md
+
+/** How long a freshly minted session stays redeemable. Five minutes (#280). */
+export const PAIRING_SESSION_TTL_MS = 5 * 60 * 1000;
+
+/** Wrong codes a single session tolerates before it is dead (#280). */
+export const PAIRING_ATTEMPT_CAP = 5;
+
+/**
+ * A pending pairing session.
+ *
+ * `codeHash` is a digest, not the code: the plaintext is printed once to the
+ * operator's terminal and never stored, so a stolen session store is not a
+ * pile of live pairing codes. Which digest is the Core's business — this
+ * module compares nothing and only carries the field.
+ *
+ * `created_by`, `tenant_id` and `auth_method` are **inert today**. #280 keeps a
+ * later OIDC layer able to gate *who may create a pairing session* without a
+ * protocol change, and these three are the hooks it will read; nothing in this
+ * feature train writes or enforces them. They keep the snake_case of the
+ * columns they will become so that the identity work does not have to rename
+ * anything to find them.
+ */
+export type PairingSession = {
+  /** Opaque session id — what a redemption names, so it cannot be replayed
+   *  against a different session. */
+  id: string;
+  /** Operator-supplied name for the machine being paired. Display only. */
+  label: string;
+  /** Digest of the pairing code. Never the code itself — see above. */
+  codeHash: string;
+  /** Wall-clock ms at mint. */
+  createdAt: number;
+  /** Wall-clock ms after which the session is no longer redeemable. */
+  expiresAt: number;
+  /** Wrong codes seen so far, capped at `attemptCap`. */
+  attempts: number;
+  /** This session's cap, copied at mint so a config change cannot retroactively
+   *  revive or kill sessions already in flight. */
+  attemptCap: number;
+  /** Wall-clock ms of the successful redemption, or `null` while pending. A
+   *  timestamp rather than a boolean because the audit log wants to say when. */
+  consumedAt: number | null;
+  /** Inert (#280): the identity that created the session, once there is one. */
+  created_by: string | null;
+  /** Inert (#280): the tenant the session belongs to, once there are tenants. */
+  tenant_id: string | null;
+  /** Inert (#280): how that identity authenticated, once it authenticates. */
+  auth_method: string | null;
+};
+
+/** What a caller must supply to mint a session; everything else is derived. */
+export type NewPairingSession = {
+  id: string;
+  label: string;
+  codeHash: string;
+  /** Mint time. The caller's clock, never this module's. */
+  now: number;
+  /** Override the five-minute default, e.g. `actana pair new --ttl`. */
+  ttlMs?: number;
+  /** Override the cap of five. Present for tests and future policy, not for a
+   *  caller looking for a way around the cap. */
+  attemptCap?: number;
+};
+
+/**
+ * Mint a pending session. The three future-proofing fields default to `null`
+ * here and are set by nothing in this train — see `PairingSession`.
+ */
+export function createPairingSession(input: NewPairingSession): PairingSession {
+  const ttlMs = input.ttlMs ?? PAIRING_SESSION_TTL_MS;
+  return {
+    id: input.id,
+    label: input.label,
+    codeHash: input.codeHash,
+    createdAt: input.now,
+    expiresAt: input.now + ttlMs,
+    attempts: 0,
+    attemptCap: input.attemptCap ?? PAIRING_ATTEMPT_CAP,
+    consumedAt: null,
+    created_by: null,
+    tenant_id: null,
+    auth_method: null,
+  };
+}
+
+/**
+ * Has the session outlived its TTL at `now`?
+ *
+ * Inclusive at the boundary — a session whose `expiresAt` is exactly `now` is
+ * still live — matching `verifyBearer`, which treats `exp === now` as valid.
+ * One rule for "expiry" across the two things a Core times out is worth more
+ * than the millisecond either way.
+ */
+export function isExpired(session: PairingSession, now: number): boolean {
+  return now > session.expiresAt;
+}
+
+/** Has the cap been reached? A dead session can never be redeemed again. */
+export function isDead(session: PairingSession): boolean {
+  return session.attempts >= session.attemptCap;
+}
+
+/** Has the session already been redeemed? Single use is single use. */
+export function isConsumed(session: PairingSession): boolean {
+  return session.consumedAt !== null;
+}
+
+/** Why a session would refuse a redemption. Ordered by how it is checked. */
+export type PairingRefusal = "expired" | "attempts-exhausted" | "already-consumed";
+
+export type PairingRedeemability =
+  | { ok: true }
+  | { ok: false; reason: PairingRefusal };
+
+/**
+ * May this session be redeemed at `now`? A typed reason rather than a boolean,
+ * so the caller can audit-log *which* defence refused — the same shape
+ * `verifyBearer` returns, and for the same reason.
+ *
+ * The caller still has to check the code itself; this is only the state gate.
+ */
+export function canRedeem(session: PairingSession, now: number): PairingRedeemability {
+  if (isConsumed(session)) return { ok: false, reason: "already-consumed" };
+  if (isDead(session)) return { ok: false, reason: "attempts-exhausted" };
+  if (isExpired(session, now)) return { ok: false, reason: "expired" };
+  return { ok: true };
+}
+
+/**
+ * Record a wrong code. Returns the next session — the input is never mutated,
+ * so a caller that fails to persist has not already changed its in-memory copy.
+ *
+ * The counter stops at the cap rather than climbing past it: past the cap the
+ * session is dead and the exact number of attempts beyond it says nothing,
+ * while an unbounded counter invites `attempts > attemptCap` states that every
+ * later reader has to reason about.
+ */
+export function recordWrongAttempt(session: PairingSession): PairingSession {
+  return { ...session, attempts: Math.min(session.attempts + 1, session.attemptCap) };
+}
+
+export type PairingConsumeResult =
+  | { ok: true; session: PairingSession }
+  | { ok: false; reason: PairingRefusal };
+
+/**
+ * Redeem the session once, stamping `consumedAt`. A second consume is refused
+ * with `already-consumed`, which is the whole of single use: the Core writes
+ * the returned session back and any replay of the same code meets this branch.
+ */
+export function consumePairingSession(
+  session: PairingSession,
+  now: number,
+): PairingConsumeResult {
+  const gate = canRedeem(session, now);
+  if (!gate.ok) return gate;
+  return { ok: true, session: { ...session, consumedAt: now } };
+}


### PR DESCRIPTION
Closes #281. Part of #280 — short-code pairing enrollment replaces the registration-blob hand-carry.

**Base is `feat/short-code-pairing`**, the feature branch for #280 — not `main`, not `beta/0.4.0`. That branch did
not exist on the remote yet, so it was cut from `origin/beta/0.4.0` and pushed as-is before this branch was cut
from it; it therefore contains nothing but the train tip plus, in time, the seven task PRs.

## What this adds

Two new modules in `packages/shared/src/`, plus their tests. Nothing else in the repository is touched — no
`exports` map, no imports from anywhere, no call sites. The package's `"./*"` wildcard already exports every file
under `src/`, so this ticket registers itself nowhere and cannot collide with the work landing beside it.

### `pairing-code.ts`

- `PAIRING_CODE_ALPHABET` — 31 characters, `A–Z` and `2–9` less `0`, `O`, `1`, `I` and `L`.
- `generatePairingCode(csprng?)` — draws 8 characters, printed `XXXX-XXXX`. Byte values 248–255 are **rejected and
  redrawn** rather than folded with `%`: 256 is not a multiple of 31, and folding would make the first eight
  characters ~14% likelier than the rest.
- `CsprngPort` — injectable, defaulting to `node:crypto.randomBytes`, in the manner of the HMAC port in
  `core-link-bearer.ts`. It yields bytes rather than integers so the rejection is exercised by the test rather than
  hidden behind `randomInt`.
- `normalisePairingCode(input)` — takes the hyphen or no hyphen, any case, stray whitespace; returns the canonical
  printed form or `null`. Out-of-alphabet characters are refused rather than guessed at.

### `pairing-session.ts`

- `PairingSession` — id, label, `codeHash`, `createdAt`, `expiresAt`, `attempts`, `attemptCap`, `consumedAt`, and
  the three inert future-proofing fields `created_by`, `tenant_id`, `auth_method`, all defaulting to `null`.
- `PAIRING_SESSION_TTL_MS` (5 minutes) and `PAIRING_ATTEMPT_CAP` (5) as named exported constants.
- Pure transitions: `isExpired(session, now)` (inclusive at the boundary, matching `verifyBearer`),
  `recordWrongAttempt`, `consumePairingSession`, and the `canRedeem` gate that names which defence refused.

Nothing here reads a socket, a disk or a clock it was not handed. `now` is always an argument, so no test needs
fake timers.

## Checks

`packages/shared`: 250 tests pass (35 of them new), `tsc --noEmit` clean, `eslint` clean on the four new files.

## Not in scope

The endpoint, CSR signing, persistence, the audit log, rate limiting and the operator verbs are #282 and #283.
These are internals and not wire types — `packages/shared` is private and stays private (ADR 0025 D4), and the SDK
declares its own shapes for whatever crosses the socket (#284).
