### PR TITLE
feat(core): the pairing server — pre-auth endpoint, CSR signing and bearer claims (#282)

### DIFF
--- a/packages/core/src/__tests__/core-first-run.test.ts
+++ b/packages/core/src/__tests__/core-first-run.test.ts
@@ -29,6 +29,7 @@ const sample: PersistedMaterial = {
   clientKey: "-----BEGIN PRIVATE KEY-----\nCLIENTKEY\n-----END PRIVATE KEY-----",
   bearerSecret: "deadbeef".repeat(8),
   coreId: "core_abcdef0123456789",
+  coreUuid: "1f2e3d4c-5b6a-4798-8a9b-0c1d2e3f4a5b",
   serverHost: "core.example.test",
 };
 

--- a/packages/core/src/__tests__/core-pairing-audit.test.ts
+++ b/packages/core/src/__tests__/core-pairing-audit.test.ts
@@ -1,0 +1,84 @@
+// What the audit log is allowed to say (#282).
+//
+// A log line is the easiest place in this feature for a secret to end up: it is
+// written on the failure path, read by people, and outlives the request by
+// however long the log is kept. So the redaction is a function with a test.
+import { describe, expect, it } from "vitest";
+import { pairingAuditor, redactPairingAuditEvent, type PairingAuditEvent } from "../core-pairing-audit";
+
+const attempt: PairingAuditEvent = {
+  outcome: "issued",
+  sessionId: "ps_1",
+  label: "laptop",
+  peer: "10.0.0.9",
+  certSerial: "0a1b",
+  at: 1_700_000_000_000,
+};
+
+describe("the audit record", () => {
+  it("keeps what an operator needs to read the attempt", () => {
+    expect(redactPairingAuditEvent(attempt)).toEqual({
+      outcome: "issued",
+      sessionId: "ps_1",
+      label: "laptop",
+      peer: "10.0.0.9",
+      certSerial: "0a1b",
+      at: 1_700_000_000_000,
+    });
+  });
+
+  it("writes nothing for a field the attempt did not have", () => {
+    const record = redactPairingAuditEvent({ outcome: "bad-request", peer: "10.0.0.9", at: 1 });
+    expect(Object.keys(record).sort()).toEqual(["at", "outcome", "peer"]);
+  });
+
+  it("drops anything not on the list, whatever a caller attaches", () => {
+    // The list is the mechanism. This is what a future field carrying the code,
+    // the CSR or a key would meet — nothing is logged until somebody adds it to
+    // `LOGGED_FIELDS`, which is a line in a diff a reviewer sees.
+    const smuggled = {
+      ...attempt,
+      code: "ABCD-EFGH",
+      csr: "-----BEGIN CERTIFICATE REQUEST-----",
+      clientKey: "-----BEGIN PRIVATE KEY-----",
+    } as PairingAuditEvent;
+
+    const record = redactPairingAuditEvent(smuggled);
+
+    expect(JSON.stringify(record)).not.toContain("ABCD-EFGH");
+    expect(JSON.stringify(record)).not.toContain("CERTIFICATE REQUEST");
+    expect(JSON.stringify(record)).not.toContain("PRIVATE KEY");
+  });
+
+  it("records a refusal's reason, which the response refuses to give", () => {
+    // The distinction the wire will not draw is exactly the one the operator
+    // reading their own Core's log needs.
+    const record = redactPairingAuditEvent({
+      outcome: "refused",
+      reason: "attempts-exhausted",
+      sessionId: "ps_1",
+      peer: "10.0.0.9",
+      attempts: 5,
+      at: 1,
+    });
+    expect(record).toMatchObject({ reason: "attempts-exhausted", attempts: 5 });
+  });
+});
+
+describe("the auditor", () => {
+  it("hands the sink an already-redacted record", () => {
+    const written: Record<string, unknown>[] = [];
+    pairingAuditor((record) => written.push(record))(attempt);
+    expect(written).toEqual([redactPairingAuditEvent(attempt)]);
+  });
+
+  it("does not let a broken sink take the request with it", () => {
+    // The attempt has already been decided by the time this runs. Losing the
+    // record is bad; answering a paired client with a 500 because the log was
+    // unwritable is worse.
+    const audit = pairingAuditor(() => {
+      throw new Error("disk full");
+    });
+    expect(() => audit(attempt)).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/core-pairing-rate-limit.test.ts
+++ b/packages/core/src/__tests__/core-pairing-rate-limit.test.ts
@@ -1,0 +1,125 @@
+// The defence the per-session attempt cap cannot provide (#280, #282).
+//
+// A session dies after five wrong codes. That bounds guessing inside one
+// session and nothing else: an attacker who can open the endpoint at will gets
+// five fresh guesses for every session an operator ever opens, as fast as they
+// can send them. These tests pin the two windows that close that gap, and the
+// memory bound that keeps the closing of it from being its own attack.
+import { describe, expect, it } from "vitest";
+import { MAX_TRACKED_PEERS, PairingRateLimiter } from "../core-pairing-rate-limit";
+
+function limiterAt(clock: { now: number }, opts: ConstructorParameters<typeof PairingRateLimiter>[0] = {}) {
+  return new PairingRateLimiter({ ...opts, now: () => clock.now });
+}
+
+describe("the per-peer window", () => {
+  it("allows up to the limit and refuses the next", () => {
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 3, windowMs: 60_000 } });
+
+    const verdicts = [1, 2, 3, 4].map(() => limiter.check("10.0.0.1"));
+
+    expect(verdicts.map((v) => v.ok)).toEqual([true, true, true, false]);
+    expect(verdicts[3]).toMatchObject({ ok: false, scope: "peer" });
+  });
+
+  it("does not count a refusal against the caller a second time", () => {
+    // Otherwise a caller who keeps knocking extends their own lockout, which is
+    // how one office behind one NAT address locks itself out for an afternoon.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 2, windowMs: 60_000 } });
+
+    limiter.check("10.0.0.1");
+    limiter.check("10.0.0.1");
+    limiter.check("10.0.0.1");
+    limiter.check("10.0.0.1");
+    clock.now += 60_001;
+
+    expect(limiter.check("10.0.0.1").ok).toBe(true);
+  });
+
+  it("keeps one peer's spending off another peer's budget", () => {
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 2, windowMs: 60_000 } });
+
+    limiter.check("10.0.0.1");
+    limiter.check("10.0.0.1");
+
+    expect(limiter.check("10.0.0.1").ok).toBe(false);
+    expect(limiter.check("10.0.0.2").ok).toBe(true);
+  });
+
+  it("lets the window slide off", () => {
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 1, windowMs: 60_000 } });
+
+    expect(limiter.check("10.0.0.1").ok).toBe(true);
+    expect(limiter.check("10.0.0.1").ok).toBe(false);
+    clock.now += 60_001;
+    expect(limiter.check("10.0.0.1").ok).toBe(true);
+  });
+
+  it("says how long to wait", () => {
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 1, windowMs: 60_000 } });
+
+    limiter.check("10.0.0.1");
+    clock.now += 10_000;
+    const refused = limiter.check("10.0.0.1");
+
+    expect(refused).toMatchObject({ ok: false, retryAfterMs: 50_000 });
+  });
+});
+
+describe("the global window", () => {
+  it("stops a spray spread across many addresses", () => {
+    // The reason keying by address is not the whole answer: every one of these
+    // callers is inside its own per-peer limit.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, {
+      peer: { limit: 10, windowMs: 60_000 },
+      global: { limit: 5, windowMs: 60_000 },
+    });
+
+    const verdicts = Array.from({ length: 6 }, (_, i) => limiter.check(`10.0.0.${i}`));
+
+    expect(verdicts.slice(0, 5).every((v) => v.ok)).toBe(true);
+    expect(verdicts[5]).toMatchObject({ ok: false, scope: "global" });
+  });
+
+  it("names the peer limit rather than the global one when both would refuse", () => {
+    // An operator who has mistyped a code eleven times should be told it was
+    // them, not the Core.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, {
+      peer: { limit: 1, windowMs: 60_000 },
+      global: { limit: 1, windowMs: 60_000 },
+    });
+
+    limiter.check("10.0.0.1");
+
+    expect(limiter.check("10.0.0.1")).toMatchObject({ ok: false, scope: "peer" });
+  });
+});
+
+describe("the memory bound", () => {
+  it("forgets the quietest peers rather than growing without limit", () => {
+    // The keys here are chosen by whoever is dialling, on a pre-auth surface.
+    // An unbounded map would be an exhaustion attack costing one packet each.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, {
+      peer: { limit: 1, windowMs: 1_000 },
+      global: { limit: Number.MAX_SAFE_INTEGER, windowMs: 60_000 },
+    });
+
+    for (let i = 0; i < MAX_TRACKED_PEERS + 50; i += 1) {
+      limiter.check(`10.${Math.floor(i / 65536)}.${Math.floor(i / 256) % 256}.${i % 256}`);
+      // Age each caller out of its own window, so eviction has candidates —
+      // the case a real Core meets, where the sprayer's earlier addresses have
+      // gone quiet by the time the map fills.
+      clock.now += 2_000;
+    }
+
+    expect(limiter.trackedPeers()).toBeLessThanOrEqual(MAX_TRACKED_PEERS);
+  });
+});

--- a/packages/core/src/__tests__/core-pairing-rate-limit.test.ts
+++ b/packages/core/src/__tests__/core-pairing-rate-limit.test.ts
@@ -6,7 +6,13 @@
 // can send them. These tests pin the two windows that close that gap, and the
 // memory bound that keeps the closing of it from being its own attack.
 import { describe, expect, it } from "vitest";
-import { MAX_TRACKED_PEERS, PairingRateLimiter } from "../core-pairing-rate-limit";
+import {
+  DEFAULT_GLOBAL_WINDOW,
+  DEFAULT_PEER_WINDOW,
+  EVICTION_BATCH,
+  MAX_TRACKED_PEERS,
+  PairingRateLimiter,
+} from "../core-pairing-rate-limit";
 
 function limiterAt(clock: { now: number }, opts: ConstructorParameters<typeof PairingRateLimiter>[0] = {}) {
   return new PairingRateLimiter({ ...opts, now: () => clock.now });
@@ -103,17 +109,36 @@ describe("the global window", () => {
 });
 
 describe("the memory bound", () => {
-  it("forgets the quietest peers rather than growing without limit", () => {
+  /** The i-th distinct source address of a spray. */
+  const sprayer = (i: number): string => `10.${Math.floor(i / 65536) % 256}.${Math.floor(i / 256) % 256}.${i % 256}`;
+
+  /** Fill the global window, which is what puts every later request on the refusal branch. */
+  function saturateGlobalWindow(limiter: PairingRateLimiter): void {
+    const perPeer = DEFAULT_PEER_WINDOW.limit;
+    const peers = Math.ceil(DEFAULT_GLOBAL_WINDOW.limit / perPeer);
+    for (let peer = 0; peer < peers; peer += 1) {
+      for (let hit = 0; hit < perPeer; hit += 1) limiter.check(`192.168.0.${peer}`);
+    }
+  }
+
+  it("forgets the quietest peers on the path that admits them", () => {
     // The keys here are chosen by whoever is dialling, on a pre-auth surface.
     // An unbounded map would be an exhaustion attack costing one packet each.
+    //
+    // The global window is the shipped one rather than a disabled one. It was
+    // `Number.MAX_SAFE_INTEGER` when this test was written, which forced every
+    // call down the allow branch and so asserted the bound only where it was
+    // never in doubt — see the test below for the branch that broke it. The
+    // clock moves two seconds a call, so sixty-a-minute is never reached here
+    // and the insert path is still the one under test.
     const clock = { now: 1_000 };
     const limiter = limiterAt(clock, {
       peer: { limit: 1, windowMs: 1_000 },
-      global: { limit: Number.MAX_SAFE_INTEGER, windowMs: 60_000 },
+      global: DEFAULT_GLOBAL_WINDOW,
     });
 
-    for (let i = 0; i < MAX_TRACKED_PEERS + 50; i += 1) {
-      limiter.check(`10.${Math.floor(i / 65536)}.${Math.floor(i / 256) % 256}.${i % 256}`);
+    for (let i = 0; i < MAX_TRACKED_PEERS + EVICTION_BATCH + 50; i += 1) {
+      expect(limiter.check(sprayer(i)).ok).toBe(true);
       // Age each caller out of its own window, so eviction has candidates —
       // the case a real Core meets, where the sprayer's earlier addresses have
       // gone quiet by the time the map fills.
@@ -121,5 +146,71 @@ describe("the memory bound", () => {
     }
 
     expect(limiter.trackedPeers()).toBeLessThanOrEqual(MAX_TRACKED_PEERS);
+  });
+
+  it("holds the bound once the global window is saturated, which is the attacker's branch", () => {
+    // The regression. Refusing used to `set` the caller into the map and return
+    // without evicting, and a saturated global window means the allow branch —
+    // the only one that evicted — is never taken again. Every fresh address was
+    // then a permanent entry. Saturating costs six addresses at the shipped
+    // limits, so this is not an expensive attack to mount.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: DEFAULT_PEER_WINDOW, global: DEFAULT_GLOBAL_WINDOW });
+    saturateGlobalWindow(limiter);
+    const trackedBeforeTheSpray = limiter.trackedPeers();
+
+    const scopes = new Set<string>();
+    for (let i = 0; i < MAX_TRACKED_PEERS * 2; i += 1) {
+      const verdict = limiter.check(sprayer(i));
+      if (!verdict.ok) scopes.add(verdict.scope);
+    }
+
+    expect([...scopes]).toEqual(["global"]);
+    expect(limiter.trackedPeers()).toBeLessThanOrEqual(MAX_TRACKED_PEERS);
+    // Stronger than the bound, and the actual fix: a refused caller is not
+    // recorded at all, so the map does not grow by one entry per attacker
+    // address in the first place.
+    expect(limiter.trackedPeers()).toBe(trackedBeforeTheSpray);
+  });
+
+  it("leaves nothing behind for a caller it refused globally", () => {
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: DEFAULT_PEER_WINDOW, global: DEFAULT_GLOBAL_WINDOW });
+    saturateGlobalWindow(limiter);
+
+    expect(limiter.check("203.0.113.7")).toMatchObject({ ok: false, scope: "global" });
+
+    expect(limiter.peerAttempts("203.0.113.7")).toBe(0);
+    // And the refusal did not charge them either — the same rule the peer
+    // branch already followed. Once the global window slides, they are a
+    // caller with a full budget rather than one that spent it being refused.
+    clock.now += DEFAULT_GLOBAL_WINDOW.windowMs + 1;
+    expect(limiter.check("203.0.113.7").ok).toBe(true);
+  });
+
+  it("does not record a caller the peer window refuses without ever having admitted", () => {
+    // A limit of zero refuses a caller who is not in the map, and the refusal
+    // must not be what puts them there.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 0, windowMs: 60_000 }, global: DEFAULT_GLOBAL_WINDOW });
+
+    expect(limiter.check("203.0.113.9")).toMatchObject({ ok: false, scope: "peer" });
+
+    expect(limiter.trackedPeers()).toBe(0);
+  });
+
+  it("still prunes a tracked caller's window when it refuses them", () => {
+    // The write the peer branch does keep: a caller already in the map has its
+    // aged-out timestamps dropped, so the map holds a window and not a history.
+    const clock = { now: 1_000 };
+    const limiter = limiterAt(clock, { peer: { limit: 2, windowMs: 60_000 }, global: DEFAULT_GLOBAL_WINDOW });
+    limiter.check("203.0.113.11");
+    clock.now += 30_000;
+    limiter.check("203.0.113.11");
+
+    expect(limiter.check("203.0.113.11")).toMatchObject({ ok: false, scope: "peer" });
+
+    clock.now += 30_001;
+    expect(limiter.peerAttempts("203.0.113.11")).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/core-pairing-redeem.test.ts
+++ b/packages/core/src/__tests__/core-pairing-redeem.test.ts
@@ -1,0 +1,552 @@
+// The pairing endpoint, against a real Core (#282).
+//
+// Everything here goes over the wire. The server is built by the Core's own
+// default factory, the certificates come from `generateCertMaterial` — the
+// material `actana setup` writes — the sessions go through the same
+// `PairingStore` the operator's `actana pair new` will write, and the client
+// dials `https` with no client certificate, because not having one is the whole
+// reason it is here.
+//
+// What that buys over a handler test: the claims this ticket makes are claims
+// about a *server* — that a route can be reached without a client certificate
+// while every other route on the same port cannot, that the certificate handed
+// back completes an mTLS handshake, that the bearer beside it satisfies the
+// `auth` frame. None of those can be observed from a handler in isolation.
+import * as fs from "node:fs";
+import * as https from "node:https";
+import { Server } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { X509Certificate, createPublicKey } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { generateCertMaterial, generateClientCsr } from "@actana/shared/core-cert-material";
+import { verifyBearer, decodeBearer } from "@actana/shared/core-link-bearer";
+import { generatePairingCode } from "@actana/shared/pairing-code";
+import { createPairingSession } from "@actana/shared/pairing-session";
+import { PairingStore, derivePairingCodeKey, hashPairingCode } from "@actana/shared/pairing-store";
+import { PtyCoreLinkServer } from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+import { createCoreFilesRequestHandler } from "../core-files-routes";
+import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "../core-pairing-wiring";
+import { PairingRateLimiter } from "../core-pairing-rate-limit";
+import type { PairingAuditEvent } from "../core-pairing-audit";
+
+const SECRET = "core-pairing-suite-secret-at-least-32-bytes";
+const CORE_UUID = "3f6d0f0a-6c1f-4a5e-9c2f-1d0a5b7e9c31";
+
+type Rig = {
+  origin: string;
+  wsUrl: string;
+  caCert: string;
+  store: PairingStore;
+  audit: PairingAuditEvent[];
+  /** Open a pending session and return its id and the code the operator reads out. */
+  openSession(opts?: { label?: string; ttlMs?: number; now?: number }): { sessionId: string; code: string };
+  clock: { now: number };
+};
+
+let server: PtyCoreLinkServer | null = null;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  server?.close();
+  server = null;
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+/** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = new Server();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address && typeof address === "object") {
+        const { port } = address;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+async function startCore(opts: { rateLimiter?: PairingRateLimiter } = {}): Promise<Rig> {
+  const material = await generateCertMaterial({ host: "127.0.0.1" });
+  const port = await freePort();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-pairing-"));
+  tempDirs.push(dir);
+  const store = new PairingStore(path.join(dir, "pairing.json"));
+  const audit: PairingAuditEvent[] = [];
+  // A clock the tests move, so "expired" is a fact rather than a wait.
+  const clock = { now: Date.now() };
+  const codeKey = derivePairingCodeKey(SECRET);
+
+  const pairingRoutes = buildCorePairingRoutes({
+    material: {
+      caCert: material.ca.cert,
+      caKey: material.ca.key,
+      bearerSecret: SECRET,
+      coreId: "core_pairing",
+      coreUuid: CORE_UUID,
+    },
+    sessions: store,
+    endpoint: `wss://127.0.0.1:${port}`,
+    now: () => clock.now,
+    audit: (event) => audit.push(event),
+    ...(opts.rateLimiter ? { rateLimiter: opts.rateLimiter } : {}),
+  });
+
+  // The file routes are mounted beside it, exactly as `core-entry` mounts them,
+  // so "every other route keeps its mTLS requirement" is asserted against a
+  // route that really is there.
+  const fileRoutes = createCoreFilesRequestHandler({
+    filesPort: { projectRoot: () => null },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+  });
+
+  // No `createServer` override — the default factory is what mounts the routes
+  // and applies the pre-auth gate, so overriding it would test a rig.
+  server = new PtyCoreLinkServer(mockCore(), {
+    port,
+    host: "127.0.0.1",
+    tls: {
+      caCert: material.ca.cert,
+      serverCert: material.server.cert,
+      serverKey: material.server.key,
+    },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+    httpRoutes: composeCoreHttpRoutes(pairingRoutes, fileRoutes),
+    isPreAuthPath: isPairingPath,
+  });
+
+  const rig: Rig = {
+    origin: `https://127.0.0.1:${port}`,
+    wsUrl: `wss://127.0.0.1:${port}`,
+    caCert: material.ca.cert,
+    store,
+    audit,
+    clock,
+    openSession: ({ label = "laptop", ttlMs, now } = {}) => {
+      const code = generatePairingCode();
+      const sessionId = `ps_${Math.random().toString(16).slice(2, 10)}`;
+      store.createSession(
+        createPairingSession({
+          id: sessionId,
+          label,
+          codeHash: hashPairingCode({ key: codeKey, sessionId, code }),
+          now: now ?? clock.now,
+          ...(ttlMs === undefined ? {} : { ttlMs }),
+        }),
+        clock.now,
+      );
+      return { sessionId, code };
+    },
+  };
+
+  // `listen` is fired without a callback inside the factory, so readiness is
+  // observed rather than awaited: poll until a request completes.
+  //
+  // The probe deliberately misses the pairing route. A probe that hit it would
+  // spend a rate-limit attempt and write an audit line before any test had
+  // started, and two suites below count exactly those.
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      await post(rig, "/healthz", "", { method: "GET" });
+      return rig;
+    } catch (err) {
+      if (Date.now() > deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+type Response = { status: number; headers: Record<string, string | string[] | undefined>; body: string };
+
+/** A pairing dial: the CA is verified, and no client certificate is presented. */
+function post(
+  rig: Rig,
+  url: string,
+  body: string | object,
+  opts: { clientCert?: { cert: string; key: string }; contentType?: string; method?: string } = {},
+): Promise<Response> {
+  const payload = typeof body === "string" ? body : JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      `${rig.origin}${url}`,
+      {
+        method: opts.method ?? "POST",
+        agent: false,
+        ca: rig.caCert,
+        ...(opts.clientCert ? { cert: opts.clientCert.cert, key: opts.clientCert.key } : {}),
+        headers: {
+          "content-type": opts.contentType ?? "application/json",
+          "content-length": String(Buffer.byteLength(payload)),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+type Redemption = { sessionId: string; code: string; csr: string; label?: string };
+
+function redeem(rig: Rig, redemption: Redemption): Promise<Response> {
+  return post(rig, "/v1/pair/redeem", {
+    sessionId: redemption.sessionId,
+    code: redemption.code,
+    client: { label: redemption.label ?? "laptop", platform: "linux" },
+    csr: redemption.csr,
+  });
+}
+
+/** The frames a client sees after dialling the core link with issued material. */
+function coreLinkAuth(rig: Rig, material: { cert: string; key: string }, bearer: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const seen: string[] = [];
+    const socket = new WebSocket(rig.wsUrl, { ca: rig.caCert, cert: material.cert, key: material.key });
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error(`no authOk — saw ${seen.join(", ") || "nothing"}`));
+    }, 10_000);
+    socket.on("open", () => socket.send(JSON.stringify({ type: "auth", reqId: "a1", bearer })));
+    socket.on("message", (data: unknown) => {
+      const frame = JSON.parse(String(data)) as { type: string };
+      seen.push(frame.type);
+      if (frame.type !== "authOk" && frame.type !== "authError") return;
+      clearTimeout(timer);
+      socket.close();
+      resolve(seen);
+    });
+    socket.on("error", (err: Error) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe("a client with a code, and no certificate, pairs end to end", () => {
+  it("issues a certificate, a CA and a bearer — and never a private key", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession({ label: "laptop" });
+    const { csrPem, privateKeyPem } = await generateClientCsr("laptop");
+
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+
+    expect(res.status).toBe(200);
+    const issued = JSON.parse(res.body) as Record<string, string>;
+    expect(Object.keys(issued).sort()).toEqual(["bearer", "caCert", "clientCert", "endpoint"]);
+    expect(issued.endpoint).toMatch(/^wss:\/\/127\.0\.0\.1:\d+$/);
+
+    // The response is searched for a key rather than checked field by field: a
+    // field added later would slip past a field-by-field assertion, and this is
+    // the property #280 will not trade — the private key never crosses the wire.
+    expect(res.body).not.toMatch(/PRIVATE KEY/);
+    expect(res.body).not.toContain(privateKeyPem.split("\n")[1]!);
+
+    const cert = new X509Certificate(issued.clientCert!);
+    expect(cert.verify(createPublicKey(issued.caCert!))).toBe(true);
+    expect(cert.ca).toBe(false);
+  }, 30_000);
+
+  it("hands back material that completes an mTLS handshake and an auth frame", async () => {
+    // The end of the flow, and the only assertion that proves the credential is
+    // *usable*: the same socket the Panel dials, with the certificate this
+    // endpoint signed and the bearer it issued beside it.
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem, privateKeyPem } = await generateClientCsr("laptop");
+
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+    const issued = JSON.parse(res.body) as Record<string, string>;
+
+    const frames = await coreLinkAuth(rig, { cert: issued.clientCert!, key: privateKeyPem }, issued.bearer!);
+
+    expect(frames).toContain("authOk");
+    expect(frames).not.toContain("authError");
+  }, 30_000);
+
+  it("issues a bearer carrying iss, sub, aud and jti beside exp", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+    const issued = JSON.parse(res.body) as Record<string, string>;
+
+    const verdict = verifyBearer(issued.bearer!, SECRET);
+    expect(verdict.ok).toBe(true);
+    if (!verdict.ok) return;
+    expect(verdict.aud).toBe(CORE_UUID);
+    expect(verdict.iss).toBe("core:core_pairing");
+    expect(verdict.sub).toBe(`pair:${new X509Certificate(issued.clientCert!).serialNumber.toLowerCase()}`);
+    expect(decodeBearer(issued.bearer!)?.jti).toMatch(/^[0-9a-f-]{36}$/);
+  }, 30_000);
+
+  it("persists the paired client so `pair ls` and `pair revoke` have something to read", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession({ label: "studio laptop" });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+    const issued = JSON.parse(res.body) as Record<string, string>;
+
+    const [client] = rig.store.listClients();
+    expect(client).toMatchObject({
+      label: "studio laptop",
+      sessionId,
+      revokedAt: null,
+      created_by: null,
+      tenant_id: null,
+      auth_method: null,
+    });
+    expect(client!.certSerial).toBe(new X509Certificate(issued.clientCert!).serialNumber.toLowerCase());
+    expect(client!.certSubject).toContain("studio laptop");
+  }, 30_000);
+});
+
+describe("the defences, over the real transport", () => {
+  it("kills the session at five wrong codes, and refuses identically throughout", async () => {
+    const rig = await startCore();
+    const { sessionId } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const refusals: Response[] = [];
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      refusals.push(await redeem(rig, { sessionId, code: "ZZZZ-ZZZZ", csr: csrPem }));
+    }
+
+    expect(refusals.map((r) => r.status)).toEqual([403, 403, 403, 403, 403]);
+    expect(new Set(refusals.map((r) => r.body)).size).toBe(1);
+    expect(rig.store.getSession(sessionId)?.attempts).toBe(5);
+
+    // And now even the right code is refused: the session is dead, not merely
+    // out of guesses.
+    const { code } = rig.openSession();
+    const dead = await redeem(rig, { sessionId, code, csr: csrPem });
+    expect(dead.status).toBe(403);
+    expect(dead.body).toBe(refusals[0]!.body);
+  }, 30_000);
+
+  it("refuses an expired session", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession({ ttlMs: 60_000 });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    rig.clock.now += 60_001;
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+
+    expect(res.status).toBe(403);
+    expect(rig.audit.at(-1)).toMatchObject({ outcome: "refused", reason: "expired" });
+  }, 30_000);
+
+  it("refuses a replay of a consumed session", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const first = await generateClientCsr("laptop");
+    const second = await generateClientCsr("attacker");
+
+    const ok = await redeem(rig, { sessionId, code, csr: first.csrPem });
+    const replay = await redeem(rig, { sessionId, code, csr: second.csrPem });
+
+    expect(ok.status).toBe(200);
+    expect(replay.status).toBe(403);
+    expect(rig.store.listClients()).toHaveLength(1);
+  }, 30_000);
+
+  it("refuses a code that belongs to another session", async () => {
+    // Session binding. The code is real, the session is real, and they are not
+    // each other's — which is the whole of "cannot be replayed against another".
+    const rig = await startCore();
+    const a = rig.openSession({ label: "a" });
+    const b = rig.openSession({ label: "b" });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const crossed = await redeem(rig, { sessionId: b.sessionId, code: a.code, csr: csrPem });
+
+    expect(crossed.status).toBe(403);
+    expect(rig.store.getSession(b.sessionId)?.attempts).toBe(1);
+    // And session A is untouched: the guess was spent against the session it
+    // named, not against the one the code came from.
+    expect(rig.store.getSession(a.sessionId)?.attempts).toBe(0);
+  }, 30_000);
+
+  it("refuses an unknown session with the same answer as a wrong code", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const unknown = await redeem(rig, { sessionId: "ps_nothing", code, csr: csrPem });
+    const wrong = await redeem(rig, { sessionId, code: "ZZZZ-ZZZZ", csr: csrPem });
+
+    expect(unknown.status).toBe(wrong.status);
+    expect(unknown.body).toBe(wrong.body);
+    expect(unknown.headers["content-length"]).toBe(wrong.headers["content-length"]);
+  }, 30_000);
+
+  it("trips its own rate limit before the per-session cap is spent", async () => {
+    // The defence the attempt cap cannot provide: this session has five
+    // attempts, and the endpoint stops the caller at three regardless.
+    const rig = await startCore({
+      rateLimiter: new PairingRateLimiter({ peer: { limit: 3, windowMs: 60_000 } }),
+    });
+    const { sessionId } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      statuses.push((await redeem(rig, { sessionId, code: "ZZZZ-ZZZZ", csr: csrPem })).status);
+    }
+
+    expect(statuses).toEqual([403, 403, 403, 429]);
+    expect(rig.store.getSession(sessionId)?.attempts).toBe(3);
+    expect(rig.audit.at(-1)).toMatchObject({ outcome: "rate-limited" });
+  }, 30_000);
+
+  it("does not spend the session on a CSR it cannot sign", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const bad = await redeem(rig, { sessionId, code, csr: "-----BEGIN CERTIFICATE REQUEST-----\nnope\n" });
+
+    expect(bad.status).toBe(400);
+    expect(rig.store.getSession(sessionId)?.consumedAt).toBeNull();
+
+    // The operator's code still works, which is the point of checking the CSR
+    // before consuming: a client bug must not cost a pairing session.
+    const { csrPem } = await generateClientCsr("laptop");
+    expect((await redeem(rig, { sessionId, code, csr: csrPem })).status).toBe(200);
+  }, 30_000);
+
+  it("lets only one of two simultaneous redemptions win", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const first = await generateClientCsr("laptop");
+    const second = await generateClientCsr("desktop");
+
+    const [a, b] = await Promise.all([
+      redeem(rig, { sessionId, code, csr: first.csrPem }),
+      redeem(rig, { sessionId, code, csr: second.csrPem }),
+    ]);
+
+    expect([a.status, b.status].sort()).toEqual([200, 403]);
+    expect(rig.store.listClients()).toHaveLength(1);
+  }, 30_000);
+
+  it("audits every attempt — success and failure — and never the code or the CSR", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession({ label: "laptop" });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    await redeem(rig, { sessionId, code: "ZZZZ-ZZZZ", csr: csrPem });
+    await redeem(rig, { sessionId, code, csr: csrPem });
+
+    expect(rig.audit.map((event) => event.outcome)).toEqual(["refused", "issued"]);
+    for (const event of rig.audit) {
+      expect(event.peer).toMatch(/127\.0\.0\.1|::ffff:127\.0\.0\.1|::1/);
+      expect(event.label).toBe("laptop");
+      const serialised = JSON.stringify(event);
+      expect(serialised).not.toContain(code);
+      expect(serialised).not.toContain("CERTIFICATE REQUEST");
+    }
+  }, 30_000);
+
+  it("refuses a body too large to be a redemption", async () => {
+    const rig = await startCore();
+    const res = await post(rig, "/v1/pair/redeem", { csr: "x".repeat(64 * 1024) });
+    expect(res.status).toBe(413);
+  }, 30_000);
+
+  it("refuses a GET at the redemption path", async () => {
+    const rig = await startCore();
+    const res = await post(rig, "/v1/pair/redeem", "", { method: "GET" });
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe("POST");
+  }, 30_000);
+});
+
+describe("the pre-auth hole is exactly one route wide", () => {
+  it("answers the pairing route to a client with no certificate", async () => {
+    const rig = await startCore();
+    const res = await post(rig, "/v1/pair/redeem", { sessionId: "ps_x", code: "AAAA-AAAA", csr: "x" });
+    // A refusal on the merits — not a TLS failure and not a 403 from the gate.
+    expect(res.status).toBe(400);
+  }, 30_000);
+
+  it("refuses every other route to that same client", async () => {
+    const rig = await startCore();
+
+    const files = await post(rig, "/v1/projects/p1/files?path=a.txt", "", { method: "GET" });
+    const unknown = await post(rig, "/healthz", "", { method: "GET" });
+
+    expect(files.status).toBe(403);
+    expect(JSON.parse(files.body).code).toBe("client-certificate-required");
+    expect(unknown.status).toBe(403);
+  }, 30_000);
+
+  it("refuses the core-link upgrade to that same client", async () => {
+    // The socket that can spawn a PTY is not part of the exception, and a
+    // pre-auth WebSocket would be one that never had to say who it was.
+    const rig = await startCore();
+
+    await expect(
+      new Promise((resolve, reject) => {
+        const socket = new WebSocket(rig.wsUrl, { ca: rig.caCert });
+        socket.on("open", () => {
+          socket.close();
+          resolve("opened");
+        });
+        socket.on("error", reject);
+      }),
+    ).rejects.toThrow(/403|Unexpected server response/i);
+  }, 30_000);
+
+  it("still serves a route to a client that does present its certificate", async () => {
+    // The gate refuses for want of a certificate, not for want of a bearer:
+    // this request has the certificate and no bearer, and must reach the file
+    // routes' own 401 rather than the gate's 403.
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem, privateKeyPem } = await generateClientCsr("laptop");
+    const issued = JSON.parse((await redeem(rig, { sessionId, code, csr: csrPem })).body) as Record<string, string>;
+
+    const res = await post(rig, "/v1/projects/p1/files?path=a.txt", "", {
+      method: "GET",
+      clientCert: { cert: issued.clientCert!, key: privateKeyPem },
+    });
+
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.body).code).toBe("unauthorized");
+  }, 30_000);
+});

--- a/packages/core/src/__tests__/core-pairing-wiring.test.ts
+++ b/packages/core/src/__tests__/core-pairing-wiring.test.ts
@@ -1,0 +1,78 @@
+// How the pairing family is mounted beside the file family (#282).
+//
+// The composition has one decision in it and it is not cosmetic: the file
+// routes claim the whole `/v1/` prefix, so asking them first would have them
+// answer `/v1/pair/redeem` with the `401` a client without a bearer gets —
+// which is every client that is here to be given one.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { CoreHttpRoutes } from "../core-files-routes";
+import { composeCoreHttpRoutes, isPairingPath } from "../core-pairing-wiring";
+
+/** A family that claims whatever its prefix names, and records that it did. */
+function family(prefix: string, claimed: string[]): CoreHttpRoutes {
+  const takes = (req: IncomingMessage): boolean => {
+    if (!(req.url ?? "").startsWith(prefix)) return false;
+    claimed.push(prefix);
+    return true;
+  };
+  return {
+    handle: (req) => takes(req),
+    handleContinue: (req) => takes(req),
+  };
+}
+
+const request = (url: string): IncomingMessage => ({ url }) as IncomingMessage;
+const response = (): ServerResponse => ({}) as ServerResponse;
+
+describe("composeCoreHttpRoutes", () => {
+  it("gives a request to the first family that claims it", () => {
+    const claimed: string[] = [];
+    const routes = composeCoreHttpRoutes(family("/v1/pair/", claimed), family("/v1/", claimed));
+
+    expect(routes.handle(request("/v1/pair/redeem"), response())).toBe(true);
+    expect(claimed).toEqual(["/v1/pair/"]);
+  });
+
+  it("does not offer it to the families behind that one", () => {
+    const claimed: string[] = [];
+    const routes = composeCoreHttpRoutes(family("/v1/pair/", claimed), family("/v1/", claimed));
+
+    routes.handle(request("/v1/pair/redeem"), response());
+
+    expect(claimed).toHaveLength(1);
+  });
+
+  it("falls through to the next family for a path the first does not claim", () => {
+    const claimed: string[] = [];
+    const routes = composeCoreHttpRoutes(family("/v1/pair/", claimed), family("/v1/", claimed));
+
+    expect(routes.handle(request("/v1/projects/p1/files"), response())).toBe(true);
+    expect(claimed).toEqual(["/v1/"]);
+  });
+
+  it("leaves an unclaimed path unclaimed, so the server keeps its 404", () => {
+    const claimed: string[] = [];
+    const routes = composeCoreHttpRoutes(family("/v1/pair/", claimed), family("/v1/", claimed));
+
+    expect(routes.handle(request("/healthz"), response())).toBe(false);
+    expect(routes.handleContinue(request("/healthz"), response())).toBe(false);
+  });
+
+  it("composes `handleContinue` the same way", () => {
+    const claimed: string[] = [];
+    const routes = composeCoreHttpRoutes(family("/v1/pair/", claimed), family("/v1/", claimed));
+
+    expect(routes.handleContinue(request("/v1/pair/redeem"), response())).toBe(true);
+    expect(claimed).toEqual(["/v1/pair/"]);
+  });
+});
+
+describe("isPairingPath", () => {
+  it("names the pairing prefix and nothing else", () => {
+    expect(isPairingPath("/v1/pair/redeem")).toBe(true);
+    expect(isPairingPath("/v1/projects/p1/files")).toBe(false);
+    expect(isPairingPath("/v1/pairing")).toBe(false);
+    expect(isPairingPath("/")).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/core-preauth-gate.test.ts
+++ b/packages/core/src/__tests__/core-preauth-gate.test.ts
@@ -1,0 +1,64 @@
+// The one hole in the mTLS wall, asserted as a rule rather than as a route
+// (#282). The end-to-end proof that a real server behaves this way is in
+// `core-pairing-redeem.test.ts`; this is the rule that server applies.
+import { describe, expect, it } from "vitest";
+import {
+  clientCertGate,
+  coreLinkUpgradeGate,
+  rejectUnauthorizedAtHandshake,
+} from "../core-preauth-gate";
+import { isPairingPath } from "../core-pairing-wiring";
+
+describe("clientCertGate", () => {
+  it("serves anything to a connection that presented a verified certificate", () => {
+    expect(clientCertGate({ pathname: "/v1/projects/p1/files", authorized: true })).toBe("serve");
+    expect(clientCertGate({ pathname: "/v1/pair/redeem", authorized: true, isPreAuthPath: isPairingPath })).toBe(
+      "serve",
+    );
+  });
+
+  it("serves the pairing path to a connection that presented none", () => {
+    expect(clientCertGate({ pathname: "/v1/pair/redeem", authorized: false, isPreAuthPath: isPairingPath })).toBe(
+      "serve",
+    );
+  });
+
+  it("refuses every other path to that connection", () => {
+    for (const pathname of ["/v1/projects/p1/files", "/v1/projects/p1/files/list", "/healthz", "/"]) {
+      expect(clientCertGate({ pathname, authorized: false, isPreAuthPath: isPairingPath })).toBe("refuse");
+    }
+  });
+
+  it("refuses everything when no pre-auth surface is configured", () => {
+    // A gate whose safety depends on a TLS flag set somewhere else is not a
+    // gate. This is the answer even on the Cores where it is unreachable.
+    expect(clientCertGate({ pathname: "/v1/pair/redeem", authorized: false })).toBe("refuse");
+  });
+
+  it("is not fooled by a path that merely starts like the pairing prefix", () => {
+    expect(
+      clientCertGate({ pathname: "/v1/pairing-secrets", authorized: false, isPreAuthPath: isPairingPath }),
+    ).toBe("refuse");
+  });
+});
+
+describe("coreLinkUpgradeGate", () => {
+  it("has no pairing exception at all", () => {
+    // A pre-auth WebSocket would be a socket that can ask this Core to spawn a
+    // PTY without ever having said who it is.
+    expect(coreLinkUpgradeGate(true)).toBe("serve");
+    expect(coreLinkUpgradeGate(false)).toBe("refuse");
+  });
+});
+
+describe("rejectUnauthorizedAtHandshake", () => {
+  it("keeps the TLS refusal for a Core that mounts no pre-auth surface", () => {
+    // Which is every Core built before #282, and every loopback Core after it:
+    // the relaxation is scoped to the Cores that actually pair.
+    expect(rejectUnauthorizedAtHandshake(undefined)).toBe(true);
+  });
+
+  it("relaxes it only where a pre-auth surface exists", () => {
+    expect(rejectUnauthorizedAtHandshake(isPairingPath)).toBe(false);
+  });
+});

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -59,6 +59,9 @@ import {
 } from "./pty-manager";
 import { PtyCoreLinkServer } from "./pty-core-link-server";
 import { buildCoreFileRoutes, shouldAnnounceFiles } from "./core-files-wiring";
+import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "./core-pairing-wiring";
+import type { CorePairingRoutesOptions } from "./core-pairing-routes";
+import { PairingStore, pairingStorePath } from "@actana/shared/pairing-store";
 import { createDirectory, listDirectory } from "./directory-browse";
 import { runCoreExec } from "./core-exec";
 import { configureProjectRootsDb } from "./project-roots";
@@ -340,6 +343,12 @@ async function startCore(): Promise<void> {
   // Panel client cert, and gates every frame behind a verified bearer. In
   // loopback mode (default) the server stays plain `ws://` and trusted — no
   // auth, no TLS, exactly as before.
+  // Set by the remote-mode block below when this Core has persisted material —
+  // the only shape of Core that can pair (#282). Left null otherwise, which is
+  // what keeps a loopback Core's TLS posture and route list exactly as they
+  // were.
+  let pairing: CorePairingRoutesOptions | null = null;
+
   const serverOpts: import("./pty-core-link-server").PtyCoreLinkServerOptions = {
     port,
     host,
@@ -444,6 +453,25 @@ async function startCore(): Promise<void> {
       }
       const { material, blob, certAction } = resolved;
       const secret: BearerSecret = material.bearerSecret;
+
+      // The pre-auth pairing endpoint (#282). Mounted only on this path, and
+      // that is the whole of the condition: pairing needs a CA key to sign
+      // with, a stable UUID to put in the bearers it issues, and a file the
+      // operator's `actana pair new` and this daemon can both see — all three
+      // are the persisted material, and a daemon started without one has
+      // nowhere for a session to live.
+      pairing = {
+        material: {
+          caCert: material.caCert,
+          caKey: material.caKey,
+          bearerSecret: material.bearerSecret,
+          coreId: material.coreId,
+          coreUuid: material.coreUuid,
+        },
+        sessions: new PairingStore(pairingStorePath(materialFile)),
+        endpoint: `wss://${publicHost}:${port}`,
+        bearerDays,
+      };
 
       serverOpts.tls = {
         caCert: material.caCert,
@@ -576,8 +604,23 @@ async function startCore(): Promise<void> {
     },
     ...(serverOpts.authVerifier ? { authVerifier: serverOpts.authVerifier } : {}),
   });
-  serverOpts.httpRoutes = fileRoutes;
+  // The pairing family goes first, and `composeCoreHttpRoutes` documents why:
+  // the file routes claim the whole `/v1/` prefix and would answer
+  // `/v1/pair/redeem` with the 401 a client without a bearer gets — which is
+  // every client that is here to be given one.
+  //
+  // `announceFiles` stays a statement about the *file* routes. The composed
+  // surface is no longer only them, so the default ("yes if any HTTP surface is
+  // mounted") would now be announcing a capability on the strength of a
+  // pairing endpoint — the exact confusion ADR 0028 D4 warns about.
+  serverOpts.httpRoutes = pairing
+    ? composeCoreHttpRoutes(buildCorePairingRoutes(pairing), fileRoutes)
+    : fileRoutes;
   serverOpts.announceFiles = shouldAnnounceFiles(fileRoutes);
+  // What the mTLS gate is allowed to serve without a client certificate. Absent
+  // unless pairing is mounted, and absent means the handshake keeps refusing
+  // uncertificated clients outright — see `core-preauth-gate.ts`.
+  if (pairing) serverOpts.isPreAuthPath = isPairingPath;
 
   const server = new PtyCoreLinkServer(core, serverOpts);
 

--- a/packages/core/src/core-first-run.ts
+++ b/packages/core/src/core-first-run.ts
@@ -36,10 +36,10 @@ import * as path from "node:path";
 import { signBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import { encodeRegistrationBlob } from "@actana/shared/registration-blob";
 import {
-  loadMaterialFromFile,
   mintFreshMaterial,
   persistMaterialToFile,
   checkServerCertHost,
+  readMaterialFile,
   reissueServerCert,
   type PersistedMaterial,
 } from "@actana/shared/core-material-store";
@@ -144,14 +144,21 @@ export type LoadOrMintResult = {
  */
 export async function loadOrMintMaterial(opts: LoadOrMintOptions): Promise<LoadOrMintResult> {
   if (fs.existsSync(opts.materialFile)) {
-    const existing = loadMaterialFromFile(opts.materialFile);
-    if (!existing) {
+    const read = readMaterialFile(opts.materialFile);
+    if (!read) {
       throw new Error(
         `${opts.materialFile} exists but could not be read as Core material. ` +
           "Fix or remove it — removing it re-mints this Core's identity and " +
           "every paired Panel has to re-pair.",
       );
     }
+    const existing = read.material;
+    // Material written before #282 has no stable core UUID, and the load just
+    // minted one. Writing it back here is what makes it stable: unpersisted, a
+    // Core would announce a different `aud` on every boot, which is the one
+    // thing that identifier exists not to do. Nothing else about the identity
+    // changes, so no Panel notices and nothing has to re-pair.
+    if (read.mintedCoreUuid) persistMaterialToFile(opts.materialFile, existing);
     const check = checkServerCertHost(existing, opts.publicHost);
     if (check === "covered" || !opts.publicHostDeclared) {
       return { material: existing, blob: null, certAction: "unchanged" };

--- a/packages/core/src/core-pairing-audit.ts
+++ b/packages/core/src/core-pairing-audit.ts
@@ -1,0 +1,135 @@
+// The audit record of every pairing attempt (#280, #282).
+//
+// Pairing is the one thing on a Core that turns knowledge of a short code into
+// a certificate this Core's CA vouches for, so "who asked, when, and what did
+// they get" is the record an operator needs after the fact — and needs for
+// failures as much as for successes, because a run of failures is what an
+// attack looks like from here.
+//
+// The whole of this module is one shape and one rule:
+//
+//   **What is logged is built from a fixed list of fields, never from the
+//   request.** The pairing code, the CSR and any key material are not on that
+//   list and cannot be added to it by a caller. A log line is the easiest place
+//   in this feature for a secret to end up — it is written on the failure path,
+//   it is read by people, and it outlives the request by however long the log
+//   is kept — so the redaction is a function with a test rather than a
+//   convention with a comment.
+//
+// The default sink is this repo's `log`, which is where every other Core-side
+// event goes; the seam exists so a test can read what was written, and so that
+// a later "ship the audit trail somewhere" has one place to attach.
+
+import log from "@actana/shared/log";
+
+/** What happened to one attempt. */
+export type PairingOutcome =
+  /** A certificate was issued. The only outcome that changes anything. */
+  | "issued"
+  /** The code, or the session's state, refused it. Indistinguishable on the wire. */
+  | "refused"
+  /** The endpoint's rate limit turned it away before the session was looked at. */
+  | "rate-limited"
+  /** The request was not shaped like a redemption at all. */
+  | "bad-request"
+  /** The Core failed — a CA key it could not read, a disk it could not write. */
+  | "core-error";
+
+/**
+ * One attempt, as the audit log records it.
+ *
+ * Every field is optional except the three that are always knowable, because a
+ * request refused before it was parsed still has to be logged: an attacker who
+ * could avoid the audit log by sending garbage would have found the way to
+ * knock quietly.
+ */
+export type PairingAuditEvent = {
+  outcome: PairingOutcome;
+  /**
+   * The internal reason, for the operator reading the log — `wrong-code`,
+   * `expired`, `unknown-session`.
+   *
+   * This is exactly the distinction the *response* refuses to draw (#282: an
+   * expired, consumed, unknown or dead session is refused identically). Here it
+   * is safe and necessary: the log is on the Core, read by the person who owns
+   * the Core, and the whole point of the uniform refusal is that the client
+   * cannot see this.
+   */
+  reason?: string;
+  /** The session the attempt named, when it named one that parsed. */
+  sessionId?: string | null;
+  /** The operator's label for that session. Display-only, and never a secret. */
+  label?: string | null;
+  /** Where the request came from — `req.socket.remoteAddress`. */
+  peer: string;
+  /** Wrong codes counted against the session after this attempt. */
+  attempts?: number;
+  /** The serial of the certificate issued, on the one outcome that issues. */
+  certSerial?: string;
+  /** Wall-clock ms. */
+  at: number;
+};
+
+/**
+ * The fields that may be written, in the order they are written.
+ *
+ * A list rather than a spread, and that is the whole mechanism: a field added
+ * to {@link PairingAuditEvent} later is not logged until somebody adds it here,
+ * which is a line in a diff a reviewer can see rather than a secret that
+ * appeared in a log because a type grew.
+ */
+const LOGGED_FIELDS = [
+  "outcome",
+  "reason",
+  "sessionId",
+  "label",
+  "peer",
+  "attempts",
+  "certSerial",
+  "at",
+] as const satisfies readonly (keyof PairingAuditEvent)[];
+
+/** Where an audit record goes. Injectable so a test can read what was written. */
+export type PairingAuditSink = (record: Record<string, unknown>) => void;
+
+/**
+ * Reduce an event to the fields that may be logged.
+ *
+ * Absent fields are dropped rather than written as `undefined`, so a line about
+ * a request that never named a session does not carry an empty `sessionId` for
+ * a reader to wonder about.
+ */
+export function redactPairingAuditEvent(event: PairingAuditEvent): Record<string, unknown> {
+  const record: Record<string, unknown> = {};
+  for (const field of LOGGED_FIELDS) {
+    const value = event[field];
+    if (value === undefined) continue;
+    record[field] = value;
+  }
+  return record;
+}
+
+/** The default sink: one structured line per attempt, at info. */
+export const logPairingAudit: PairingAuditSink = (record) => {
+  log.info("pairing.attempt", record);
+};
+
+/**
+ * Build the audit function the endpoint calls.
+ *
+ * The redaction happens here rather than in the sink, so that every sink — this
+ * repo's log today, something else later — gets the same already-safe record
+ * and none of them has to be trusted to redact.
+ */
+export function pairingAuditor(sink: PairingAuditSink = logPairingAudit): (event: PairingAuditEvent) => void {
+  return (event) => {
+    try {
+      sink(redactPairingAuditEvent(event));
+    } catch {
+      // An audit sink that throws must not take the request with it. The
+      // attempt has already been decided by the time this runs; losing the
+      // record is bad, and answering a paired client with a 500 because the
+      // log was unwritable is worse.
+    }
+  };
+}

--- a/packages/core/src/core-pairing-rate-limit.ts
+++ b/packages/core/src/core-pairing-rate-limit.ts
@@ -21,6 +21,12 @@
 // is a backstop against a distributed spray, not a limit an operator pairing a
 // handful of laptops should ever meet.
 //
+// The peer map is bounded, and the bound is a claim about the branch an
+// attacker drives rather than about the happy path: once the global window is
+// saturated every request is refused, so a bound enforced only where a request
+// is *allowed* is a bound that stops holding exactly when it is needed. See
+// {@link PairingRateLimiter.check}.
+//
 // No timers, no background sweep: a window is decided by comparing timestamps
 // when a request arrives. A Core that is not being paired with does no work
 // here at all.
@@ -61,6 +67,12 @@ export const DEFAULT_GLOBAL_WINDOW: RateLimitWindow = { limit: 60, windowMs: 60_
  */
 export const MAX_TRACKED_PEERS = 4096;
 
+/** Peers evicted in one pass, so the scan is amortised. See {@link MAX_TRACKED_PEERS}. */
+export const EVICTION_BATCH = 512;
+
+/** What an eviction pass trims down to — the cap, less one batch. */
+export const EVICTION_TARGET_PEERS = MAX_TRACKED_PEERS - EVICTION_BATCH;
+
 export type PairingRateLimiterOptions = {
   peer?: RateLimitWindow;
   global?: RateLimitWindow;
@@ -96,18 +108,41 @@ export class PairingRateLimiter {
    * The peer window is checked first so that a refusal names the limit the
    * caller actually hit — an operator who has mistyped a code eleven times
    * should be told it was them, not the Core.
+   *
+   * **A refusal never puts a peer in the map.** That is the memory bound, and
+   * it is stated here rather than left to {@link evictIfCrowded} because the
+   * eviction pass alone was not enough: it used to run on the allow path only,
+   * and once the global window is saturated the allow path is never taken
+   * again. Every request from a fresh address then added a permanent entry to
+   * a map nothing was pruning — one packet per entry, on this Core's only
+   * pre-auth surface, which is the exact attack this module's header claims to
+   * prevent. Saturating the global window costs six addresses at the default
+   * limits, so it was cheap to drive.
+   *
+   * So the two refusal branches below write nothing a fresh caller can grow,
+   * and the eviction pass runs on the way out of *every* branch. Either one
+   * would hold the bound today; together the invariant does not depend on
+   * which branch a future edit adds a `set` to.
    */
   check(peer: string): RateLimitVerdict {
     const now = this.now();
     const peerHits = within(this.peers.get(peer) ?? [], now, this.peerWindow.windowMs);
     if (peerHits.length >= this.peerWindow.limit) {
-      this.peers.set(peer, peerHits);
+      // Only ever a rewrite of the pruned window for a caller already tracked.
+      // `has` rather than a bare `set`, because a limit of zero would otherwise
+      // land an unseen caller here and insert an empty array for them.
+      if (this.peers.has(peer)) this.peers.set(peer, peerHits);
+      this.evictIfCrowded();
       return { ok: false, scope: "peer", retryAfterMs: retryAfter(peerHits, now, this.peerWindow) };
     }
     const globalHits = within(this.globalHits, now, this.globalWindow.windowMs);
     if (globalHits.length >= this.globalWindow.limit) {
       this.globalHits = globalHits;
-      this.peers.set(peer, peerHits);
+      // Nothing is recorded against the caller here, and nothing should be: a
+      // globally-refused attempt was not charged to their window either, which
+      // is the same rule the peer branch already followed — a refusal is not
+      // counted against the caller a second time.
+      this.evictIfCrowded();
       return { ok: false, scope: "global", retryAfterMs: retryAfter(globalHits, now, this.globalWindow) };
     }
     this.peers.set(peer, [...peerHits, now]);
@@ -134,19 +169,27 @@ export class PairingRateLimiter {
    * the entry is rewritten on every hit, and the ordering this relies on is
    * only "roughly oldest first", which is all an eviction policy for a
    * memory guard needs to be).
+   *
+   * It evicts down to {@link EVICTION_TARGET_PEERS} rather than to the cap, and
+   * the gap between the two is what stops this being quadratic. Trimming to
+   * exactly the cap leaves the map one insert over it again immediately, so the
+   * scan below ran on *every* subsequent insert — 50,000 addresses took ~53s in
+   * the review that found it. Leaving headroom means one scan per
+   * {@link EVICTION_BATCH} inserts, and the cap is still never exceeded by more
+   * than the single entry that triggered the pass.
    */
   private evictIfCrowded(): void {
     if (this.peers.size <= MAX_TRACKED_PEERS) return;
     const cutoff = this.now() - this.peerWindow.windowMs;
     for (const [peer, hits] of this.peers) {
       if (hits.length === 0 || hits[hits.length - 1]! <= cutoff) this.peers.delete(peer);
-      if (this.peers.size <= MAX_TRACKED_PEERS) return;
+      if (this.peers.size <= EVICTION_TARGET_PEERS) return;
     }
     // Everything tracked is still inside its window: drop from the front, which
     // is the least recently *first* seen, rather than growing without bound.
     for (const peer of this.peers.keys()) {
       this.peers.delete(peer);
-      if (this.peers.size <= MAX_TRACKED_PEERS) return;
+      if (this.peers.size <= EVICTION_TARGET_PEERS) return;
     }
   }
 }

--- a/packages/core/src/core-pairing-rate-limit.ts
+++ b/packages/core/src/core-pairing-rate-limit.ts
@@ -1,0 +1,164 @@
+// Rate limiting for the Core's one pre-auth endpoint (#280, #282).
+//
+// The per-session attempt cap already bounds guessing *within* a session: five
+// wrong codes and that session is dead. It bounds nothing across sessions. An
+// attacker who can reach the endpoint can hold a thousand guesses a second
+// against every session an operator ever opens, and each one costs them five
+// tries against a five-minute window rather than one. That is why #280 lists
+// rate limiting as a defence of its own and this module is separate from
+// `pairing-session.ts`: the cap is per session and this is per caller, and
+// collapsing them would leave the gap between them open.
+//
+// Two windows, both fixed-size and both counted here:
+//
+//   • **Per peer** — the address the TCP connection came from. This is the one
+//     that stops a single machine spraying codes.
+//   • **Global** — every attempt this Core saw, whatever the source. This is
+//     the one that survives an attacker with a thousand source addresses, and
+//     it is why "just key it by IP" is not the whole answer.
+//
+// The global window is deliberately generous relative to the per-peer one: it
+// is a backstop against a distributed spray, not a limit an operator pairing a
+// handful of laptops should ever meet.
+//
+// No timers, no background sweep: a window is decided by comparing timestamps
+// when a request arrives. A Core that is not being paired with does no work
+// here at all.
+
+/** A verdict, with what to tell the caller when it is a refusal. */
+export type RateLimitVerdict =
+  | { ok: true }
+  | { ok: false; scope: "peer" | "global"; retryAfterMs: number };
+
+export type RateLimitWindow = {
+  /** Attempts allowed inside one window. */
+  limit: number;
+  /** The window, in ms. */
+  windowMs: number;
+};
+
+/**
+ * Ten attempts a minute from one address.
+ *
+ * An operator pairing a machine sends one request; a human retyping a code
+ * they misheard sends a handful. Ten is far above the honest case and far
+ * below what makes guessing 2^39.6 codes worth starting.
+ */
+export const DEFAULT_PEER_WINDOW: RateLimitWindow = { limit: 10, windowMs: 60_000 };
+
+/** Sixty attempts a minute across every caller — the distributed-spray backstop. */
+export const DEFAULT_GLOBAL_WINDOW: RateLimitWindow = { limit: 60, windowMs: 60_000 };
+
+/**
+ * How many peers are tracked before the quietest are forgotten.
+ *
+ * This is a pre-auth surface, so the set of keys is chosen by whoever is
+ * dialling: an unbounded map here is a memory exhaustion attack that costs the
+ * attacker one packet per entry. Evicting the least recently seen peer is safe
+ * in the direction that matters — an evicted peer starts a fresh window, but
+ * getting evicted requires 4,096 *other* addresses to have been seen inside
+ * the same minute, which the global window is already refusing.
+ */
+export const MAX_TRACKED_PEERS = 4096;
+
+export type PairingRateLimiterOptions = {
+  peer?: RateLimitWindow;
+  global?: RateLimitWindow;
+  /** Injectable clock. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+/**
+ * A fixed-window counter over the pairing endpoint.
+ *
+ * {@link check} both decides and records: an allowed attempt is counted, and a
+ * refused one is not counted again. Counting a refusal would let a caller
+ * extend their own lockout by continuing to knock, which sounds like a feature
+ * and is in fact how a shared NAT address locks out an office.
+ */
+export class PairingRateLimiter {
+  private readonly peerWindow: RateLimitWindow;
+  private readonly globalWindow: RateLimitWindow;
+  private readonly now: () => number;
+  /** Per peer: the attempt timestamps inside the current window. */
+  private readonly peers = new Map<string, number[]>();
+  private globalHits: number[] = [];
+
+  constructor(opts: PairingRateLimiterOptions = {}) {
+    this.peerWindow = opts.peer ?? DEFAULT_PEER_WINDOW;
+    this.globalWindow = opts.global ?? DEFAULT_GLOBAL_WINDOW;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Take one attempt for `peer`, or refuse it.
+   *
+   * The peer window is checked first so that a refusal names the limit the
+   * caller actually hit — an operator who has mistyped a code eleven times
+   * should be told it was them, not the Core.
+   */
+  check(peer: string): RateLimitVerdict {
+    const now = this.now();
+    const peerHits = within(this.peers.get(peer) ?? [], now, this.peerWindow.windowMs);
+    if (peerHits.length >= this.peerWindow.limit) {
+      this.peers.set(peer, peerHits);
+      return { ok: false, scope: "peer", retryAfterMs: retryAfter(peerHits, now, this.peerWindow) };
+    }
+    const globalHits = within(this.globalHits, now, this.globalWindow.windowMs);
+    if (globalHits.length >= this.globalWindow.limit) {
+      this.globalHits = globalHits;
+      this.peers.set(peer, peerHits);
+      return { ok: false, scope: "global", retryAfterMs: retryAfter(globalHits, now, this.globalWindow) };
+    }
+    this.peers.set(peer, [...peerHits, now]);
+    this.globalHits = [...globalHits, now];
+    this.evictIfCrowded();
+    return { ok: true };
+  }
+
+  /** Attempts counted for one peer inside the current window. For tests and logs. */
+  peerAttempts(peer: string): number {
+    return within(this.peers.get(peer) ?? [], this.now(), this.peerWindow.windowMs).length;
+  }
+
+  /** Peers currently tracked. Bounded by {@link MAX_TRACKED_PEERS}. */
+  trackedPeers(): number {
+    return this.peers.size;
+  }
+
+  /**
+   * Forget the quietest peers once the map is too big.
+   *
+   * `Map` iterates in insertion order and every recorded attempt re-inserts its
+   * peer at the end (`set` after a `delete` is what would guarantee that — but
+   * the entry is rewritten on every hit, and the ordering this relies on is
+   * only "roughly oldest first", which is all an eviction policy for a
+   * memory guard needs to be).
+   */
+  private evictIfCrowded(): void {
+    if (this.peers.size <= MAX_TRACKED_PEERS) return;
+    const cutoff = this.now() - this.peerWindow.windowMs;
+    for (const [peer, hits] of this.peers) {
+      if (hits.length === 0 || hits[hits.length - 1]! <= cutoff) this.peers.delete(peer);
+      if (this.peers.size <= MAX_TRACKED_PEERS) return;
+    }
+    // Everything tracked is still inside its window: drop from the front, which
+    // is the least recently *first* seen, rather than growing without bound.
+    for (const peer of this.peers.keys()) {
+      this.peers.delete(peer);
+      if (this.peers.size <= MAX_TRACKED_PEERS) return;
+    }
+  }
+}
+
+/** The timestamps still inside the window ending at `now`. */
+function within(hits: number[], now: number, windowMs: number): number[] {
+  const cutoff = now - windowMs;
+  return hits.filter((at) => at > cutoff);
+}
+
+/** How long until the oldest attempt in the window falls out of it. */
+function retryAfter(hits: number[], now: number, window: RateLimitWindow): number {
+  const oldest = hits[0] ?? now;
+  return Math.max(0, oldest + window.windowMs - now);
+}

--- a/packages/core/src/core-pairing-routes.ts
+++ b/packages/core/src/core-pairing-routes.ts
@@ -1,0 +1,584 @@
+// The Core's pairing endpoint — the one route on this machine that answers a
+// client holding no certificate (#280, #282).
+//
+// A client with a pairing code posts here, and what it gets back is the
+// credential every other surface on this Core requires it to already have. That
+// makes this file the Core's only pre-auth attack surface, and the reason the
+// defences below are not negotiable:
+//
+//   POST /v1/pair/redeem
+//   { "sessionId", "code", "client": { … }, "csr": "-----BEGIN CERTIFICATE REQUEST-----" }
+//   → 200 { "caCert", "clientCert", "bearer", "endpoint" }
+//
+// **The private key is not in that exchange, in either direction.** The client
+// generates its key pair, keeps the private half and sends a CSR; this Core
+// signs it and sends back a certificate. There is nothing here that could
+// return a key because there is nothing here that has one (#280).
+//
+// **Validation runs in a fixed order** — rate limit, then session lookup and
+// binding, then TTL, then single use, then the attempt cap, and only then the
+// code itself. The order is the design's, not a convenience: every check before
+// the code is one an attacker cannot influence with a guess, so a guess reaches
+// the comparison only after the cheap defences have had their say.
+//
+// **Every refusal is the same refusal.** Expired, consumed, unknown, dead,
+// wrong code — one status, one body, no header that differs. A response that
+// said *which* would tell an attacker whether a session id exists, whether it
+// is still live, and whether their last guess was closer; the audit log on this
+// Core says all of it, because the operator reading that log already owns the
+// Core.
+//
+// It mounts on the `https.Server` the core link and the `/v1/…` file routes
+// already share (ADR 0028 — one port, one certificate, two protocols), through
+// the same `CoreHttpRoutes` shape `core-files-routes.ts` returns.
+// `core-preauth-gate.ts` is what lets an uncertificated client reach it without
+// opening anything else, and `core-pairing-wiring.ts` is where the two are tied
+// together.
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { CsrRejectedError, assertSignableCsr, signClientCsr } from "@actana/shared/core-cert-material";
+import { signBearer } from "@actana/shared/core-link-bearer";
+import { normalisePairingCode } from "@actana/shared/pairing-code";
+import { isConsumed, isDead, isExpired, type PairingSession } from "@actana/shared/pairing-session";
+import {
+  derivePairingCodeKey,
+  hashPairingCode,
+  pairingCodeMatches,
+  type PairedClient,
+  type PairingConsumeOutcome,
+} from "@actana/shared/pairing-store";
+import log from "@actana/shared/log";
+import type { CoreHttpRoutes } from "./core-files-routes";
+import { pairingAuditor, type PairingAuditEvent } from "./core-pairing-audit";
+import { PairingRateLimiter } from "./core-pairing-rate-limit";
+
+/** Everything this module answers lives under here. */
+export const CORE_PAIRING_ROUTE_PREFIX = "/v1/pair/";
+
+/** The one route. Named so the pre-auth gate and the tests agree on the string. */
+export const CORE_PAIRING_REDEEM_PATH = "/v1/pair/redeem";
+
+/**
+ * The most a redemption body may weigh.
+ *
+ * A CSR for a 2048-bit RSA key is around 1 KB in PEM; 16 KB leaves room for a
+ * larger key and a label without leaving a pre-auth endpoint willing to buffer
+ * whatever an attacker feels like sending.
+ */
+export const MAX_REDEEM_BODY_BYTES = 16 * 1024;
+
+/**
+ * How much of an over-sized body is read before the socket is simply dropped.
+ *
+ * A client that sent a request slightly too big gets a `413` it can act on; a
+ * sender still going at a megabyte is not making a request this Core has any
+ * reason to finish reading.
+ */
+export const DRAIN_CEILING_BYTES = 1024 * 1024;
+
+/** How long an issued bearer is good for, when the caller does not say. */
+export const DEFAULT_PAIRED_BEARER_DAYS = 365;
+
+/**
+ * The store of sessions and paired clients, as this endpoint uses it.
+ *
+ * A port rather than the class, so the endpoint can be exercised against an
+ * in-memory double — `PairingStore` in `@actana/shared/pairing-store` satisfies
+ * it structurally and is what the daemon passes.
+ */
+export interface PairingSessionPort {
+  /** The session with this id, or `null`. */
+  getSession(id: string): PairingSession | null;
+  /** Count a wrong code. Returns the session as it now stands, or `null`. */
+  recordWrongAttempt(id: string): PairingSession | null;
+  /** Mark consumed if it may be — the step that decides who wins a race. */
+  consume(id: string, now: number): PairingConsumeOutcome;
+  /** Persist the identity of a client that just paired. */
+  recordClient(client: PairedClient): void;
+}
+
+/** What this Core signs and speaks as. A slice of `PersistedMaterial`. */
+export type PairingIssuerMaterial = {
+  /** PEM CA certificate — signed against, and handed to the client. */
+  caCert: string;
+  /** PEM CA private key. Never leaves this process. */
+  caKey: string;
+  /** HMAC secret for the issued bearer, and the root of the code digest key. */
+  bearerSecret: string;
+  /** The `coreId` claim, as every bearer has always carried. */
+  coreId: string;
+  /** The stable core UUID — the `aud` claim (#280). */
+  coreUuid: string;
+};
+
+export type CorePairingRoutesOptions = {
+  material: PairingIssuerMaterial;
+  sessions: PairingSessionPort;
+  /**
+   * The `wss://host:port` a paired client dials afterwards — what goes in the
+   * response's `endpoint`, and from there into the client's blob-shaped
+   * credential. The Core's own idea of its public address, not a value derived
+   * from the request: a `Host` header is chosen by the caller, and a client
+   * that pinned it would have pinned whatever an attacker wrote there.
+   */
+  endpoint: string;
+  /** Issued bearer lifetime. Defaults to {@link DEFAULT_PAIRED_BEARER_DAYS}. */
+  bearerDays?: number;
+  /** Shared across requests. A fresh default one is made when omitted. */
+  rateLimiter?: PairingRateLimiter;
+  /** Where attempts are recorded. Defaults to this repo's log. */
+  audit?: (event: PairingAuditEvent) => void;
+  /** Injectable clock. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+/** A refusal, in the JSON shape `core-files-routes.ts` already answers with. */
+type Refusal = { status: number; code: string; message: string; headers?: Record<string, string> };
+
+/**
+ * The single refusal every session-state and wrong-code failure answers with.
+ *
+ * One object, referenced by every branch, because "indistinguishable" is a
+ * property that decays the moment two call sites write their own version of it.
+ */
+const PAIRING_REFUSED: Refusal = {
+  status: 403,
+  code: "pairing-refused",
+  message: "this pairing code cannot be redeemed",
+};
+
+/** Build the pairing route family. */
+export function createCorePairingRequestHandler(opts: CorePairingRoutesOptions): CoreHttpRoutes {
+  const now = opts.now ?? (() => Date.now());
+  const rateLimiter = opts.rateLimiter ?? new PairingRateLimiter({ now });
+  const audit = opts.audit ?? pairingAuditor();
+  const bearerDays = opts.bearerDays ?? DEFAULT_PAIRED_BEARER_DAYS;
+  const codeKey = derivePairingCodeKey(opts.material.bearerSecret);
+
+  function handle(req: IncomingMessage, res: ServerResponse): boolean {
+    const url = new URL(req.url ?? "/", "https://core.invalid");
+    if (!url.pathname.startsWith(CORE_PAIRING_ROUTE_PREFIX)) return false;
+    void route(req, res, url).catch((err: unknown) => {
+      // Anything reaching here is a bug in this file: every expected refusal
+      // is returned rather than thrown. Say nothing useful on the wire.
+      log.error("core-pairing.unhandled", { error: err instanceof Error ? err.message : String(err) });
+      audit({ outcome: "core-error", reason: "unhandled", peer: peerOf(req), at: now() });
+      sendRefusal(res, { status: 500, code: "core-error", message: "the Core failed to handle this request" });
+    });
+    return true;
+  }
+
+  /**
+   * `Expect: 100-continue` on a redemption.
+   *
+   * A listener has to exist or Node answers `100 Continue` itself for every
+   * route on this server (see `mountHttpRoutes`), so the choice is what to do
+   * rather than whether to be here. An oversized body is refused before it is
+   * sent; everything else is continued and handled exactly as a plain POST,
+   * which keeps one path through {@link route} and one rate-limit count.
+   */
+  function handleContinue(req: IncomingMessage, res: ServerResponse): boolean {
+    const url = new URL(req.url ?? "/", "https://core.invalid");
+    if (!url.pathname.startsWith(CORE_PAIRING_ROUTE_PREFIX)) return false;
+    const declared = Number(req.headers["content-length"] ?? 0);
+    if (Number.isFinite(declared) && declared > MAX_REDEEM_BODY_BYTES) {
+      sendRefusal(res, tooLarge());
+      return true;
+    }
+    res.writeContinue();
+    return handle(req, res);
+  }
+
+  async function route(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+    const peer = peerOf(req);
+
+    if (url.pathname !== CORE_PAIRING_REDEEM_PATH) {
+      return sendRefusal(res, { status: 404, code: "not-found", message: `no route for ${url.pathname}` });
+    }
+    if (req.method !== "POST") {
+      return sendRefusal(res, {
+        status: 405,
+        code: "method-not-allowed",
+        message: `${req.method ?? "?"} is not allowed here — use POST`,
+        headers: { allow: "POST" },
+      });
+    }
+
+    // ── 1. Rate limit ──
+    // First, and before anything is read off the socket: this is the defence
+    // that has to hold when the attacker is not playing along, and every check
+    // after it costs this process something an attacker can ask for at will.
+    const verdict = rateLimiter.check(peer);
+    if (!verdict.ok) {
+      audit({ outcome: "rate-limited", reason: verdict.scope, peer, at: now() });
+      return sendRefusal(res, {
+        status: 429,
+        code: "rate-limited",
+        message: "too many pairing attempts — wait and try again",
+        headers: { "retry-after": String(Math.ceil(verdict.retryAfterMs / 1000)) },
+      });
+    }
+
+    const body = await readJsonBody(req);
+    if (!body.ok) {
+      audit({ outcome: "bad-request", reason: body.reason, peer, at: now() });
+      return sendRefusal(res, body.refusal);
+    }
+    const request = parseRedeemRequest(body.value);
+    if (!request.ok) {
+      audit({ outcome: "bad-request", reason: request.reason, peer, at: now() });
+      return sendRefusal(res, {
+        status: 400,
+        code: "bad-request",
+        message: request.message,
+      });
+    }
+    const { sessionId, code, label: clientLabel, csr } = request.value;
+
+    // ── 2. Session lookup and binding ──
+    // The redemption names one session and is answered by that session or by
+    // nothing. There is no search for a session the code might belong to, which
+    // is what "cannot be replayed against another" means in code: the digest
+    // below is taken over this session's id, so a code lifted from session A
+    // does not hash to session B's stored digest even if it is the right code.
+    const session = opts.sessions.getSession(sessionId);
+    if (!session) {
+      audit({ outcome: "refused", reason: "unknown-session", sessionId, peer, at: now() });
+      return sendRefusal(res, PAIRING_REFUSED);
+    }
+
+    // ── 3. TTL · 4. Single use · 5. Attempt cap ──
+    // Written out in the order #282 fixes rather than delegated to `canRedeem`,
+    // whose internal order is its own. Nothing observable turns on which of the
+    // three answers first — all three produce the one refusal — but the order a
+    // reader has to check against the spec is the order it is written in.
+    const at = now();
+    if (isExpired(session, at)) return refuse(res, audit, session, peer, "expired");
+    if (isConsumed(session)) return refuse(res, audit, session, peer, "already-consumed");
+    if (isDead(session)) return refuse(res, audit, session, peer, "attempts-exhausted");
+
+    // ── 6. The code ──
+    // A code that is not in the alphabet at all is a wrong code, not a protocol
+    // error: it is a guess that cannot be right, and treating it as a 400 would
+    // hand an attacker a free probe that never costs them an attempt.
+    const canonical = normalisePairingCode(code);
+    const candidate =
+      canonical === null ? null : hashPairingCode({ key: codeKey, sessionId, code: canonical });
+    if (candidate === null || !pairingCodeMatches(session.codeHash, candidate)) {
+      const after = opts.sessions.recordWrongAttempt(sessionId);
+      audit({
+        outcome: "refused",
+        reason: canonical === null ? "malformed-code" : "wrong-code",
+        sessionId,
+        label: session.label,
+        peer,
+        attempts: after?.attempts ?? session.attempts,
+        at: now(),
+      });
+      return sendRefusal(res, PAIRING_REFUSED);
+    }
+
+    // ── The CSR, before anything is spent ──
+    // Checked here rather than at the signature below so that a malformed
+    // request does not consume the operator's session: the code was right, so
+    // this is a client bug rather than an attack, and the operator should not
+    // have to mint a new code for it. An attacker gains nothing — they had to
+    // know the code to get this far.
+    try {
+      await assertSignableCsr(csr);
+    } catch (err) {
+      if (!(err instanceof CsrRejectedError)) throw err;
+      audit({
+        outcome: "bad-request",
+        reason: `csr-${err.rejection}`,
+        sessionId,
+        label: session.label,
+        peer,
+        at: now(),
+      });
+      return sendRefusal(res, { status: 400, code: "bad-request", message: "the CSR was not acceptable" });
+    }
+
+    // ── Consume, then issue ──
+    // This is the step that decides a race, and it is a single synchronous
+    // read-modify-write inside the store. Two redemptions arriving together
+    // both reach here; one marks the session consumed and goes on to sign, the
+    // other is told `already-consumed` and gets the same refusal a replay gets.
+    const consumed = opts.sessions.consume(sessionId, at);
+    if (!consumed.ok) return refuse(res, audit, session, peer, consumed.reason);
+
+    let issued;
+    try {
+      issued = await signClientCsr({
+        ca: { cert: opts.material.caCert, key: opts.material.caKey },
+        csrPem: csr,
+        // The subject is the Core's to write, from what the operator typed when
+        // they opened the session — never from the CSR, which is the client's
+        // to fill in. See `signClientCsr`.
+        subject: `CN=${certCommonName(session.label || clientLabel || sessionId)}`,
+      });
+    } catch (err) {
+      // The session is spent and no certificate exists. That is the safe
+      // direction: the operator runs `actana pair new` again, where the other
+      // one would leave a live code after a failed issuance.
+      log.error("core-pairing.sign-failed", { error: err instanceof Error ? err.message : String(err) });
+      audit({ outcome: "core-error", reason: "sign-failed", sessionId, label: session.label, peer, at: now() });
+      return sendRefusal(res, { status: 500, code: "core-error", message: "this Core could not sign the request" });
+    }
+
+    const client: PairedClient = {
+      certSerial: issued.serial,
+      certSubject: issued.subject,
+      label: session.label,
+      sessionId,
+      pairedAt: at,
+      certNotAfter: issued.notAfter,
+      revokedAt: null,
+      // Inert (#280), carried across from the session so a later identity layer
+      // can read on the client what it wrote on the session.
+      created_by: session.created_by,
+      tenant_id: session.tenant_id,
+      auth_method: session.auth_method,
+    };
+    opts.sessions.recordClient(client);
+
+    const bearer = signBearer(
+      {
+        coreId: opts.material.coreId,
+        exp: at + bearerDays * 24 * 60 * 60 * 1000,
+        // The four claims #280 fixes on, all inert in this train. `sub` is the
+        // certificate serial because that is what identifies *this pairing* —
+        // a label is whatever the operator typed, possibly twice.
+        iss: `core:${opts.material.coreId}`,
+        sub: `pair:${issued.serial}`,
+        aud: opts.material.coreUuid,
+        jti: randomUUID(),
+      },
+      opts.material.bearerSecret,
+    );
+
+    audit({
+      outcome: "issued",
+      sessionId,
+      label: session.label,
+      peer,
+      certSerial: issued.serial,
+      at: now(),
+    });
+
+    // Four fields, and the absence of a fifth is the point: there is no key
+    // here, and `core-pairing-redeem.test.ts` asserts the response never
+    // contains one.
+    sendJson(res, 200, {
+      caCert: opts.material.caCert,
+      clientCert: issued.cert,
+      bearer,
+      endpoint: opts.endpoint,
+    });
+  }
+
+  return { handle, handleContinue };
+}
+
+/** Answer the one refusal, and record which defence produced it. */
+function refuse(
+  res: ServerResponse,
+  audit: (event: PairingAuditEvent) => void,
+  session: PairingSession,
+  peer: string,
+  reason: string,
+): void {
+  audit({
+    outcome: "refused",
+    reason,
+    sessionId: session.id,
+    label: session.label,
+    peer,
+    attempts: session.attempts,
+    at: Date.now(),
+  });
+  sendRefusal(res, PAIRING_REFUSED);
+}
+
+type RedeemRequest = {
+  sessionId: string;
+  code: string;
+  label: string | null;
+  csr: string;
+};
+
+type ParseResult =
+  | { ok: true; value: RedeemRequest }
+  | { ok: false; reason: string; message: string };
+
+/**
+ * Read the redemption out of a parsed JSON body.
+ *
+ * Refuses everything it does not recognise rather than coercing it: this is the
+ * one endpoint on the Core where the sender is unauthenticated, so "was it a
+ * string?" is the last question asked before the answer is used in a
+ * cryptographic operation.
+ */
+function parseRedeemRequest(body: unknown): ParseResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, reason: "not-an-object", message: "the body must be a JSON object" };
+  }
+  const o = body as Record<string, unknown>;
+  const sessionId = o.sessionId;
+  const code = o.code;
+  const csr = o.csr;
+  if (typeof sessionId !== "string" || sessionId.length === 0 || sessionId.length > 128) {
+    return { ok: false, reason: "bad-session-id", message: "`sessionId` must be a non-empty string" };
+  }
+  if (typeof code !== "string" || code.length === 0 || code.length > 64) {
+    return { ok: false, reason: "bad-code", message: "`code` must be a non-empty string" };
+  }
+  if (typeof csr !== "string" || !csr.includes("BEGIN CERTIFICATE REQUEST")) {
+    return { ok: false, reason: "bad-csr", message: "`csr` must be a PEM certificate request" };
+  }
+  const client = o.client;
+  const label =
+    client && typeof client === "object" && typeof (client as Record<string, unknown>).label === "string"
+      ? String((client as Record<string, unknown>).label).slice(0, 64)
+      : null;
+  return { ok: true, value: { sessionId, code, label, csr } };
+}
+
+type BodyResult =
+  | { ok: true; value: unknown }
+  | { ok: false; reason: string; refusal: Refusal };
+
+/**
+ * Read the request body, refusing anything over {@link MAX_REDEEM_BODY_BYTES}.
+ *
+ * The cap is enforced as the bytes arrive, not against `content-length`: a
+ * `content-length` is whatever the sender wrote, and a chunked body has none at
+ * all.
+ *
+ * Past the cap nothing is kept, and the rest of the body is **drained rather
+ * than cut off**. Destroying the socket there is the obvious move and it is
+ * wrong: the refusal would be written into a connection that is about to be
+ * reset, so a client sending one byte too many would see a dropped connection
+ * instead of the `413` telling it why. Draining costs the read of a body the
+ * sender has already put on the wire, and it stops at
+ * {@link DRAIN_CEILING_BYTES} — past *that* the sender is not a client that
+ * mis-sized a request, and the socket goes.
+ */
+function readJsonBody(req: IncomingMessage): Promise<BodyResult> {
+  const contentType = String(req.headers["content-type"] ?? "").split(";")[0]!.trim().toLowerCase();
+  if (contentType !== "" && contentType !== "application/json") {
+    return Promise.resolve({
+      ok: false,
+      reason: "content-type",
+      refusal: {
+        status: 415,
+        code: "unsupported-media-type",
+        message: "a redemption is `application/json`",
+      },
+    });
+  }
+  return new Promise<BodyResult>((resolve) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let tooBig = false;
+    let settled = false;
+    const settle = (result: BodyResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_REDEEM_BODY_BYTES) {
+        tooBig = true;
+        chunks.length = 0;
+        if (size > DRAIN_CEILING_BYTES) {
+          settle({ ok: false, reason: "too-large", refusal: tooLarge() });
+          req.destroy();
+        }
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (tooBig) return settle({ ok: false, reason: "too-large", refusal: tooLarge() });
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } catch {
+        settle({
+          ok: false,
+          reason: "bad-json",
+          refusal: { status: 400, code: "bad-request", message: "the body was not JSON" },
+        });
+        return;
+      }
+      settle({ ok: true, value: parsed });
+    });
+    req.on("error", () => {
+      settle({
+        ok: false,
+        reason: "read-failed",
+        refusal: { status: 400, code: "bad-request", message: "the request body could not be read" },
+      });
+    });
+  });
+}
+
+function tooLarge(): Refusal {
+  return {
+    status: 413,
+    code: "payload-too-large",
+    message: `a redemption is at most ${MAX_REDEEM_BODY_BYTES} bytes`,
+  };
+}
+
+/**
+ * The address this attempt came from, for the audit log.
+ *
+ * `unknown` rather than an empty string when the socket has already gone: a log
+ * line that says where it came from and a log line that says nothing must not
+ * look the same.
+ */
+function peerOf(req: IncomingMessage): string {
+  return req.socket.remoteAddress ?? "unknown";
+}
+
+/**
+ * A label as it can appear inside a certificate subject.
+ *
+ * The operator typed this, and it ends up in an X.509 distinguished name where
+ * `,`, `=` and `+` are structure rather than text. Everything outside a
+ * conservative set is replaced rather than escaped: a certificate subject is
+ * not the place to be clever, and no operator will miss the difference between
+ * `my laptop` and `my-laptop` in a `pair ls` row.
+ */
+function certCommonName(label: string): string {
+  const cleaned = label.replace(/[^A-Za-z0-9 ._-]/g, "-").trim().slice(0, 48);
+  return cleaned.length > 0 ? cleaned : "paired-client";
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": String(Buffer.byteLength(body)),
+    "cache-control": "no-store",
+  });
+  res.end(body);
+}
+
+function sendRefusal(res: ServerResponse, refusal: Refusal): void {
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  const body = JSON.stringify({ code: refusal.code, error: refusal.message });
+  res.writeHead(refusal.status, {
+    "content-type": "application/json",
+    "content-length": String(Buffer.byteLength(body)),
+    "cache-control": "no-store",
+    ...refusal.headers,
+  });
+  res.end(body);
+}

--- a/packages/core/src/core-pairing-wiring.ts
+++ b/packages/core/src/core-pairing-wiring.ts
@@ -1,0 +1,62 @@
+// How `core-entry` mounts the pairing endpoint beside the file routes, and what
+// the mTLS gate is told about it (#282).
+//
+// `core-files-wiring.ts` exists because the one decision in the file routes'
+// wiring — are they gated by a bearer? — was got wrong when it lived inline in
+// `core-entry.ts`, which no test can import. This module exists for the same
+// reason and holds three decisions of its own, each of which is a security
+// property rather than plumbing:
+//
+//   1. **Order.** The pairing family is consulted before the file family. The
+//      file routes claim the whole `/v1/` prefix, so a composition that asked
+//      them first would have them answer `/v1/pair/redeem` — with a `401`,
+//      since they require a bearer and a pairing client has none. Pairing would
+//      be unreachable, and the failure would look like an auth bug rather than
+//      a mounting bug.
+//   2. **Exactly one path is pre-auth.** {@link isPairingPath} is the predicate
+//      `core-preauth-gate.ts` consults, and it names the pairing prefix and
+//      nothing else. It is a function here rather than a string in the server
+//      so that the set of pre-auth paths has one definition.
+//   3. **A Core without pairing material mounts nothing.** No CA key, no
+//      endpoint to hand out — and, through the gate, no relaxation of the TLS
+//      handshake. The loopback Core is unchanged by this ticket.
+import type { CoreHttpRoutes } from "./core-files-routes";
+import {
+  CORE_PAIRING_ROUTE_PREFIX,
+  createCorePairingRequestHandler,
+  type CorePairingRoutesOptions,
+} from "./core-pairing-routes";
+
+/** Is this pathname the Core's pre-auth surface? The whole of it, and only it. */
+export function isPairingPath(pathname: string): boolean {
+  return pathname.startsWith(CORE_PAIRING_ROUTE_PREFIX);
+}
+
+/**
+ * Build the pairing route family.
+ *
+ * A thin pass-through today, and kept anyway: `core-entry` reaches for a
+ * wiring module rather than a route factory for every other surface it mounts,
+ * and the day pairing grows a second decision this is where it goes.
+ */
+export function buildCorePairingRoutes(opts: CorePairingRoutesOptions): CoreHttpRoutes {
+  return createCorePairingRequestHandler(opts);
+}
+
+/**
+ * Compose several route families into the one surface the server mounts.
+ *
+ * First to claim a request answers it; a family that returns `false` has said
+ * the path is none of its business, which is the contract `CoreHttpRoutes`
+ * already documents. Everything nobody claims still falls through to the
+ * server's own 404, so the Core's HTTP surface stays a closed list.
+ *
+ * **Order is the argument order**, and decision 1 in this file's header is why
+ * that matters here rather than being a detail.
+ */
+export function composeCoreHttpRoutes(...families: CoreHttpRoutes[]): CoreHttpRoutes {
+  return {
+    handle: (req, res) => families.some((family) => family.handle(req, res)),
+    handleContinue: (req, res) => families.some((family) => family.handleContinue(req, res)),
+  };
+}

--- a/packages/core/src/core-preauth-gate.ts
+++ b/packages/core/src/core-preauth-gate.ts
@@ -1,0 +1,90 @@
+// The one hole in the Core's mTLS wall, and the wall around it (#282).
+//
+// Every route on a remote Core and the core link itself sit behind the mutual
+// TLS handshake: `pty-core-link-server.ts` builds its `https.Server` with
+// `requestCert: true, rejectUnauthorized: true`, so a client with no
+// certificate is refused by TLS before a byte of HTTP is parsed. Pairing is the
+// one exchange where that cannot hold — the client is posting a CSR precisely
+// *because* it has no certificate yet — and this module is how the exception is
+// made without becoming a hole.
+//
+// **Why the TLS flag has to move at all.** There is no per-route TLS. A
+// server either demands a verified client certificate to complete a handshake
+// or it does not, and the decision is made before the request line exists. So
+// a Core that serves a pre-auth route completes the handshake without one
+// (`rejectUnauthorized: false`, with `requestCert` still true so a certificate
+// that *is* presented is still parsed and verified) and enforces the same rule
+// one layer up, per request, from `socket.authorized`.
+//
+// **What that costs, stated plainly.** Refusal moves from the TLS layer to the
+// HTTP layer: an unauthenticated caller now gets a `403` where they used to get
+// a handshake failure. What it does not cost is access — the gate below is
+// applied to every request and every WebSocket upgrade, and it defaults to
+// refusing.
+//
+// **And a Core with no pairing surface does not pay it.** No pre-auth path
+// means the server keeps `rejectUnauthorized: true` and behaves exactly as it
+// did before this ticket, TLS refusal and all. The relaxation is scoped to the
+// Cores that mount the endpoint, which is what "without weakening the mTLS
+// posture of every other route" means here.
+
+/** Does this pathname name the pre-auth surface? See `core-pairing-wiring.ts`. */
+export type PreAuthPathPredicate = (pathname: string) => boolean;
+
+/** What the gate decides. There is no third answer. */
+export type ClientCertVerdict = "serve" | "refuse";
+
+/** The status a refused request gets, and the body that explains it. */
+export const CLIENT_CERT_REFUSAL_STATUS = 403;
+export const CLIENT_CERT_REFUSAL_CODE = "client-certificate-required";
+export const CLIENT_CERT_REFUSAL_MESSAGE =
+  "this Core requires a client certificate on every route but its pairing endpoint";
+
+/**
+ * May this request be served on a connection that presented no verified client
+ * certificate?
+ *
+ * The default is `refuse`, and every argument has to line up to get anything
+ * else: an authorized connection is served whatever it asked for, and an
+ * unauthorized one is served only what the predicate names.
+ *
+ * `isPreAuthPath` absent means no pre-auth surface is mounted, which is the
+ * loopback Core and every Core built before #282. Such a server keeps
+ * `rejectUnauthorized: true` and never reaches this function with
+ * `authorized: false` — but it answers `refuse` if it does, because a gate
+ * whose safety depends on a flag set somewhere else is not a gate.
+ */
+export function clientCertGate(opts: {
+  pathname: string;
+  authorized: boolean;
+  isPreAuthPath?: PreAuthPathPredicate;
+}): ClientCertVerdict {
+  if (opts.authorized) return "serve";
+  if (!opts.isPreAuthPath) return "refuse";
+  return opts.isPreAuthPath(opts.pathname) ? "serve" : "refuse";
+}
+
+/**
+ * May this connection be upgraded to the core link?
+ *
+ * Separate from {@link clientCertGate} because the answer is not a function of
+ * the path: the core link is the Panel's authenticated session with this Core,
+ * and no pairing exception reaches it. A pre-auth WebSocket would be a socket
+ * that could ask this Core to spawn a PTY without ever proving who it was.
+ */
+export function coreLinkUpgradeGate(authorized: boolean): ClientCertVerdict {
+  return authorized ? "serve" : "refuse";
+}
+
+/**
+ * Should the TLS server demand a verified client certificate to complete the
+ * handshake at all?
+ *
+ * Yes unless a pre-auth surface is mounted — see the header. Written as a named
+ * function rather than inlined at the `https.createServer` call so that the one
+ * line that relaxes this Core's TLS posture is a line with a name, a reason and
+ * a test, rather than a ternary inside an options object.
+ */
+export function rejectUnauthorizedAtHandshake(isPreAuthPath: PreAuthPathPredicate | undefined): boolean {
+  return isPreAuthPath === undefined;
+}

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -39,6 +39,15 @@
 
 import log from "@actana/shared/log";
 import type { CoreHttpRoutes } from "./core-files-routes";
+import {
+  CLIENT_CERT_REFUSAL_CODE,
+  CLIENT_CERT_REFUSAL_MESSAGE,
+  CLIENT_CERT_REFUSAL_STATUS,
+  clientCertGate,
+  coreLinkUpgradeGate,
+  rejectUnauthorizedAtHandshake,
+  type PreAuthPathPredicate,
+} from "./core-preauth-gate";
 import type { WebSocketServer, WebSocket } from "ws";
 import {
   CORE_LINK_PROTOCOL_VERSION,
@@ -290,6 +299,11 @@ export type PtyCoreLinkServerOptions = {
      * no HTTP at all, which is what it did before this ticket.
      */
     httpRoutes?: CoreHttpRoutes;
+    /**
+     * Which of those routes may be served to a client presenting no
+     * certificate (#282). See {@link PtyCoreLinkServerOptions.isPreAuthPath}.
+     */
+    isPreAuthPath?: PreAuthPathPredicate;
   }) => WebSocketServerLike;
   /**
    * The per-Core event log. When provided, PTY lifecycle events are
@@ -418,6 +432,20 @@ export type PtyCoreLinkServerOptions = {
    * {@link announceMultiConnection} does.
    */
   announceFiles?: boolean;
+  /**
+   * The Core's pre-auth surface: which paths this server may answer on a
+   * connection that presented no client certificate (#282).
+   *
+   * Absent — every Core before this ticket, and every Core that does not mount
+   * the pairing endpoint — the TLS handshake keeps demanding a verified client
+   * certificate and nothing here changes. Present, the handshake accepts a
+   * connection without one and `core-preauth-gate.ts` refuses it, per request
+   * and per upgrade, everywhere this predicate does not say yes.
+   *
+   * Wired by `core-pairing-wiring.ts`'s `isPairingPath`; see that module and
+   * `core-preauth-gate.ts` for why the relaxation is scoped this way.
+   */
+  isPreAuthPath?: PreAuthPathPredicate;
 };
 
 /**
@@ -619,7 +647,13 @@ export class PtyCoreLinkServer {
     // them: one https.Server answering a WebSocket upgrade and the `/v1/…`
     // routes, never two listeners (#165 F2, ADR 0028).
     this.announceFiles = opts.announceFiles ?? Boolean(opts.httpRoutes);
-    this.server = create({ port: opts.port, host, tls: opts.tls, httpRoutes: opts.httpRoutes });
+    this.server = create({
+      port: opts.port,
+      host,
+      tls: opts.tls,
+      httpRoutes: opts.httpRoutes,
+      ...(opts.isPreAuthPath ? { isPreAuthPath: opts.isPreAuthPath } : {}),
+    });
     this.eventLog = opts.eventLog ?? null;
     this.liveEventPollMs = opts.liveEventPollMs ?? DEFAULT_LIVE_EVENT_POLL_MS;
     this.authVerifier = opts.authVerifier ?? null;
@@ -2102,6 +2136,7 @@ function defaultCreateServer(opts: {
   host: string;
   tls?: TlsOptions;
   httpRoutes?: CoreHttpRoutes;
+  isPreAuthPath?: PreAuthPathPredicate;
 }): WebSocketServerLike {
   // Lazy require so this module stays importable in tests without `ws` at
   // import time.
@@ -2118,16 +2153,40 @@ function defaultCreateServer(opts: {
       key: opts.tls.serverKey,
       ca: opts.tls.caCert,
       requestCert: true,
-      rejectUnauthorized: true,
+      // True unless this Core mounts a pre-auth surface, in which case the
+      // handshake has to complete for a client that has no certificate *yet* —
+      // it is here to be issued one — and the same rule is enforced per request
+      // and per upgrade below instead. `core-preauth-gate.ts` is where that
+      // trade is written out; nothing about it is decided in this file.
+      rejectUnauthorized: rejectUnauthorizedAtHandshake(opts.isPreAuthPath),
       // Disable Nagle on accepted sockets. PTY output is a stream of small
       // writes; coalescing them against the Panel's delayed ACKs adds tens of
       // ms of jitter to every repaint. Set explicitly rather than relying on
       // the runtime's default.
       noDelay: true,
     });
-    mountHttpRoutes(tlsServer, opts.httpRoutes);
+    mountHttpRoutes(tlsServer, opts.httpRoutes, opts.isPreAuthPath);
     tlsServer.listen(opts.port, opts.host);
-    const wss = new WebSocketServer({ server: tlsServer });
+    // `noServer`, so the upgrade is ours to allow or refuse: the core link is
+    // never pre-auth, and a WebSocket that reached this Core without a client
+    // certificate would be a socket that can spawn a PTY without having said
+    // who it is. In the `{ server }` form `ws` owns the `upgrade` event and
+    // there is nowhere to put that check. The cost is that `ws` no longer
+    // forwards the HTTP server's `error` for us — a listen failure has to reach
+    // the caller — so both are forwarded explicitly below.
+    const wss = new WebSocketServer({ noServer: true });
+    tlsServer.on("upgrade", (req, socket, head) => {
+      if (coreLinkUpgradeGate(clientCertVerified(req)) === "refuse") {
+        socket.write(
+          `HTTP/1.1 ${CLIENT_CERT_REFUSAL_STATUS} Forbidden\r\n` +
+            "connection: close\r\n" +
+            "content-length: 0\r\n\r\n",
+        );
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+    });
     return {
       close: (cb) => {
         wss.close(() => tlsServer.close(cb));
@@ -2139,6 +2198,7 @@ function defaultCreateServer(opts: {
           });
         } else if (event === "error") {
           wss.on("error", (err: Error) => (cb as (err: Error) => void)(err));
+          tlsServer.on("error", (err: Error) => (cb as (err: Error) => void)(err));
         }
       },
     };
@@ -2203,16 +2263,62 @@ function defaultCreateServer(opts: {
 function mountHttpRoutes(
   server: import("node:http").Server | import("node:https").Server,
   routes: CoreHttpRoutes | undefined,
+  isPreAuthPath?: PreAuthPathPredicate,
 ): void {
   if (!routes) return;
   server.on("request", (req, res) => {
+    if (!mayServe(req, isPreAuthPath)) return respondClientCertRequired(res);
     if (routes.handle(req, res)) return;
     respondNotFound(res);
   });
   server.on("checkContinue", (req, res) => {
+    if (!mayServe(req, isPreAuthPath)) return respondClientCertRequired(res);
     if (routes.handleContinue(req, res)) return;
     respondNotFound(res);
   });
+}
+
+/**
+ * Is this request allowed on the connection it arrived on (#282)?
+ *
+ * The gate is asked on every request, including on a plain `http` Core, where
+ * there are no certificates at all and {@link clientCertVerified} answers
+ * `true` — the loopback surface is as trusted as the rest of that Core, which
+ * is the trade ADR 0004 already made for every core-link frame.
+ */
+function mayServe(
+  req: import("node:http").IncomingMessage,
+  isPreAuthPath: PreAuthPathPredicate | undefined,
+): boolean {
+  const pathname = new URL(req.url ?? "/", "https://core.invalid").pathname;
+  const verdict = clientCertGate({
+    pathname,
+    authorized: clientCertVerified(req),
+    ...(isPreAuthPath ? { isPreAuthPath } : {}),
+  });
+  return verdict === "serve";
+}
+
+/**
+ * Did this connection present a client certificate this Core's CA vouches for?
+ *
+ * `authorized` is Node's own verdict from the handshake, and it is `undefined`
+ * on a plain TCP socket — a Core running `ws://` on loopback, where the
+ * question does not arise. `!== false` rather than `=== true` says exactly
+ * that: only a TLS socket that was *checked and failed* is unauthorized here.
+ */
+function clientCertVerified(req: import("node:http").IncomingMessage): boolean {
+  const socket = req.socket as unknown as { authorized?: boolean };
+  return socket.authorized !== false;
+}
+
+function respondClientCertRequired(res: import("node:http").ServerResponse): void {
+  const body = JSON.stringify({ code: CLIENT_CERT_REFUSAL_CODE, error: CLIENT_CERT_REFUSAL_MESSAGE });
+  res.writeHead(CLIENT_CERT_REFUSAL_STATUS, {
+    "content-type": "application/json",
+    "content-length": String(Buffer.byteLength(body)),
+  });
+  res.end(body);
 }
 
 function respondNotFound(res: import("node:http").ServerResponse): void {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@actana/sdk": "workspace:*",
+    "@peculiar/x509": "^1.14.2",
     "selfsigned": "^5.5.0"
   },
   "devDependencies": {

--- a/packages/shared/src/__tests__/core-cert-material.test.ts
+++ b/packages/shared/src/__tests__/core-cert-material.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { X509Certificate, createPublicKey } from "node:crypto";
-import { generateCertMaterial } from "../core-cert-material";
+import { X509Certificate, createPublicKey, webcrypto } from "node:crypto";
+import * as x509 from "@peculiar/x509";
+import { generateCertMaterial, generateClientCsr, signClientCsr } from "../core-cert-material";
 
 // Core generates a self-signed CA + server cert + Panel client cert at
 // start (ADR 0002). The Core holds the server cert; the Panel pins the CA
@@ -63,5 +64,165 @@ describe("core cert material", () => {
     const bCaPub = createPublicKey(b.ca.cert);
     const aServer = new X509Certificate(a.server.cert);
     expect(aServer.verify(bCaPub)).toBe(false);
+  });
+});
+
+// ─── CSR signing (#282) ─────────────────────────────────────────────────────
+//
+// The pairing endpoint's whole cryptographic claim: a certificate signed here
+// from a client's own CSR is the same certificate, to the mTLS handshake, as
+// the one an operator used to hand-carry — and the private key never came near
+// this process.
+
+describe("signing a client CSR against the Core's CA", () => {
+  it("issues a client leaf that verifies against the CA and is not itself a CA", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const issued = await signClientCsr({
+      ca: { cert: mat.ca.cert, key: mat.ca.key },
+      csrPem,
+      subject: "CN=laptop",
+    });
+
+    const cert = new X509Certificate(issued.cert);
+    expect(cert.verify(createPublicKey(mat.ca.cert))).toBe(true);
+    expect(cert.ca).toBe(false);
+    expect(cert.subject).toContain("laptop");
+    expect(issued.serial).toBe(cert.serialNumber.toLowerCase());
+    expect(issued.notAfter).toBeGreaterThan(Date.now());
+  });
+
+  it("writes the same client-leaf extensions the hand-carried client cert has", async () => {
+    // The comparison is the assertion: whatever `generateCertMaterial` writes
+    // for the Panel's client cert is what a paired client must get, because the
+    // handshake on the other end cannot tell them apart and must not have to.
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const { csrPem } = await generateClientCsr("laptop");
+
+    const issued = await signClientCsr({
+      ca: { cert: mat.ca.cert, key: mat.ca.key },
+      csrPem,
+      subject: "CN=laptop",
+    });
+
+    const paired = new x509.X509Certificate(issued.cert);
+    const handCarried = new x509.X509Certificate(mat.client.cert);
+    const extensions = (cert: x509.X509Certificate): unknown =>
+      cert.extensions
+        .map((ext) => {
+          if (ext instanceof x509.BasicConstraintsExtension) return `basicConstraints:cA=${ext.ca}`;
+          if (ext instanceof x509.KeyUsagesExtension) return `keyUsage:${ext.usages}`;
+          if (ext instanceof x509.ExtendedKeyUsageExtension) return `extKeyUsage:${ext.usages.join(",")}`;
+          return null;
+        })
+        .filter((line) => line !== null)
+        .sort();
+    expect(extensions(paired)).toEqual(extensions(handCarried));
+    expect(extensions(paired)).toContain("basicConstraints:cA=false");
+  });
+
+  it("takes only the public key from the CSR — never its subject or its extensions", async () => {
+    // A client that has spent a pairing code still does not get to say what its
+    // certificate means. This CSR asks to be a CA under another name; the
+    // issued certificate is neither.
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const keys = (await webcrypto.subtle.generateKey(
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+      true,
+      ["sign", "verify"],
+    )) as Parameters<typeof x509.Pkcs10CertificateRequestGenerator.create>[0]["keys"];
+    const greedy = await x509.Pkcs10CertificateRequestGenerator.create({
+      name: "CN=mission-control-core-ca",
+      keys,
+      signingAlgorithm: { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      extensions: [new x509.BasicConstraintsExtension(true, 5, true)],
+    });
+
+    const issued = await signClientCsr({
+      ca: { cert: mat.ca.cert, key: mat.ca.key },
+      csrPem: greedy.toString("pem"),
+      subject: "CN=laptop",
+    });
+
+    const cert = new X509Certificate(issued.cert);
+    expect(cert.ca).toBe(false);
+    expect(cert.subject).toContain("laptop");
+    expect(cert.subject).not.toContain("mission-control-core-ca");
+    // The key, on the other hand, is exactly the one that asked.
+    const requested = new x509.Pkcs10CertificateRequest(greedy.toString("pem"));
+    expect(new x509.X509Certificate(issued.cert).publicKey.toString("pem")).toBe(
+      requested.publicKey.toString("pem"),
+    );
+  });
+
+  it("refuses a CSR whose signature does not match the key it carries", async () => {
+    // Proof of possession is the only thing the CSR's own signature proves, and
+    // it is the reason this Core will not certify a key somebody else holds.
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const { csrPem } = await generateClientCsr("laptop");
+    const lines = csrPem.trim().split("\n");
+    const body = lines.slice(1, -1).join("");
+    const bytes = Buffer.from(body, "base64");
+    bytes[bytes.length - 1] = bytes[bytes.length - 1]! ^ 0xff;
+    const tampered = `${lines[0]}\n${bytes.toString("base64")}\n${lines[lines.length - 1]}`;
+
+    await expect(
+      signClientCsr({ ca: { cert: mat.ca.cert, key: mat.ca.key }, csrPem: tampered, subject: "CN=laptop" }),
+    ).rejects.toMatchObject({ name: "CsrRejectedError", rejection: "bad-signature" });
+  });
+
+  it("refuses something that is not a CSR at all", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    await expect(
+      signClientCsr({ ca: { cert: mat.ca.cert, key: mat.ca.key }, csrPem: "not a CSR", subject: "CN=laptop" }),
+    ).rejects.toMatchObject({ name: "CsrRejectedError", rejection: "unparseable" });
+  });
+
+  it("refuses an RSA key too small to be worth a signature", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const weakAlg = {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+      modulusLength: 1024,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    };
+    const keys = (await webcrypto.subtle.generateKey(weakAlg, true, ["sign", "verify"])) as Parameters<
+      typeof x509.Pkcs10CertificateRequestGenerator.create
+    >[0]["keys"];
+    const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+      name: "CN=weak",
+      keys,
+      signingAlgorithm: { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    });
+
+    await expect(
+      signClientCsr({
+        ca: { cert: mat.ca.cert, key: mat.ca.key },
+        csrPem: csr.toString("pem"),
+        subject: "CN=weak",
+      }),
+    ).rejects.toMatchObject({ name: "CsrRejectedError", rejection: "weak-key" });
+  });
+
+  it("gives every issuance its own serial", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const first = await generateClientCsr("laptop");
+    const second = await generateClientCsr("desktop");
+    const ca = { cert: mat.ca.cert, key: mat.ca.key };
+
+    const a = await signClientCsr({ ca, csrPem: first.csrPem, subject: "CN=laptop" });
+    const b = await signClientCsr({ ca, csrPem: second.csrPem, subject: "CN=desktop" });
+
+    expect(a.serial).not.toBe(b.serial);
+    // Positive, per RFC 5280 §4.1.2.2 — the top bit of the first byte is clear.
+    expect(parseInt(a.serial.slice(0, 2), 16)).toBeLessThan(0x80);
+  });
+
+  it("mints a client CSR whose private key it hands back and never embeds", async () => {
+    const { csrPem, privateKeyPem } = await generateClientCsr("laptop");
+    expect(csrPem).toMatch(/-----BEGIN CERTIFICATE REQUEST-----/);
+    expect(privateKeyPem).toMatch(/-----BEGIN PRIVATE KEY-----/);
+    expect(csrPem).not.toContain("PRIVATE KEY");
   });
 });

--- a/packages/shared/src/__tests__/core-link-bearer.test.ts
+++ b/packages/shared/src/__tests__/core-link-bearer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
 import {
   signBearer,
   verifyBearer,
@@ -114,6 +115,82 @@ describe("core-link bearer", () => {
       const result = verifyBearer(token, SECRET, { now: exp + 1 });
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.reason).toBe("expired");
+    });
+  });
+
+  // ─── Standard claims (#280, #282) ────────────────────────────────────────
+  //
+  // The pairing endpoint issues bearers carrying `iss`, `sub`, `aud` and `jti`
+  // beside the `exp` that was already there. Nothing in this train reads them;
+  // what these tests pin is that adding them broke neither direction — a token
+  // with the claims verifies, and a token from before they existed still does.
+
+  describe("standard claims", () => {
+    const claims = {
+      coreId: "core_abc",
+      exp: Date.now() + 60_000,
+      iss: "core:core_abc",
+      sub: "pair:laptop",
+      aud: "6f1a2b3c-4d5e-4f60-8a9b-0c1d2e3f4a5b",
+      jti: "01H0000000000000000000",
+    };
+
+    it("carries every claim through sign and verify", () => {
+      const result = verifyBearer(signBearer(claims, SECRET), SECRET, { now: claims.exp });
+      expect(result).toMatchObject({
+        ok: true,
+        coreId: claims.coreId,
+        exp: claims.exp,
+        iss: claims.iss,
+        sub: claims.sub,
+        aud: claims.aud,
+        jti: claims.jti,
+      });
+    });
+
+    it("still verifies a bearer minted before the claims existed", () => {
+      // The compatibility that matters: every Panel paired before #282 holds a
+      // `{coreId, exp}` token, and a Core that refused it would lock them out
+      // of a Core that had merely been upgraded.
+      const legacy = signBearer({ coreId: "core_abc", exp: claims.exp }, SECRET);
+      const result = verifyBearer(legacy, SECRET, { now: claims.exp });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.aud).toBeUndefined();
+    });
+
+    it("leaves an absent claim out of the payload rather than writing it null", () => {
+      const legacy = signBearer({ coreId: "core_abc", exp: claims.exp }, SECRET);
+      const payload = JSON.parse(Buffer.from(legacy.split(".")[0]!, "base64url").toString("utf8"));
+      expect(Object.keys(payload).sort()).toEqual(["coreId", "exp"]);
+    });
+
+    it("exposes the claims to a decode that does not verify", () => {
+      expect(decodeBearer(signBearer(claims, SECRET))).toMatchObject({
+        aud: claims.aud,
+        jti: claims.jti,
+      });
+    });
+
+    it("calls a claim of the wrong type malformed, not merely absent", () => {
+      // Hand-built rather than signed through `signBearer`, because the type
+      // system stops this shape being minted here — and does not stop it
+      // arriving on a socket.
+      const payload = Buffer.from(JSON.stringify({ coreId: "core_abc", exp: claims.exp, aud: 7 }), "utf8")
+        .toString("base64url");
+      const sig = createHmac("sha256", SECRET).update(payload).digest().toString("base64url");
+      const result = verifyBearer(`${payload}.${sig}`, SECRET, { now: claims.exp });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("malformed");
+    });
+
+    it("still refuses a token whose claims were edited after signing", () => {
+      const token = signBearer(claims, SECRET);
+      const payload = JSON.parse(Buffer.from(token.split(".")[0]!, "base64url").toString("utf8"));
+      payload.aud = "some-other-core";
+      const forged = `${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}.${token.split(".")[1]}`;
+      const result = verifyBearer(forged, SECRET, { now: claims.exp });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("bad-signature");
     });
   });
 });

--- a/packages/shared/src/__tests__/core-material-store.test.ts
+++ b/packages/shared/src/__tests__/core-material-store.test.ts
@@ -8,6 +8,7 @@ import {
   loadMaterial,
   materialFilePath,
   mintFreshMaterial,
+  readMaterialFile,
   reissueServerCert,
   checkServerCertHost,
   type PersistedMaterial,
@@ -29,6 +30,7 @@ const sample: PersistedMaterial = {
   clientKey: "-----BEGIN PRIVATE KEY-----\nCLIENTKEY\n-----END PRIVATE KEY-----",
   bearerSecret: "deadbeef".repeat(8),
   coreId: "core_abcdef0123456789",
+  coreUuid: "6f1a2b3c-4d5e-4f60-8a9b-0c1d2e3f4a5b",
   serverHost: "10.0.0.5",
 };
 
@@ -180,6 +182,64 @@ describe("core material store", () => {
 
     it("prefers the recorded host over the fallback", () => {
       expect(checkServerCertHost(sample, "10.0.0.5", "stale.example")).toBe("covered");
+    });
+  });
+
+  // ─── The stable core UUID (#280, #282) ───────────────────────────────────
+  //
+  // A second identifier only earns its place if it outlives the first. This one
+  // is what an issued bearer's `aud` names, so what these tests actually pin is
+  // that nothing an operator does to a certificate can change the audience.
+
+  describe("the stable core UUID", () => {
+    it("mints one at install", async () => {
+      const minted = await mintFreshMaterial("10.0.0.5");
+      expect(minted.coreUuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it("gives two Cores two different UUIDs", async () => {
+      const a = await mintFreshMaterial("10.0.0.5");
+      const b = await mintFreshMaterial("10.0.0.5");
+      expect(a.coreUuid).not.toBe(b.coreUuid);
+    });
+
+    it("survives reissueServerCert unchanged", async () => {
+      // The whole point of the field. A Core that moves re-signs its server
+      // cert from the CA it already holds; a `aud` that changed with it would
+      // be no more stable than the certificate it was supposed to outlive.
+      const minted = await mintFreshMaterial("10.0.0.5");
+      const reissued = await reissueServerCert(minted, "10.0.0.9");
+      expect(reissued.coreUuid).toBe(minted.coreUuid);
+      expect(reissued.serverCert).not.toBe(minted.serverCert);
+    });
+
+    it("mints one on load for material written before the field existed", () => {
+      // An install that predates #282 must not have to be redone to gain a
+      // UUID — and re-minting the material to get one would lock out every
+      // paired Panel.
+      const file = materialFilePath(dir);
+      const { coreUuid: _dropped, ...legacy } = sample;
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(file, JSON.stringify(legacy, null, 2));
+
+      const read = readMaterialFile(file);
+
+      expect(read?.mintedCoreUuid).toBe(true);
+      expect(read?.material.coreUuid).not.toBe("");
+      expect(read?.material.coreId).toBe(sample.coreId);
+      expect(read?.material.caKey).toBe(sample.caKey);
+    });
+
+    it("reports a stored UUID as stored, and returns it verbatim", () => {
+      persistMaterial(dir, sample);
+      const read = readMaterialFile(materialFilePath(dir));
+      expect(read?.mintedCoreUuid).toBe(false);
+      expect(read?.material.coreUuid).toBe(sample.coreUuid);
+    });
+
+    it("round-trips through persist and load", () => {
+      persistMaterial(dir, sample);
+      expect(loadMaterial(dir)?.coreUuid).toBe(sample.coreUuid);
     });
   });
 });

--- a/packages/shared/src/__tests__/pairing-store.test.ts
+++ b/packages/shared/src/__tests__/pairing-store.test.ts
@@ -1,0 +1,228 @@
+// The file a Core keeps its pairing state in (#282).
+//
+// `pairing-session.ts` owns the rules and holds nothing; this is the other
+// half. Two processes read and write it — the operator's `actana pair new` and
+// the daemon's redemption endpoint — so what these tests pin is that the
+// transitions survive the round trip through disk, and that the one transition
+// with a race in it decides that race.
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createPairingSession, PAIRING_ATTEMPT_CAP } from "../pairing-session";
+import {
+  PAIRING_SESSION_RETENTION_MS,
+  PairingStore,
+  derivePairingCodeKey,
+  hashPairingCode,
+  pairingCodeMatches,
+  pairingStorePath,
+  type PairedClient,
+} from "../pairing-store";
+
+let dir: string;
+let store: PairingStore;
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-pairing-store-"));
+  store = new PairingStore(path.join(dir, "pairing.json"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function session(id = "ps_1", now = NOW, ttlMs?: number) {
+  return createPairingSession({
+    id,
+    label: "laptop",
+    codeHash: "a".repeat(64),
+    now,
+    ...(ttlMs === undefined ? {} : { ttlMs }),
+  });
+}
+
+function client(certSerial = "0a1b"): PairedClient {
+  return {
+    certSerial,
+    certSubject: "CN=laptop",
+    label: "laptop",
+    sessionId: "ps_1",
+    pairedAt: NOW,
+    certNotAfter: NOW + 365 * 24 * 60 * 60 * 1000,
+    revokedAt: null,
+    created_by: null,
+    tenant_id: null,
+    auth_method: null,
+  };
+}
+
+describe("the file", () => {
+  it("reads as empty before anything has written it", () => {
+    // A daemon booting before its first `pair new` must not treat "no file" as
+    // a failure, and must not create one it has nothing to put in.
+    expect(store.read()).toEqual({ version: 1, sessions: [], clients: [] });
+    expect(fs.existsSync(path.join(dir, "pairing.json"))).toBe(false);
+  });
+
+  it("reads as empty rather than throwing on a corrupt file", () => {
+    fs.writeFileSync(path.join(dir, "pairing.json"), "{ this is not json");
+    expect(store.read().sessions).toEqual([]);
+  });
+
+  it("drops a row that is not the shape it claims", () => {
+    fs.writeFileSync(
+      path.join(dir, "pairing.json"),
+      JSON.stringify({ version: 1, sessions: [{ id: "ps_1" }, session()], clients: [] }),
+    );
+    expect(store.listSessions()).toHaveLength(1);
+  });
+
+  it("is written owner-only, because a live code's digest is in it", () => {
+    store.createSession(session(), NOW);
+    const mode = fs.statSync(path.join(dir, "pairing.json")).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("sits beside the material file it is derived from", () => {
+    expect(pairingStorePath("/var/lib/actana/material.json")).toBe("/var/lib/actana/pairing.json");
+  });
+});
+
+describe("sessions", () => {
+  it("round-trips a minted session", () => {
+    store.createSession(session(), NOW);
+    expect(store.getSession("ps_1")).toMatchObject({ id: "ps_1", label: "laptop", attempts: 0, consumedAt: null });
+  });
+
+  it("counts a wrong attempt and stops at the cap", () => {
+    store.createSession(session(), NOW);
+    for (let i = 0; i < PAIRING_ATTEMPT_CAP + 3; i += 1) store.recordWrongAttempt("ps_1");
+    expect(store.getSession("ps_1")?.attempts).toBe(PAIRING_ATTEMPT_CAP);
+  });
+
+  it("says nothing about a session that is not there", () => {
+    expect(store.recordWrongAttempt("ps_nothing")).toBeNull();
+    expect(store.consume("ps_nothing", NOW)).toEqual({ ok: false, reason: "unknown" });
+  });
+
+  it("consumes once and refuses the replay", () => {
+    store.createSession(session(), NOW);
+
+    const first = store.consume("ps_1", NOW);
+    const second = store.consume("ps_1", NOW);
+
+    expect(first).toMatchObject({ ok: true });
+    expect(second).toEqual({ ok: false, reason: "already-consumed" });
+    expect(store.getSession("ps_1")?.consumedAt).toBe(NOW);
+  });
+
+  it("refuses to consume an expired session", () => {
+    store.createSession(session("ps_1", NOW, 60_000), NOW);
+    expect(store.consume("ps_1", NOW + 60_001)).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("refuses to consume a dead session", () => {
+    store.createSession(session(), NOW);
+    for (let i = 0; i < PAIRING_ATTEMPT_CAP; i += 1) store.recordWrongAttempt("ps_1");
+    expect(store.consume("ps_1", NOW)).toEqual({ ok: false, reason: "attempts-exhausted" });
+  });
+
+  it("forgets a session a day after it settled, and keeps a fresh one", () => {
+    store.createSession(session("ps_old", NOW - PAIRING_SESSION_RETENTION_MS - 60_000, 60_000), NOW);
+    store.createSession(session("ps_new", NOW), NOW);
+
+    expect(store.listSessions().map((s) => s.id)).toEqual(["ps_new"]);
+  });
+
+  it("answers a pruned session exactly as it answers an unknown one", () => {
+    // Pruning must not be observable: both are `unknown`, and the endpoint
+    // turns both into the same refusal.
+    store.createSession(session("ps_old", NOW - PAIRING_SESSION_RETENTION_MS - 60_000, 60_000), NOW);
+    store.createSession(session("ps_new", NOW), NOW);
+
+    expect(store.consume("ps_old", NOW)).toEqual({ ok: false, reason: "unknown" });
+    expect(store.consume("ps_never", NOW)).toEqual({ ok: false, reason: "unknown" });
+  });
+});
+
+describe("paired clients", () => {
+  it("records one and lists it", () => {
+    store.recordClient(client(), NOW);
+    expect(store.listClients()).toEqual([client()]);
+  });
+
+  it("keeps the sessions beside them", () => {
+    store.createSession(session(), NOW);
+    store.recordClient(client(), NOW);
+    expect(store.getSession("ps_1")).not.toBeNull();
+  });
+
+  it("revokes by serial, and stamps rather than deletes", () => {
+    // `actana pair revoke` has to be able to say what it revoked, and a row
+    // that vanished would take the trail of the pairing with it.
+    store.recordClient(client("0a1b"), NOW);
+    store.recordClient(client("0c2d"), NOW);
+
+    const revoked = store.revokeClient("0a1b", NOW + 5);
+
+    expect(revoked).toMatchObject({ certSerial: "0a1b", revokedAt: NOW + 5 });
+    expect(store.listClients().find((c) => c.certSerial === "0c2d")?.revokedAt).toBeNull();
+  });
+
+  it("says nothing about a serial it never issued", () => {
+    expect(store.revokeClient("nope", NOW)).toBeNull();
+  });
+
+  it("leaves an already-revoked pairing's timestamp alone", () => {
+    store.recordClient(client("0a1b"), NOW);
+    store.revokeClient("0a1b", NOW + 5);
+    expect(store.revokeClient("0a1b", NOW + 500)?.revokedAt).toBe(NOW + 5);
+  });
+});
+
+describe("the code digest", () => {
+  const key = derivePairingCodeKey("a-core-bearer-secret");
+
+  it("is not the code, and not a hash anybody can take without the secret", () => {
+    const mine = hashPairingCode({ key, sessionId: "ps_1", code: "ABCD-EFGH" });
+    const theirs = hashPairingCode({
+      key: derivePairingCodeKey("some-other-core"),
+      sessionId: "ps_1",
+      code: "ABCD-EFGH",
+    });
+
+    expect(mine).not.toContain("ABCD");
+    expect(mine).not.toBe(theirs);
+  });
+
+  it("differs from the bearer's own HMAC over the same input", () => {
+    // The domain separator. Neither use may be an oracle for the other.
+    expect(derivePairingCodeKey("s").toString("hex")).not.toBe(
+      hashPairingCode({ key: Buffer.from("s"), sessionId: "", code: "" }),
+    );
+  });
+
+  it("binds the digest to the session it was minted for", () => {
+    // Session binding under the cryptography as well as at the lookup: a digest
+    // lifted out of one session's row does not match another's.
+    const a = hashPairingCode({ key, sessionId: "ps_a", code: "ABCD-EFGH" });
+    const b = hashPairingCode({ key, sessionId: "ps_b", code: "ABCD-EFGH" });
+    expect(a).not.toBe(b);
+  });
+
+  it("matches a digest of the same code and refuses everything else", () => {
+    const stored = hashPairingCode({ key, sessionId: "ps_1", code: "ABCD-EFGH" });
+
+    expect(pairingCodeMatches(stored, hashPairingCode({ key, sessionId: "ps_1", code: "ABCD-EFGH" }))).toBe(true);
+    expect(pairingCodeMatches(stored, hashPairingCode({ key, sessionId: "ps_1", code: "ABCD-EFGJ" }))).toBe(false);
+  });
+
+  it("refuses a digest of the wrong length rather than throwing", () => {
+    // `timingSafeEqual` throws on a length mismatch, and a pre-auth endpoint is
+    // not a place to find that out at runtime.
+    expect(pairingCodeMatches("aabb", "aa")).toBe(false);
+    expect(pairingCodeMatches("", "")).toBe(false);
+  });
+});

--- a/packages/shared/src/core-cert-material.ts
+++ b/packages/shared/src/core-cert-material.ts
@@ -14,6 +14,8 @@
 // Core process only — never imported by the browser.
 
 import selfsigned from "selfsigned";
+import * as x509 from "@peculiar/x509";
+import { randomBytes, webcrypto } from "node:crypto";
 
 export type CertPem = {
   /** PEM-encoded certificate. */
@@ -194,4 +196,333 @@ export async function issueServerCert(opts: IssueServerCertOptions): Promise<Cer
 /** Crude IPv4 detector — good enough for SAN choice (no false positives that matter). */
 function isIp(host: string): boolean {
   return /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+}
+
+// ─── CSR signing (#282) ─────────────────────────────────────────────────────
+//
+// Everything above generates a key pair *and* a certificate for it, because
+// everything above signs for a party the Core is standing in for. Pairing is
+// the case where it is not: the client's key is born on the client and never
+// crosses the wire in either direction (#280), so what arrives here is a
+// certificate signing request and the only thing the Core adds is its
+// signature.
+//
+// `selfsigned` cannot do this — its one export mints keys. So this half talks
+// to `@peculiar/x509` directly, which is the library `selfsigned` itself is
+// built on: the same ASN.1 encoder and the same Node WebCrypto backend already
+// in the dependency tree, reached one layer lower rather than pulled in beside
+// it.
+
+// The WebCrypto types, taken from `@peculiar/x509`'s own signatures rather than
+// from an ambient global.
+//
+// `Crypto`, `CryptoKey` and `CryptoKeyPair` are ambient names, and which ones
+// exist — and what they mean — depends on the `lib` of whichever tsconfig is
+// compiling this file. Three do: the Core's (Node types, no `CryptoKeyPair`),
+// the Panel's (DOM types, where `CryptoKey` is a *different* type from
+// `node:crypto`'s), and `packages/shared`'s own. Naming the library's parameter
+// types instead is the one spelling that compiles under all three, and the
+// casts below are the boundary between Node's WebCrypto and the library's view
+// of it — a boundary that exists only in the type system, since `selfsigned`
+// hands the same objects to the same library at runtime.
+type X509Crypto = NonNullable<Parameters<typeof x509.cryptoProvider.set>[1]>;
+type X509SigningKey = x509.X509CertificateCreateWithKeyParams["signingKey"];
+type X509KeyPair = x509.Pkcs10CertificateRequestCreateParams["keys"];
+
+// `@peculiar/x509` resolves its crypto through a module-global provider, and
+// `selfsigned` sets the same one at import. Setting it here too is not
+// redundant: this module is imported by paths that never touch `selfsigned`
+// (the pairing endpoint signs a CSR without generating anything), and a
+// provider that happens to be set by whoever was imported first is not a
+// dependency, it is a coincidence.
+x509.cryptoProvider.set(webcrypto as unknown as X509Crypto);
+
+/**
+ * RSA-2048 with SHA-256 — what {@link generateCertMaterial} already issues, and
+ * therefore what a CA key loaded from `material.json` is.
+ *
+ * The algorithm is named at import rather than read off the key because
+ * WebCrypto's `importKey` demands it up front: PKCS#8 says the key is RSA, not
+ * what it may be used for or with which digest.
+ */
+const CA_SIGNING_ALGORITHM = { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" } as const;
+
+/** Client key pairs this module mints for its own callers. See {@link generateClientCsr}. */
+const CLIENT_KEY_ALGORITHM = {
+  name: "RSASSA-PKCS1-v1_5",
+  hash: "SHA-256",
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([1, 0, 1]),
+} as const;
+
+/**
+ * Smallest RSA modulus this CA will sign.
+ *
+ * A pairing code buys one certificate, and a client that asks for a 512-bit key
+ * gets a certificate this Core's own CA vouches for. Refusing here costs a
+ * legitimate client nothing — every client in this repository mints 2048 — and
+ * denies an attacker who has spent a code the option of a key they can factor
+ * afterwards.
+ */
+const MIN_RSA_MODULUS_BITS = 2048;
+
+/** How long an issued client certificate is good for. A year, as every leaf here is. */
+const CLIENT_LEAF_DAYS = LEAF_DAYS;
+
+/** Why a CSR was refused. The endpoint maps every one of these to one refusal. */
+export type CsrRejection =
+  | "unparseable"
+  | "bad-signature"
+  | "weak-key"
+  | "unsupported-key";
+
+/** A CSR the Core would not sign, with the reason for the audit log. */
+export class CsrRejectedError extends Error {
+  constructor(readonly rejection: CsrRejection, message: string) {
+    super(message);
+    this.name = "CsrRejectedError";
+  }
+}
+
+export type SignClientCsrOptions = {
+  /** The CA to sign against — `PersistedMaterial`'s `caCert` + `caKey`. */
+  ca: CertAuthority;
+  /** The PEM `CERTIFICATE REQUEST` the client posted. */
+  csrPem: string;
+  /**
+   * The subject to issue for, as a distinguished name (`CN=laptop`).
+   *
+   * The Core's to decide, not the CSR's. A certificate signing request carries
+   * a subject and a set of requested extensions, and honouring either would let
+   * a client that has spent a pairing code choose what its certificate *says* —
+   * up to and including `cA: true`, which would turn one paired laptop into a
+   * second certificate authority this Core trusts. So the subject is passed in
+   * by the caller from what the operator typed, the extensions below are fixed,
+   * and the only thing taken from the request is the public key it is proving
+   * possession of.
+   */
+  subject: string;
+  /** Leaf validity in days. Defaults to a year. */
+  days?: number;
+  /** Backdate/align the validity window. Defaults to now. */
+  notBefore?: Date;
+};
+
+/** An issued client certificate, and the two fields that identify it later. */
+export type SignedClientCert = {
+  /** PEM-encoded client certificate. No key: there is no key here to hand back. */
+  cert: string;
+  /** Hex serial, unique per issuance — what `actana pair revoke` names (#283). */
+  serial: string;
+  /** The subject as issued. */
+  subject: string;
+  /** Wall-clock ms after which the certificate stops verifying. */
+  notAfter: number;
+};
+
+/**
+ * Sign a client CSR against the Core's own CA, with the client-leaf extensions.
+ *
+ * The extensions are exactly the ones {@link generateCertMaterial} writes for
+ * the Panel's client cert — `basicConstraints cA:false`, `keyUsage
+ * digitalSignature + keyEncipherment`, `extKeyUsage clientAuth` — because the
+ * certificate this returns has to be indistinguishable, to the mTLS handshake
+ * on `pty-core-link-server.ts`, from the one an operator hand-carried in a
+ * registration blob. A paired client is a client, not a second kind of client.
+ *
+ * The CSR's own signature is verified first, and that check is not a formality:
+ * it is the only proof that whoever posted the request holds the private key
+ * for the public key inside it. Without it, an attacker who spent a pairing
+ * code could submit somebody else's public key and have this CA issue a
+ * certificate for a key they do not hold — useless to them, but a certificate
+ * naming a machine that never asked for one.
+ *
+ * Throws {@link CsrRejectedError} for anything wrong with the request. Callers
+ * on the pre-auth surface must not pass the reason back to the client — it is
+ * for the audit log.
+ */
+export async function signClientCsr(opts: SignClientCsrOptions): Promise<SignedClientCert> {
+  const csr = await readSignableCsr(opts.csrPem);
+
+  const notBefore = opts.notBefore ?? new Date();
+  const notAfter = addDays(notBefore, opts.days ?? CLIENT_LEAF_DAYS);
+  const caCert = new x509.X509Certificate(opts.ca.cert);
+  const caKey = await importCaKey(opts.ca.key);
+
+  const issued = await x509.X509CertificateGenerator.create({
+    // 16 random bytes, forced positive: a serial is the certificate's name in
+    // every later revocation list and `pair ls` row, and two clients sharing
+    // one would make a revocation ambiguous.
+    serialNumber: randomSerial(),
+    subject: opts.subject,
+    issuer: caCert.subject,
+    notBefore,
+    notAfter,
+    signingAlgorithm: CA_SIGNING_ALGORITHM,
+    publicKey: csr.publicKey,
+    signingKey: caKey,
+    extensions: [
+      new x509.BasicConstraintsExtension(false, undefined, true),
+      new x509.KeyUsagesExtension(
+        x509.KeyUsageFlags.digitalSignature | x509.KeyUsageFlags.keyEncipherment,
+        true,
+      ),
+      new x509.ExtendedKeyUsageExtension([x509.ExtendedKeyUsage.clientAuth]),
+    ],
+  });
+
+  return {
+    cert: issued.toString("pem"),
+    serial: issued.serialNumber,
+    subject: issued.subject,
+    notAfter: notAfter.getTime(),
+  };
+}
+
+/**
+ * Read a CSR this CA would sign, or throw {@link CsrRejectedError}.
+ *
+ * Exported because the pairing endpoint has to know whether a request is
+ * signable **before** it consumes the pairing session: consuming is what stops
+ * two redemptions both winning, so it happens last, and a client whose CSR was
+ * malformed should not have spent the operator's session to find that out.
+ * {@link signClientCsr} calls this too, so the two paths cannot drift on what
+ * "acceptable" means.
+ */
+export async function assertSignableCsr(csrPem: string): Promise<void> {
+  await readSignableCsr(csrPem);
+}
+
+/** Parse, prove possession, and check the key is worth a signature. */
+async function readSignableCsr(csrPem: string): Promise<x509.Pkcs10CertificateRequest> {
+  let csr: x509.Pkcs10CertificateRequest;
+  try {
+    csr = new x509.Pkcs10CertificateRequest(csrPem);
+  } catch (err) {
+    throw new CsrRejectedError("unparseable", `the CSR could not be read: ${errorText(err)}`);
+  }
+
+  let selfSigned: boolean;
+  try {
+    selfSigned = await csr.verify();
+  } catch (err) {
+    throw new CsrRejectedError("bad-signature", `the CSR signature could not be checked: ${errorText(err)}`);
+  }
+  if (!selfSigned) {
+    throw new CsrRejectedError("bad-signature", "the CSR is not signed by the key it carries");
+  }
+
+  assertKeyStrongEnough(csr.publicKey);
+  return csr;
+}
+
+/** A client key pair and the CSR that proves possession of it. */
+export type ClientCsr = {
+  /** PEM `CERTIFICATE REQUEST` to post to a Core's pairing endpoint. */
+  csrPem: string;
+  /** PEM PKCS#8 private key. **Stays on the machine that made it.** */
+  privateKeyPem: string;
+};
+
+/**
+ * Mint a client key pair and a CSR for it — the client half of pairing.
+ *
+ * Lives beside the signer because the two are one contract and a mismatch
+ * between them is the failure neither side can diagnose alone: this is what the
+ * Core's own tests post at {@link signClientCsr}, so the request shape the CA
+ * accepts is exercised by the code that produces it rather than asserted twice.
+ *
+ * The published SDK will declare its own (ADR 0025 D1 — the protocol ships with
+ * the client, and `@actana/shared` is private). That is not duplication of a
+ * wire type: a CSR *is* a wire-standard format, and what would be duplicated is
+ * a call to WebCrypto.
+ */
+export async function generateClientCsr(commonName: string): Promise<ClientCsr> {
+  const keys = (await webcrypto.subtle.generateKey(CLIENT_KEY_ALGORITHM, true, [
+    "sign",
+    "verify",
+  ])) as unknown as X509KeyPair;
+  const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+    name: `CN=${commonName}`,
+    keys,
+    signingAlgorithm: CLIENT_KEY_ALGORITHM,
+  });
+  const pkcs8 = await webcrypto.subtle.exportKey("pkcs8", keys.privateKey);
+  return {
+    csrPem: csr.toString("pem"),
+    privateKeyPem: derToPem("PRIVATE KEY", Buffer.from(pkcs8)),
+  };
+}
+
+/**
+ * Refuse a key too small to be worth a signature.
+ *
+ * Only RSA is checked for size because only RSA has a size that can be wrong in
+ * this way; an EC key's curve is its strength and every curve WebCrypto will
+ * parse here is stronger than 2048-bit RSA. A key algorithm this build cannot
+ * reason about at all is refused rather than waved through — an unknown is not
+ * a pass.
+ */
+function assertKeyStrongEnough(publicKey: x509.PublicKey): void {
+  const algorithm = publicKey.algorithm as { name?: string; modulusLength?: number };
+  const name = String(algorithm.name ?? "");
+  if (name.startsWith("RSA")) {
+    const bits = algorithm.modulusLength ?? 0;
+    if (bits < MIN_RSA_MODULUS_BITS) {
+      throw new CsrRejectedError(
+        "weak-key",
+        `the CSR carries a ${bits}-bit RSA key; this Core signs ${MIN_RSA_MODULUS_BITS} and up`,
+      );
+    }
+    return;
+  }
+  if (name === "ECDSA" || name === "Ed25519") return;
+  throw new CsrRejectedError("unsupported-key", `this Core does not sign ${name || "unnamed"} keys`);
+}
+
+/** Import a PEM PKCS#8 CA key as a WebCrypto signing key. */
+async function importCaKey(pem: string): Promise<X509SigningKey> {
+  try {
+    return (await webcrypto.subtle.importKey("pkcs8", pemToDer(pem), CA_SIGNING_ALGORITHM, false, [
+      "sign",
+    ])) as unknown as X509SigningKey;
+  } catch (err) {
+    // Not a `CsrRejectedError`: nothing is wrong with the *request*. The Core's
+    // own CA key is unreadable, which is an operator-visible failure of this
+    // Core and not something the client did.
+    throw new Error(`this Core's CA key could not be read for signing: ${errorText(err)}`);
+  }
+}
+
+/** A positive 16-byte serial, hex-encoded — RFC 5280 §4.1.2.2 wants positive. */
+function randomSerial(): string {
+  const bytes = randomBytes(16);
+  bytes[0] = bytes[0]! & 0x7f;
+  return bytes.toString("hex");
+}
+
+/**
+ * PEM to DER, as a `Uint8Array` backed by its own `ArrayBuffer`.
+ *
+ * Not a `Buffer`: WebCrypto's `BufferSource` will not take one, because a
+ * `Buffer` may be a view onto a pooled — possibly shared — allocation.
+ */
+function pemToDer(pem: string) {
+  const body = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  const decoded = Buffer.from(body, "base64");
+  const der = new Uint8Array(new ArrayBuffer(decoded.byteLength));
+  der.set(decoded);
+  return der;
+}
+
+function derToPem(label: string, der: Buffer): string {
+  const body = der.toString("base64").replace(/(.{64})/g, "$1\n").trimEnd();
+  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/shared/src/core-link-bearer.ts
+++ b/packages/shared/src/core-link-bearer.ts
@@ -7,7 +7,9 @@
 // rolling renewal over the live socket).
 //
 // The token is a compact, URL-safe string: `base64url(payload).base64url(sig)`
-// where `payload` is JSON `{coreId, exp}` and `sig` is HMAC-SHA256 over the
+// where `payload` is JSON `{coreId, exp}` — since #282 optionally carrying the
+// standard `iss`, `sub`, `aud` and `jti` claims beside them, all four inert in
+// this train — and `sig` is HMAC-SHA256 over the
 // payload string, keyed by the shared secret provisioned at Core install
 // (carried in the registration blob). ~50 lines of app-layer code on top of
 // TLS; the mTLS handshake is the key-pair handshake, TLS 1.3 is the symmetric
@@ -28,7 +30,35 @@ export type BearerClaims = {
   coreId: string;
   /** Wall-clock ms expiry (JWT `exp`-style). Inclusive at the boundary. */
   exp: number;
+  /**
+   * Who issued this bearer — the Core itself, as `core:<coreId>` (#282).
+   *
+   * The four claims below are the standard set #280 fixes on, and **nothing in
+   * this feature train reads them**. They exist so that a later identity layer
+   * can gate a bearer on who and what it was issued for without a protocol
+   * change, which is only possible if the tokens minted today already carry the
+   * fields. Every one of them is optional, and that is load-bearing rather than
+   * lax: bearers signed before this existed are `{coreId, exp}` and must keep
+   * verifying, so absence is a valid token and not a malformed one.
+   */
+  iss?: string;
+  /** The subject the bearer speaks for — the paired client's identity (#282). */
+  sub?: string;
+  /**
+   * The audience: this Core's **stable UUID**, not its `coreId` (#280).
+   *
+   * `coreId` is `core_<hex>` and is re-minted whenever an operator regenerates
+   * the material; the UUID in `core-material-store.ts` survives that and a
+   * `reissueServerCert`, which is what makes it the thing a token can name and
+   * a Panel can pin.
+   */
+  aud?: string;
+  /** Unique token id, so a later layer can revoke or de-duplicate one (#280). */
+  jti?: string;
 };
+
+/** The optional standard claims, in the order {@link signBearer} writes them. */
+const STANDARD_CLAIMS = ["iss", "sub", "aud", "jti"] as const;
 
 /**
  * HMAC port. The default implementation uses `node:crypto.createHmac`, which is
@@ -66,7 +96,8 @@ function safeEqual(a: Buffer, b: Buffer): boolean {
 }
 
 /**
- * Sign `{coreId, exp}` with `secret` and return the URL-safe bearer string
+ * Sign `{coreId, exp}` — plus whichever of `iss`, `sub`, `aud` and `jti` the
+ * caller supplied — with `secret`, and return the URL-safe bearer string
  * `base64url(payload).base64url(sig)`.
  */
 export function signBearer(
@@ -74,13 +105,31 @@ export function signBearer(
   secret: BearerSecret,
   hmac: HmacPort = defaultHmac,
 ): string {
-  const payloadJson = JSON.stringify({ coreId: claims.coreId, exp: claims.exp });
+  // Absent claims are left out of the payload rather than written as `null`.
+  // A Core that mints no `aud` produces byte-for-byte the token it produced
+  // before this file knew what an `aud` was, so nothing downstream can start
+  // depending on the shape having grown.
+  const payload: Record<string, string | number> = { coreId: claims.coreId, exp: claims.exp };
+  for (const claim of STANDARD_CLAIMS) {
+    const value = claims[claim];
+    if (value !== undefined) payload[claim] = value;
+  }
+  const payloadJson = JSON.stringify(payload);
   const payloadB64 = encodeBase64Url(Buffer.from(payloadJson, "utf8"));
   const sig = hmac.sha256(secret, payloadB64);
   return `${payloadB64}${SEP}${encodeBase64Url(sig)}`;
 }
 
-export type BearerVerifyOk = { ok: true; coreId: string; exp: number };
+export type BearerVerifyOk = {
+  ok: true;
+  coreId: string;
+  exp: number;
+  /** The standard claims, when the Core that signed this one minted them (#282). */
+  iss?: string;
+  sub?: string;
+  aud?: string;
+  jti?: string;
+};
 export type BearerVerifyErr =
   | { ok: false; reason: "malformed" }
   | { ok: false; reason: "bad-signature" }
@@ -131,9 +180,31 @@ export function verifyBearer(
   if (typeof obj.coreId !== "string" || typeof obj.exp !== "number" || !Number.isFinite(obj.exp)) {
     return { ok: false, reason: "malformed" };
   }
+  const claims = readStandardClaims(parsed as Record<string, unknown>);
+  // A claim that is present but not a string is a token this Core did not mint
+  // and cannot reason about. It signed, so it is not `bad-signature`; it is
+  // simply not the shape — which is what `malformed` already means here.
+  if (claims === null) return { ok: false, reason: "malformed" };
   const now = opts.now ?? Date.now();
   if (obj.exp < now) return { ok: false, reason: "expired" };
-  return { ok: true, coreId: obj.coreId, exp: obj.exp };
+  return { ok: true, coreId: obj.coreId, exp: obj.exp, ...claims };
+}
+
+/**
+ * Pull the optional standard claims out of a decoded payload, or `null` when
+ * one of them is present with a non-string value.
+ *
+ * Absence is never a failure — see {@link BearerClaims}.
+ */
+function readStandardClaims(payload: Record<string, unknown>): Partial<BearerClaims> | null {
+  const claims: Partial<BearerClaims> = {};
+  for (const claim of STANDARD_CLAIMS) {
+    const value = payload[claim];
+    if (value === undefined) continue;
+    if (typeof value !== "string") return null;
+    claims[claim] = value;
+  }
+  return claims;
 }
 
 /**
@@ -161,5 +232,7 @@ export function decodeBearer(token: string): BearerClaims | null {
   if (typeof obj.coreId !== "string" || typeof obj.exp !== "number" || !Number.isFinite(obj.exp)) {
     return null;
   }
-  return { coreId: obj.coreId, exp: obj.exp };
+  const claims = readStandardClaims(parsed as Record<string, unknown>);
+  if (claims === null) return null;
+  return { coreId: obj.coreId, exp: obj.exp, ...claims };
 }

--- a/packages/shared/src/core-material-store.ts
+++ b/packages/shared/src/core-material-store.ts
@@ -13,7 +13,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { generateCertMaterial, issueServerCert } from "./core-cert-material";
 import log from "@actana/shared/log";
 
@@ -40,6 +40,23 @@ export type PersistedMaterial = {
   bearerSecret: string;
   /** The coreId embedded in the bearer. */
   coreId: string;
+  /**
+   * This Core's **stable identifier**, minted once and never replaced (#280).
+   *
+   * Not a second `coreId`, and the difference is the whole point of the field.
+   * `coreId` is `core_<hex>` and belongs to a *set of material*: regenerating a
+   * leaked token mints fresh material and a fresh `coreId` with it. This UUID
+   * belongs to the *Core*, so it survives a {@link reissueServerCert} and is
+   * the identifier a bearer's `aud` can name and a Panel can pin without being
+   * invalidated by an operator re-issuing a certificate.
+   *
+   * Minted at install by {@link mintFreshMaterial} and, for material written
+   * before this field existed, minted on load by {@link loadMaterialFromFile} —
+   * so an already-installed Core picks one up on its next boot with no
+   * re-install and nothing pinned going stale. See
+   * {@link readMaterialFile} for who writes that first one back to disk.
+   */
+  coreUuid: string;
   /**
    * The public host `serverCert`'s SAN was signed for. This is what makes a
    * moved Core detectable without parsing the certificate back out of the PEM
@@ -87,6 +104,7 @@ export async function mintFreshMaterial(publicHost: string): Promise<PersistedMa
     clientKey: generated.client.key,
     bearerSecret: randomBytes(32).toString("hex"),
     coreId: `core_${randomBytes(8).toString("hex")}`,
+    coreUuid: randomUUID(),
     serverHost: publicHost,
   };
 }
@@ -122,11 +140,17 @@ export function checkServerCertHost(
  * keeping everything else byte-for-byte.
  *
  * This is what a changed public host does now (ADR 0016 D18). The CA key, the
- * bearer secret, the `coreId` and the Panel's client cert all survive, so a
- * Panel paired before the move still validates this Core against the CA it
- * pinned — where the re-mint this replaced locked that Panel out for what is
- * usually a typo'd env var. Revoking a leaked pairing token stays the
- * deliberate act it was: {@link mintFreshMaterial} via `actana token regenerate`.
+ * bearer secret, the `coreId`, the `coreUuid` and the Panel's client cert all
+ * survive the spread below, so a Panel paired before the move still validates
+ * this Core against the CA it pinned — where the re-mint this replaced locked
+ * that Panel out for what is usually a typo'd env var. Revoking a leaked
+ * pairing token stays the deliberate act it was: {@link mintFreshMaterial} via
+ * `actana token regenerate`.
+ *
+ * The `coreUuid` is called out because it is the one field with a *claim* on
+ * it: it is what an issued bearer's `aud` names (#280), and an audience that
+ * changed whenever a certificate was re-signed would be no more stable than the
+ * certificate. `core-material-store.test.ts` asserts it across this call.
  */
 export async function reissueServerCert(
   material: PersistedMaterial,
@@ -189,8 +213,40 @@ export function loadMaterial(configDir: string): PersistedMaterial | null {
  * corrupt JSON, or a payload missing required fields / wrong-typed fields.
  * Used by `core-entry.ts` which receives the full path via
  * `AC_CORE_MATERIAL_FILE`.
+ *
+ * A file with no `coreUuid` — every file written before #282 — loads with a
+ * freshly minted one. See {@link readMaterialFile} when you need to know that
+ * happened, which is the only way the new UUID reaches the disk.
  */
 export function loadMaterialFromFile(filePath: string): PersistedMaterial | null {
+  return readMaterialFile(filePath)?.material ?? null;
+}
+
+/** What {@link readMaterialFile} found, and what it had to invent. */
+export type MaterialFileRead = {
+  material: PersistedMaterial;
+  /**
+   * True when the file carried no `coreUuid` and this read minted one.
+   *
+   * The caller has to persist the material when this is set, and the caller
+   * rather than this function because reading is not writing: `actana core ls`
+   * reads material it has no business rewriting, while the daemon's boot path
+   * (`core-first-run.ts`) is the one place that owns the file. An unpersisted
+   * mint is not a correctness failure — nothing reads `aud` in this train — but
+   * it would hand every boot a different audience, so the one caller that can
+   * write does.
+   */
+  mintedCoreUuid: boolean;
+};
+
+/**
+ * Load material and say whether the stable UUID had to be minted (#282).
+ *
+ * The primitive {@link loadMaterialFromFile} delegates to. Split out rather
+ * than folded into it so that every existing reader keeps its signature and
+ * only the boot path has to care about writing the mint back.
+ */
+export function readMaterialFile(filePath: string): MaterialFileRead | null {
   let raw: string;
   try {
     raw = fs.readFileSync(filePath, "utf8");
@@ -219,18 +275,29 @@ export function loadMaterialFromFile(filePath: string): PersistedMaterial | null
     log.warn("core-material.load: missing or wrong-typed fields", { filePath });
     return null;
   }
+  // Absent in material written before #282, and minted here rather than
+  // refused: the identity on disk is intact, the UUID is an addition to it, and
+  // an install that predates the field must not have to be redone to gain one.
+  // Empty string is treated as absent for the same reason `serverHost` is —
+  // a field that is there but says nothing is not a value.
+  const storedUuid = typeof o.coreUuid === "string" ? o.coreUuid : "";
+  const mintedCoreUuid = storedUuid === "";
   return {
-    caCert: o.caCert,
-    caKey: o.caKey,
-    serverCert: o.serverCert,
-    serverKey: o.serverKey,
-    clientCert: o.clientCert,
-    clientKey: o.clientKey,
-    bearerSecret: o.bearerSecret,
-    coreId: o.coreId,
-    // Absent in material written before D18. Not a validation failure — the
-    // identity is intact and only the SAN's provenance is unknown, so it loads
-    // as "unknown host" and {@link serverCertCoversHost} takes it from there.
-    serverHost: typeof o.serverHost === "string" ? o.serverHost : "",
+    material: {
+      caCert: o.caCert,
+      caKey: o.caKey,
+      serverCert: o.serverCert,
+      serverKey: o.serverKey,
+      clientCert: o.clientCert,
+      clientKey: o.clientKey,
+      bearerSecret: o.bearerSecret,
+      coreId: o.coreId,
+      coreUuid: mintedCoreUuid ? randomUUID() : storedUuid,
+      // Absent in material written before D18. Not a validation failure — the
+      // identity is intact and only the SAN's provenance is unknown, so it loads
+      // as "unknown host" and {@link serverCertCoversHost} takes it from there.
+      serverHost: typeof o.serverHost === "string" ? o.serverHost : "",
+    },
+    mintedCoreUuid,
   };
 }

--- a/packages/shared/src/pairing-store.ts
+++ b/packages/shared/src/pairing-store.ts
@@ -1,0 +1,360 @@
+// Where a Core keeps its pending pairing sessions and the clients it has
+// already paired (#280, #282).
+//
+// `pairing-session.ts` owns the *rules* — TTL, the attempt cap, single use —
+// and holds no state at all. This module is the other half: one JSON file, read
+// and rewritten under it, so that the two processes that need a pairing session
+// can both see it. There are two, and that is the whole reason this file lives
+// in `packages/shared` rather than beside the endpoint in `packages/core`:
+//
+//   • **`actana pair new`** (#283) mints the session and prints the code. It
+//     runs in the `actana` CLI, and `actana-cli-entry.ts` says why that binary
+//     never imports `@actana/core` — one binary does both jobs by keeping the
+//     daemon's bundle out of its own.
+//   • **The Core daemon** redeems it, at the pre-auth endpoint in
+//     `packages/core/src/core-pairing-routes.ts`.
+//
+// So this sits next to `core-material-store.ts`, which is in `packages/shared`
+// for exactly that reason after #288 — the CLI writes the material and the
+// daemon reads it — and it deliberately mirrors that module's shape: a JSON
+// file at a path derived from the material file, 0600 because what is in it is
+// sensitive, and a reader that treats a corrupt file as "nothing here" rather
+// than crashing a daemon at boot.
+//
+// **What is sensitive here is not the code.** The plaintext pairing code is
+// printed once to the operator's terminal and never written down; what is
+// stored is a keyed digest of it (see {@link hashPairingCode}), so a copy of
+// this file is not a copy of the live codes.
+//
+// Core-side only — never imported by the browser.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { PairingRefusal, PairingSession } from "./pairing-session";
+import { canRedeem, recordWrongAttempt } from "./pairing-session";
+
+/** The filename, beside `material.json` in the same directory. */
+export const PAIRING_STORE_FILENAME = "pairing.json";
+
+/**
+ * The pairing file for a Core whose material file is `materialFile`.
+ *
+ * Derived from the material path rather than configured separately, the way
+ * `registrationBlobPath` derives the blob file: the daemon is handed exactly
+ * one path (`AC_CORE_MATERIAL_FILE`), a container mounts exactly one volume,
+ * and a second env var to keep in step with it is a second thing to get wrong.
+ */
+export function pairingStorePath(materialFile: string): string {
+  return path.join(path.dirname(materialFile), PAIRING_STORE_FILENAME);
+}
+
+/**
+ * A client this Core has paired — one row per issued certificate.
+ *
+ * This is what `actana pair ls` lists and what `actana pair revoke` revokes
+ * (#283), which is why the certificate's serial is here: the serial is the only
+ * thing that names one issuance unambiguously, where a label is whatever the
+ * operator typed twice.
+ */
+export type PairedClient = {
+  /** The certificate serial, hex. The identity of this pairing. */
+  certSerial: string;
+  /** The certificate subject as issued, e.g. `CN=laptop`. */
+  certSubject: string;
+  /** The operator's name for the machine, carried over from the session. */
+  label: string;
+  /** The session this client redeemed. Kept so an audit can join the two. */
+  sessionId: string;
+  /** Wall-clock ms of the successful redemption. */
+  pairedAt: number;
+  /** Wall-clock ms the issued certificate stops verifying. */
+  certNotAfter: number;
+  /** Wall-clock ms of `actana pair revoke`, or `null` while the pairing stands. */
+  revokedAt: number | null;
+  /** Inert (#280): copied from the session, for a later identity layer. */
+  created_by: string | null;
+  /** Inert (#280). */
+  tenant_id: string | null;
+  /** Inert (#280). */
+  auth_method: string | null;
+};
+
+/** The file's shape. Versioned so a later change can migrate rather than guess. */
+export type PairingRecords = {
+  version: 1;
+  sessions: PairingSession[];
+  clients: PairedClient[];
+};
+
+/** An empty store — what a missing or unreadable file reads as. */
+export function emptyPairingRecords(): PairingRecords {
+  return { version: 1, sessions: [], clients: [] };
+}
+
+/**
+ * How long a session stays in the file after it stops being redeemable.
+ *
+ * Expired and consumed sessions are kept for a day rather than deleted on the
+ * spot, because they are what an operator reads when asking why a pairing
+ * failed an hour ago. Beyond that they are only file size: the refusal a
+ * pruned session produces is byte-identical to the one it produced while it
+ * was still there (see {@link PairingStore.consume}), so pruning cannot change
+ * what any client observes.
+ */
+export const PAIRING_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export type PairingConsumeOutcome =
+  | { ok: true; session: PairingSession }
+  | { ok: false; reason: PairingRefusal | "unknown" };
+
+/**
+ * The pairing file, as the daemon and the CLI both drive it.
+ *
+ * Every method reads the file, changes what it must and writes it back, rather
+ * than holding the parsed records in memory. That is a deliberate cost: the
+ * CLI and the daemon are two processes over one file, and an in-memory copy in
+ * the daemon would go stale the moment an operator ran `actana pair new` — the
+ * exact sequence pairing consists of.
+ *
+ * **What this gives, and what it does not.** Within one process the
+ * read-mutate-write in {@link consume} runs to completion without yielding, so
+ * two concurrent redemptions cannot both find the session unconsumed: the
+ * second one sees `already-consumed` and the endpoint refuses it. Across
+ * processes there is no lock, and a `pair new` landing in the same millisecond
+ * as a redemption can lose its write. That trade is taken knowingly — the
+ * alternative is a lockfile protocol between a daemon and a one-shot CLI for a
+ * collision measured in milliseconds a few times in a Core's life, and the
+ * failure it would prevent is "the operator runs `pair new` again".
+ */
+export class PairingStore {
+  constructor(private readonly filePath: string) {}
+
+  /** Everything on disk. A missing, corrupt or wrong-shaped file reads as empty. */
+  read(): PairingRecords {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.filePath, "utf8");
+    } catch {
+      return emptyPairingRecords();
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return emptyPairingRecords();
+    }
+    if (!parsed || typeof parsed !== "object") return emptyPairingRecords();
+    const o = parsed as Partial<PairingRecords>;
+    return {
+      version: 1,
+      sessions: Array.isArray(o.sessions) ? o.sessions.filter(isPairingSession) : [],
+      clients: Array.isArray(o.clients) ? o.clients.filter(isPairedClient) : [],
+    };
+  }
+
+  /** Add a freshly minted session. `actana pair new`'s one write. */
+  createSession(session: PairingSession, now: number = Date.now()): void {
+    const records = this.read();
+    records.sessions = prune([...records.sessions.filter((s) => s.id !== session.id), session], now);
+    this.write(records);
+  }
+
+  /** One session by id, or `null`. */
+  getSession(id: string): PairingSession | null {
+    return this.read().sessions.find((session) => session.id === id) ?? null;
+  }
+
+  /** Every session still on file, newest first. What `actana pair ls` reads. */
+  listSessions(): PairingSession[] {
+    return [...this.read().sessions].sort((a, b) => b.createdAt - a.createdAt);
+  }
+
+  /**
+   * Count a wrong code against a session and persist the count.
+   *
+   * Returns the session as it now stands — at the cap, it is dead and no later
+   * redemption can revive it. Returns `null` for a session that is not there,
+   * which the caller must treat exactly as it treats a refusal, so that a
+   * guess cannot be used to learn whether a session id exists.
+   */
+  recordWrongAttempt(id: string): PairingSession | null {
+    const records = this.read();
+    const index = records.sessions.findIndex((session) => session.id === id);
+    if (index === -1) return null;
+    const updated = recordWrongAttempt(records.sessions[index]!);
+    records.sessions[index] = updated;
+    this.write(records);
+    return updated;
+  }
+
+  /**
+   * Mark a session consumed, or say why it cannot be.
+   *
+   * **This is the step that issues.** The endpoint calls it *before* it signs
+   * anything, so the window in which two redemptions could both be signing is
+   * closed by the write below rather than by the certificate that follows it.
+   * A signature that then fails leaves the session consumed and the operator
+   * runs `pair new` again: that is the safe direction to fail, where the other
+   * one hands two clients a certificate for one code.
+   */
+  consume(id: string, now: number): PairingConsumeOutcome {
+    const records = this.read();
+    const index = records.sessions.findIndex((session) => session.id === id);
+    if (index === -1) return { ok: false, reason: "unknown" };
+    const gate = canRedeem(records.sessions[index]!, now);
+    if (!gate.ok) return { ok: false, reason: gate.reason };
+    const consumed: PairingSession = { ...records.sessions[index]!, consumedAt: now };
+    records.sessions[index] = consumed;
+    this.write(records);
+    return { ok: true, session: consumed };
+  }
+
+  /** Record an issued client identity. What `pair ls` and `pair revoke` read. */
+  recordClient(client: PairedClient, now: number = Date.now()): void {
+    const records = this.read();
+    records.clients = [...records.clients.filter((c) => c.certSerial !== client.certSerial), client];
+    records.sessions = prune(records.sessions, now);
+    this.write(records);
+  }
+
+  /** Every paired client, newest first. */
+  listClients(): PairedClient[] {
+    return [...this.read().clients].sort((a, b) => b.pairedAt - a.pairedAt);
+  }
+
+  /**
+   * Revoke one pairing by certificate serial. Returns the revoked row, or
+   * `null` when no such serial is paired here.
+   *
+   * Revoking is a stamp, not a delete: a row that vanished would take the
+   * audit trail of the pairing with it, and #283's `pair revoke` has to be able
+   * to say what it revoked.
+   */
+  revokeClient(certSerial: string, now: number): PairedClient | null {
+    const records = this.read();
+    const index = records.clients.findIndex((client) => client.certSerial === certSerial);
+    if (index === -1) return null;
+    if (records.clients[index]!.revokedAt !== null) return records.clients[index]!;
+    const revoked: PairedClient = { ...records.clients[index]!, revokedAt: now };
+    records.clients[index] = revoked;
+    this.write(records);
+    return revoked;
+  }
+
+  /**
+   * Write the file, owner-only, through a temporary file and a rename.
+   *
+   * The rename is what makes a reader see either the old file or the new one:
+   * a daemon polling this while the CLI writes it must never read half a JSON
+   * document and conclude the operator has no sessions.
+   */
+  private write(records: PairingRecords): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    const tmp = `${this.filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(records, null, 2), { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmp, this.filePath);
+    try {
+      fs.chmodSync(this.filePath, 0o600);
+    } catch {
+      /* best effort — non-POSIX filesystems have no mode to set */
+    }
+  }
+}
+
+/** Drop sessions that stopped being interesting a day ago. See the constant. */
+function prune(sessions: PairingSession[], now: number): PairingSession[] {
+  return sessions.filter((session) => {
+    const settled = session.consumedAt ?? session.expiresAt;
+    return now - settled < PAIRING_SESSION_RETENTION_MS;
+  });
+}
+
+function isPairingSession(value: unknown): value is PairingSession {
+  if (!value || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.id === "string" &&
+    typeof o.label === "string" &&
+    typeof o.codeHash === "string" &&
+    typeof o.createdAt === "number" &&
+    typeof o.expiresAt === "number" &&
+    typeof o.attempts === "number" &&
+    typeof o.attemptCap === "number" &&
+    (o.consumedAt === null || typeof o.consumedAt === "number")
+  );
+}
+
+function isPairedClient(value: unknown): value is PairedClient {
+  if (!value || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.certSerial === "string" &&
+    typeof o.certSubject === "string" &&
+    typeof o.label === "string" &&
+    typeof o.pairedAt === "number" &&
+    (o.revokedAt === null || typeof o.revokedAt === "number")
+  );
+}
+
+// ─── The code digest ────────────────────────────────────────────────────────
+//
+// `pairing-session.ts` carries a `codeHash` and deliberately says nothing about
+// what hashes it. This is that decision, made once for both the process that
+// mints a session and the process that redeems one.
+
+/** Domain separator, so the derived key cannot collide with the bearer's use. */
+const PAIRING_CODE_KEY_INFO = "actana:pairing-code:v1";
+
+/**
+ * Derive the key the code digest is taken under, from the Core's bearer secret.
+ *
+ * A bare `sha256(code)` would not do. The code is eight characters from a
+ * 31-character alphabet — around 2^39.6 possibilities — which is a number of
+ * hashes an attacker who has copied `pairing.json` can simply enumerate. A
+ * digest keyed by a secret that is *not* in that file cannot be attacked that
+ * way at all without the material file too.
+ *
+ * The bearer secret is reused rather than a second secret invented, because a
+ * second secret is a second thing to mint, persist and lose; the separator
+ * above is what keeps this from being the same computation the bearer does, so
+ * neither use is an oracle for the other.
+ */
+export function derivePairingCodeKey(bearerSecret: string): Buffer {
+  return createHmac("sha256", bearerSecret).update(PAIRING_CODE_KEY_INFO).digest();
+}
+
+/**
+ * The digest stored in a session's `codeHash`.
+ *
+ * Bound to the session id as well as the code, which is session binding at the
+ * cryptographic layer rather than only at the lookup: a digest lifted from one
+ * session's row cannot be matched against another session, even by something
+ * that can write this file.
+ *
+ * `code` must be the canonical form from `normalisePairingCode` — the hash of
+ * `abcd-efgh` and of `ABCDEFGH` are different strings, and the endpoint
+ * canonicalises before it gets here for exactly that reason.
+ */
+export function hashPairingCode(opts: { key: Buffer; sessionId: string; code: string }): string {
+  return createHmac("sha256", opts.key).update(`${opts.sessionId}:${opts.code}`).digest("hex");
+}
+
+/**
+ * Compare a candidate digest against a stored one in constant time.
+ *
+ * The comparison is on the *digests*, not the codes, so a timing signal here
+ * would leak the digest rather than the code — but a digest is enough to
+ * redeem, being what the store compares, so it gets `timingSafeEqual` all the
+ * same. `core-link-bearer.ts` makes the same call for the same reason.
+ */
+export function pairingCodeMatches(storedHash: string, candidateHash: string): boolean {
+  const stored = Buffer.from(storedHash, "hex");
+  const candidate = Buffer.from(candidateHash, "hex");
+  if (stored.length === 0 || stored.length !== candidate.length) return false;
+  try {
+    return timingSafeEqual(stored, candidate);
+  } catch {
+    return false;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@actana/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@peculiar/x509':
+        specifier: ^1.14.2
+        version: 1.14.3
       selfsigned:
         specifier: ^5.5.0
         version: 5.5.0


### PR DESCRIPTION
The server half of #280: the endpoint a client with a pairing code posts to, and everything this Core does before it hands back a credential.

`POST /v1/pair/redeem` takes `{ sessionId, code, client, csr }` and answers `{ caCert, clientCert, bearer, endpoint }`. The client's key is born on the client and never crosses the wire in either direction — there is nothing in this endpoint that could return one, because there is nothing in it that has one.

Base is `feat/short-code-pairing`, not `beta/0.4.0` and not `main`.

## The three decisions worth a reviewer's time

**1. How a pre-auth route exists on an mTLS server.** There is no per-route TLS: a server either demands a verified client certificate before the request line exists or it does not. So a Core that mounts the pairing endpoint completes the handshake without one (`requestCert: true`, `rejectUnauthorized: false`) and enforces the same rule one layer up — per request and per WebSocket upgrade, from `socket.authorized`, in `core-preauth-gate.ts`.

The cost, stated plainly: refusal moves from the TLS layer to the HTTP layer, so an unauthenticated caller gets a `403` where it used to get a handshake failure. What it does not cost is access — the gate defaults to refusing, the core link has no pairing exception at all, and **a Core that mounts no pre-auth surface keeps `rejectUnauthorized: true` and behaves exactly as it did before this PR.** `core-files-mtls.test.ts` is unchanged and still asserts the old behaviour.

The WebSocket moves to `ws`'s `noServer` mode, because in the `{ server }` form `ws` owns the `upgrade` event and there is nowhere to put the check. `ws` then stops forwarding the HTTP server's `error`, so a listen failure is forwarded explicitly instead.

**2. Where the pairing state lives.** In `packages/shared/src/pairing-store.ts`, beside `pairing-session.ts` and `core-material-store.ts` — not in `packages/core`. Two processes need it: `actana pair new` (#283) mints the session from the `actana` CLI, whose entry point says at length why that binary never imports `@actana/core`, and the daemon redeems it. That is the same reason `core-material-store.ts` moved into `packages/shared` in #288.

The stored `codeHash` is an HMAC keyed by a value derived from the bearer secret with its own domain separator, and it covers the session id as well as the code. A bare `sha256` would not do: eight characters from a 31-character alphabet is ~2^39.6 digests, enumerable by anyone who copies the file. Binding the digest to the session id makes session binding hold cryptographically, not only at the lookup.

**3. The order of the two "spend" steps.** The CSR is checked *before* the session is consumed, and the session is consumed *before* anything is signed. A malformed CSR is a client bug and must not cost the operator a session; consuming is what decides a race, so two simultaneous redemptions both reach that line, one marks the session consumed and goes on to sign, and the other gets the refusal a replay gets. A signature that then fails leaves the session spent — the safe direction, where the other one hands two clients a certificate for one code.

## Also here

- **Uniform refusal.** Expired, consumed, unknown, dead, wrong code: one status, one body, no header that differs. The audit log on the Core says which — the operator reading it already owns the Core.
- **Rate limiting** independent of the per-session cap, in two fixed windows (per peer, and a global backstop against a spray from many addresses), with a bounded peer map — the keys are chosen by whoever is dialling.
- **Bearer claims.** `iss`, `sub`, `aud`, `jti` beside `exp`, all inert in this train, all optional so every bearer minted before this still verifies. `sub` is the certificate serial; `aud` is the new stable core UUID.
- **The stable core UUID** is minted at install, minted on load for material that predates it (and written back by the daemon's boot path), and survives `reissueServerCert` — asserted directly, because an audience that changed when a certificate was re-signed would be no more stable than the certificate.
- **CSR signing** goes through `core-cert-material.ts` against the Core's own CA, with the same client-leaf extensions `generateCertMaterial` writes for the hand-carried Panel cert — the test asserts the two sets are *equal* rather than restating them. Nothing else is taken from the request: not the subject, not the requested extensions (a CSR asking for `cA: true` gets a leaf like everyone else), only the public key whose possession it proves.
- **`@peculiar/x509`** is added to `packages/shared` — `selfsigned` cannot sign a CSR, and this is the library `selfsigned` is itself built on, so it was already in the tree.

## Tests

`core-pairing-redeem.test.ts` runs against a real in-process Core built by the default server factory: happy path end to end, five wrong codes killing the session, expired, replay of a consumed session, a code redeemed against the wrong session, the rate limit tripping, no private key anywhere in the response, the issued certificate verifying against the Core CA — and that certificate plus its bearer completing a real mTLS handshake and an `auth` frame on the core link. Alongside it: the pre-auth gate, the route composition order, the rate limiter, the audit redaction, and the pairing store.

`pnpm typecheck`, `pnpm lint` and `pnpm test` are green locally (one panel flake under load, green on re-run in isolation and in full).

## For task 4 (#284)

The wire shape above is what the SDK declares. It is what #280 describes — the code, the client info and a CSR in; `caCert`, `clientCert`, `bearer` and `endpoint` out — so there is no change to settle in #280 before that task starts.

Refs #282
Part of #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JQhKrubNJNE2tMLysbR1z
