### PR TITLE
feat(sdk): client pairing — keypair, CSR, fingerprint-verified dial and code redemption (#284)

### DIFF
--- a/packages/sdk/src/__tests__/core-pairing.test.ts
+++ b/packages/sdk/src/__tests__/core-pairing.test.ts
@@ -29,7 +29,7 @@ import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { X509Certificate, createPublicKey } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
-import { generateCertMaterial } from "@actana/shared/core-cert-material";
+import { generateCertMaterial, issueServerCert } from "@actana/shared/core-cert-material";
 import { verifyBearer } from "@actana/shared/core-link-bearer";
 import { generatePairingCode } from "@actana/shared/pairing-code";
 import { createPairingSession } from "@actana/shared/pairing-session";
@@ -37,7 +37,6 @@ import { PairingStore, derivePairingCodeKey, hashPairingCode } from "@actana/sha
 import type { CoreHttpRoutes } from "@actana/core/core-files-routes";
 import { createCoreFilesRequestHandler } from "@actana/core/core-files-routes";
 import { PairingRateLimiter } from "@actana/core/core-pairing-rate-limit";
-import type { PairingAuditEvent } from "@actana/core/core-pairing-audit";
 import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "@actana/core/core-pairing-wiring";
 import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
 import type { PtyCore, PtyCoreEvent } from "@actana/core/pty-manager";
@@ -53,6 +52,18 @@ import {
 import { coreConnectionFromBlob, type CoreRegistrationBlob } from "../core-registration-blob";
 import { createNodeCoreLinkSocket } from "../core-link-socket";
 
+/**
+ * The audit line, as this suite reads it — one field, and it is the one #282
+ * refuses to put on the wire.
+ *
+ * Declared rather than imported from the Core. #297 moves that module to
+ * `packages/shared`, and the two branches merge cleanly: git would report no
+ * conflict while leaving an import of a file that no longer exists, and because
+ * it was an `import type` the vitest run would not have caught it either. A
+ * structural read of one field costs nothing and survives the move.
+ */
+type PairingAuditLine = { outcome: string; reason?: string };
+
 const SECRET = "sdk-pairing-suite-secret-at-least-32-bytes";
 const CORE_UUID = "9c1f4a5e-3f6d-0f0a-6c1f-1d0a5b7e9c31";
 
@@ -64,7 +75,7 @@ type Rig = {
   origin: string;
   caCert: string;
   fingerprint: string;
-  audit: PairingAuditEvent[];
+  audit: PairingAuditLine[];
   wire: WireLog;
   clock: { now: number };
   openSession(opts?: { label?: string; ttlMs?: number }): { sessionId: string; code: string };
@@ -141,7 +152,7 @@ async function startCore(opts: { rateLimiter?: PairingRateLimiter } = {}): Promi
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-sdk-pairing-"));
   tempDirs.push(dir);
   const store = new PairingStore(path.join(dir, "pairing.json"));
-  const audit: PairingAuditEvent[] = [];
+  const audit: PairingAuditLine[] = [];
   const wire: WireLog = { requests: 0, bodies: [] };
   const clock = { now: Date.now() };
   const codeKey = derivePairingCodeKey(SECRET);
@@ -580,6 +591,19 @@ describe("every refusal a caller can act on is a different failure", () => {
     expect(parsePairingTicket("abcd efgh", "ps_7f3a")).toEqual({ sessionId: "ps_7f3a", code: "ABCD-EFGH" });
     // An explicit session id wins, and the code beside it is read as a code.
     expect(parsePairingTicket("ABCD-EFGH", "ps_other")).toEqual({ sessionId: "ps_other", code: "ABCD-EFGH" });
+    // Both at once — a caller that always forwards `--session` while an
+    // operator pastes whatever they were read out. This used to keep the
+    // `ps_7f3a:` prefix inside the code and refuse a perfectly good pairing.
+    expect(parsePairingTicket("ps_7f3a:ABCD-EFGH", "ps_7f3a")).toEqual({
+      sessionId: "ps_7f3a",
+      code: "ABCD-EFGH",
+    });
+    // And two that disagree are refused rather than resolved: one of them is a
+    // mistake, and redeeming against the wrong session fails in a way that
+    // looks exactly like a mistyped code.
+    const clash = (): unknown => parsePairingTicket("ps_7f3a:ABCD-EFGH", "ps_other");
+    expect(clash).toThrow(CorePairingError);
+    expect(clash).toThrow(/must agree/);
   });
 });
 
@@ -589,6 +613,8 @@ describe("every refusal a caller can act on is a different failure", () => {
 async function startStub(opts: {
   cert: { cert: string; key: string; ca: string };
   answer?: { status: number; body: string; headers?: Record<string, string> };
+  /** The loopback address to bind. `127.0.0.2` is a Core reached off its SAN. */
+  host?: string;
 }): Promise<{ address: string; requests: number; server: https.Server }> {
   const state = { requests: 0 };
   const stub = https.createServer({ cert: opts.cert.cert, key: opts.cert.key, ca: opts.cert.ca }, (req, res) => {
@@ -601,10 +627,11 @@ async function startStub(opts: {
     });
   });
   stubs.push(stub);
-  await new Promise<void>((resolve) => stub.listen(0, "127.0.0.1", () => resolve()));
+  const host = opts.host ?? "127.0.0.1";
+  await new Promise<void>((resolve) => stub.listen(0, host, () => resolve()));
   const port = (stub.address() as { port: number }).port;
   return {
-    address: `127.0.0.1:${port}`,
+    address: `${host}:${port}`,
     get requests() {
       return state.requests;
     },
@@ -651,6 +678,9 @@ describe("the redemption dial is pinned to the certificate authority that matche
     );
 
     expect(failure.failure).toBe<CorePairingFailure>("fingerprint-mismatch");
+    // The pin refusing, by name: OpenSSL finds the pinned CA by subject and the
+    // impostor's signature does not check out against it.
+    expect(failure.detail.tlsCode).toBe("CERT_SIGNATURE_FAILURE");
     expect(stub.requests).toBe(0);
   }, 30_000);
 
@@ -685,6 +715,70 @@ describe("the redemption dial is pinned to the certificate authority that matche
 
     expect(failure.failure).toBe<CorePairingFailure>("fingerprint-mismatch");
     expect(stub.requests).toBe(1);
+  }, 30_000);
+});
+
+describe("a certificate problem is not an accusation", () => {
+  it("tells a Core reached off its SAN from a Core that is not the right Core", async () => {
+    // A Core set up for one address and reached at another: a second interface,
+    // a tunnel, a DNS name added later. `core-cert-material.ts` covers the
+    // configured host plus loopback and nothing else, so the fingerprint
+    // matches perfectly and Node's hostname check still refuses.
+    //
+    // This used to be reported as `fingerprint-mismatch` — the operator was
+    // told they were being intercepted and went looking for an attacker.
+    const material = await generateCertMaterial({ host: "127.0.0.1" });
+    const stub = await startStub({
+      cert: { cert: material.server.cert, key: material.server.key, ca: material.ca.cert },
+      host: "127.0.0.2",
+      answer: { status: 200, body: "{}" },
+    });
+
+    const failure = await failureOf(
+      pairWithCore({
+        address: stub.address,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: fingerprintOf(new X509Certificate(material.ca.cert).raw),
+        timeoutMs: 5_000,
+      }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("hostname-mismatch");
+    expect(failure.detail.tlsCode).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+    expect(failure.message).toContain("127.0.0.2");
+    // Said plainly, because the wrong sentence here costs an operator an
+    // afternoon: this is the CA they were told to expect.
+    expect(failure.message).toContain("presented the expected certificate authority");
+    expect(stub.requests).toBe(0);
+  }, 30_000);
+
+  it("reports an expired server certificate as a certificate problem, not a mismatch", async () => {
+    const ca = await generateCertMaterial({ host: "127.0.0.1" });
+    const stale = await issueServerCert({
+      ca: { cert: ca.ca.cert, key: ca.ca.key },
+      host: "127.0.0.1",
+      days: 1,
+      notBefore: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000),
+    });
+    const stub = await startStub({
+      cert: { cert: stale.cert, key: stale.key, ca: ca.ca.cert },
+      answer: { status: 200, body: "{}" },
+    });
+
+    const failure = await failureOf(
+      pairWithCore({
+        address: stub.address,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: fingerprintOf(new X509Certificate(ca.ca.cert).raw),
+        timeoutMs: 5_000,
+      }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("certificate-invalid");
+    expect(failure.detail.tlsCode).toBe("CERT_HAS_EXPIRED");
+    expect(stub.requests).toBe(0);
   }, 30_000);
 });
 
@@ -734,7 +828,35 @@ describe("answers that are not a Core's", () => {
     const incomplete = await failureAgainst({ status: 200, body: JSON.stringify({ endpoint: "wss://x:1" }) });
     expect(incomplete.failure).toBe<CorePairingFailure>("malformed-response");
     expect(incomplete.message).toContain("caCert");
+
+    // `JSON.parse("null")` succeeds, and so does an array. Both used to reach
+    // the field sweep, where `null` threw a raw `TypeError` past the failure
+    // union every caller of this module switches on.
+    const nulled = await failureAgainst({ status: 200, body: "null" });
+    expect(nulled.failure).toBe<CorePairingFailure>("malformed-response");
+
+    const listed = await failureAgainst({ status: 200, body: "[]" });
+    expect(listed.failure).toBe<CorePairingFailure>("malformed-response");
   }, 60_000);
+
+  it("refuses a credential for a plaintext endpoint", async () => {
+    // `coreConnectionFromBlob` reads TLS off the scheme: a `ws://` endpoint
+    // yields `tls: null` and still carries the bearer, so accepting one here
+    // would hand back a credential that ships the bearer in cleartext on every
+    // later dial — undoing the whole of what the pinned exchange bought.
+    const failure = await failureAgainst({
+      status: 200,
+      body: JSON.stringify({
+        endpoint: "ws://127.0.0.1:9443",
+        caCert: "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----",
+        clientCert: "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----",
+        bearer: "b",
+      }),
+    });
+
+    expect(failure.failure).toBe<CorePairingFailure>("malformed-response");
+    expect(failure.message).toContain("ws://127.0.0.1:9443");
+  }, 30_000);
 });
 
 describe("nothing this package ships stays unverified", () => {

--- a/packages/sdk/src/__tests__/core-pairing.test.ts
+++ b/packages/sdk/src/__tests__/core-pairing.test.ts
@@ -1,0 +1,780 @@
+// SDK pairing, against a real Core (#284).
+//
+// Everything the client claims here is a claim about an exchange, so almost
+// nothing below is stubbed: the server is the Core's own `PtyCoreLinkServer`
+// with the Core's own pairing routes mounted through its own wiring, the
+// certificates come from `generateCertMaterial` (what `actana setup` writes),
+// the sessions go into the `PairingStore` the operator's `actana pair new` will
+// write, and the client is `pairWithCore` with nothing patched underneath it.
+//
+// Two things are staged rather than real, and both are staged because the
+// property under test cannot be observed otherwise:
+//
+//   • **Request bodies are recorded** by a route family wrapped around the
+//     pairing one. "The private key never appears in any request body" and "the
+//     code is not sent when the fingerprint does not match" are both statements
+//     about bytes on the wire, and a client-side assertion would be the client
+//     grading its own homework.
+//   • **A Core that changes its certificate between the bootstrap dial and the
+//     redemption** is an https server whose secure context is swapped after the
+//     first handshake. No real Core does that; an attacker in the middle of one
+//     is exactly that shape, and it is the only way to prove the redemption
+//     dial is pinned rather than merely polite.
+
+import * as fs from "node:fs";
+import * as https from "node:https";
+import { Server } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { X509Certificate, createPublicKey } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateCertMaterial } from "@actana/shared/core-cert-material";
+import { verifyBearer } from "@actana/shared/core-link-bearer";
+import { generatePairingCode } from "@actana/shared/pairing-code";
+import { createPairingSession } from "@actana/shared/pairing-session";
+import { PairingStore, derivePairingCodeKey, hashPairingCode } from "@actana/shared/pairing-store";
+import type { CoreHttpRoutes } from "@actana/core/core-files-routes";
+import { createCoreFilesRequestHandler } from "@actana/core/core-files-routes";
+import { PairingRateLimiter } from "@actana/core/core-pairing-rate-limit";
+import type { PairingAuditEvent } from "@actana/core/core-pairing-audit";
+import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "@actana/core/core-pairing-wiring";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "@actana/core/pty-manager";
+import {
+  CORE_PAIRING_REDEEM_PATH,
+  CorePairingError,
+  fetchCorePairingIdentity,
+  fingerprintOf,
+  pairWithCore,
+  parsePairingTicket,
+  type CorePairingFailure,
+} from "../core-pairing";
+import { coreConnectionFromBlob, type CoreRegistrationBlob } from "../core-registration-blob";
+import { createNodeCoreLinkSocket } from "../core-link-socket";
+
+const SECRET = "sdk-pairing-suite-secret-at-least-32-bytes";
+const CORE_UUID = "9c1f4a5e-3f6d-0f0a-6c1f-1d0a5b7e9c31";
+
+/** What the pairing endpoint was actually sent, byte for byte. */
+type WireLog = { requests: number; bodies: string[] };
+
+type Rig = {
+  address: string;
+  origin: string;
+  caCert: string;
+  fingerprint: string;
+  audit: PairingAuditEvent[];
+  wire: WireLog;
+  clock: { now: number };
+  openSession(opts?: { label?: string; ttlMs?: number }): { sessionId: string; code: string };
+  store: PairingStore;
+};
+
+let server: PtyCoreLinkServer | null = null;
+const stubs: https.Server[] = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  server?.close();
+  server = null;
+  while (stubs.length > 0) stubs.pop()!.close();
+  while (tempDirs.length > 0) fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+/** A free TCP port on 127.0.0.1, found by briefly binding port 0. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = new Server();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address && typeof address === "object") {
+        const { port } = address;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+/**
+ * Copy every byte posted to the pairing prefix, then hand the request on.
+ *
+ * The `data` listener is attached in the same tick as the real handler's — the
+ * route reads its body synchronously from `handle` — so flowing mode delivers
+ * every chunk to both and nothing is stolen from the server underneath.
+ */
+function recording(inner: CoreHttpRoutes, wire: WireLog): CoreHttpRoutes {
+  const tee = (fn: (req: IncomingMessage, res: ServerResponse) => boolean) =>
+    (req: IncomingMessage, res: ServerResponse): boolean => {
+      if ((req.url ?? "").startsWith("/v1/pair/")) {
+        wire.requests += 1;
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => wire.bodies.push(Buffer.concat(chunks).toString("utf8")));
+      }
+      return fn(req, res);
+    };
+  return { handle: tee(inner.handle), handleContinue: tee(inner.handleContinue) };
+}
+
+async function startCore(opts: { rateLimiter?: PairingRateLimiter } = {}): Promise<Rig> {
+  const material = await generateCertMaterial({ host: "127.0.0.1" });
+  const port = await freePort();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-sdk-pairing-"));
+  tempDirs.push(dir);
+  const store = new PairingStore(path.join(dir, "pairing.json"));
+  const audit: PairingAuditEvent[] = [];
+  const wire: WireLog = { requests: 0, bodies: [] };
+  const clock = { now: Date.now() };
+  const codeKey = derivePairingCodeKey(SECRET);
+
+  const pairingRoutes = buildCorePairingRoutes({
+    material: {
+      caCert: material.ca.cert,
+      caKey: material.ca.key,
+      bearerSecret: SECRET,
+      coreId: "core_pairing",
+      coreUuid: CORE_UUID,
+    },
+    sessions: store,
+    endpoint: `wss://127.0.0.1:${port}`,
+    now: () => clock.now,
+    audit: (event) => audit.push(event),
+    ...(opts.rateLimiter ? { rateLimiter: opts.rateLimiter } : {}),
+  });
+
+  const fileRoutes = createCoreFilesRequestHandler({
+    filesPort: { projectRoot: () => null },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+  });
+
+  server = new PtyCoreLinkServer(mockCore(), {
+    port,
+    host: "127.0.0.1",
+    tls: {
+      caCert: material.ca.cert,
+      serverCert: material.server.cert,
+      serverKey: material.server.key,
+    },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+    httpRoutes: composeCoreHttpRoutes(recording(pairingRoutes, wire), fileRoutes),
+    isPreAuthPath: isPairingPath,
+  });
+
+  const rig: Rig = {
+    address: `127.0.0.1:${port}`,
+    origin: `https://127.0.0.1:${port}`,
+    caCert: material.ca.cert,
+    fingerprint: fingerprintOf(new X509Certificate(material.ca.cert).raw),
+    audit,
+    wire,
+    clock,
+    store,
+    openSession: ({ label = "laptop", ttlMs } = {}) => {
+      const code = generatePairingCode();
+      const sessionId = `ps_${Math.random().toString(16).slice(2, 10)}`;
+      store.createSession(
+        createPairingSession({
+          id: sessionId,
+          label,
+          codeHash: hashPairingCode({ key: codeKey, sessionId, code }),
+          now: clock.now,
+          ...(ttlMs === undefined ? {} : { ttlMs }),
+        }),
+        clock.now,
+      );
+      return { sessionId, code };
+    },
+  };
+
+  // Readiness is observed rather than awaited, as the Core's own suite does —
+  // and on a route that is not the pairing one, so no probe spends a rate-limit
+  // attempt or writes an audit line before a test has started.
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = https.request(
+          { host: "127.0.0.1", port, path: "/healthz", method: "GET", ca: material.ca.cert, agent: false },
+          (res) => {
+            res.resume();
+            res.on("end", () => resolve());
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+      return rig;
+    } catch (err) {
+      if (Date.now() > deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+/** The pairing failure of a call that must not have produced a blob. */
+async function failureOf(promise: Promise<unknown>): Promise<CorePairingError> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof CorePairingError) return err;
+    throw err;
+  }
+  throw new Error("expected the pairing attempt to fail, and it did not");
+}
+
+/** Dial the core link with a blob and report the frames the Core answers with. */
+function coreLinkAuth(blob: CoreRegistrationBlob): Promise<string[]> {
+  const connection = coreConnectionFromBlob(blob);
+  return new Promise((resolve, reject) => {
+    const seen: string[] = [];
+    const socket = createNodeCoreLinkSocket(connection.url, connection.tls ?? undefined);
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error(`no authOk — saw ${seen.join(", ") || "nothing"}`));
+    }, 10_000);
+    socket.on("open", () => socket.send(JSON.stringify({ type: "auth", reqId: "a1", bearer: connection.bearer })));
+    socket.on("message", (data: unknown) => {
+      const frame = JSON.parse(String(data)) as { type: string };
+      seen.push(frame.type);
+      if (frame.type !== "authOk" && frame.type !== "authError") return;
+      clearTimeout(timer);
+      socket.close();
+      resolve(seen);
+    });
+    socket.on("error", (err: Error) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** The public key inside a PEM certificate, as DER, for comparing to a key. */
+function certificatePublicKey(certPem: string): string {
+  return new X509Certificate(certPem).publicKey.export({ type: "spki", format: "der" }).toString("base64");
+}
+
+function privateKeyPublicHalf(keyPem: string): string {
+  return createPublicKey(keyPem).export({ type: "spki", format: "der" }).toString("base64");
+}
+
+describe("a client with a code pairs with a Core it has verified", () => {
+  it("returns a blob assembled from the response and the key that never moved", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession({ label: "laptop" });
+
+    const blob = await pairWithCore({
+      address: rig.address,
+      sessionId,
+      code,
+      expectedCaFingerprint: rig.fingerprint,
+      label: "laptop",
+      platform: "linux",
+    });
+
+    expect(blob.endpoint).toMatch(/^wss:\/\/127\.0\.0\.1:\d+$/);
+    expect(blob.caCert).toBe(rig.caCert);
+    expect(blob.clientCert).toContain("BEGIN CERTIFICATE");
+    expect(blob.clientKey).toContain("BEGIN PRIVATE KEY");
+    expect(blob.bearer.length).toBeGreaterThan(0);
+
+    // The certificate the Core signed is a certificate *for the key this
+    // machine generated* — which is the whole of what a CSR buys, and the only
+    // proof that the `clientKey` in the blob is the returned credential's other
+    // half rather than a key that merely came back in the same object.
+    expect(certificatePublicKey(blob.clientCert)).toBe(privateKeyPublicHalf(blob.clientKey));
+
+    // The bearer is the Core's, and it verifies against the Core's secret.
+    expect(verifyBearer(blob.bearer, SECRET)).not.toBeNull();
+  }, 30_000);
+
+  it("sends the CSR and never the private key", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const blob = await pairWithCore({
+      address: rig.address,
+      sessionId,
+      code,
+      expectedCaFingerprint: rig.fingerprint,
+      label: "laptop",
+    });
+
+    expect(rig.wire.bodies).toHaveLength(1);
+    const sent = rig.wire.bodies[0]!;
+
+    // Searched rather than checked field by field: a field added to the request
+    // later would slip past an assertion that only looked at the four it knows.
+    expect(sent).not.toMatch(/PRIVATE KEY/);
+    for (const line of blob.clientKey.split("\n").filter((l) => l.length > 16)) {
+      expect(sent).not.toContain(line);
+    }
+
+    const body = JSON.parse(sent) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(["client", "code", "csr", "sessionId"]);
+    expect(body.sessionId).toBe(sessionId);
+    expect(String(body.csr)).toContain("BEGIN CERTIFICATE REQUEST");
+    expect(body.client).toEqual({ label: "laptop" });
+  }, 30_000);
+
+  it("hands back material that completes an mTLS handshake and an auth frame", async () => {
+    // The end of the flow, through the SDK's own front door: the blob goes
+    // straight into `coreConnectionFromBlob` with no conversion, and what comes
+    // out of that dials the same socket every Core client dials.
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const blob = await pairWithCore({
+      address: rig.address,
+      sessionId,
+      code,
+      expectedCaFingerprint: rig.fingerprint,
+    });
+
+    const frames = await coreLinkAuth(blob);
+
+    expect(frames).toContain("authOk");
+    expect(frames).not.toContain("authError");
+  }, 30_000);
+
+  it("accepts the fingerprint in the shapes a human copies it in", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const blob = await pairWithCore({
+      address: `https://${rig.address}`,
+      sessionId,
+      code: code.toLowerCase().replace("-", " "),
+      expectedCaFingerprint: `sha256:${rig.fingerprint.replace(/:/g, "").toLowerCase()}`,
+    });
+
+    expect(blob.clientCert).toContain("BEGIN CERTIFICATE");
+  }, 30_000);
+});
+
+describe("the fingerprint is checked before the code is sent", () => {
+  it("reports the presented fingerprint without a code to send", async () => {
+    const rig = await startCore();
+
+    const identity = await fetchCorePairingIdentity({ address: rig.address });
+
+    expect(identity.fingerprint).toBe(rig.fingerprint);
+    expect(identity.caCert.replace(/\s/g, "")).toBe(rig.caCert.replace(/\s/g, ""));
+    expect(identity.httpsOrigin).toBe(rig.origin);
+    expect(rig.wire.requests).toBe(0);
+  }, 30_000);
+
+  it("is the format `actana pair new` prints — colon-separated uppercase hex of the DER", async () => {
+    const rig = await startCore();
+
+    const identity = await fetchCorePairingIdentity({ address: rig.address });
+
+    expect(identity.fingerprint).toMatch(/^([0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+    // Node computes the same digest independently, over the certificate it
+    // parsed rather than the bytes this module hashed.
+    expect(identity.fingerprint).toBe(new X509Certificate(rig.caCert).fingerprint256);
+  }, 30_000);
+
+  it("aborts on a mismatch, naming both fingerprints, with the Core never asked", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const wrong = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+
+    const failure = await failureOf(
+      pairWithCore({ address: rig.address, sessionId, code, expectedCaFingerprint: wrong }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("fingerprint-mismatch");
+    expect(failure.message).toContain(wrong);
+    expect(failure.message).toContain(rig.fingerprint);
+    expect(failure.detail.expectedFingerprint).toBe(wrong);
+    expect(failure.detail.presentedFingerprint).toBe(rig.fingerprint);
+
+    // The property the whole ticket turns on, asserted from the server's side:
+    // the endpoint was never reached, so the code was never on the wire.
+    expect(rig.wire.requests).toBe(0);
+    expect(rig.wire.bodies).toEqual([]);
+    expect(rig.audit).toEqual([]);
+    // And the session is untouched: no attempt was spent on a Core the operator
+    // never described.
+    expect(rig.store.getSession(sessionId)?.attempts).toBe(0);
+  }, 30_000);
+
+  it("refuses to send a code when it was given no fingerprint to check", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const failure = await failureOf(pairWithCore({ address: rig.address, sessionId, code }));
+
+    expect(failure.failure).toBe<CorePairingFailure>("fingerprint-unconfirmed");
+    expect(failure.detail.presentedFingerprint).toBe(rig.fingerprint);
+    expect(failure.detail.presentedCaCert).toContain("BEGIN CERTIFICATE");
+    expect(rig.wire.requests).toBe(0);
+  }, 30_000);
+});
+
+describe("every refusal a caller can act on is a different failure", () => {
+  it("tells a refused code from a rate limit, and both from an unreachable Core", async () => {
+    // One rig, walked through the Core's refusals in the order a client meets
+    // them. Sharing the rig is deliberate: the point is that the *same* client
+    // call reports four different things.
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const wrongCode = await failureOf(
+      pairWithCore({
+        address: rig.address,
+        sessionId,
+        code: code === "AAAA-AAAA" ? "BBBB-BBBB" : "AAAA-AAAA",
+        expectedCaFingerprint: rig.fingerprint,
+      }),
+    );
+    expect(wrongCode.failure).toBe<CorePairingFailure>("refused");
+    expect(wrongCode.detail.status).toBe(403);
+    expect(wrongCode.detail.coreCode).toBe("pairing-refused");
+    // The Core knows which of the four it was. The client is told one thing on
+    // purpose (`core-pairing-routes.ts`: "every refusal is the same refusal"),
+    // and the distinction lives in the audit log the operator owns.
+    expect(rig.audit.at(-1)?.reason).toBe("wrong-code");
+
+    const good = await pairWithCore({
+      address: rig.address,
+      sessionId,
+      code,
+      expectedCaFingerprint: rig.fingerprint,
+    });
+    expect(good.clientCert).toContain("BEGIN CERTIFICATE");
+
+    // Single use: the same code again is refused, and refused identically.
+    const replay = await failureOf(
+      pairWithCore({ address: rig.address, sessionId, code, expectedCaFingerprint: rig.fingerprint }),
+    );
+    expect(replay.failure).toBe<CorePairingFailure>("refused");
+    expect(rig.audit.at(-1)?.reason).toBe("already-consumed");
+
+    // An expired session, by moving the Core's clock rather than waiting.
+    const expiring = rig.openSession({ ttlMs: 60_000 });
+    rig.clock.now += 120_000;
+    const expired = await failureOf(
+      pairWithCore({
+        address: rig.address,
+        sessionId: expiring.sessionId,
+        code: expiring.code,
+        expectedCaFingerprint: rig.fingerprint,
+      }),
+    );
+    expect(expired.failure).toBe<CorePairingFailure>("refused");
+    expect(rig.audit.at(-1)?.reason).toBe("expired");
+
+    // An unknown session — the same refusal again, and no leak of whether it
+    // ever existed.
+    const unknown = await failureOf(
+      pairWithCore({
+        address: rig.address,
+        sessionId: "ps_nosuchsession",
+        code,
+        expectedCaFingerprint: rig.fingerprint,
+      }),
+    );
+    expect(unknown.failure).toBe<CorePairingFailure>("refused");
+  }, 60_000);
+
+  it("reports a spent attempt cap as a refusal, and a rate limit as its own failure", async () => {
+    // A limiter tight enough to trip inside a test, and generous enough to let
+    // the five wrong attempts before it through.
+    const limiter = new PairingRateLimiter({
+      peer: { limit: 6, windowMs: 60_000 },
+      global: { limit: 100, windowMs: 60_000 },
+    });
+    const rig = await startCore({ rateLimiter: limiter });
+    const { sessionId, code } = rig.openSession();
+    const wrong = code === "AAAA-AAAA" ? "BBBB-BBBB" : "AAAA-AAAA";
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const refusal = await failureOf(
+        pairWithCore({ address: rig.address, sessionId, code: wrong, expectedCaFingerprint: rig.fingerprint }),
+      );
+      expect(refusal.failure).toBe<CorePairingFailure>("refused");
+    }
+    expect(rig.audit.at(-1)?.reason).toBe("wrong-code");
+
+    // The session is dead now, and the right code no longer works — still one
+    // refusal, still nothing said about which defence answered.
+    const dead = await failureOf(
+      pairWithCore({ address: rig.address, sessionId, code, expectedCaFingerprint: rig.fingerprint }),
+    );
+    expect(dead.failure).toBe<CorePairingFailure>("refused");
+    expect(rig.audit.at(-1)?.reason).toBe("attempts-exhausted");
+
+    // And one more trips the limiter, which the Core *does* distinguish,
+    // because a client that waits is not a client that guessed.
+    const limited = await failureOf(
+      pairWithCore({ address: rig.address, sessionId, code, expectedCaFingerprint: rig.fingerprint }),
+    );
+    expect(limited.failure).toBe<CorePairingFailure>("rate-limited");
+    expect(limited.detail.status).toBe(429);
+    expect(limited.detail.retryAfterSeconds).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("reports an address nothing is listening on as unreachable", async () => {
+    const port = await freePort();
+
+    const failure = await failureOf(
+      pairWithCore({
+        address: `127.0.0.1:${port}`,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+        timeoutMs: 5_000,
+      }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("unreachable");
+    expect(failure.message).toContain(String(port));
+  }, 30_000);
+
+  it("refuses what it can refuse without a Core at all", async () => {
+    // Address, code and fingerprint are all checked before a socket is opened:
+    // a typo does not cost a dial, and — for the code — does not spend one of
+    // the five attempts on the operator's session.
+    expect((await failureOf(pairWithCore({ address: "", code: "x" }))).failure).toBe("bad-address");
+    expect((await failureOf(pairWithCore({ address: "ws://core:9443", code: "x" }))).failure).toBe("bad-address");
+    expect(
+      (await failureOf(pairWithCore({ address: "core:9443", code: "ABC", sessionId: "ps_1" }))).failure,
+    ).toBe("bad-code");
+    expect((await failureOf(pairWithCore({ address: "core:9443", code: "ABCD-EFGH" }))).failure).toBe("bad-code");
+    expect(
+      (
+        await failureOf(
+          pairWithCore({
+            address: "core:9443",
+            code: "ABCD-EFGH",
+            sessionId: "ps_1",
+            expectedCaFingerprint: "not-a-fingerprint",
+          }),
+        )
+      ).failure,
+    ).toBe("bad-fingerprint");
+  });
+
+  it("reads a session id carried on the code, and one passed beside it", () => {
+    expect(parsePairingTicket("ps_7f3a:abcd-efgh")).toEqual({ sessionId: "ps_7f3a", code: "ABCD-EFGH" });
+    expect(parsePairingTicket("abcd efgh", "ps_7f3a")).toEqual({ sessionId: "ps_7f3a", code: "ABCD-EFGH" });
+    // An explicit session id wins, and the code beside it is read as a code.
+    expect(parsePairingTicket("ABCD-EFGH", "ps_other")).toEqual({ sessionId: "ps_other", code: "ABCD-EFGH" });
+  });
+});
+
+// ─── A Core that is not the Core that was verified ───
+
+/** An https server answering one canned response, on material a test controls. */
+async function startStub(opts: {
+  cert: { cert: string; key: string; ca: string };
+  answer?: { status: number; body: string; headers?: Record<string, string> };
+}): Promise<{ address: string; requests: number; server: https.Server }> {
+  const state = { requests: 0 };
+  const stub = https.createServer({ cert: opts.cert.cert, key: opts.cert.key, ca: opts.cert.ca }, (req, res) => {
+    state.requests += 1;
+    req.resume();
+    req.on("end", () => {
+      const answer = opts.answer ?? { status: 500, body: "{}" };
+      res.writeHead(answer.status, { "content-type": "application/json", ...(answer.headers ?? {}) });
+      res.end(answer.body);
+    });
+  });
+  stubs.push(stub);
+  await new Promise<void>((resolve) => stub.listen(0, "127.0.0.1", () => resolve()));
+  const port = (stub.address() as { port: number }).port;
+  return {
+    address: `127.0.0.1:${port}`,
+    get requests() {
+      return state.requests;
+    },
+    server: stub,
+  };
+}
+
+describe("the redemption dial is pinned to the certificate authority that matched", () => {
+  it("sends nothing to a Core that changes its certificate after the fingerprint check", async () => {
+    // The man-in-the-middle shape: the bootstrap dial sees the CA the operator
+    // read out, and the redemption dial — a second connection — gets somebody
+    // else's. If the code were posted on an unverified connection this is where
+    // it would leak, so the assertion is that the second server saw no request.
+    const honest = await generateCertMaterial({ host: "127.0.0.1" });
+    const impostor = await generateCertMaterial({ host: "127.0.0.1" });
+    const stub = await startStub({
+      cert: { cert: honest.server.cert, key: honest.server.key, ca: honest.ca.cert },
+      answer: { status: 200, body: JSON.stringify({ endpoint: "wss://127.0.0.1:1", caCert: "x", clientCert: "x", bearer: "x" }) },
+    });
+    // Swapped between the two connections. `connection` fires before the
+    // handshake, and Node's own listener — registered first — has already built
+    // that socket's context by then, so the swap goes in a `setImmediate`: too
+    // late for the bootstrap dial, and long before the redemption opens the
+    // second one.
+    stub.server.once("connection", () =>
+      setImmediate(() => {
+        stub.server.setSecureContext({
+          cert: impostor.server.cert,
+          key: impostor.server.key,
+          ca: impostor.ca.cert,
+        });
+      }),
+    );
+
+    const honestFingerprint = fingerprintOf(new X509Certificate(honest.ca.cert).raw);
+    const failure = await failureOf(
+      pairWithCore({
+        address: stub.address,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: honestFingerprint,
+        timeoutMs: 5_000,
+      }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("fingerprint-mismatch");
+    expect(stub.requests).toBe(0);
+  }, 30_000);
+
+  it("refuses a Core that answers with a certificate authority it did not present", async () => {
+    // The same trust question one layer up: the CA in the response is what
+    // every later dial pins, so a Core that hands back a different one is
+    // asking this client to trust something no human read out.
+    const honest = await generateCertMaterial({ host: "127.0.0.1" });
+    const other = await generateCertMaterial({ host: "127.0.0.1" });
+    const stub = await startStub({
+      cert: { cert: honest.server.cert, key: honest.server.key, ca: honest.ca.cert },
+      answer: {
+        status: 200,
+        body: JSON.stringify({
+          endpoint: "wss://127.0.0.1:1",
+          caCert: other.ca.cert,
+          clientCert: honest.client.cert,
+          bearer: "b",
+        }),
+      },
+    });
+
+    const failure = await failureOf(
+      pairWithCore({
+        address: stub.address,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: fingerprintOf(new X509Certificate(honest.ca.cert).raw),
+        timeoutMs: 5_000,
+      }),
+    );
+
+    expect(failure.failure).toBe<CorePairingFailure>("fingerprint-mismatch");
+    expect(stub.requests).toBe(1);
+  }, 30_000);
+});
+
+describe("answers that are not a Core's", () => {
+  async function failureAgainst(answer: {
+    status: number;
+    body: string;
+    headers?: Record<string, string>;
+  }): Promise<CorePairingError> {
+    const material = await generateCertMaterial({ host: "127.0.0.1" });
+    const stub = await startStub({
+      cert: { cert: material.server.cert, key: material.server.key, ca: material.ca.cert },
+      answer,
+    });
+    return failureOf(
+      pairWithCore({
+        address: stub.address,
+        sessionId: "ps_1",
+        code: "ABCD-EFGH",
+        expectedCaFingerprint: fingerprintOf(new X509Certificate(material.ca.cert).raw),
+        timeoutMs: 5_000,
+      }),
+    );
+  }
+
+  it("tells a Core with no pairing endpoint from one that failed, and both from a bad answer", async () => {
+    const missing = await failureAgainst({ status: 404, body: JSON.stringify({ code: "not-found", error: "no route" }) });
+    expect(missing.failure).toBe<CorePairingFailure>("not-pairable");
+    expect(missing.detail.status).toBe(404);
+
+    const broken = await failureAgainst({
+      status: 500,
+      body: JSON.stringify({ code: "core-error", error: "this Core could not sign the request" }),
+    });
+    expect(broken.failure).toBe<CorePairingFailure>("core-error");
+
+    const rejected = await failureAgainst({
+      status: 400,
+      body: JSON.stringify({ code: "bad-request", error: "the CSR was not acceptable" }),
+    });
+    expect(rejected.failure).toBe<CorePairingFailure>("rejected");
+    expect(rejected.message).toContain("the CSR was not acceptable");
+
+    const garbage = await failureAgainst({ status: 200, body: "not json at all" });
+    expect(garbage.failure).toBe<CorePairingFailure>("malformed-response");
+
+    const incomplete = await failureAgainst({ status: 200, body: JSON.stringify({ endpoint: "wss://x:1" }) });
+    expect(incomplete.failure).toBe<CorePairingFailure>("malformed-response");
+    expect(incomplete.message).toContain("caCert");
+  }, 60_000);
+});
+
+describe("nothing this package ships stays unverified", () => {
+  it("has exactly one unverified dial, and it is the bootstrap one", () => {
+    // The rule #284 states as "no code path leaves `rejectUnauthorized: false`
+    // in place for anything after the fingerprint check", read off the source
+    // rather than inferred from behaviour: a second one could be added tomorrow
+    // in a path no test happens to drive, and this is what would fail.
+    const src = path.resolve(import.meta.dirname, "..");
+    const shipped = fs
+      .readdirSync(src, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts"));
+
+    const relaxed: string[] = [];
+    for (const entry of shipped) {
+      const lines = fs.readFileSync(path.join(src, entry.name), "utf8").split("\n");
+      for (const [index, line] of lines.entries()) {
+        // Comments out: this file argues about the flag in prose, and prose is
+        // not a code path.
+        if (/^\s*(\/\/|\*|\/\*)/.test(line)) continue;
+        if (/rejectUnauthorized:\s*false/.test(line)) relaxed.push(`${entry.name}:${index + 1}`);
+      }
+    }
+
+    expect(relaxed).toHaveLength(1);
+    expect(relaxed[0]).toMatch(/^core-pairing\.ts:/);
+
+    // And it is inside the bootstrap dial — the one function that runs before
+    // there is anything to verify against, and sends nothing.
+    const source = fs.readFileSync(path.join(src, "core-pairing.ts"), "utf8");
+    const bootstrap = source.slice(source.indexOf("function presentedChain"), source.indexOf("function chainOf"));
+    expect(bootstrap).toContain("rejectUnauthorized: false");
+  });
+});
+
+describe("the route this client posts to", () => {
+  it("is the one the Core mounts", () => {
+    // Two constants, one string, and a mismatch that would be a 404 in
+    // production and nothing at all in a suite that declared its own.
+    expect(CORE_PAIRING_REDEEM_PATH).toBe("/v1/pair/redeem");
+    expect(isPairingPath(CORE_PAIRING_REDEEM_PATH)).toBe(true);
+  });
+});

--- a/packages/sdk/src/__tests__/package-boundaries.test.ts
+++ b/packages/sdk/src/__tests__/package-boundaries.test.ts
@@ -87,6 +87,24 @@ function withoutComments(source: string): string {
  */
 const ALLOWED_DEPENDENCIES: ReadonlySet<string> = new Set(["ws", "undici"]);
 
+/**
+ * Node's own builtins, which are not on that list because they are not
+ * dependencies at all.
+ *
+ * `node:crypto`, `node:tls` and `node:https` are what `core-pairing.ts` mints a
+ * key pair, reads a presented certificate chain and posts a redemption with
+ * (#284), and there is nothing to install for any of them: the `node:` scheme
+ * is unresolvable *except* on a Node runtime, which `engines` already requires.
+ * The rule this file enforces is "a published package must not depend on a
+ * private one", and a builtin cannot be a private one.
+ *
+ * The prefix is required rather than merely accepted. Bare `crypto` resolves to
+ * the builtin today and to whatever a `crypto` package on the registry is
+ * tomorrow, so it stays an offence — the fixture below plants one and asserts
+ * it is caught.
+ */
+const NODE_BUILTIN_PREFIX = "node:";
+
 /** Every import in these files that is neither a relative path nor an allowed dependency. */
 function offendingImports(files: string[]): string[] {
   const offences: string[] = [];
@@ -96,6 +114,7 @@ function offendingImports(files: string[]): string[] {
       const allowed =
         specifier.startsWith("./") ||
         specifier.startsWith("../") ||
+        specifier.startsWith(NODE_BUILTIN_PREFIX) ||
         ALLOWED_DEPENDENCIES.has(specifier);
       if (!allowed) offences.push(`${path.basename(file)} imports ${specifier}`);
     }
@@ -149,8 +168,16 @@ describe("package boundaries", () => {
     temporaryDirs.push(root);
     mkdirSync(path.join(root, "transport"), { recursive: true });
     mkdirSync(path.join(root, "__tests__"), { recursive: true });
-    writeFileSync(path.join(root, "ok.ts"), 'import { a } from "./a";\nimport WS from "ws";\n');
+    writeFileSync(
+      path.join(root, "ok.ts"),
+      'import { a } from "./a";\nimport WS from "ws";\nimport { sign } from "node:crypto";\n',
+    );
     writeFileSync(path.join(root, "single.ts"), "import { z } from 'zod';\n");
+    // Bare `crypto`, without the scheme. It resolves to the builtin today and
+    // to a registry package the day someone publishes one, which is exactly the
+    // ambiguity `node:` exists to remove — so it is an offence, and saying so
+    // here is what keeps the allowance above a prefix rather than a guess.
+    writeFileSync(path.join(root, "bare-builtin.ts"), 'import { sign } from "crypto";\n');
     writeFileSync(path.join(root, "transport", "nested.ts"), 'import x from "@actana/shared/x";\n');
     // Left out on both counts: a test directory, and a `.test.ts` file beside
     // shipped code. Neither is shipped, and both import what shipped code cannot.
@@ -160,6 +187,7 @@ describe("package boundaries", () => {
     const offences = offendingImports(shippedSources(root));
 
     expect(offences).toEqual([
+      "bare-builtin.ts imports crypto",
       "single.ts imports zod",
       "nested.ts imports @actana/shared/x",
     ]);

--- a/packages/sdk/src/core-pairing-csr.ts
+++ b/packages/sdk/src/core-pairing-csr.ts
@@ -1,0 +1,195 @@
+// The client half of pairing that never leaves the machine: a key pair, and the
+// certificate signing request that proves possession of it (#280, #284).
+//
+// A pairing exchange hands a Core a *public* key and gets a certificate back.
+// This module is where the other half stays. Everything here runs before a
+// socket is opened, and the only value that ever crosses one is
+// {@link ClientCsr.csrPem} — the private key is returned to the caller, put
+// into the resulting `CoreRegistrationBlob`, and never given to
+// `core-pairing.ts` in a form it could serialise.
+//
+// **Why a hand-written PKCS#10 encoder rather than a library.** `node:crypto`
+// generates key pairs and signs, and it exports a public key as a DER
+// `SubjectPublicKeyInfo` — which is the only structure in a CSR that is hard to
+// produce. What is left is four fields in a fixed order (RFC 2986 §4), so the
+// choice was a ~90-line encoder against a new dependency on the one package in
+// this repository whose dependency list is a reviewed artifact
+// (`__tests__/package-boundaries.test.ts`, and ADR 0025's "a private one is a
+// broken install"). The encoder is checked where it counts: the suite posts
+// what it produces at the real Core, whose `assertSignableCsr` parses it with
+// `@peculiar/x509` and verifies the signature before signing. A CSR this file
+// got wrong fails that test rather than shipping.
+//
+// **RSA-2048, matching the Core.** `@actana/shared/core-cert-material` refuses
+// anything under 2048 bits (`MIN_RSA_MODULUS_BITS`), and its own
+// `generateClientCsr` mints exactly this. A client that asked for something
+// more exotic would be betting on the CA's parser rather than on the algorithm
+// the CA is known to sign.
+
+import { generateKeyPair, sign } from "node:crypto";
+
+/** A client key pair and the request that asks a Core's CA to certify it. */
+export type ClientCsr = {
+  /** PEM `CERTIFICATE REQUEST`, for the body of a redemption. */
+  csrPem: string;
+  /**
+   * PEM PKCS#8 private key. **Stays on the machine that made it** — it is the
+   * `clientKey` of the resulting blob and appears in no request, ever.
+   */
+  privateKeyPem: string;
+};
+
+/** Modulus size. See the header: what the Core's CA is known to sign. */
+const RSA_MODULUS_BITS = 2048;
+
+/** Longest common name written into the request. The Core caps its own at 48. */
+const MAX_COMMON_NAME = 48;
+
+/** The common name used when a caller offers nothing usable. */
+const FALLBACK_COMMON_NAME = "actana-client";
+
+/**
+ * Mint a key pair and a CSR naming `commonName`.
+ *
+ * The subject here is a *request*, and the Core does not honour it: the
+ * certificate is issued for the label the operator typed when they opened the
+ * pairing session (`core-pairing-routes.ts`, "the subject is the Core's to
+ * write"). It is filled in anyway because a CSR with an empty subject is a
+ * worse artifact to debug than one that says which machine asked.
+ */
+export async function generateClientCsr(commonName: string): Promise<ClientCsr> {
+  const { publicKey, privateKey } = await new Promise<{
+    publicKey: import("node:crypto").KeyObject;
+    privateKey: import("node:crypto").KeyObject;
+  }>((resolve, reject) => {
+    generateKeyPair("rsa", { modulusLength: RSA_MODULUS_BITS }, (err, publicKey, privateKey) => {
+      if (err) reject(err);
+      else resolve({ publicKey, privateKey });
+    });
+  });
+
+  const spki = new Uint8Array(publicKey.export({ type: "spki", format: "der" }));
+  const info = derSequence(
+    DER_VERSION_V1,
+    derName(certificationRequestName(commonName)),
+    spki,
+    // `attributes [0] IMPLICIT SET OF Attribute`, empty. Not optional in RFC
+    // 2986 — a request with the field left out is one some parsers reject —
+    // and nothing this client asks for belongs in it: requested extensions are
+    // exactly what the Core refuses to honour.
+    DER_EMPTY_ATTRIBUTES,
+  );
+
+  // RSASSA-PKCS1-v1_5 over SHA-256, which is what `sign` produces for an RSA
+  // key with no `padding` given, and what the algorithm identifier below says.
+  const signature = new Uint8Array(sign("sha256", info, privateKey));
+
+  const csr = derSequence(info, DER_SHA256_WITH_RSA, derBitString(signature));
+
+  return {
+    csrPem: derToPem("CERTIFICATE REQUEST", csr),
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+}
+
+/**
+ * A common name as it can appear in a distinguished name.
+ *
+ * Same conservative set the Core applies to the label it issues for, for the
+ * same reason: an X.509 name is structure, `,` and `=` and `+` are part of it,
+ * and a CSR is not the place to find out whose escaping is right.
+ */
+function certificationRequestName(label: string): string {
+  const cleaned = label.replace(/[^A-Za-z0-9 ._-]/g, "-").trim().slice(0, MAX_COMMON_NAME);
+  return cleaned.length > 0 ? cleaned : FALLBACK_COMMON_NAME;
+}
+
+// ─── A DER writer, as much of one as a CSR needs ───
+//
+// Tags are written as constants rather than an enum: there are five of them,
+// each is used once, and a reader checking this file against RFC 2986 wants the
+// byte.
+
+/** `INTEGER 0` — `version` is v1, and v1 is zero. */
+const DER_VERSION_V1 = Uint8Array.from([0x02, 0x01, 0x00]);
+
+/** `[0]` constructed, zero-length: the empty attribute set. */
+const DER_EMPTY_ATTRIBUTES = Uint8Array.from([0xa0, 0x00]);
+
+/**
+ * `AlgorithmIdentifier` for `sha256WithRSAEncryption` — OID
+ * 1.2.840.113549.1.1.11, with the explicit `NULL` parameters RFC 4055 §5
+ * requires for it. Written out because it is a constant in every request this
+ * file produces; an OID encoder would be more code and one more thing to get
+ * wrong.
+ */
+const DER_SHA256_WITH_RSA = Uint8Array.from([
+  0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00,
+]);
+
+/** OID 2.5.4.3, `id-at-commonName`. */
+const DER_OID_COMMON_NAME = Uint8Array.from([0x06, 0x03, 0x55, 0x04, 0x03]);
+
+/** `SEQUENCE` of the given already-encoded members. */
+function derSequence(...members: Uint8Array[]): Uint8Array {
+  return derTagged(0x30, concat(members));
+}
+
+/** `RDNSequence` with the one relative distinguished name `CN=<value>`. */
+function derName(commonName: string): Uint8Array {
+  const attribute = derSequence(DER_OID_COMMON_NAME, derUtf8String(commonName));
+  const rdn = derTagged(0x31, attribute); // SET
+  return derSequence(rdn);
+}
+
+function derUtf8String(value: string): Uint8Array {
+  return derTagged(0x0c, new TextEncoder().encode(value));
+}
+
+/**
+ * `BIT STRING` holding whole bytes.
+ *
+ * The leading zero is the count of unused bits in the final byte. A signature
+ * is a whole number of bytes, so it is always zero — and it is always present,
+ * because a `BIT STRING` without it is a malformed one.
+ */
+function derBitString(bytes: Uint8Array): Uint8Array {
+  return derTagged(0x03, concat([Uint8Array.from([0x00]), bytes]));
+}
+
+/** `tag | length | content`, with the length in DER's short or long form. */
+function derTagged(tag: number, content: Uint8Array): Uint8Array {
+  return concat([Uint8Array.from([tag]), derLength(content.length), content]);
+}
+
+/**
+ * DER's definite length.
+ *
+ * Under 128 the length is the byte. At or above it, the first byte is `0x80`
+ * plus the number of bytes that follow, big-endian and with no leading zero —
+ * the "minimal number of octets" DER insists on, which is why this counts the
+ * bytes rather than always writing four.
+ */
+function derLength(length: number): Uint8Array {
+  if (length < 0x80) return Uint8Array.from([length]);
+  const bytes: number[] = [];
+  for (let rest = length; rest > 0; rest = Math.floor(rest / 256)) bytes.unshift(rest % 256);
+  return Uint8Array.from([0x80 | bytes.length, ...bytes]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/** DER to PEM: base64 in 64-column lines between the two armour lines. */
+function derToPem(label: string, der: Uint8Array): string {
+  const body = Buffer.from(der).toString("base64").replace(/(.{64})/g, "$1\n").trimEnd();
+  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+}

--- a/packages/sdk/src/core-pairing.ts
+++ b/packages/sdk/src/core-pairing.ts
@@ -1,0 +1,798 @@
+// Pairing, from the client's side: a key pair born here, a fingerprint checked
+// before a secret moves, and a `CoreRegistrationBlob` at the end of it (#280,
+// #284).
+//
+// An operator on the Core runs `actana pair new` and reads out two things — an
+// eight-character code and the SHA-256 fingerprint of that Core's CA. This
+// module is what the other machine does with them:
+//
+//   1. dial the Core's HTTPS surface with nothing trusted yet, and read the
+//      certificate chain it presents;
+//   2. compute the fingerprint of the CA in that chain and compare it with the
+//      one the operator read out;
+//   3. **only then** post the code, a client label and a CSR;
+//   4. put the response together with the private key that never moved, and
+//      hand back the shape every other client surface already takes.
+//
+// **Step 2 is the whole security argument.** A client at step 1 has an address
+// and a code and no trust anchor, so the dial cannot verify anything and does
+// not pretend to. What it must not do is *stay* that way: the fingerprint is
+// compared while nothing secret has been sent, and the redemption in step 3 is
+// a second, separate connection pinned to the exact CA certificate that
+// matched — `rejectUnauthorized: true`, plus a `checkServerIdentity` that
+// re-runs both the hostname check and the fingerprint comparison before the
+// handshake completes. There is no code path here that sends the code over an
+// unverified connection, and no blob comes back pinned to a CA that was not
+// the one compared.
+//
+// **A caller with no fingerprint is not a caller with a waived one.** Passing
+// no `expectedCaFingerprint` is the first-contact case (#286's UI wants to show
+// the operator's fingerprint beside the Core's before anyone types anything),
+// and it is answered by reporting the presented fingerprint back — through
+// {@link fetchCorePairingIdentity}, which has no code to send, or as the
+// `fingerprint-unconfirmed` failure of {@link pairWithCore}, which has one and
+// does not send it.
+//
+// **The wire types below are declared here, not imported from
+// `@actana/shared`.** The reasoning is `core-registration-blob.ts`'s and it
+// applies unchanged: `packages/shared` is private and stays private ([ADR
+// 0025][adr] D4), so an SDK that imported the pairing request and response from
+// it would be a published package with a dependency nobody outside this
+// repository can resolve — the arrangement that ADR rejected (D1: the protocol
+// ships with the client). These declarations are structurally identical to what
+// `packages/core/src/core-pairing-routes.ts` reads and answers with, and the
+// field names are the wire's rather than either side's.
+//
+// [adr]: ../../docs/adr/0025-the-protocol-ships-with-the-client.md
+
+import { createHash } from "node:crypto";
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+import { checkServerIdentity as checkTlsServerIdentity, connect as tlsConnect } from "node:tls";
+import type { DetailedPeerCertificate, PeerCertificate } from "node:tls";
+import { generateClientCsr } from "./core-pairing-csr.ts";
+import type { CoreRegistrationBlob } from "./core-registration-blob.ts";
+
+// ─── The wire ───
+
+/** The one route a client with no certificate may reach on a Core. */
+export const CORE_PAIRING_REDEEM_PATH = "/v1/pair/redeem";
+
+/** What the client says about itself. The Core keeps the label and ignores the rest. */
+export type CorePairingClientInfo = {
+  /** The machine's own name for itself, e.g. a hostname. */
+  label?: string;
+  /** `process.platform`, for the operator reading `actana pair ls`. */
+  platform?: string;
+};
+
+/**
+ * The redemption request body.
+ *
+ * `sessionId` names the pairing session the code belongs to and is not
+ * optional: the Core hashes a candidate code together with the session id and
+ * refuses to search for a session a code might fit, which is what stops a code
+ * lifted from one session being replayed against another.
+ */
+export type CorePairingRedeemRequest = {
+  sessionId: string;
+  code: string;
+  client: CorePairingClientInfo;
+  /** PEM `CERTIFICATE REQUEST`. The private half is not in this object. */
+  csr: string;
+};
+
+/**
+ * The 200 body.
+ *
+ * Four fields, and the absence of a fifth is the point: there is no key here,
+ * because the Core never had one. {@link pairWithCore} supplies the fifth from
+ * the key it generated locally.
+ */
+export type CorePairingRedeemResponse = {
+  /** The `wss://host:port` core link to dial from now on. */
+  endpoint: string;
+  /** PEM CA certificate — the trust anchor for every later dial. */
+  caCert: string;
+  /** PEM client certificate, signed from the CSR just posted. */
+  clientCert: string;
+  /** The signed bearer for the `auth` frame. */
+  bearer: string;
+};
+
+/** A refusal body, as every non-200 answer from the pairing route is shaped. */
+export type CorePairingRefusalBody = {
+  /** The Core's machine-readable reason, e.g. `pairing-refused`. */
+  code?: string;
+  /** The human-readable one. */
+  error?: string;
+};
+
+// ─── Failures ───
+
+/**
+ * Why a pairing attempt did not produce a blob.
+ *
+ * The list is what a caller can *act* on, and it stops where the Core's own
+ * answers stop. `refused` covers a wrong code, an expired session, one already
+ * redeemed and one whose attempts are spent, because the Core answers all four
+ * with one status and one body on purpose (`core-pairing-routes.ts`, "every
+ * refusal is the same refusal"): telling them apart on the wire would tell an
+ * attacker whether a session exists and whether their last guess was closer.
+ * A client that reported four different things would be inventing three of
+ * them. The distinction the operator needs is in the Core's audit log, which
+ * is where #282 put it deliberately.
+ */
+export type CorePairingFailure =
+  /** The address could not be read as a Core's HTTPS or core-link address. */
+  | "bad-address"
+  /** The code was not eight characters, or named no pairing session. */
+  | "bad-code"
+  /** The expected fingerprint was not a SHA-256 fingerprint. */
+  | "bad-fingerprint"
+  /** Nothing answered at that address, or the dial timed out. */
+  | "unreachable"
+  /** The Core presented a chain with no CA in it — nothing to pin. */
+  | "no-ca-presented"
+  /** No fingerprint was given to check against. The code was not sent. */
+  | "fingerprint-unconfirmed"
+  /** The presented CA is not the expected one. The code was not sent. */
+  | "fingerprint-mismatch"
+  /** Wrong, expired, already redeemed, or out of attempts — see above. */
+  | "refused"
+  /** Too many attempts from this client, too fast. Try again later. */
+  | "rate-limited"
+  /** The Core would not accept the request itself — a bug on this side. */
+  | "rejected"
+  /** There is no pairing endpoint on that Core. */
+  | "not-pairable"
+  /** The Core failed while handling the redemption. */
+  | "core-error"
+  /** A 200 that was not a redemption response. */
+  | "malformed-response";
+
+/** Everything a failure knows beyond its {@link CorePairingFailure}. */
+export type CorePairingErrorDetail = {
+  /** The HTTP status, when the failure came from one. */
+  status?: number;
+  /** `retry-after`, in seconds, on a `rate-limited` failure. */
+  retryAfterSeconds?: number;
+  /** The Core's own refusal code, when it sent one. */
+  coreCode?: string;
+  /** The fingerprint the caller was told to expect. */
+  expectedFingerprint?: string;
+  /** The fingerprint the Core actually presented. */
+  presentedFingerprint?: string;
+  /** The CA the Core presented, PEM — for a UI that wants to show it. */
+  presentedCaCert?: string;
+};
+
+/**
+ * A pairing attempt that did not produce a blob.
+ *
+ * One class with a {@link CorePairingFailure} rather than a class per failure:
+ * the CLI (#285) and the Panel (#286) both switch on the reason to write a
+ * sentence, and a `switch` over a union is checked by the compiler where a
+ * chain of `instanceof` is not.
+ */
+export class CorePairingError extends Error {
+  override readonly name = "CorePairingError";
+  /** Which failure this is. Switch on it; do not read the message. */
+  readonly failure: CorePairingFailure;
+  /** Whatever the failure knows beyond its reason. */
+  readonly detail: CorePairingErrorDetail;
+
+  // Fields are assigned rather than declared as constructor parameters: this
+  // package is loaded by plain `node` with nothing but type stripping
+  // (`__tests__/plain-node-consumption.test.ts`), and a parameter property is
+  // syntax that stripping cannot erase.
+  constructor(
+    failure: CorePairingFailure,
+    message: string,
+    detail: CorePairingErrorDetail = {},
+    options: { cause?: unknown } = {},
+  ) {
+    super(message, options);
+    this.failure = failure;
+    this.detail = detail;
+  }
+}
+
+// ─── First contact ───
+
+/** What a bootstrap dial learns about a Core before anything is trusted. */
+export type CorePairingIdentity = {
+  /** SHA-256 over the CA's DER, colon-separated uppercase hex. */
+  fingerprint: string;
+  /** The PEM CA certificate that fingerprint is of. */
+  caCert: string;
+  /** The host that was dialled. */
+  host: string;
+  /** The port that was dialled. */
+  port: number;
+  /** `https://host:port` — where a redemption would be posted. */
+  httpsOrigin: string;
+};
+
+/** How long a dial or a redemption may take before it is called unreachable. */
+export const DEFAULT_PAIRING_TIMEOUT_MS = 15_000;
+
+/**
+ * Dial a Core and report the CA it presents — **without a code to send**.
+ *
+ * This is the first-contact mode, and the reason it is a separate function
+ * rather than a flag is that it takes no code: a UI that shows the operator's
+ * fingerprint beside the Core's, and asks a human whether they match, cannot
+ * leak a secret it was never given. {@link pairWithCore} calls it too, so the
+ * fingerprint a caller confirms is computed by the same code that later
+ * enforces it.
+ *
+ * The dial is unverified, because at this point in the flow there is nothing to
+ * verify against — that is what the fingerprint the operator read out is for.
+ * Nothing is sent on this connection and it is closed as soon as the chain has
+ * been read.
+ */
+export async function fetchCorePairingIdentity(opts: {
+  /** `host:port`, `https://host:port` or `wss://host:port`. */
+  address: string;
+  /** Defaults to {@link DEFAULT_PAIRING_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}): Promise<CorePairingIdentity> {
+  const { host, port, httpsOrigin } = parseCoreAddress(opts.address);
+  const chain = await presentedChain(host, port, opts.timeoutMs ?? DEFAULT_PAIRING_TIMEOUT_MS);
+  const ca = certificateAuthorityIn(chain);
+  if (!ca) {
+    throw new CorePairingError(
+      "no-ca-presented",
+      `${httpsOrigin} presented a certificate chain with no certificate authority in it, so there is nothing to compare against the fingerprint`,
+    );
+  }
+  return { fingerprint: fingerprintOf(ca.raw), caCert: derToCertificatePem(ca.raw), host, port, httpsOrigin };
+}
+
+// ─── Pairing ───
+
+export type PairWithCoreOptions = {
+  /** The Core's address: `host:port`, `https://host:port` or `wss://host:port`. */
+  address: string;
+  /**
+   * The pairing code the operator read out — `XXXX-XXXX`, in any case and with
+   * or without the hyphen.
+   *
+   * A code names a session, and the Core will not go looking for which one, so
+   * the session id has to travel with it. Either pass it as `sessionId`, or
+   * pass a single `<sessionId>:<XXXX-XXXX>` string here and this reads both out
+   * of it. Which of the two an operator is given is #280's to settle across
+   * `actana pair new` (#283) and `actana core pair` (#285); both forms parse
+   * here so that neither is a change to this module.
+   */
+  code: string;
+  /** The pairing session the code belongs to, when `code` does not carry it. */
+  sessionId?: string;
+  /**
+   * The CA fingerprint the operator read out, in any of the forms a human
+   * copies it in: colon-separated or not, upper or lower case.
+   *
+   * **Absent is not "skip the check".** With no fingerprint this function
+   * refuses with `fingerprint-unconfirmed` and reports the presented one in the
+   * error, having sent no code — see {@link fetchCorePairingIdentity}.
+   */
+  expectedCaFingerprint?: string | null;
+  /** What this machine calls itself, for the operator's `actana pair ls`. */
+  label?: string;
+  /** This machine's platform, e.g. `process.platform`. */
+  platform?: string;
+  /** Defaults to {@link DEFAULT_PAIRING_TIMEOUT_MS}, per connection. */
+  timeoutMs?: number;
+};
+
+/**
+ * Pair with a Core and return the credential it issued.
+ *
+ * The result is a {@link CoreRegistrationBlob} and nothing downstream can tell
+ * it from a hand-carried one: `coreConnectionFromBlob` unpacks it,
+ * `httpsBaseUrlFor` derives the HTTPS origin, the PEMs go into the mTLS
+ * handshake and the bearer into the `auth` frame — exactly as they do today.
+ * `clientKey` is the key generated on this machine a few lines above; it was
+ * never sent, and the Core has never seen it.
+ *
+ * Throws {@link CorePairingError} for everything that is not a blob.
+ */
+export async function pairWithCore(opts: PairWithCoreOptions): Promise<CoreRegistrationBlob> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_PAIRING_TIMEOUT_MS;
+
+  // Read the address and the ticket first. Both are failures a caller can fix
+  // without a Core being involved, and neither is worth a dial to discover.
+  const address = parseCoreAddress(opts.address);
+  const ticket = parsePairingTicket(opts.code, opts.sessionId);
+  const expected = opts.expectedCaFingerprint ? parseFingerprint(opts.expectedCaFingerprint) : null;
+
+  const identity = await fetchCorePairingIdentity({ address: opts.address, timeoutMs });
+
+  // ── The comparison, and everything that turns on it ──
+  if (!expected) {
+    throw new CorePairingError(
+      "fingerprint-unconfirmed",
+      `${identity.httpsOrigin} presents a certificate authority with fingerprint ${identity.fingerprint}; no expected fingerprint was given, so the pairing code was not sent`,
+      { presentedFingerprint: identity.fingerprint, presentedCaCert: identity.caCert },
+    );
+  }
+  if (expected !== identity.fingerprint) {
+    throw new CorePairingError(
+      "fingerprint-mismatch",
+      `${identity.httpsOrigin} presented a certificate authority with fingerprint ${identity.fingerprint}, but ${expected} was expected — the pairing code was not sent`,
+      {
+        expectedFingerprint: expected,
+        presentedFingerprint: identity.fingerprint,
+        presentedCaCert: identity.caCert,
+      },
+    );
+  }
+
+  // Past the comparison, and only past it. The key pair is minted here rather
+  // than above so that a mismatch costs a dial rather than a dial and an RSA
+  // key generation — and so that nothing exists to be sent until the Core on
+  // the other end is the one the operator described.
+  const { csrPem, privateKeyPem } = await generateClientCsr(opts.label ?? "actana-client");
+
+  const body: CorePairingRedeemRequest = {
+    sessionId: ticket.sessionId,
+    code: ticket.code,
+    client: {
+      ...(opts.label === undefined ? {} : { label: opts.label }),
+      ...(opts.platform === undefined ? {} : { platform: opts.platform }),
+    },
+    csr: csrPem,
+  };
+
+  const answer = await postRedemption({
+    host: address.host,
+    port: address.port,
+    origin: identity.httpsOrigin,
+    caCert: identity.caCert,
+    expectedFingerprint: expected,
+    body: JSON.stringify(body),
+    timeoutMs,
+  });
+
+  const issued = readRedeemResponse(answer, identity.httpsOrigin);
+
+  // The CA in the response is the one every later dial pins, so it is held to
+  // the same fingerprint the bootstrap dial was. A Core that presented one CA
+  // in its handshake and handed back another would be asking this client to
+  // trust something no human ever read out.
+  const issuedFingerprint = fingerprintOf(pemToDer(issued.caCert));
+  if (issuedFingerprint !== expected) {
+    throw new CorePairingError(
+      "fingerprint-mismatch",
+      `${identity.httpsOrigin} answered with a certificate authority whose fingerprint is ${issuedFingerprint}, not the ${expected} it presented in the handshake`,
+      { expectedFingerprint: expected, presentedFingerprint: issuedFingerprint },
+    );
+  }
+
+  return {
+    endpoint: issued.endpoint,
+    ...(opts.label === undefined ? {} : { label: opts.label }),
+    caCert: issued.caCert,
+    clientCert: issued.clientCert,
+    // The field that never crossed the wire, put back into the shape.
+    clientKey: privateKeyPem,
+    bearer: issued.bearer,
+  };
+}
+
+// ─── The pieces ───
+
+/** A pairing code, and the session it names. */
+export type PairingTicket = { sessionId: string; code: string };
+
+/**
+ * Read a ticket out of what a human typed.
+ *
+ * The code is checked for *shape* — eight alphanumerics, hyphens and spaces
+ * ignored — and not against the Core's alphabet. That is a deliberate stop:
+ * the alphabet is an internal of `packages/shared` (which this package may not
+ * import) and mirroring it here would be a copy free to drift, which ADR 0025
+ * D3 is about. What the shape check buys is worth having on its own: a code
+ * that could not be right whatever the alphabet is never spends one of the
+ * five attempts the operator's session has.
+ */
+export function parsePairingTicket(input: string, sessionId?: string): PairingTicket {
+  const trimmed = input.trim();
+  const separator = trimmed.indexOf(":");
+  const explicit = sessionId?.trim() ?? "";
+  const carried = separator === -1 ? "" : trimmed.slice(0, separator).trim();
+  const rawCode = separator === -1 || explicit !== "" ? trimmed : trimmed.slice(separator + 1);
+
+  const session = explicit !== "" ? explicit : carried;
+  if (session === "") {
+    throw new CorePairingError(
+      "bad-code",
+      "a pairing code names a pairing session — pass the session id as `sessionId`, or a `<sessionId>:<XXXX-XXXX>` code",
+    );
+  }
+
+  const stripped = rawCode.replace(/[\s-]/g, "").toUpperCase();
+  if (!/^[A-Z0-9]{8}$/.test(stripped)) {
+    throw new CorePairingError(
+      "bad-code",
+      `a pairing code is eight characters, written XXXX-XXXX — "${rawCode.trim()}" is not`,
+    );
+  }
+  return { sessionId: session, code: `${stripped.slice(0, 4)}-${stripped.slice(4)}` };
+}
+
+/** A Core's address, in the two forms this module needs it. */
+type CoreAddress = { host: string; port: number; httpsOrigin: string };
+
+/**
+ * Read `host:port`, `https://host:port` or `wss://host:port`.
+ *
+ * `ws://` and `http://` are refused rather than upgraded: there is no
+ * certificate on a plaintext dial, so there is no fingerprint to check, and
+ * pairing over one would be the silent unverified exchange this module exists
+ * to make impossible. A caller that meant the secure port should say so.
+ */
+export function parseCoreAddress(address: string): CoreAddress {
+  const trimmed = address.trim();
+  if (trimmed === "") throw new CorePairingError("bad-address", "a Core address is required");
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new CorePairingError("bad-address", `"${address}" is not a Core address — try host:port`);
+  }
+  if (url.protocol === "ws:" || url.protocol === "http:") {
+    throw new CorePairingError(
+      "bad-address",
+      `pairing needs the Core's TLS port: "${address}" names a plaintext one, and there is no certificate on it to check the fingerprint against`,
+    );
+  }
+  if (url.protocol !== "https:" && url.protocol !== "wss:") {
+    throw new CorePairingError("bad-address", `"${address}" is not a Core address — try host:port`);
+  }
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+  if (host === "") throw new CorePairingError("bad-address", `"${address}" names no host`);
+  const port = url.port === "" ? 443 : Number(url.port);
+  return { host, port, httpsOrigin: `https://${url.host}` };
+}
+
+/**
+ * A fingerprint as this module compares them: colon-separated uppercase hex,
+ * which is the form `actana pair new` prints and a human copies.
+ */
+export function parseFingerprint(input: string): string {
+  const hex = input.trim().replace(/^sha-?256[:=]/i, "").replace(/[\s:]/g, "").toUpperCase();
+  if (!/^[0-9A-F]{64}$/.test(hex)) {
+    throw new CorePairingError(
+      "bad-fingerprint",
+      `"${input.trim()}" is not a SHA-256 fingerprint — expected 32 bytes of hex, as AA:BB:…`,
+    );
+  }
+  return groupHex(hex);
+}
+
+/** SHA-256 over a certificate's DER, in the form {@link parseFingerprint} yields. */
+export function fingerprintOf(der: Uint8Array): string {
+  return groupHex(createHash("sha256").update(der).digest("hex").toUpperCase());
+}
+
+function groupHex(hex: string): string {
+  return (hex.match(/../g) ?? []).join(":");
+}
+
+/**
+ * The chain a Core presents, deepest certificate last.
+ *
+ * `rejectUnauthorized: false` is here and nowhere else in this file. It is what
+ * "no trust anchor yet" means in code: the client has an address and a
+ * fingerprint on a piece of paper, and the only way to compare the two is to
+ * look at what the server presents. Nothing is sent on this socket, and it is
+ * destroyed as soon as the chain has been copied out.
+ */
+function presentedChain(host: string, port: number, timeoutMs: number): Promise<DetailedPeerCertificate[]> {
+  return new Promise((resolve, reject) => {
+    const socket = tlsConnect({
+      host,
+      port,
+      rejectUnauthorized: false,
+      // An IP address is not a valid SNI server name (RFC 6066), and Node warns
+      // about sending one. The certificate is identified by its fingerprint
+      // here rather than by its name, so there is nothing to lose by omitting
+      // it in that case.
+      ...(isIP(host) === 0 ? { servername: host } : {}),
+    });
+    const settle = (fn: () => void): void => {
+      clearTimeout(timer);
+      socket.removeAllListeners();
+      socket.destroy();
+      fn();
+    };
+    const timer = setTimeout(() => {
+      settle(() =>
+        reject(
+          new CorePairingError("unreachable", `${host}:${port} did not answer within ${timeoutMs}ms`),
+        ),
+      );
+    }, timeoutMs);
+    socket.once("secureConnect", () => {
+      const chain = chainOf(socket.getPeerCertificate(true));
+      settle(() => resolve(chain));
+    });
+    socket.once("error", (err: Error) => {
+      settle(() =>
+        reject(
+          new CorePairingError("unreachable", `${host}:${port} could not be reached: ${err.message}`, {}, { cause: err }),
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Walk a peer certificate up to the root.
+ *
+ * Node hands back the chain as a linked list through `issuerCertificate`, and
+ * terminates it by pointing the root at itself — so the loop stops on a
+ * certificate it has already seen rather than on a null, which is the shape
+ * that would spin forever.
+ */
+function chainOf(leaf: DetailedPeerCertificate): DetailedPeerCertificate[] {
+  const chain: DetailedPeerCertificate[] = [];
+  const seen = new Set<string>();
+  let current: DetailedPeerCertificate | undefined = leaf;
+  while (current && current.raw && !seen.has(current.fingerprint256)) {
+    seen.add(current.fingerprint256);
+    chain.push(current);
+    current = current.issuerCertificate;
+  }
+  return chain;
+}
+
+/**
+ * The certificate authority in a presented chain: the last one, when it is
+ * self-issued.
+ *
+ * A Core presents its server certificate and the CA above it, and that CA — the
+ * one `actana pair new` fingerprints from `PersistedMaterial.caCert` — is the
+ * root of what it sends. If the chain ends somewhere else the Core has sent a
+ * partial chain, and there is nothing here to compare: the alternative,
+ * fingerprinting whatever is at the top, would compare the operator's CA
+ * fingerprint against a leaf and fail with a mismatch that describes the wrong
+ * problem.
+ */
+function certificateAuthorityIn(chain: DetailedPeerCertificate[]): DetailedPeerCertificate | null {
+  const top = chain.at(-1);
+  if (!top) return null;
+  return sameName(top.subject, top.issuer) ? top : null;
+}
+
+function sameName(a: PeerCertificate["subject"], b: PeerCertificate["issuer"]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+type RedemptionAnswer = { status: number; body: string; retryAfterSeconds?: number };
+
+/**
+ * Post the redemption on a connection pinned to the CA that just matched.
+ *
+ * Three things hold the code to that connection, and they are deliberately not
+ * one thing: `ca` is the single certificate the bootstrap dial fingerprinted,
+ * so no other authority can complete this handshake; `rejectUnauthorized` is
+ * true, so the verification is enforced rather than reported; and
+ * `checkServerIdentity` re-runs Node's own hostname check *and* the fingerprint
+ * comparison, before the handshake completes and therefore before a byte of the
+ * body is written. The last is redundant against the first two by construction
+ * — which is the point of having it, since the first two are options on an
+ * object and the day one of them is edited away the third still refuses.
+ */
+function postRedemption(opts: {
+  host: string;
+  port: number;
+  origin: string;
+  caCert: string;
+  expectedFingerprint: string;
+  body: string;
+  timeoutMs: number;
+}): Promise<RedemptionAnswer> {
+  return new Promise((resolve, reject) => {
+    const req = httpsRequest(
+      {
+        host: opts.host,
+        port: opts.port,
+        path: CORE_PAIRING_REDEEM_PATH,
+        method: "POST",
+        ca: opts.caCert,
+        rejectUnauthorized: true,
+        agent: false,
+        ...(isIP(opts.host) === 0 ? { servername: opts.host } : {}),
+        checkServerIdentity: (host: string, cert: PeerCertificate) => {
+          const identity = checkTlsServerIdentity(host, cert);
+          if (identity) return identity;
+          const ca = certificateAuthorityIn(chainOf(cert as DetailedPeerCertificate));
+          if (!ca) {
+            return pinFailure(`${opts.origin} presented no certificate authority on the redemption dial`);
+          }
+          const presented = fingerprintOf(ca.raw);
+          if (presented !== opts.expectedFingerprint) {
+            return pinFailure(
+              `${opts.origin} presented ${presented} on the redemption dial, not the ${opts.expectedFingerprint} it presented before`,
+            );
+          }
+          return undefined;
+        },
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(opts.body)),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          clearTimeout(timer);
+          const retryAfter = Number(res.headers["retry-after"]);
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+            ...(Number.isFinite(retryAfter) ? { retryAfterSeconds: retryAfter } : {}),
+          });
+        });
+      },
+    );
+    const timer = setTimeout(() => {
+      req.destroy(new Error(`no answer within ${opts.timeoutMs}ms`));
+    }, opts.timeoutMs);
+    req.on("error", (err: Error) => {
+      clearTimeout(timer);
+      reject(
+        // A dial that was pinned and did not verify is not an unreachable Core;
+        // it is a different Core, and saying "unreachable" would send an
+        // operator looking at their network for something that is not there.
+        // Either way the body was never written: the failure is the handshake's,
+        // and the code went nowhere.
+        certificateFailure(err)
+          ? new CorePairingError(
+              "fingerprint-mismatch",
+              `${opts.origin} did not verify against the certificate authority whose fingerprint was confirmed: ${err.message}`,
+              { expectedFingerprint: opts.expectedFingerprint },
+              { cause: err },
+            )
+          : new CorePairingError("unreachable", `${opts.origin} could not be reached: ${err.message}`, {}, { cause: err }),
+      );
+    });
+    req.end(opts.body);
+  });
+}
+
+/**
+ * Turn an answer into a response or a {@link CorePairingError}.
+ *
+ * The mapping is the Core's status table read back: `403` is the one refusal
+ * that covers four states, `429` carries a `retry-after` a caller can wait out,
+ * `400` and its neighbours mean this client sent something wrong, and `404`
+ * means the Core has no pairing endpoint at all — which is what an operator who
+ * has not run `actana pair new` on a Core built before #282 will see.
+ */
+function readRedeemResponse(answer: RedemptionAnswer, origin: string): CorePairingRedeemResponse {
+  if (answer.status !== 200) throw refusalFor(answer, origin);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(answer.body);
+  } catch {
+    throw new CorePairingError("malformed-response", `${origin} answered 200 with something that was not JSON`, {
+      status: answer.status,
+    });
+  }
+  const fields = parsed as Partial<Record<keyof CorePairingRedeemResponse, unknown>>;
+  const missing = (["endpoint", "caCert", "clientCert", "bearer"] as const).filter(
+    (field) => typeof fields[field] !== "string" || (fields[field] as string).length === 0,
+  );
+  if (missing.length > 0) {
+    throw new CorePairingError(
+      "malformed-response",
+      `${origin} answered 200 without ${missing.join(", ")}`,
+      { status: answer.status },
+    );
+  }
+  return {
+    endpoint: fields.endpoint as string,
+    caCert: fields.caCert as string,
+    clientCert: fields.clientCert as string,
+    bearer: fields.bearer as string,
+  };
+}
+
+function refusalFor(answer: RedemptionAnswer, origin: string): CorePairingError {
+  const body = safeRefusal(answer.body);
+  const detail: CorePairingErrorDetail = {
+    status: answer.status,
+    ...(body.code === undefined ? {} : { coreCode: body.code }),
+  };
+  const said = body.error ?? `HTTP ${answer.status}`;
+
+  if (answer.status === 429) {
+    return new CorePairingError(
+      "rate-limited",
+      `${origin} is refusing pairing attempts for now: ${said}`,
+      { ...detail, ...(answer.retryAfterSeconds === undefined ? {} : { retryAfterSeconds: answer.retryAfterSeconds }) },
+    );
+  }
+  if (answer.status === 403) {
+    return new CorePairingError(
+      "refused",
+      `${origin} refused the pairing code: it is wrong, expired, already used, or the session is out of attempts`,
+      detail,
+    );
+  }
+  if (answer.status === 404) {
+    return new CorePairingError("not-pairable", `${origin} has no pairing endpoint — ${said}`, detail);
+  }
+  if (answer.status >= 500) {
+    return new CorePairingError("core-error", `${origin} failed to handle the redemption: ${said}`, detail);
+  }
+  return new CorePairingError("rejected", `${origin} would not accept the redemption: ${said}`, detail);
+}
+
+/**
+ * The `code` this module's own `checkServerIdentity` refusals carry.
+ *
+ * Node reports a refusal from `checkServerIdentity` by destroying the socket
+ * with the returned error, which arrives at the request as an ordinary
+ * `error` event indistinguishable from a connection reset. Tagging it is what
+ * lets {@link certificateFailure} tell "this is not the Core you confirmed"
+ * from "nothing answered".
+ */
+const PIN_FAILURE_CODE = "ERR_ACTANA_PAIRING_PIN";
+
+/** An error for `checkServerIdentity` to refuse a handshake with. */
+function pinFailure(message: string): Error {
+  return Object.assign(new Error(message), { code: PIN_FAILURE_CODE });
+}
+
+/**
+ * Did this connection fail because the certificate did not verify?
+ *
+ * The tagged refusal above, then OpenSSL's own verdicts, which Node surfaces as
+ * `code` — `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `SELF_SIGNED_CERT_IN_CHAIN`,
+ * `CERT_HAS_EXPIRED` and the rest of a list too long and too version-dependent
+ * to enumerate, plus the `ERR_TLS_*` family Node raises itself. Matched by
+ * prefix rather than by an exhaustive set: a verification failure this function
+ * did not recognise would be reported as `unreachable`, which is the wrong
+ * sentence for the one case that matters most.
+ */
+function certificateFailure(err: unknown): boolean {
+  const code = String((err as { code?: unknown } | null)?.code ?? "");
+  if (code === PIN_FAILURE_CODE) return true;
+  return (
+    code.startsWith("ERR_TLS_") ||
+    code.startsWith("ERR_SSL_") ||
+    code.includes("CERT") ||
+    code.startsWith("UNABLE_TO_") ||
+    code.startsWith("DEPTH_ZERO_")
+  );
+}
+
+function safeRefusal(body: string): CorePairingRefusalBody {
+  try {
+    const parsed = JSON.parse(body) as CorePairingRefusalBody;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** DER to a PEM `CERTIFICATE`, in the 64-column form every PEM reader expects. */
+function derToCertificatePem(der: Uint8Array): string {
+  const body = Buffer.from(der).toString("base64").replace(/(.{64})/g, "$1\n").trimEnd();
+  return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----\n`;
+}
+
+/** The first certificate in a PEM, as DER. Throws nothing: an empty PEM yields no bytes. */
+function pemToDer(pem: string): Uint8Array {
+  const match = /-----BEGIN CERTIFICATE-----([\s\S]*?)-----END CERTIFICATE-----/.exec(pem);
+  return new Uint8Array(Buffer.from((match?.[1] ?? "").replace(/\s+/g, ""), "base64"));
+}

--- a/packages/sdk/src/core-pairing.ts
+++ b/packages/sdk/src/core-pairing.ts
@@ -138,6 +138,18 @@ export type CorePairingFailure =
   | "fingerprint-unconfirmed"
   /** The presented CA is not the expected one. The code was not sent. */
   | "fingerprint-mismatch"
+  /**
+   * The expected CA, on an address its certificate does not cover.
+   *
+   * Its own failure rather than a mismatch, because it is not an attack and
+   * saying so sends the operator hunting for one: a Core's server certificate
+   * covers the host it was set up for plus loopback, so reaching a Core over a
+   * second interface, a tunnel or a DNS name added later fails here with the
+   * fingerprint matching perfectly.
+   */
+  | "hostname-mismatch"
+  /** The expected CA, and a certificate that is expired or otherwise unusable. */
+  | "certificate-invalid"
   /** Wrong, expired, already redeemed, or out of attempts — see above. */
   | "refused"
   /** Too many attempts from this client, too fast. Try again later. */
@@ -165,6 +177,8 @@ export type CorePairingErrorDetail = {
   presentedFingerprint?: string;
   /** The CA the Core presented, PEM — for a UI that wants to show it. */
   presentedCaCert?: string;
+  /** The TLS or OpenSSL code behind a dial failure, e.g. `CERT_HAS_EXPIRED`. */
+  tlsCode?: string;
 };
 
 /**
@@ -402,8 +416,21 @@ export function parsePairingTicket(input: string, sessionId?: string): PairingTi
   const separator = trimmed.indexOf(":");
   const explicit = sessionId?.trim() ?? "";
   const carried = separator === -1 ? "" : trimmed.slice(0, separator).trim();
-  const rawCode = separator === -1 || explicit !== "" ? trimmed : trimmed.slice(separator + 1);
+  // The prefix is stripped whenever there is one, whether or not a session id
+  // was also passed: a caller that always forwards `--session` while letting an
+  // operator paste whatever they were read out hands in both, and refusing that
+  // would refuse the one shape this function exists to be tolerant of.
+  const rawCode = separator === -1 ? trimmed : trimmed.slice(separator + 1);
 
+  if (explicit !== "" && carried !== "" && explicit !== carried) {
+    // Two session ids that disagree is not a shape to pick a winner from: one
+    // of them is a mistake, and redeeming against the wrong session refuses in
+    // a way that looks like a bad code.
+    throw new CorePairingError(
+      "bad-code",
+      `the code names session "${carried}" and "${explicit}" was passed beside it — they must agree`,
+    );
+  }
   const session = explicit !== "" ? explicit : carried;
   if (session === "") {
     throw new CorePairingError(
@@ -562,6 +589,12 @@ function chainOf(leaf: DetailedPeerCertificate): DetailedPeerCertificate[] {
  * fingerprinting whatever is at the top, would compare the operator's CA
  * fingerprint against a leaf and fail with a mismatch that describes the wrong
  * problem.
+ *
+ * That makes "a Core presents a chain ending in its own root" a property of the
+ * pairing flow rather than a detail of this file: a Core that later fronts an
+ * intermediate, or serves a partial chain, breaks first contact for every
+ * client. It belongs in #280 beside the rest of the flow's properties, and is
+ * written here so the dependency is visible from the code that has it.
  */
 function certificateAuthorityIn(chain: DetailedPeerCertificate[]): DetailedPeerCertificate | null {
   const top = chain.at(-1);
@@ -647,24 +680,51 @@ function postRedemption(opts: {
     }, opts.timeoutMs);
     req.on("error", (err: Error) => {
       clearTimeout(timer);
-      reject(
-        // A dial that was pinned and did not verify is not an unreachable Core;
-        // it is a different Core, and saying "unreachable" would send an
-        // operator looking at their network for something that is not there.
-        // Either way the body was never written: the failure is the handshake's,
-        // and the code went nowhere.
-        certificateFailure(err)
-          ? new CorePairingError(
-              "fingerprint-mismatch",
-              `${opts.origin} did not verify against the certificate authority whose fingerprint was confirmed: ${err.message}`,
-              { expectedFingerprint: opts.expectedFingerprint },
-              { cause: err },
-            )
-          : new CorePairingError("unreachable", `${opts.origin} could not be reached: ${err.message}`, {}, { cause: err }),
-      );
+      // Whatever this turns out to be, the body was never written: the failure
+      // is the handshake's, and the code went nowhere. What is decided here is
+      // only which of four things the operator is told — and one of them
+      // accuses somebody, so see {@link classifyDialFailure}.
+      const code = failureCode(err);
+      const tls = code === undefined ? {} : { tlsCode: code };
+      reject(dialFailure(classifyDialFailure(err), err, opts, tls));
     });
     req.end(opts.body);
   });
+}
+
+/** One sentence per {@link DialFailure}, and the failure that carries it. */
+function dialFailure(
+  kind: DialFailure,
+  err: Error,
+  opts: { origin: string; host: string; expectedFingerprint: string },
+  tls: { tlsCode?: string },
+): CorePairingError {
+  const cause = { cause: err };
+  if (kind === "pin") {
+    return new CorePairingError(
+      "fingerprint-mismatch",
+      `${opts.origin} did not present the certificate authority whose fingerprint was confirmed — the pairing code was not sent (${err.message})`,
+      { ...tls, expectedFingerprint: opts.expectedFingerprint },
+      cause,
+    );
+  }
+  if (kind === "hostname") {
+    return new CorePairingError(
+      "hostname-mismatch",
+      `${opts.origin} presented the expected certificate authority, but its certificate does not cover ${opts.host} — dial the address this Core was set up for (${err.message})`,
+      { ...tls, expectedFingerprint: opts.expectedFingerprint },
+      cause,
+    );
+  }
+  if (kind === "certificate") {
+    return new CorePairingError(
+      "certificate-invalid",
+      `${opts.origin} presented the expected certificate authority, but its certificate could not be used: ${err.message}`,
+      { ...tls, expectedFingerprint: opts.expectedFingerprint },
+      cause,
+    );
+  }
+  return new CorePairingError("unreachable", `${opts.origin} could not be reached: ${err.message}`, tls, cause);
 }
 
 /**
@@ -687,6 +747,15 @@ function readRedeemResponse(answer: RedemptionAnswer, origin: string): CorePairi
       status: answer.status,
     });
   }
+  // `JSON.parse("null")` succeeds, and an array parses too. Both would reach
+  // the sweep below as something a field can be read off without complaint from
+  // the compiler, and `null` would throw a raw `TypeError` out of a function
+  // whose whole contract is that failures arrive as a `CorePairingError`.
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CorePairingError("malformed-response", `${origin} answered 200 with something that was not an object`, {
+      status: answer.status,
+    });
+  }
   const fields = parsed as Partial<Record<keyof CorePairingRedeemResponse, unknown>>;
   const missing = (["endpoint", "caCert", "clientCert", "bearer"] as const).filter(
     (field) => typeof fields[field] !== "string" || (fields[field] as string).length === 0,
@@ -698,8 +767,24 @@ function readRedeemResponse(answer: RedemptionAnswer, origin: string): CorePairi
       { status: answer.status },
     );
   }
+  // The endpoint decides whether anything later is protected at all.
+  // `coreConnectionFromBlob` reads TLS off the scheme and nothing else: a
+  // `ws://` endpoint yields `tls: null` **and still carries the bearer**, so a
+  // Core that answered with one — misconfigured, or hostile — would hand back a
+  // credential whose every later dial ships the bearer in cleartext with no
+  // client certificate. That is the property this module spent a bootstrap
+  // dial, a fingerprint comparison and a pinned second connection to establish,
+  // undone by one field nobody looked at.
+  const endpoint = (fields.endpoint as string).trim();
+  if (!endpoint.startsWith("wss://")) {
+    throw new CorePairingError(
+      "malformed-response",
+      `${origin} answered with the endpoint ${endpoint}, which is not a \`wss://\` core link — a paired credential is only a credential on one`,
+      { status: answer.status },
+    );
+  }
   return {
-    endpoint: fields.endpoint as string,
+    endpoint,
     caCert: fields.caCert as string,
     clientCert: fields.clientCert as string,
     bearer: fields.bearer as string,
@@ -743,8 +828,8 @@ function refusalFor(answer: RedemptionAnswer, origin: string): CorePairingError 
  * Node reports a refusal from `checkServerIdentity` by destroying the socket
  * with the returned error, which arrives at the request as an ordinary
  * `error` event indistinguishable from a connection reset. Tagging it is what
- * lets {@link certificateFailure} tell "this is not the Core you confirmed"
- * from "nothing answered".
+ * lets {@link classifyDialFailure} tell "this is not the Core you confirmed"
+ * from "nothing answered" — and from the two failures that are neither.
  */
 const PIN_FAILURE_CODE = "ERR_ACTANA_PAIRING_PIN";
 
@@ -754,26 +839,101 @@ function pinFailure(message: string): Error {
 }
 
 /**
- * Did this connection fail because the certificate did not verify?
+ * Was this failure about the certificate at all?
  *
- * The tagged refusal above, then OpenSSL's own verdicts, which Node surfaces as
- * `code` — `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `SELF_SIGNED_CERT_IN_CHAIN`,
+ * OpenSSL's verdicts reach Node as `code` — `UNABLE_TO_VERIFY_LEAF_SIGNATURE`,
  * `CERT_HAS_EXPIRED` and the rest of a list too long and too version-dependent
- * to enumerate, plus the `ERR_TLS_*` family Node raises itself. Matched by
- * prefix rather than by an exhaustive set: a verification failure this function
- * did not recognise would be reported as `unreachable`, which is the wrong
- * sentence for the one case that matters most.
+ * to enumerate — beside the `ERR_TLS_*` family Node raises itself. Matched by
+ * prefix, deliberately: a verification failure this predicate did not recognise
+ * would be reported as `unreachable`, which sends an operator looking at their
+ * network for a problem that is in their certificates.
+ *
+ * It answers only that question. Which certificate failure it was — the pin,
+ * the hostname, or an unusable certificate — is {@link classifyDialFailure}'s,
+ * and that one is enumerated rather than guessed.
  */
-function certificateFailure(err: unknown): boolean {
-  const code = String((err as { code?: unknown } | null)?.code ?? "");
-  if (code === PIN_FAILURE_CODE) return true;
+function certificateFailure(code: string): boolean {
   return (
     code.startsWith("ERR_TLS_") ||
     code.startsWith("ERR_SSL_") ||
     code.includes("CERT") ||
     code.startsWith("UNABLE_TO_") ||
-    code.startsWith("DEPTH_ZERO_")
+    code.startsWith("DEPTH_ZERO_") ||
+    code.startsWith("SELF_SIGNED_")
   );
+}
+
+/**
+ * OpenSSL verdicts that mean **this chain does not lead to the pinned CA**.
+ *
+ * Every one of them is a statement about who signed what: no issuer, an issuer
+ * that is not the one supplied, a signature that does not check out, a chain
+ * that ends in a self-signed certificate that is not the pinned root. On a dial
+ * whose `ca` is the single certificate the operator's fingerprint matched,
+ * that is the pin refusing — the same event `checkServerIdentity` reports when
+ * it gets far enough to run.
+ *
+ * Enumerated rather than prefix-matched, because this is the set that decides
+ * whether a person is told they are being attacked.
+ */
+const CHAIN_FAILURE_CODES: ReadonlySet<string> = new Set([
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "CERT_SIGNATURE_FAILURE",
+  "CERT_UNTRUSTED",
+  "INVALID_CA",
+]);
+
+/** Node's own verdict when a certificate does not cover the address dialled. */
+const HOSTNAME_FAILURE_CODE = "ERR_TLS_CERT_ALTNAME_INVALID";
+
+/** What a failed redemption dial was actually about. */
+type DialFailure =
+  /** The peer is not the Core whose CA fingerprint was confirmed. */
+  | "pin"
+  /** The right CA, on an address its certificate does not cover. */
+  | "hostname"
+  /** The right CA, and a certificate that is expired or otherwise unusable. */
+  | "certificate"
+  /** Nothing about certificates: refused, reset, timed out. */
+  | "transport";
+
+/**
+ * Classify a failure on the pinned dial.
+ *
+ * The distinction this draws is the module's most consequential sentence, and
+ * it used to be drawn wrong: any code containing `CERT` was reported as a
+ * fingerprint mismatch, so `ERR_TLS_CERT_ALTNAME_INVALID` — a Core set up for
+ * one address and reached at another, which `core-cert-material.ts` makes an
+ * ordinary configuration rather than an exotic one — told the operator they
+ * were being intercepted. So did an expired server certificate. **A
+ * misconfigured Core must not be reported as an attack**: the person who reads
+ * that goes looking for an attacker instead of for their own SAN list.
+ *
+ * So the width and the accusation are now two separate decisions.
+ * {@link certificateFailure} still decides broadly whether the failure was
+ * about the certificate at all — being wrong there only costs the wrong noun.
+ * Whether it was the *pin* is decided by an enumerated set plus the tagged
+ * refusal, and anything certificate-shaped that is in neither is reported as an
+ * invalid certificate. Nothing is lost by that default: the exchange is refused
+ * either way and the code was never written to the socket — the only thing that
+ * changes is which sentence a person is shown.
+ */
+function classifyDialFailure(err: unknown): DialFailure {
+  const code = String((err as { code?: unknown } | null)?.code ?? "");
+  if (code === PIN_FAILURE_CODE) return "pin";
+  if (CHAIN_FAILURE_CODES.has(code)) return "pin";
+  if (code === HOSTNAME_FAILURE_CODE) return "hostname";
+  return certificateFailure(code) ? "certificate" : "transport";
+}
+
+/** The `code` a dial failure carried, for {@link CorePairingErrorDetail.tlsCode}. */
+function failureCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === "string" && code.length > 0 ? code : undefined;
 }
 
 function safeRefusal(body: string): CorePairingRefusalBody {


### PR DESCRIPTION
Closes #284.

The client half of short-code pairing (#280), in `packages/sdk` — the package a third party installs to talk to a Core, and the one function both `actana core pair` (#285) and the Panel's first-contact UI (#286) will call.

**Base is `feat/short-code-pairing`**, not `main` and not the train. The pairing server this drives is #282, already on that branch.

## What lands

- `packages/sdk/src/core-pairing.ts` — the wire types, the bootstrap dial, the fingerprint comparison, the redemption, and a failure union a caller can switch on.
- `packages/sdk/src/core-pairing-csr.ts` — a key pair from `node:crypto` and a PKCS#10 CSR built over it, with no new dependency.
- `packages/sdk/src/__tests__/core-pairing.test.ts` — the flow against the Core's own server, its own routes and its own certificates.
- `packages/sdk/src/__tests__/package-boundaries.test.ts` — the sweep now allows `node:`-prefixed builtins, and still refuses bare `crypto`.

Nothing outside `packages/sdk` is touched: the CLI dispatch and the link server are #283's and #285's.

## The shape

```ts
const identity = await fetchCorePairingIdentity({ address: "core.example:9443" });
// → { fingerprint: "75:5C:…:E8", caCert, host, port, httpsOrigin }  — no code sent

const blob = await pairWithCore({
  address: "core.example:9443",
  sessionId: "ps_7f3a1c20",
  code: "ABCD-EFGH",
  expectedCaFingerprint: "75:5C:…:E8",
  label: "laptop",
});
const connection = coreConnectionFromBlob(blob); // no conversion
```

## The security argument, and where it is asserted

1. The bootstrap dial is unverified because at that point there is nothing to verify against — that is what the operator's fingerprint is for. It is the **only** `rejectUnauthorized: false` in the package, and a test sweeps the shipped sources to keep it that way.
2. The comparison happens with nothing secret sent. On a mismatch the test asserts from the *server's* side that the endpoint was never reached, no audit line was written, and no attempt was spent on the operator's session.
3. The redemption is a second connection pinned to the CA that matched — `ca` set to that one certificate, `rejectUnauthorized: true`, and a `checkServerIdentity` that re-runs the hostname check and the fingerprint comparison before the handshake completes. A Core that swaps its certificate between the two connections gets no request at all; that test stages exactly that.
4. The CA in the response is held to the same fingerprint, so the blob never pins something no human read out.
5. The private key is generated locally and put back into the blob after the response arrives. The suite records the request bytes and asserts the key is not among them.

## Two things worth a reviewer's attention

**The session id.** The Core requires `sessionId` beside the code and refuses to search for the session a code might belong to (#282, session binding). #283's `actana pair new` prints "the code, the CA fingerprint and the expiry" — with no session id in that list, and #284 describes the client function as taking "the address, the code and the fingerprint". Those two do not currently meet. Rather than settle it here, `pairWithCore` accepts either form — an explicit `sessionId`, or a single `"<sessionId>:<XXXX-XXXX>"` code that carries it — so whichever way #280 settles it, #283 and #285 change and this module does not. **This is the coordination #284 asks to happen in #280 rather than in a PR review.**

**Four refusals arrive as one.** `wrong / expired / consumed / attempts-exhausted` reach the client as a single `refused` failure, because the Core answers all four with one status and one body deliberately — telling them apart on the wire is the leak #282 refuses to ship. Rate-limited, fingerprint-mismatch, unreachable, not-pairable, rejected, core-error and malformed-response are each their own. See the acceptance-criteria comment below.

## Checks

`pnpm --filter @actana/sdk test` (270 passed, 5 skipped), `typecheck`, `eslint packages/sdk`, and the published build (`tsc -p tsconfig.build.json`) are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TVDf5cTzELMEasHVANmZ
