### PR TITLE
feat(cli): pairing — actana pair new, ls and revoke, and the daemon that enforces a revocation (#283)

### DIFF
--- a/packages/cli/src/__tests__/actana-machine-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-machine-cli.test.ts
@@ -524,6 +524,61 @@ describe("token", () => {
   });
 });
 
+// ─── pair (#283) ────────────────────────────────────────────────────────────
+//
+// `actana-pair.test.ts` is where the three verbs are exercised. What is here is
+// the other question, and it is the one #288 exists over: does the verb an
+// operator reads about in `actana --help` actually answer on this binary, on
+// the machine that has the Core. The suite reaches it the long way round —
+// through `runActanaCli`, after a real `setup` — so a `pair` wired into the
+// help and not into the dispatch would fail here.
+
+describe("pair", () => {
+  it("reaches the Core-side pairing verbs through the real dispatch", async () => {
+    await setup(fakeSystem());
+    out.length = 0;
+    err.length = 0;
+
+    expect(await runActanaCli(deps(["pair", "new", "--label", "laptop"], fakeSystem()))).toBe(0);
+    expect(out.join("\n")).toMatch(/^Pairing code\s+[A-Z2-9]{4}-[A-Z2-9]{4}$/m);
+    expect(out.join("\n")).toMatch(/^CA fingerprint\s+[0-9A-F]{2}(:[0-9A-F]{2}){31}$/m);
+  });
+
+  it("writes the session beside the material, where the daemon reads it", async () => {
+    await setup(fakeSystem());
+    await runActanaCli(deps(["pair", "new", "--label", "laptop"], fakeSystem()));
+    const pairingFile = path.join(layoutForHome().configDir, "pairing.json");
+    expect(fs.existsSync(pairingFile)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(pairingFile, "utf8")).sessions).toHaveLength(1);
+  });
+
+  it("lists what it minted, without the code", async () => {
+    await setup(fakeSystem());
+    await runActanaCli(deps(["pair", "new", "--label", "laptop"], fakeSystem()));
+    const code = out.join("\n").match(/Pairing code\s+(\S+)/)![1]!;
+    out.length = 0;
+
+    expect(await runActanaCli(deps(["pair", "ls"], fakeSystem()))).toBe(0);
+    expect(out.join("\n")).toContain("laptop");
+    expect(out.join("\n")).not.toContain(code);
+  });
+
+  it("says which machine it is for, in the top-level help and its own", async () => {
+    await runActanaCli(deps(["--help"], fakeSystem()));
+    expect(out.join("\n")).toMatch(/^\s+pair\b/m);
+    expect(out.join("\n")).toMatch(/actana core pair.*client end/);
+    out.length = 0;
+
+    await runActanaCli(deps(["pair", "--help"], fakeSystem()));
+    expect(out.join("\n")).toMatch(/You are on the Core/);
+  });
+
+  it("fails clearly when nothing is installed", async () => {
+    expect(await runActanaCli(deps(["pair", "ls"], fakeSystem()))).toBe(1);
+    expect(err.join("\n")).toContain("actana setup");
+  });
+});
+
 describe("token regenerate", () => {
   it("issues credentials the old pairing token's no longer match", async () => {
     await setup(fakeSystem());

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -1,0 +1,427 @@
+// `actana pair` — the Core-side operator verbs (#283).
+//
+// The suite drives `runPairCommand` directly, against a real `material.json`
+// and a real pairing file on a real temporary disk. Both halves are deliberate.
+// The material is real because the fingerprint the command prints is a hash of
+// a certificate, and a stub certificate would let a wrong hash pass; the disk
+// is real because the whole reason the pairing store is a file is that the CLI
+// and the daemon are two processes, and an in-memory double would test a
+// version of this command that does not exist.
+//
+// The daemon's half of revocation — a revoked certificate refused at the gate,
+// a revoked bearer refused at the `auth` frame, a live link closed — is not
+// here. It cannot be: it happens in another process. It is in
+// `packages/core/src/__tests__/core-pairing-revocation.test.ts` and
+// `core-link-revocation.test.ts`, which is the seam this command writes to.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { X509Certificate } from "node:crypto";
+import {
+  loadMaterialFromFile,
+  materialFilePath,
+  mintFreshMaterial,
+  persistMaterialToFile,
+  type PersistedMaterial,
+} from "@actana/shared/core-material-store";
+import { normalisePairingCode, PAIRING_CODE_ALPHABET } from "@actana/shared/pairing-code";
+import { createPairingSession, PAIRING_SESSION_TTL_MS } from "@actana/shared/pairing-session";
+import {
+  derivePairingCodeKey,
+  hashPairingCode,
+  pairingCodeMatches,
+  PairingStore,
+  pairingStorePath,
+  type PairedClient,
+} from "@actana/shared/pairing-store";
+import { runPairCommand, parseDuration, MAX_PAIRING_TTL_MS } from "../actana-pair.ts";
+import type { ActanaCliDeps } from "../cli-deps.ts";
+import { stubClientHalf, stubMachineHalf } from "./machine-fixture.ts";
+
+const NOW = Date.UTC(2026, 7, 20, 12, 0, 0);
+
+let dir: string;
+let materialPath: string;
+let material: PersistedMaterial;
+let out: string[];
+let err: string[];
+let audited: Record<string, unknown>[];
+
+/** One run of `actana pair <argv>`, with its two streams captured. */
+function run(argv: string[], now = NOW): number {
+  out = [];
+  err = [];
+  const deps: ActanaCliDeps = {
+    ...stubClientHalf(() => now),
+    ...stubMachineHalf(),
+    argv: ["pair", ...argv],
+    env: {},
+    home: dir,
+    out: (line: string) => out.push(line),
+    err: (line: string) => err.push(line),
+  };
+  return runPairCommand(deps, argv, {
+    materialPath: () => materialPath,
+    audit: (record) => audited.push(record),
+  });
+}
+
+function store(): PairingStore {
+  return new PairingStore(pairingStorePath(materialPath));
+}
+
+/** A paired client, as the redemption endpoint would have written one. */
+function paired(over: Partial<PairedClient> = {}): PairedClient {
+  return {
+    certSerial: "0a1b2c3d",
+    certSubject: "CN=laptop",
+    label: "laptop",
+    sessionId: "ps_1",
+    pairedAt: NOW - 60_000,
+    certNotAfter: NOW + 365 * 24 * 60 * 60 * 1000,
+    revokedAt: null,
+    created_by: null,
+    tenant_id: null,
+    auth_method: null,
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-pair-"));
+  materialPath = materialFilePath(dir);
+  material = await mintFreshMaterial("10.0.0.5");
+  persistMaterialToFile(materialPath, material);
+  out = [];
+  err = [];
+  audited = [];
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** The value of one `LABEL   value` line from the command's stdout. */
+function field(name: string): string {
+  const line = out.find((l) => l.startsWith(name));
+  if (!line) throw new Error(`no "${name}" line in:\n${out.join("\n")}`);
+  return line.slice(name.length).trim();
+}
+
+// ─── pair new ───────────────────────────────────────────────────────────────
+
+describe("actana pair new", () => {
+  it("prints a well-formed code from the unambiguous alphabet", () => {
+    expect(run(["new", "--label", "laptop"])).toBe(0);
+    const code = field("Pairing code");
+    expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+    // The five characters a human transcribes wrong are not in it (#280/#281).
+    expect(code.replace("-", "").split("").every((ch) => PAIRING_CODE_ALPHABET.includes(ch))).toBe(true);
+    expect(normalisePairingCode(code)).toBe(code);
+  });
+
+  it("prints a fingerprint that matches this Core's own CA", () => {
+    run(["new"]);
+    expect(field("CA fingerprint")).toBe(new X509Certificate(material.caCert).fingerprint256);
+    expect(field("CA fingerprint")).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/);
+  });
+
+  it("defaults the TTL to the shared five-minute constant, not a literal here", () => {
+    run(["new"]);
+    const session = store().listSessions()[0]!;
+    expect(session.expiresAt - session.createdAt).toBe(PAIRING_SESSION_TTL_MS);
+    expect(field("Expires")).toContain("in 5 minutes");
+  });
+
+  it("honours --ttl, in the session and in what it printed", () => {
+    run(["new", "--ttl", "30s"]);
+    const session = store().listSessions()[0]!;
+    expect(session.expiresAt - session.createdAt).toBe(30_000);
+    expect(field("Expires")).toBe("2026-08-20T12:00:30Z (in 30 seconds)");
+  });
+
+  it("prints the expiry as an absolute time AND a relative one", () => {
+    run(["new", "--ttl", "2h"]);
+    expect(field("Expires")).toBe("2026-08-20T14:00:00Z (in 2 hours)");
+  });
+
+  it("refuses a --ttl with no unit rather than guessing seconds or minutes", () => {
+    expect(run(["new", "--ttl", "5"])).toBe(2);
+    expect(err.join("\n")).toMatch(/number and a unit/);
+    expect(store().listSessions()).toEqual([]);
+  });
+
+  it("refuses a TTL longer than the store keeps a settled session", () => {
+    expect(run(["new", "--ttl", "48h"])).toBe(2);
+    expect(parseDuration("48h")).toEqual({
+      error: expect.stringContaining("cannot exceed") as unknown as string,
+    });
+    expect(MAX_PAIRING_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("stores a digest of the code and never the code itself", () => {
+    run(["new", "--label", "laptop"]);
+    const code = field("Pairing code");
+    const session = store().listSessions()[0]!;
+    expect(JSON.stringify(session)).not.toContain(code);
+    expect(JSON.stringify(session)).not.toContain(code.replace("-", ""));
+    // And the digest is one the daemon can check, which is the only thing that
+    // makes storing a digest rather than the code workable at all.
+    expect(
+      pairingCodeMatches(
+        session.codeHash,
+        hashPairingCode({
+          key: derivePairingCodeKey(material.bearerSecret),
+          sessionId: session.id,
+          code,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("mints a different code every time", () => {
+    run(["new"]);
+    const first = field("Pairing code");
+    run(["new"]);
+    expect(field("Pairing code")).not.toBe(first);
+    expect(store().listSessions()).toHaveLength(2);
+  });
+
+  it("keeps stdout to the facts, and the prose on stderr", () => {
+    run(["new", "--label", "laptop"]);
+    expect(out.every((line) => /^(Pairing code|CA fingerprint|Expires|Label|Session) /.test(line))).toBe(true);
+    expect(err.join("\n")).toMatch(/Read the code AND the fingerprint/);
+  });
+
+  it("says so rather than writing a session when this Core has no material", () => {
+    fs.rmSync(materialPath);
+    expect(run(["new"])).toBe(1);
+    expect(err.join("\n")).toMatch(/no pairing material/);
+    expect(fs.existsSync(pairingStorePath(materialPath))).toBe(false);
+  });
+
+  it("rejects an unknown flag rather than ignoring it", () => {
+    expect(run(["new", "--tll", "5m"])).toBe(2);
+    expect(err.join("\n")).toMatch(/--tll/);
+  });
+});
+
+// ─── pair ls ────────────────────────────────────────────────────────────────
+
+describe("actana pair ls", () => {
+  it("says the list is empty rather than printing an empty table", () => {
+    expect(run(["ls"])).toBe(0);
+    const text = out.join("\n");
+    expect(text).toMatch(/Pending codes\n\s+None\./);
+    expect(text).toMatch(/Paired clients\n\s+None\./);
+    expect(text).not.toMatch(/LABEL/);
+  });
+
+  it("shows pending codes and paired clients in two separate sections", () => {
+    run(["new", "--label", "laptop"]);
+    store().recordClient(paired({ label: "desktop", certSubject: "CN=desktop" }));
+
+    expect(run(["ls"])).toBe(0);
+    const text = out.join("\n");
+    const pendingAt = text.indexOf("Pending codes");
+    const pairedAt = text.indexOf("Paired clients");
+    expect(pendingAt).toBeGreaterThanOrEqual(0);
+    expect(pairedAt).toBeGreaterThan(pendingAt);
+    expect(text.slice(pendingAt, pairedAt)).toMatch(/laptop/);
+    expect(text.slice(pairedAt)).toMatch(/desktop.*CN=desktop/s);
+  });
+
+  it("shows a pending code's label, created, expiry and attempts used of five", () => {
+    run(["new", "--label", "laptop"]);
+    run(["ls"]);
+    const row = out.find((line) => line.includes("laptop"))!;
+    expect(row).toContain("2026-08-20T12:00:00Z");
+    expect(row).toContain("2026-08-20T12:05:00Z");
+    expect(row).toContain("0 of 5");
+  });
+
+  it("never prints a pairing code", () => {
+    run(["new", "--label", "laptop"]);
+    const code = field("Pairing code");
+    run(["ls"]);
+    expect(out.join("\n")).not.toContain(code);
+    expect(out.join("\n")).not.toContain(code.replace("-", ""));
+    // Nor the digest of it: `ls` publishes named fields, not the stored row.
+    expect(out.join("\n")).not.toContain(store().listSessions()[0]!.codeHash);
+  });
+
+  it("leaves a code out of --json too", () => {
+    run(["new", "--label", "laptop"]);
+    const code = field("Pairing code");
+    const hash = store().listSessions()[0]!.codeHash;
+    run(["ls", "--json"]);
+    const payload = JSON.parse(out.join("\n")) as {
+      pending: { label: string; attemptCap: number }[];
+      clients: unknown[];
+    };
+    expect(payload.pending[0]!.label).toBe("laptop");
+    expect(payload.pending[0]!.attemptCap).toBe(5);
+    expect(out.join("\n")).not.toContain(code);
+    expect(out.join("\n")).not.toContain(hash);
+  });
+
+  it("drops a session that is no longer redeemable from the pending section", () => {
+    run(["new", "--label", "laptop", "--ttl", "30s"]);
+    expect(run(["ls"], NOW + 31_000)).toBe(0);
+    expect(out.join("\n")).toMatch(/Pending codes\n\s+None\./);
+  });
+
+  it("keeps a revoked client visible, and says it is revoked", () => {
+    store().recordClient(paired());
+    store().revokeClient("0a1b2c3d", NOW);
+    run(["ls"]);
+    expect(out.join("\n")).toMatch(/revoked 2026-08-20T12:00:00Z/);
+  });
+});
+
+// ─── pair revoke ────────────────────────────────────────────────────────────
+
+describe("actana pair revoke", () => {
+  it("marks a paired client revoked, by label", () => {
+    store().recordClient(paired());
+    expect(run(["revoke", "laptop"])).toBe(0);
+    expect(store().listClients()[0]!.revokedAt).toBe(NOW);
+    expect(out.join("\n")).toMatch(/Unpaired laptop/);
+  });
+
+  it("takes a certificate serial, including a prefix of one", () => {
+    store().recordClient(paired({ certSerial: "0a1b2c3d4e5f", label: "" }));
+    expect(run(["revoke", "0a1b2c"])).toBe(0);
+    expect(store().listClients()[0]!.revokedAt).toBe(NOW);
+  });
+
+  it("stops the credential working — which is what the daemon reads", () => {
+    // This command's whole output on the wire is this row. The daemon's
+    // enforcement is tested where it lives; what is pinned here is that the
+    // fact it enforces on is written, and written against the serial that
+    // identifies the issuance rather than the label.
+    store().recordClient(paired({ certSerial: "0a1b2c3d" }));
+    run(["revoke", "laptop"]);
+    const row = store().listClients().find((c) => c.certSerial === "0a1b2c3d")!;
+    expect(row.revokedAt).toBe(NOW);
+    expect(out.join("\n")).toMatch(/certificate and its bearer stop working/);
+    expect(out.join("\n")).toMatch(/closes any link it has open/);
+  });
+
+  it("cancels a pending session so its code can never be redeemed", () => {
+    run(["new", "--label", "laptop"]);
+    const sessionId = field("Session");
+
+    expect(run(["revoke", sessionId])).toBe(0);
+    expect(store().consume(sessionId, NOW)).toEqual({ ok: false, reason: "revoked" });
+    expect(out.join("\n")).toMatch(/Cancelled the pending code/);
+  });
+
+  it("cancels a pending session named by its label", () => {
+    run(["new", "--label", "laptop"]);
+    const sessionId = field("Session");
+    expect(run(["revoke", "laptop"])).toBe(0);
+    expect(store().consume(sessionId, NOW)).toEqual({ ok: false, reason: "revoked" });
+  });
+
+  it("refuses to guess when a label matches more than one thing", () => {
+    store().recordClient(paired({ label: "laptop", certSerial: "aaaa" }));
+    store().recordClient(paired({ label: "laptop", certSerial: "bbbb" }));
+    expect(run(["revoke", "laptop"])).toBe(1);
+    expect(err.join("\n")).toMatch(/matches 2 of them/);
+    expect(store().listClients().every((c) => c.revokedAt === null)).toBe(true);
+  });
+
+  it("says so when nothing matches, and revokes nothing", () => {
+    store().recordClient(paired());
+    expect(run(["revoke", "nobody"])).toBe(1);
+    expect(err.join("\n")).toMatch(/nothing here matches/i);
+    expect(store().listClients()[0]!.revokedAt).toBe(null);
+  });
+
+  it("needs a target", () => {
+    expect(run(["revoke"])).toBe(2);
+    expect(err.join("\n")).toMatch(/a target is required/);
+  });
+
+  it("audit-logs the revocation through the same auditor the endpoint uses", () => {
+    store().recordClient(paired());
+    run(["revoke", "laptop"]);
+    expect(audited).toEqual([
+      {
+        outcome: "revoked",
+        reason: "client",
+        sessionId: "ps_1",
+        label: "laptop",
+        peer: "local-cli",
+        certSerial: "0a1b2c3d",
+        at: NOW,
+      },
+    ]);
+  });
+
+  it("audit-logs a cancelled session too", () => {
+    run(["new", "--label", "laptop"]);
+    run(["revoke", field("Session")]);
+    expect(audited[0]).toMatchObject({ outcome: "revoked", reason: "pending-session", label: "laptop" });
+  });
+
+  it("does not pretend a cancel undoes a redemption", () => {
+    const session = createPairingSession({ id: "ps_9", label: "spent", codeHash: "h", now: NOW });
+    store().createSession(session, NOW);
+    store().consume("ps_9", NOW);
+    // A consumed session is not pending, so it is not a revoke target at all —
+    // the client it issued is. The message says which.
+    expect(run(["revoke", "ps_9"])).toBe(1);
+    expect(err.join("\n")).toMatch(/nothing here matches/i);
+  });
+});
+
+// ─── help ───────────────────────────────────────────────────────────────────
+
+describe("actana pair --help", () => {
+  it("lists the three verbs", () => {
+    expect(run(["--help"])).toBe(0);
+    const text = out.join("\n");
+    for (const verb of ["pair new", "pair ls", "pair revoke"]) expect(text).toContain(verb);
+  });
+
+  it("says plainly which machine this runs on", () => {
+    run(["--help"]);
+    const text = out.join("\n");
+    expect(text).toMatch(/You are on the Core/);
+    // And names the other command, because the trap is that both exist.
+    expect(text).toMatch(/actana core pair/);
+  });
+
+  it("prints the help and reports usage when no verb was given", () => {
+    expect(run([])).toBe(2);
+    expect(out.join("\n")).toMatch(/actana pair —/);
+  });
+
+  it("rejects an unknown verb", () => {
+    expect(run(["frobnicate"])).toBe(2);
+    expect(err.join("\n")).toMatch(/unknown verb "frobnicate"/);
+  });
+});
+
+describe("--ttl parsing", () => {
+  it("reads a number and a unit", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+    expect(parseDuration("5m")).toBe(300_000);
+    expect(parseDuration("2h")).toBe(7_200_000);
+  });
+
+  it("refuses everything else", () => {
+    for (const bad of ["5", "5 m", "m", "-5m", "5d", "0s", ""]) {
+      expect(parseDuration(bad)).toHaveProperty("error");
+    }
+  });
+});
+
+describe("the material this all reads", () => {
+  it("is the one on disk, so the CLI and the daemon cannot disagree", () => {
+    expect(loadMaterialFromFile(materialPath)?.coreId).toBe(material.coreId);
+  });
+});

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -205,6 +205,38 @@ describe("actana pair new", () => {
     expect(run(["new", "--tll", "5m"])).toBe(2);
     expect(err.join("\n")).toMatch(/--tll/);
   });
+
+  it("refuses a bare positional instead of minting an unlabelled code", () => {
+    // `actana pair new laptop` used to exit 0 having minted a code called
+    // nothing. The operator reads it out believing it is `laptop`, `pair ls`
+    // shows `(unnamed)`, and `pair revoke laptop` says nothing matches.
+    expect(run(["new", "laptop"])).toBe(2);
+    expect(err.join("\n")).toMatch(/unexpected argument "laptop"/);
+    expect(err.join("\n")).toMatch(/--label laptop/);
+    expect(store().listSessions()).toEqual([]);
+  });
+
+  it("refuses a single-dash flag rather than reading it as a positional", () => {
+    expect(run(["new", "-l", "laptop"])).toBe(2);
+    expect(err.join("\n")).toMatch(/unknown option: -l/);
+    expect(store().listSessions()).toEqual([]);
+  });
+
+  it("refuses to mint against a pairing file it cannot read", () => {
+    // `createSession` reads the whole document, adds a session and writes it
+    // back — so minting on a corrupt file replaces it, taking the record of who
+    // was revoked with it. The daemon would then read a clean store and serve
+    // every revoked certificate again.
+    fs.writeFileSync(pairingStorePath(materialPath), '{"version":1,"clients":[{"certSerial"');
+    expect(run(["new", "--label", "laptop"])).toBe(1);
+    expect(err.join("\n")).toMatch(/not valid JSON/);
+    expect(err.join("\n")).toMatch(/refuses every client it has paired/);
+    expect(err.join("\n")).toMatch(/Do not delete it/);
+    // And the file it declined to rewrite is exactly as it was.
+    expect(fs.readFileSync(pairingStorePath(materialPath), "utf8")).toBe(
+      '{"version":1,"clients":[{"certSerial"',
+    );
+  });
 });
 
 // ─── pair ls ────────────────────────────────────────────────────────────────
@@ -270,6 +302,19 @@ describe("actana pair ls", () => {
     run(["new", "--label", "laptop", "--ttl", "30s"]);
     expect(run(["ls"], NOW + 31_000)).toBe(0);
     expect(out.join("\n")).toMatch(/Pending codes\n\s+None\./);
+  });
+
+  it("refuses a bare positional", () => {
+    expect(run(["ls", "laptop"])).toBe(2);
+    expect(err.join("\n")).toMatch(/unexpected argument "laptop"/);
+  });
+
+  it("says the file is unreadable rather than reporting a Core that paired nobody", () => {
+    store().recordClient(paired());
+    fs.writeFileSync(pairingStorePath(materialPath), "{ not json");
+    expect(run(["ls"])).toBe(1);
+    expect(err.join("\n")).toMatch(/not valid JSON/);
+    expect(out.join("\n")).not.toMatch(/None\./);
   });
 
   it("keeps a revoked client visible, and says it is revoked", () => {
@@ -343,6 +388,35 @@ describe("actana pair revoke", () => {
   it("needs a target", () => {
     expect(run(["revoke"])).toBe(2);
     expect(err.join("\n")).toMatch(/a target is required/);
+  });
+
+  it("refuses a blank target rather than matching everything", () => {
+    // `actana pair revoke "$SERIAL"` with `SERIAL` unset. `""` prefix-matches
+    // every serial and every session id, and on a Core with exactly one client
+    // the ambiguity check never fires — so it used to revoke it and exit 0.
+    store().recordClient(paired());
+    expect(run(["revoke", ""])).toBe(2);
+    expect(err.join("\n")).toMatch(/a target is required/);
+    expect(store().listClients()[0]!.revokedAt).toBe(null);
+
+    expect(run(["revoke", "   "])).toBe(2);
+    expect(store().listClients()[0]!.revokedAt).toBe(null);
+  });
+
+  it("refuses a blank target even when a pending code is the only thing here", () => {
+    run(["new", "--label", "laptop"]);
+    const sessionId = field("Session");
+    expect(run(["revoke", ""])).toBe(2);
+    expect(store().consume(sessionId, NOW).ok).toBe(true);
+  });
+
+  it("refuses to revoke against a pairing file it cannot read", () => {
+    store().recordClient(paired());
+    const corrupt = '{"version":1,"sessions":[],"clients":[{"certSerial":7}]}';
+    fs.writeFileSync(pairingStorePath(materialPath), corrupt);
+    expect(run(["revoke", "laptop"])).toBe(1);
+    expect(err.join("\n")).toMatch(/is not a client this build knows/);
+    expect(fs.readFileSync(pairingStorePath(materialPath), "utf8")).toBe(corrupt);
   });
 
   it("audit-logs the revocation through the same auditor the endpoint uses", () => {

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -35,7 +35,12 @@ import {
   pairingStorePath,
   type PairedClient,
 } from "@actana/shared/pairing-store";
-import { runPairCommand, parseDuration, MAX_PAIRING_TTL_MS } from "../actana-pair.ts";
+import {
+  describeDuration,
+  MAX_PAIRING_TTL_MS,
+  parseDuration,
+  runPairCommand,
+} from "../actana-pair.ts";
 import type { ActanaCliDeps } from "../cli-deps.ts";
 import { stubClientHalf, stubMachineHalf } from "./machine-fixture.ts";
 
@@ -115,9 +120,12 @@ describe("actana pair new", () => {
   it("prints a well-formed code from the unambiguous alphabet", () => {
     expect(run(["new", "--label", "laptop"])).toBe(0);
     const code = field("Pairing code");
-    expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
-    // The five characters a human transcribes wrong are not in it (#280/#281).
-    expect(code.replace("-", "").split("").every((ch) => PAIRING_CODE_ALPHABET.includes(ch))).toBe(true);
+    // Built from the alphabet rather than written out, so the assertion cannot
+    // drift from it: a hand-typed `[A-Z2-9]` would admit `O`, `I` and `L`, which
+    // are three of the five characters #281 drops precisely because a human
+    // transcribes them wrong.
+    expect(code).toMatch(new RegExp(`^[${PAIRING_CODE_ALPHABET}]{4}-[${PAIRING_CODE_ALPHABET}]{4}$`));
+    for (const excluded of ["0", "O", "1", "I", "L"]) expect(code).not.toContain(excluded);
     expect(normalisePairingCode(code)).toBe(code);
   });
 
@@ -477,6 +485,35 @@ describe("actana pair --help", () => {
   it("rejects an unknown verb", () => {
     expect(run(["frobnicate"])).toBe(2);
     expect(err.join("\n")).toMatch(/unknown verb "frobnicate"/);
+  });
+});
+
+describe("the relative half of an expiry", () => {
+  it("floors and carries a second unit rather than rounding to the largest", () => {
+    // Rounding made `--ttl 90m` print "in 2 hours" and `--ttl 90s` print "in 2
+    // minutes". The relative half is the half read out down a phone line, and a
+    // code described as living longer than it does is one nobody hurries for.
+    run(["new", "--ttl", "90m"]);
+    expect(field("Expires")).toBe("2026-08-20T13:30:00Z (in 1 hour 30 minutes)");
+    run(["new", "--ttl", "90s"]);
+    expect(field("Expires")).toBe("2026-08-20T12:01:30Z (in 1 minute 30 seconds)");
+  });
+
+  it("drops the second unit when it is zero, so the ordinary cases stay short", () => {
+    expect(describeDuration(5 * 60_000)).toBe("5 minutes");
+    expect(describeDuration(30_000)).toBe("30 seconds");
+    expect(describeDuration(60_000)).toBe("1 minute");
+    expect(describeDuration(MAX_PAIRING_TTL_MS)).toBe("24 hours");
+  });
+
+  it("never overstates how long a code has left", () => {
+    for (const ms of [1_000, 59_000, 61_000, 89_000, 3_599_000, 5_400_000, 86_399_000]) {
+      const spoken = describeDuration(ms);
+      const hours = Number(/(\d+) hours?/.exec(spoken)?.[1] ?? 0);
+      const minutes = Number(/(\d+) minutes?/.exec(spoken)?.[1] ?? 0);
+      const seconds = Number(/(\d+) seconds?/.exec(spoken)?.[1] ?? 0);
+      expect(hours * 3_600_000 + minutes * 60_000 + seconds * 1_000).toBeLessThanOrEqual(ms);
+    }
   });
 });
 

--- a/packages/cli/src/__tests__/module-halves.ts
+++ b/packages/cli/src/__tests__/module-halves.ts
@@ -61,6 +61,9 @@ export const MACHINE_MODULES: Record<string, string> = {
   "actana-launchd.ts": "writes the LaunchAgent plist macOS starts the daemon from",
   "actana-layout.ts": "resolves every path this install owns under the operator's home",
   "actana-manifest.ts": "reads the extracted tarball's `core-manifest.json`",
+  "actana-pair.ts":
+    "mints, lists and revokes the pairing codes THIS machine's Core hands out (#283) — the " +
+    "Core end of enrollment, reading and writing this install's own pairing store",
   "actana-release.ts": "maps this machine to a release target and reads a release's checksums",
   "actana-service.ts": "the init-system port: enable, start, stop and query the unit",
   "actana-setup.ts": "lays down the tree, registers the service and mints the pairing material",

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -6,6 +6,7 @@
 //     actana status    daemon state, versions, endpoint, Harness availability
 //     actana token     reprint the pairing token
 //     actana token regenerate   mint fresh credentials, invalidating the old ones
+//     actana pair      enroll a client on this Core: pair new | ls | revoke
 //     actana update    fetch, verify and swap in a release, then restart
 //     actana start|stop|restart|logs
 //     actana harnesses install <id>   install a Harness, the vendor's way
@@ -109,6 +110,7 @@ import { runActanaUpdate } from "./actana-update.ts";
 import { parseArgs } from "./cli-args.ts";
 import { registryPaths } from "./blob-registry.ts";
 import { runCoreCommand } from "./core-command.ts";
+import { runPairCommand } from "./actana-pair.ts";
 import { runProjectCommand } from "./project-command.ts";
 import { runHarnessCommand } from "./harness-command.ts";
 import { runEventsCommand } from "./events-command.ts";
@@ -173,6 +175,8 @@ This machine's own Core
   token      Reprint the pairing token
   token regenerate
              Issue fresh pairing credentials and invalidate the old ones
+  pair       Enroll a client on this Core — \`pair new\`, \`pair ls\`, \`pair revoke\`.
+             This is the Core end: \`actana core pair\` is the client end
   update     Install the latest release and restart the daemon
   start      Start the Core daemon
   stop       Stop the Core daemon
@@ -753,6 +757,33 @@ async function cmdStatus(deps: ActanaCliDeps, argv: string[]): Promise<number> {
   return summarizeHealth(report) === "healthy" ? 0 : 1;
 }
 
+/**
+ * `actana pair` — mint, list and revoke this Core's pairing codes (#283).
+ *
+ * Thin here on purpose. The verb belongs to the machine half and needs exactly
+ * one thing from the install — where `material.json` is — so that is what this
+ * resolves and hands over; `actana-pair.ts` holds every decision about codes,
+ * fingerprints, expiry and revocation, and is driven directly by its own tests
+ * without a fake install underneath it.
+ *
+ * **Not refused in a container.** `pair` is not a lifecycle verb that Docker
+ * owns (ADR 0016 D13) — it is how an operator enrolls a client on the Core in
+ * front of them, and a containerised Core is the case where that matters most.
+ * `actana-container.ts`'s refusal table is what decides this, and `pair` is
+ * deliberately not on it.
+ */
+function cmdPair(deps: ActanaCliDeps, argv: string[]): number {
+  // The install is resolved on demand rather than up front, so that `actana
+  // pair --help` answers on a machine that has never run `actana setup` — the
+  // help is a question about this program, not about this box.
+  return runPairCommand(deps, argv, {
+    materialPath: () => {
+      const installed = requireInstall(deps);
+      return installed ? materialPathFor(deps, installed.layout) : null;
+    },
+  });
+}
+
 async function cmdToken(deps: ActanaCliDeps, argv: string[]): Promise<number> {
   if (argv[0] === "regenerate") return cmdTokenRegenerate(deps, argv.slice(1));
 
@@ -1301,6 +1332,8 @@ export async function runActanaCli(deps: ActanaCliDeps): Promise<number> {
       return cmdStatus(deps, rest);
     case "token":
       return cmdToken(deps, rest);
+    case "pair":
+      return cmdPair(deps, rest);
     case "update":
       return cmdUpdate(deps, rest);
     case "start":

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -166,6 +166,16 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
     deps.err(`actana pair new: ${flags.error}.`);
     return EXIT_USAGE;
   }
+  // `actana pair new laptop` used to mint an *unlabelled* code and exit 0. The
+  // operator then reads that code out believing it is called `laptop`, `pair
+  // ls` shows `(unnamed)`, and `pair revoke laptop` says nothing matches. An
+  // argument this verb has no use for is a mistake, exactly as an unknown flag
+  // is.
+  if (flags.positionals.length > 0) {
+    deps.err(`actana pair new: unexpected argument "${flags.positionals[0]}".`);
+    deps.err(`The name goes in a flag — \`actana pair new --label ${flags.positionals[0]}\`.`);
+    return EXIT_USAGE;
+  }
 
   const rawTtl = valueFlag(flags.values, "ttl");
   const ttl = rawTtl === undefined ? PAIRING_SESSION_TTL_MS : parseDuration(rawTtl);
@@ -183,6 +193,9 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
     deps.err("Run `actana setup` — pairing needs a CA to sign against.");
     return EXIT_FAILURE;
   }
+
+  const store = openStore(deps, materialPath, "new");
+  if (!store) return EXIT_FAILURE;
 
   const now = deps.now();
   const label = valueFlag(flags.values, "label") ?? "";
@@ -203,7 +216,7 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
     ttlMs: ttl,
   });
 
-  new PairingStore(pairingStorePath(materialPath)).createSession(session, now);
+  store.createSession(session, now);
 
   // stdout: the three facts a human reads out. stderr: everything explaining
   // them, so a `pair new` that is being piped or screen-scraped stays three
@@ -227,11 +240,18 @@ function pairLs(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): n
     deps.err(`actana pair ls: ${flags.error}.`);
     return EXIT_USAGE;
   }
+  if (flags.positionals.length > 0) {
+    deps.err(`actana pair ls: unexpected argument "${flags.positionals[0]}".`);
+    deps.err("`ls` takes no arguments — it lists everything.");
+    return EXIT_USAGE;
+  }
 
   const materialPath = ctx.materialPath();
   if (materialPath === null) return EXIT_FAILURE;
 
-  const store = new PairingStore(pairingStorePath(materialPath));
+  const store = openStore(deps, materialPath, "ls");
+  if (!store) return EXIT_FAILURE;
+
   const now = deps.now();
   const pending = store.listSessions().filter((session) => canRedeem(session, now).ok);
   const clients = store.listClients();
@@ -311,7 +331,13 @@ function pairRevoke(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext
     return EXIT_USAGE;
   }
   const [target, ...extra] = flags.positionals;
-  if (target === undefined) {
+  // Blank as well as absent, and that is not tidiness. `""` prefix-matches
+  // every serial and every session id, so `actana pair revoke "$SERIAL"` in a
+  // script where `SERIAL` is unset matches everything — and on a Core with
+  // exactly one client the ambiguity check below does not fire, so it revokes
+  // it and exits 0. That check is the whole defence against revoking the wrong
+  // machine, and this is the input that walks straight past it.
+  if (target === undefined || target.trim() === "") {
     deps.err("actana pair revoke: a target is required — `actana pair revoke <serial|session|label>`.");
     return EXIT_USAGE;
   }
@@ -323,7 +349,9 @@ function pairRevoke(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext
   const materialPath = ctx.materialPath();
   if (materialPath === null) return EXIT_FAILURE;
 
-  const store = new PairingStore(pairingStorePath(materialPath));
+  const store = openStore(deps, materialPath, "revoke");
+  if (!store) return EXIT_FAILURE;
+
   const now = deps.now();
   const audit = pairingAuditor(ctx.audit ?? ((record) => deps.err(`pairing.revoke ${formatJson(record)}`)));
 
@@ -405,6 +433,39 @@ function pairRevoke(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext
 }
 
 /**
+ * This Core's pairing store, or `null` after saying why it cannot be used.
+ *
+ * `readStrict` rather than `read`, and every verb here goes through it.
+ * `PairingStore.read` answers an unreadable file with an empty store, and each
+ * of these verbs would then do something wrong with that answer: `ls` would
+ * report a Core that has paired nobody, `revoke` would say nothing matches, and
+ * `new` would be worse than either — `createSession` reads the whole document,
+ * adds a session and writes it back, so minting against a corrupt file
+ * *replaces* it, taking the record of which clients are revoked with it.
+ *
+ * That last one is not hypothetical damage. The daemon fails closed on exactly
+ * this file (`core-pairing-revocation.ts`), so a Core with an unreadable
+ * `pairing.json` is refusing every client it ever paired — and a `pair new`
+ * that quietly rewrote the file would end that refusal by forgetting who was
+ * revoked, handing every revoked certificate its access back. Recovery has to
+ * be repairing the file, so these verbs decline to be the thing that destroys
+ * it.
+ */
+function openStore(deps: ActanaCliDeps, materialPath: string, verb: string): PairingStore | null {
+  const store = new PairingStore(pairingStorePath(materialPath));
+  try {
+    store.readStrict();
+  } catch (err) {
+    deps.err(`actana pair ${verb}: ${err instanceof Error ? err.message : String(err)}.`);
+    deps.err("While that file cannot be read, this Core refuses every client it has paired.");
+    deps.err("Repair the JSON or restore it from a backup. Do not delete it — it is the record");
+    deps.err("of which pairings were revoked, and deleting it would un-revoke every one of them.");
+    return null;
+  }
+  return store;
+}
+
+/**
  * Does this target name this client?
  *
  * A serial matches on a prefix — serials are 32 hex characters and nobody
@@ -445,10 +506,14 @@ function readFlags(argv: string[], spec: Record<string, FlagKind>): ReadFlags {
   const positionals: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i]!;
-    if (!token.startsWith("--")) {
+    if (!token.startsWith("-")) {
       positionals.push(token);
       continue;
     }
+    // A single-dash token is a flag this build does not know, never a value.
+    // Read as a positional, `actana pair new -l laptop` would have minted an
+    // unlabelled code from two arguments that both look like they were used.
+    if (!token.startsWith("--")) return { error: `unknown option: ${token}` };
     const eq = token.indexOf("=");
     const name = eq >= 0 ? token.slice(2, eq) : token.slice(2);
     const kind = spec[name];

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -1,0 +1,548 @@
+// `actana pair` — the Core-side operator's half of short-code enrollment (#283).
+//
+//   actana pair new [--label <label>] [--ttl <duration>]
+//   actana pair ls [--json]
+//   actana pair revoke <target>
+//
+// **This runs on the machine that IS the Core.** That sentence is in the help
+// text and it is in this header for the same reason: there are two pairing
+// commands in one binary and they belong to opposite ends of the exchange.
+// `actana pair` mints a code on this Core and takes one back; `actana core
+// pair` (#285) is the *client* command that spends a code somebody read out to
+// you. One binary now carries both (#288), so the only thing separating them
+// is which words the operator types — the help on each has to make the machine
+// obvious or the mistake is silent.
+//
+// **The code exists in exactly one place: the terminal `pair new` printed it
+// on.** What is persisted is a keyed digest (`hashPairingCode`), so `pair ls`
+// *cannot* print a code — there is none in the store to print. That is the
+// design working, not an omission, and `pair-command.test.ts` asserts it rather
+// than trusting it.
+//
+// **What the fingerprint is for.** `pair new` prints the CA fingerprint beside
+// the code because the client's first dial is the one dial it cannot verify any
+// other way: it holds no certificate, so it has nothing pinned. A human reads
+// both out, and the client checks the CA it is presented against the
+// fingerprint *before* it sends the code (#280 step 3, #284). Printing it in
+// the conventional colon-separated upper-case hex is therefore part of the
+// contract — see `certFingerprintSha256`.
+//
+// The store is the one in `@actana/shared/pairing-store`, which lives there
+// rather than in `packages/core` precisely so this command and the daemon can
+// both drive it: this process mints sessions and revokes clients, the daemon
+// redeems them and enforces the revocations. Neither imports the other.
+
+import { randomUUID } from "node:crypto";
+import { certFingerprintSha256 } from "@actana/shared/core-cert-material";
+import { loadMaterialFromFile } from "@actana/shared/core-material-store";
+import { generatePairingCode } from "@actana/shared/pairing-code";
+import {
+  createPairingSession,
+  canRedeem,
+  isConsumed,
+  isRevoked,
+  PAIRING_SESSION_TTL_MS,
+  type PairingSession,
+} from "@actana/shared/pairing-session";
+import {
+  derivePairingCodeKey,
+  hashPairingCode,
+  pairingStorePath,
+  PairingStore,
+  PAIRING_SESSION_RETENTION_MS,
+  type PairedClient,
+} from "@actana/shared/pairing-store";
+import {
+  LOCAL_OPERATOR_PEER,
+  pairingAuditor,
+  type PairingAuditSink,
+} from "@actana/shared/pairing-audit";
+import { formatJson, formatTable } from "./cli-output.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+
+export const PAIR_HELP = `actana pair — enroll a client on THIS machine's Core
+
+**You are on the Core.** These verbs mint and take back the pairing codes this
+Core hands out. The client end of the same exchange is \`actana core pair\`, and
+it runs on the machine being paired — not here.
+
+Usage
+  actana pair new [--label <name>] [--ttl <duration>]
+                                  mint a one-time code and print it
+  actana pair ls [--json]         pending codes, and the clients already paired
+  actana pair revoke <target>     unpair a client, or cancel a pending code
+
+Flags
+  --label <name>   what to call the machine being paired (default: unnamed)
+  --ttl <duration> how long the code stays good — \`30s\`, \`5m\`, \`2h\`
+                   (default: ${describeDuration(PAIRING_SESSION_TTL_MS)})
+  --json           machine-readable output — \`ls\`
+  -h, --help       show this help
+
+Minting a code
+  \`pair new\` prints three things: the code, this Core's CA fingerprint, and
+  when the code expires. Read the code AND the fingerprint out to whoever is at
+  the client — the client checks the fingerprint against the certificate this
+  Core presents before it sends the code, which is what makes that first dial
+  verifiable when the client has nothing pinned yet.
+
+  The code is printed once and never stored. This Core keeps only a keyed
+  digest of it, so nothing — including \`pair ls\` — can print it again. A lost
+  code is re-minted, not recovered.
+
+Revoking
+  \`revoke\` takes a certificate serial, a session id, or a label that matches
+  exactly one of either. Pointed at a paired client it unpairs the machine and
+  its credential stops working, including any core link it has open right now.
+  Pointed at a pending code it cancels the code before anyone spends it.`;
+
+/** What every verb here needs from the install: where this Core's material is. */
+export type PairCommandContext = {
+  /**
+   * Resolve the absolute path to this Core's `material.json`, or `null` after
+   * saying there is no Core installed here.
+   *
+   * A thunk rather than a string, so that the *order* lives in one place. Help
+   * is a question about this program and not about this machine — `actana pair
+   * --help` has to answer on a laptop that has never run `actana setup`, the
+   * same way `actana --help` does — and a context that had already resolved an
+   * install would have refused before this function was reached.
+   */
+  materialPath: () => string | null;
+  /**
+   * Where a revocation's audit record goes.
+   *
+   * Defaults to this CLI's stderr, and that default is the whole reason the
+   * seam exists. The daemon's auditor writes through `@actana/shared/log`,
+   * which is `console.log` — stdout. In a one-shot CLI whose stdout is a
+   * pairing code an operator may be piping, an audit line on stdout would be a
+   * line in the middle of the credential. So the record is the same record,
+   * built by the same `pairingAuditor` and reduced by the same field list, and
+   * only the sink differs.
+   */
+  audit?: PairingAuditSink;
+};
+
+/** Dispatch a `pair` sub-verb. `argv` is everything after `pair`. */
+export function runPairCommand(
+  deps: ActanaCliDeps,
+  argv: string[],
+  ctx: PairCommandContext,
+): number {
+  const [verb, ...rest] = argv;
+
+  if (verb === undefined || verb === "--help" || verb === "-h" || verb === "help") {
+    deps.out(PAIR_HELP);
+    // No verb is a question, not a mistake — the same answer `actana core`
+    // gives, and the same exit code: usage when nothing was asked for.
+    return verb === undefined ? EXIT_USAGE : EXIT_OK;
+  }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    deps.out(PAIR_HELP);
+    return EXIT_OK;
+  }
+
+  switch (verb) {
+    case "new":
+      return pairNew(deps, rest, ctx);
+    case "ls":
+    case "list":
+      return pairLs(deps, rest, ctx);
+    case "revoke":
+      return pairRevoke(deps, rest, ctx);
+    default:
+      deps.err(`actana pair: unknown verb "${verb}".`);
+      deps.err("Verbs: new, ls, revoke. `actana pair --help` lists them.");
+      return EXIT_USAGE;
+  }
+}
+
+// ─── new ────────────────────────────────────────────────────────────────────
+
+function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): number {
+  const flags = readFlags(rest, { label: "value", ttl: "value" });
+  if ("error" in flags) {
+    deps.err(`actana pair new: ${flags.error}.`);
+    return EXIT_USAGE;
+  }
+
+  const rawTtl = valueFlag(flags.values, "ttl");
+  const ttl = rawTtl === undefined ? PAIRING_SESSION_TTL_MS : parseDuration(rawTtl);
+  if (typeof ttl !== "number") {
+    deps.err(`actana pair new: ${ttl.error}.`);
+    return EXIT_USAGE;
+  }
+
+  const materialPath = ctx.materialPath();
+  if (materialPath === null) return EXIT_FAILURE;
+
+  const material = loadMaterialFromFile(materialPath);
+  if (!material) {
+    deps.err(`actana pair new: this Core has no pairing material at ${materialPath}.`);
+    deps.err("Run `actana setup` — pairing needs a CA to sign against.");
+    return EXIT_FAILURE;
+  }
+
+  const now = deps.now();
+  const label = valueFlag(flags.values, "label") ?? "";
+  const sessionId = randomUUID();
+  const code = generatePairingCode();
+  const session = createPairingSession({
+    id: sessionId,
+    label,
+    // The digest, never the code. The key is derived from this Core's bearer
+    // secret, which is in `material.json` and not in the pairing file — so a
+    // copy of the pairing file alone cannot be brute-forced back into codes.
+    codeHash: hashPairingCode({
+      key: derivePairingCodeKey(material.bearerSecret),
+      sessionId,
+      code,
+    }),
+    now,
+    ttlMs: ttl,
+  });
+
+  new PairingStore(pairingStorePath(materialPath)).createSession(session, now);
+
+  // stdout: the three facts a human reads out. stderr: everything explaining
+  // them, so a `pair new` that is being piped or screen-scraped stays three
+  // labelled lines and nothing else.
+  deps.err("Read the code AND the fingerprint out to the machine you are pairing.");
+  deps.err("The code is printed once — this Core keeps only a digest of it.");
+  deps.out(`Pairing code   ${code}`);
+  deps.out(`CA fingerprint ${certFingerprintSha256(material.caCert)}`);
+  deps.out(`Expires        ${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`);
+  if (label) deps.out(`Label          ${label}`);
+  deps.out(`Session        ${sessionId}`);
+  deps.err(`Cancel it before it is used with \`actana pair revoke ${sessionId}\`.`);
+  return EXIT_OK;
+}
+
+// ─── ls ─────────────────────────────────────────────────────────────────────
+
+function pairLs(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): number {
+  const flags = readFlags(rest, { json: "boolean" });
+  if ("error" in flags) {
+    deps.err(`actana pair ls: ${flags.error}.`);
+    return EXIT_USAGE;
+  }
+
+  const materialPath = ctx.materialPath();
+  if (materialPath === null) return EXIT_FAILURE;
+
+  const store = new PairingStore(pairingStorePath(materialPath));
+  const now = deps.now();
+  const pending = store.listSessions().filter((session) => canRedeem(session, now).ok);
+  const clients = store.listClients();
+
+  if (flags.values.json) {
+    // Field by field rather than a spread of the row, for the reason
+    // `redactPairingAuditEvent` is a list: a spread would publish whatever the
+    // stored shape grows next, and what it stores includes `codeHash`.
+    deps.out(
+      formatJson({
+        pending: pending.map((session) => ({
+          id: session.id,
+          label: session.label,
+          createdAt: session.createdAt,
+          expiresAt: session.expiresAt,
+          attempts: session.attempts,
+          attemptCap: session.attemptCap,
+        })),
+        clients: clients.map((client) => ({
+          certSerial: client.certSerial,
+          certSubject: client.certSubject,
+          label: client.label,
+          pairedAt: client.pairedAt,
+          certNotAfter: client.certNotAfter,
+          revokedAt: client.revokedAt,
+        })),
+      }),
+    );
+    return EXIT_OK;
+  }
+
+  deps.out("Pending codes");
+  if (pending.length === 0) {
+    deps.out("  None. `actana pair new` mints one.");
+  } else {
+    for (const line of formatTable(
+      ["LABEL", "CREATED", "EXPIRES", "ATTEMPTS", "SESSION"],
+      pending.map((session) => [
+        session.label || "(unnamed)",
+        absoluteTime(session.createdAt),
+        `${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`,
+        `${session.attempts} of ${session.attemptCap}`,
+        session.id,
+      ]),
+    )) {
+      deps.out(`  ${line}`);
+    }
+  }
+
+  deps.out("");
+  deps.out("Paired clients");
+  if (clients.length === 0) {
+    deps.out("  None. A client appears here once it redeems a code.");
+  } else {
+    for (const line of formatTable(
+      ["LABEL", "SUBJECT", "PAIRED", "STATUS", "SERIAL"],
+      clients.map((client) => [
+        client.label || "(unnamed)",
+        client.certSubject,
+        absoluteTime(client.pairedAt),
+        client.revokedAt === null ? "paired" : `revoked ${absoluteTime(client.revokedAt)}`,
+        client.certSerial,
+      ]),
+    )) {
+      deps.out(`  ${line}`);
+    }
+  }
+  return EXIT_OK;
+}
+
+// ─── revoke ─────────────────────────────────────────────────────────────────
+
+function pairRevoke(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): number {
+  const flags = readFlags(rest, {});
+  if ("error" in flags) {
+    deps.err(`actana pair revoke: ${flags.error}.`);
+    return EXIT_USAGE;
+  }
+  const [target, ...extra] = flags.positionals;
+  if (target === undefined) {
+    deps.err("actana pair revoke: a target is required — `actana pair revoke <serial|session|label>`.");
+    return EXIT_USAGE;
+  }
+  if (extra.length > 0) {
+    deps.err(`actana pair revoke: unexpected argument "${extra[0]}".`);
+    return EXIT_USAGE;
+  }
+
+  const materialPath = ctx.materialPath();
+  if (materialPath === null) return EXIT_FAILURE;
+
+  const store = new PairingStore(pairingStorePath(materialPath));
+  const now = deps.now();
+  const audit = pairingAuditor(ctx.audit ?? ((record) => deps.err(`pairing.revoke ${formatJson(record)}`)));
+
+  const clients = store.listClients().filter((client) => client.revokedAt === null);
+  const sessions = store.listSessions().filter((session) => canRedeem(session, now).ok);
+  const matched = [
+    ...clients.filter((client) => matchesClient(client, target)).map((client) => ({ client })),
+    ...sessions.filter((session) => matchesSession(session, target)).map((session) => ({ session })),
+  ];
+
+  if (matched.length === 0) {
+    deps.err(`actana pair revoke: nothing here matches "${target}".`);
+    deps.err("`actana pair ls` lists the pending codes and the paired clients.");
+    return EXIT_FAILURE;
+  }
+  if (matched.length > 1) {
+    // Never guess. Two machines paired under one label is the ordinary way this
+    // happens, and revoking the wrong one is not something an operator finds
+    // out about until the machine they meant to keep stops working.
+    deps.err(`actana pair revoke: "${target}" matches ${matched.length} of them.`);
+    for (const match of matched) {
+      deps.err(
+        "  " +
+          ("client" in match
+            ? `client ${match.client.certSerial} (${match.client.label || "unnamed"})`
+            : `pending code ${match.session.id} (${match.session.label || "unnamed"})`),
+      );
+    }
+    deps.err("Name the serial or the session id.");
+    return EXIT_FAILURE;
+  }
+
+  const only = matched[0]!;
+  if ("client" in only) {
+    const revoked = store.revokeClient(only.client.certSerial, now);
+    if (!revoked) {
+      deps.err(`actana pair revoke: ${only.client.certSerial} is no longer paired here.`);
+      return EXIT_FAILURE;
+    }
+    audit({
+      outcome: "revoked",
+      reason: "client",
+      sessionId: revoked.sessionId,
+      label: revoked.label,
+      peer: LOCAL_OPERATOR_PEER,
+      certSerial: revoked.certSerial,
+      at: now,
+    });
+    deps.out(`Unpaired ${revoked.label || "the client"} (${revoked.certSubject}, serial ${revoked.certSerial}).`);
+    // Said rather than implied. The daemon is a different process: it notices
+    // the revocation from the store and drops the link, and until it has, the
+    // certificate is still one its CA signed. "Stops working" is a promise this
+    // command cannot keep on its own, so it names who keeps it.
+    deps.out("Its certificate and its bearer stop working, and this Core closes any link it has open.");
+    return EXIT_OK;
+  }
+
+  const cancelled = store.cancelSession(only.session.id, now);
+  if (!cancelled || !isRevoked(cancelled)) {
+    deps.err(
+      cancelled && isConsumed(cancelled)
+        ? `actana pair revoke: ${only.session.id} was already redeemed — revoke the client instead.`
+        : `actana pair revoke: ${only.session.id} is no longer pending here.`,
+    );
+    return EXIT_FAILURE;
+  }
+  audit({
+    outcome: "revoked",
+    reason: "pending-session",
+    sessionId: cancelled.id,
+    label: cancelled.label,
+    peer: LOCAL_OPERATOR_PEER,
+    attempts: cancelled.attempts,
+    at: now,
+  });
+  deps.out(`Cancelled the pending code for ${cancelled.label || "an unnamed machine"} (${cancelled.id}).`);
+  deps.out("It cannot be redeemed. `actana pair new` mints another.");
+  return EXIT_OK;
+}
+
+/**
+ * Does this target name this client?
+ *
+ * A serial matches on a prefix — serials are 32 hex characters and nobody
+ * types one in full — but a label matches only in full. A label is prose the
+ * operator chose, and `laptop` prefix-matching `laptop-2` would make the
+ * ambiguity check above miss the very collision it exists to catch.
+ */
+function matchesClient(client: PairedClient, target: string): boolean {
+  const wanted = target.toLowerCase();
+  return (
+    client.label.toLowerCase() === wanted ||
+    client.certSerial.toLowerCase().startsWith(wanted) ||
+    client.certSubject.toLowerCase() === wanted
+  );
+}
+
+function matchesSession(session: PairingSession, target: string): boolean {
+  const wanted = target.toLowerCase();
+  return session.label.toLowerCase() === wanted || session.id.toLowerCase().startsWith(wanted);
+}
+
+// ─── flags, durations and times ─────────────────────────────────────────────
+
+type FlagKind = "value" | "boolean";
+type ReadFlags =
+  | { values: Record<string, string | true | undefined>; positionals: string[] }
+  | { error: string };
+
+/**
+ * Parse this verb's flags and positionals.
+ *
+ * `actana-cli.ts` has a `parseFlags` of its own and it is deliberately not
+ * reused: that one rejects every positional, because none of the machine verbs
+ * it was written for take one. `pair revoke <target>` does.
+ */
+function readFlags(argv: string[], spec: Record<string, FlagKind>): ReadFlags {
+  const values: Record<string, string | true | undefined> = {};
+  const positionals: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const eq = token.indexOf("=");
+    const name = eq >= 0 ? token.slice(2, eq) : token.slice(2);
+    const kind = spec[name];
+    if (!kind) return { error: `unknown option: ${token}` };
+    if (kind === "boolean") {
+      if (eq >= 0) return { error: `--${name} takes no value` };
+      values[name] = true;
+      continue;
+    }
+    const value = eq >= 0 ? token.slice(eq + 1) : argv[++i];
+    if (value === undefined || value.startsWith("-")) return { error: `--${name} needs a value` };
+    values[name] = value;
+  }
+  return { values, positionals };
+}
+
+/**
+ * One value flag, as the string it can only be.
+ *
+ * The parsed bag is typed `string | true` because it holds both kinds of flag;
+ * a `"value"` entry in the spec is never `true`, and this is where that fact is
+ * asserted once instead of at each of its readers.
+ */
+function valueFlag(
+  values: Record<string, string | true | undefined>,
+  name: string,
+): string | undefined {
+  const raw = values[name];
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/**
+ * The longest TTL this Core will mint, and it is not an arbitrary number.
+ *
+ * The store prunes a session a day after it settles, so a TTL past that would
+ * let a *live* session be pruned out from under the client holding its code —
+ * a code that stops working with no expiry anybody can see. Tying the ceiling
+ * to the retention window is what keeps the two from drifting apart.
+ */
+export const MAX_PAIRING_TTL_MS = PAIRING_SESSION_RETENTION_MS;
+
+/**
+ * Read `30s`, `5m`, `2h` as milliseconds, or say what is wrong with it.
+ *
+ * A unit is required. A bare `5` is the one input where a wrong guess is
+ * invisible: read as seconds it is a code that dies before the operator
+ * finishes reading it out, read as minutes it is a code that outlives the phone
+ * call by four. Neither failure announces itself, so the parser asks instead.
+ */
+export function parseDuration(input: string): number | { error: string } {
+  const match = /^(\d+)(s|m|h)$/.exec(input.trim());
+  if (!match) {
+    return { error: `--ttl wants a number and a unit — \`30s\`, \`5m\`, \`2h\` — not ${JSON.stringify(input)}` };
+  }
+  const scale = { s: 1000, m: 60 * 1000, h: 60 * 60 * 1000 }[match[2] as "s" | "m" | "h"];
+  const ms = Number(match[1]) * scale;
+  if (ms <= 0) return { error: "--ttl must be longer than nothing" };
+  if (ms > MAX_PAIRING_TTL_MS) {
+    return { error: `--ttl cannot exceed ${describeDuration(MAX_PAIRING_TTL_MS)}` };
+  }
+  return ms;
+}
+
+/** `300000` -> `5 minutes`. Used by the help text and the ceiling's refusal. */
+export function describeDuration(ms: number): string {
+  const units: Array<[number, string]> = [
+    [60 * 60 * 1000, "hour"],
+    [60 * 1000, "minute"],
+    [1000, "second"],
+  ];
+  for (const [size, name] of units) {
+    if (ms >= size) {
+      const count = Math.round(ms / size);
+      return `${count} ${name}${count === 1 ? "" : "s"}`;
+    }
+  }
+  return `${ms} ms`;
+}
+
+/**
+ * The absolute half of an expiry, in UTC ISO 8601.
+ *
+ * UTC rather than the operator's local time, because the other half of this
+ * exchange is a person on a different machine — often in a different timezone —
+ * being read a time down a phone line. A local time is only unambiguous to
+ * whoever is standing at the terminal that printed it.
+ */
+export function absoluteTime(ms: number): string {
+  return new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/** The relative half: `in 5 minutes`, `in 30 seconds`, `expired 2 minutes ago`. */
+export function relativeTime(at: number, now: number): string {
+  const delta = at - now;
+  const magnitude = describeDuration(Math.abs(delta));
+  return delta >= 0 ? `in ${magnitude}` : `expired ${magnitude} ago`;
+}

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -548,10 +548,16 @@ function valueFlag(
 /**
  * The longest TTL this Core will mint, and it is not an arbitrary number.
  *
- * The store prunes a session a day after it settles, so a TTL past that would
- * let a *live* session be pruned out from under the client holding its code —
- * a code that stops working with no expiry anybody can see. Tying the ceiling
- * to the retention window is what keeps the two from drifting apart.
+ * A pairing code is a pre-auth secret guarding CSR signing — #280 fixes its
+ * default life at five minutes for exactly that reason — and the ceiling is
+ * where "one-time code" stops describing the thing on the operator's screen. A
+ * day is that point.
+ *
+ * It is spelled as the store's retention window rather than as a number of its
+ * own so this file carries one day-long horizon instead of two. That is the
+ * whole of the relationship: `prune` measures from `consumedAt ?? expiresAt`,
+ * which is in the future for the entire life of a pending session, so a live
+ * session is never a pruning candidate whatever its TTL.
  */
 export const MAX_PAIRING_TTL_MS = PAIRING_SESSION_RETENTION_MS;
 
@@ -577,20 +583,40 @@ export function parseDuration(input: string): number | { error: string } {
   return ms;
 }
 
-/** `300000` -> `5 minutes`. Used by the help text and the ceiling's refusal. */
+/**
+ * `300000` -> `5 minutes`, `5400000` -> `1 hour 30 minutes`.
+ *
+ * Two units and a floor, never a rounded one. Rounding to the largest unit that
+ * fits made `--ttl 90m` print "in 2 hours" and `--ttl 90s` print "in 2 minutes"
+ * — and the relative half is the half a human reads down a phone line, which is
+ * the only reason it is printed beside an exact absolute time at all. A code
+ * described as living longer than it does is a code the person at the other end
+ * stops hurrying for.
+ *
+ * The second unit is dropped when it is zero, so the ordinary cases are the
+ * short strings they were: "5 minutes", "30 seconds", "24 hours". Used by the
+ * expiry lines, the help text's default and the ceiling's refusal alike.
+ */
 export function describeDuration(ms: number): string {
   const units: Array<[number, string]> = [
     [60 * 60 * 1000, "hour"],
     [60 * 1000, "minute"],
     [1000, "second"],
   ];
-  for (const [size, name] of units) {
-    if (ms >= size) {
-      const count = Math.round(ms / size);
-      return `${count} ${name}${count === 1 ? "" : "s"}`;
-    }
+  for (let i = 0; i < units.length; i++) {
+    const [size, name] = units[i]!;
+    if (ms < size) continue;
+    const whole = Math.floor(ms / size);
+    const next = units[i + 1];
+    const remainder = ms - whole * size;
+    const tail = next && remainder >= next[0] ? ` ${countOf(Math.floor(remainder / next[0]), next[1])}` : "";
+    return `${countOf(whole, name)}${tail}`;
   }
   return `${ms} ms`;
+}
+
+function countOf(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? "" : "s"}`;
 }
 
 /**

--- a/packages/core/src/__tests__/core-link-revocation.test.ts
+++ b/packages/core/src/__tests__/core-link-revocation.test.ts
@@ -1,0 +1,289 @@
+// A revoked pairing, from the running Core's side of the link (#283).
+//
+// `actana pair revoke` runs in another process and stamps a row in the pairing
+// store. Nothing about that is enforcement — the certificate is still one this
+// Core's CA signed, the bearer still verifies against the same secret, and a
+// link that is already open is still carrying frames. These tests are the three
+// places the daemon makes it true:
+//
+//   1. a revoked certificate never becomes a registered connection,
+//   2. a revoked bearer never passes the `auth` frame, and
+//   3. a link a revoked client already holds is closed rather than left running
+//      until a handshake that, for a healthy client, never comes.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PtyCoreLinkServer,
+  type CoreLinkPeer,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import { PairingRevocations, pairingBearerSubject } from "../core-pairing-revocation";
+import type { PairedClient } from "@actana/shared/pairing-store";
+import type { PtyCore } from "../pty-manager";
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  closed = false;
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = 3;
+    this.emit("close");
+  }
+  terminate(): void {
+    this.close();
+  }
+  ping(): void {}
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(frame: unknown): void {
+    this.emit("message", JSON.stringify(frame));
+  }
+  ofType<T extends Record<string, unknown>>(type: string): T[] {
+    return this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === type) as T[];
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike, peer?: CoreLinkPeer) => void) | null = null;
+  connect(ws: FakeWebSocket, peer?: CoreLinkPeer): void {
+    this.connCb?.(ws as unknown as WebSocketLike, peer);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike, peer?: CoreLinkPeer) => void;
+  }
+}
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: () => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+const NOW = 1_700_000_000_000;
+const LIVE_SERIAL = "0a1b2c";
+const REVOKED_SERIAL = "ff00ff";
+
+function client(certSerial: string, revokedAt: number | null): PairedClient {
+  return {
+    certSerial,
+    certSubject: `CN=${certSerial}`,
+    label: certSerial,
+    sessionId: "ps_1",
+    pairedAt: NOW,
+    certNotAfter: NOW + 1,
+    revokedAt,
+    created_by: null,
+    tenant_id: null,
+    auth_method: null,
+  };
+}
+
+let rows: PairedClient[];
+let revocations: PairingRevocations;
+let wss: FakeWebSocketServer;
+let server: PtyCoreLinkServer;
+
+/** A bearer verifier that answers for whichever pairing the test names. */
+function verifierFor(serial: string) {
+  return () => ({ ok: true as const, coreId: "core-1", exp: NOW + 1, sub: pairingBearerSubject(serial) });
+}
+
+type ServerOptions = ConstructorParameters<typeof PtyCoreLinkServer>[1];
+
+function start(opts: Partial<ServerOptions> = {}): void {
+  wss = new FakeWebSocketServer();
+  server = new PtyCoreLinkServer(mockCore(), {
+    port: 0,
+    createServer: () => wss as unknown as WebSocketServerLike,
+    revocation: revocations,
+    ...opts,
+  });
+}
+
+function connect(peer?: CoreLinkPeer): FakeWebSocket {
+  const ws = new FakeWebSocket();
+  wss.connect(ws, peer);
+  return ws;
+}
+
+beforeEach(() => {
+  rows = [client(LIVE_SERIAL, null), client(REVOKED_SERIAL, NOW)];
+  revocations = new PairingRevocations({ listClients: () => rows });
+  revocations.refresh();
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe("a revoked certificate never becomes a connection", () => {
+  it("is closed instead of registered", () => {
+    start();
+    const ws = connect({ certSerial: REVOKED_SERIAL });
+    expect(ws.closed).toBe(true);
+    // Not even a `ready`: a client whose certificate was revoked is not owed a
+    // conversation by the Core that revoked it.
+    expect(ws.sent).toEqual([]);
+  });
+
+  it("does not answer frames sent on it anyway", () => {
+    start();
+    const ws = connect({ certSerial: REVOKED_SERIAL });
+    ws.receive({ type: "findByTask", reqId: "a1", taskId: "t1" });
+    expect(ws.ofType("findByTaskResult")).toEqual([]);
+  });
+
+  it("leaves an unrevoked client alone", () => {
+    start();
+    const ws = connect({ certSerial: LIVE_SERIAL });
+    expect(ws.closed).toBe(false);
+    expect(ws.ofType("ready")).toHaveLength(1);
+  });
+
+  it("leaves a Core with no pairing surface alone", () => {
+    // No `revocation` at all: a loopback Core has no pairing store, so there is
+    // nothing on that machine that could have been revoked.
+    start({ revocation: undefined });
+    const ws = connect({ certSerial: REVOKED_SERIAL });
+    expect(ws.closed).toBe(false);
+    expect(ws.ofType("ready")).toHaveLength(1);
+  });
+
+  it("matches however the peer's serial is spelled", () => {
+    start();
+    // Node reports the peer certificate's serial in upper case; the store holds
+    // whatever `@peculiar/x509` issued.
+    expect(connect({ certSerial: REVOKED_SERIAL.toUpperCase() }).closed).toBe(true);
+  });
+});
+
+describe("a revoked bearer never passes the auth frame", () => {
+  it("is refused and the socket closed", () => {
+    start({ authVerifier: verifierFor(REVOKED_SERIAL) });
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+
+    expect(ws.ofType("authOk")).toEqual([]);
+    // `expired` rather than a fourth reason: the wire's three live in
+    // `@actana/sdk`, and from where the client stands a revoked credential is
+    // one whose validity ended. Its reconnect path leads to re-pairing, which
+    // is where the operator who revoked it wants it to go.
+    expect(ws.ofType<{ reason: string }>("authError")).toEqual([
+      { type: "authError", reqId: "a1", reason: "expired" },
+    ]);
+    expect(ws.closed).toBe(true);
+  });
+
+  it("holds everything back that a pre-auth connection is held back from", () => {
+    start({ authVerifier: verifierFor(REVOKED_SERIAL) });
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    ws.receive({ type: "findByTask", reqId: "b1", taskId: "t1" });
+    expect(ws.ofType("findByTaskResult")).toEqual([]);
+  });
+
+  it("lets an unrevoked pairing's bearer through", () => {
+    start({ authVerifier: verifierFor(LIVE_SERIAL) });
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    expect(ws.ofType("authOk")).toHaveLength(1);
+    expect(ws.closed).toBe(false);
+  });
+
+  it("says nothing about a bearer that names no pairing at all", () => {
+    // Bearers minted before pairing existed carry `{coreId, exp}`. They are
+    // governed by their own expiry, not by a list they are not on.
+    start({ authVerifier: () => ({ ok: true as const, coreId: "core-1", exp: NOW + 1 }) });
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    expect(ws.ofType("authOk")).toHaveLength(1);
+  });
+});
+
+describe("a link a revoked client already holds", () => {
+  it("is closed rather than left running until the next handshake", () => {
+    start();
+    const ws = connect({ certSerial: LIVE_SERIAL });
+    expect(ws.closed).toBe(false);
+
+    // What the sweep hands the server one second after `actana pair revoke`.
+    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  it("stops dispatching that client's frames on the way out", () => {
+    start();
+    const ws = connect({ certSerial: LIVE_SERIAL });
+    server.closeRevoked([LIVE_SERIAL]);
+    ws.receive({ type: "findByTask", reqId: "a1", taskId: "t1" });
+    expect(ws.ofType("findByTaskResult")).toEqual([]);
+  });
+
+  it("closes a link identified only by the bearer it authenticated with", () => {
+    // A client behind a terminating proxy presents this Core no certificate.
+    // The pairing its bearer names is still the pairing that was revoked.
+    start({ authVerifier: verifierFor(LIVE_SERIAL) });
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    expect(ws.ofType("authOk")).toHaveLength(1);
+
+    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  it("leaves every other client connected", () => {
+    start();
+    const revoked = connect({ certSerial: LIVE_SERIAL });
+    const other = connect({ certSerial: "beef" });
+    const loopback = connect();
+
+    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    expect(revoked.closed).toBe(true);
+    expect(other.closed).toBe(false);
+    expect(loopback.closed).toBe(false);
+    other.receive({ type: "findByTask", reqId: "b1", taskId: "t1" });
+    expect(other.ofType("findByTaskResult")).toHaveLength(1);
+  });
+
+  it("closes every link that pairing holds, not just the first", () => {
+    start();
+    const first = connect({ certSerial: LIVE_SERIAL });
+    const second = connect({ certSerial: LIVE_SERIAL });
+    expect(server.closeRevoked([LIVE_SERIAL])).toBe(2);
+    expect(first.closed).toBe(true);
+    expect(second.closed).toBe(true);
+  });
+
+  it("does nothing for a pairing holding no link", () => {
+    start();
+    connect({ certSerial: LIVE_SERIAL });
+    expect(server.closeRevoked(["nothing-here"])).toBe(0);
+  });
+});

--- a/packages/core/src/__tests__/core-link-revocation.test.ts
+++ b/packages/core/src/__tests__/core-link-revocation.test.ts
@@ -106,6 +106,7 @@ function client(certSerial: string, revokedAt: number | null): PairedClient {
 }
 
 let rows: PairedClient[];
+let storeReadable: boolean;
 let revocations: PairingRevocations;
 let wss: FakeWebSocketServer;
 let server: PtyCoreLinkServer;
@@ -135,7 +136,13 @@ function connect(peer?: CoreLinkPeer): FakeWebSocket {
 
 beforeEach(() => {
   rows = [client(LIVE_SERIAL, null), client(REVOKED_SERIAL, NOW)];
-  revocations = new PairingRevocations({ listClients: () => rows });
+  storeReadable = true;
+  revocations = new PairingRevocations({
+    readStrict: () => {
+      if (!storeReadable) throw new Error("pairing.json is not valid JSON");
+      return { clients: rows };
+    },
+  });
   revocations.refresh();
 });
 
@@ -233,15 +240,19 @@ describe("a link a revoked client already holds", () => {
     const ws = connect({ certSerial: LIVE_SERIAL });
     expect(ws.closed).toBe(false);
 
-    // What the sweep hands the server one second after `actana pair revoke`.
-    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    // What the sweep calls one second after `actana pair revoke`.
+    rows[0] = client(LIVE_SERIAL, NOW);
+    revocations.refresh();
+    expect(server.closeRevoked()).toBe(1);
     expect(ws.closed).toBe(true);
   });
 
   it("stops dispatching that client's frames on the way out", () => {
     start();
     const ws = connect({ certSerial: LIVE_SERIAL });
-    server.closeRevoked([LIVE_SERIAL]);
+    rows[0] = client(LIVE_SERIAL, NOW);
+    revocations.refresh();
+    server.closeRevoked();
     ws.receive({ type: "findByTask", reqId: "a1", taskId: "t1" });
     expect(ws.ofType("findByTaskResult")).toEqual([]);
   });
@@ -254,7 +265,9 @@ describe("a link a revoked client already holds", () => {
     ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
     expect(ws.ofType("authOk")).toHaveLength(1);
 
-    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    rows[0] = client(LIVE_SERIAL, NOW);
+    revocations.refresh();
+    expect(server.closeRevoked()).toBe(1);
     expect(ws.closed).toBe(true);
   });
 
@@ -264,7 +277,9 @@ describe("a link a revoked client already holds", () => {
     const other = connect({ certSerial: "beef" });
     const loopback = connect();
 
-    expect(server.closeRevoked([LIVE_SERIAL])).toBe(1);
+    rows[0] = client(LIVE_SERIAL, NOW);
+    revocations.refresh();
+    expect(server.closeRevoked()).toBe(1);
     expect(revoked.closed).toBe(true);
     expect(other.closed).toBe(false);
     expect(loopback.closed).toBe(false);
@@ -276,14 +291,69 @@ describe("a link a revoked client already holds", () => {
     start();
     const first = connect({ certSerial: LIVE_SERIAL });
     const second = connect({ certSerial: LIVE_SERIAL });
-    expect(server.closeRevoked([LIVE_SERIAL])).toBe(2);
+    rows[0] = client(LIVE_SERIAL, NOW);
+    revocations.refresh();
+    expect(server.closeRevoked()).toBe(2);
     expect(first.closed).toBe(true);
     expect(second.closed).toBe(true);
   });
 
-  it("does nothing for a pairing holding no link", () => {
+  it("does nothing while nothing that is connected is revoked", () => {
     start();
     connect({ certSerial: LIVE_SERIAL });
-    expect(server.closeRevoked(["nothing-here"])).toBe(0);
+    // `REVOKED_SERIAL` is revoked and holds no link; `LIVE_SERIAL` holds one
+    // and is not revoked.
+    expect(server.closeRevoked()).toBe(0);
+  });
+
+  it("closes every pairing's link when the store becomes unreadable", () => {
+    // The fail-closed direction, at the layer the gates cannot reach. This is
+    // the case a list of newly-revoked serials could never have carried:
+    // nothing was named, and everything is revoked.
+    start({ authVerifier: verifierFor(LIVE_SERIAL) });
+    const byCert = connect({ certSerial: LIVE_SERIAL });
+    const byBearer = connect({ certSerial: null });
+    byBearer.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    const loopback = connect();
+
+    storeReadable = false;
+    expect(revocations.refresh().ok).toBe(false);
+
+    expect(server.closeRevoked()).toBe(2);
+    expect(byCert.closed).toBe(true);
+    expect(byBearer.closed).toBe(true);
+    // A connection that named no pairing at all is not one that could have been
+    // revoked — and on a loopback Core it is every connection there is.
+    expect(loopback.closed).toBe(false);
+  });
+
+  it("refuses a new connection from any pairing while the store is unreadable", () => {
+    start();
+    storeReadable = false;
+    revocations.refresh();
+    expect(connect({ certSerial: LIVE_SERIAL }).closed).toBe(true);
+    expect(connect({ certSerial: "some-other-pairing" }).closed).toBe(true);
+    expect(connect().closed).toBe(false);
+  });
+
+  it("refuses a bearer from any pairing while the store is unreadable", () => {
+    start({ authVerifier: verifierFor(LIVE_SERIAL) });
+    storeReadable = false;
+    revocations.refresh();
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    expect(ws.ofType("authOk")).toEqual([]);
+    expect(ws.ofType<{ reason: string }>("authError")[0]!.reason).toBe("expired");
+  });
+
+  it("still lets a hand-carried bearer through while the store is unreadable", () => {
+    // It names no pairing, so no row about it could have gone unread — and it
+    // is what the operator's own Panel holds while they go and fix the file.
+    start({ authVerifier: () => ({ ok: true as const, coreId: "core-1", exp: NOW + 1 }) });
+    storeReadable = false;
+    revocations.refresh();
+    const ws = connect({ certSerial: null });
+    ws.receive({ type: "auth", reqId: "a1", bearer: "whatever" });
+    expect(ws.ofType("authOk")).toHaveLength(1);
   });
 });

--- a/packages/core/src/__tests__/core-pairing-redeem.test.ts
+++ b/packages/core/src/__tests__/core-pairing-redeem.test.ts
@@ -30,7 +30,7 @@ import type { PtyCore, PtyCoreEvent } from "../pty-manager";
 import { createCoreFilesRequestHandler } from "../core-files-routes";
 import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "../core-pairing-wiring";
 import { PairingRateLimiter } from "../core-pairing-rate-limit";
-import type { PairingAuditEvent } from "../core-pairing-audit";
+import type { PairingAuditEvent } from "@actana/shared/pairing-audit";
 
 const SECRET = "core-pairing-suite-secret-at-least-32-bytes";
 const CORE_UUID = "3f6d0f0a-6c1f-4a5e-9c2f-1d0a5b7e9c31";

--- a/packages/core/src/__tests__/core-pairing-redeem.test.ts
+++ b/packages/core/src/__tests__/core-pairing-redeem.test.ts
@@ -496,6 +496,45 @@ describe("the defences, over the real transport", () => {
   }, 30_000);
 });
 
+describe("a session the operator cancelled (#283)", () => {
+  it("is refused, and the refusal is indistinguishable from every other one", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+
+    rig.store.cancelSession(sessionId, rig.clock.now);
+
+    const res = await redeem(rig, { sessionId, code, csr: csrPem });
+    expect(res.status).toBe(403);
+    expect(rig.store.listClients()).toEqual([]);
+  }, 30_000);
+
+  it("says `revoked` in the audit log, not `wrong-code`", async () => {
+    // The operator reading this log has to be able to see that their own
+    // cancellation is what stopped the redemption. Caught in the state ladder
+    // rather than left to `consume()` is what makes that true.
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+    rig.store.cancelSession(sessionId, rig.clock.now);
+
+    await redeem(rig, { sessionId, code, csr: csrPem });
+
+    expect(rig.audit.at(-1)).toMatchObject({ outcome: "refused", reason: "revoked", sessionId });
+  }, 30_000);
+
+  it("does not spend an attempt the session will never get to use", async () => {
+    const rig = await startCore();
+    const { sessionId } = rig.openSession();
+    const { csrPem } = await generateClientCsr("laptop");
+    rig.store.cancelSession(sessionId, rig.clock.now);
+
+    await redeem(rig, { sessionId, code: "AAAA-BBBB", csr: csrPem });
+
+    expect(rig.store.getSession(sessionId)?.attempts).toBe(0);
+  }, 30_000);
+});
+
 describe("the pre-auth hole is exactly one route wide", () => {
   it("answers the pairing route to a client with no certificate", async () => {
     const rig = await startCore();

--- a/packages/core/src/__tests__/core-pairing-revocation.test.ts
+++ b/packages/core/src/__tests__/core-pairing-revocation.test.ts
@@ -14,7 +14,10 @@ import {
   startPairingRevocationSweep,
 } from "../core-pairing-revocation";
 import { clientCertGate, coreLinkUpgradeGate } from "../core-preauth-gate";
-import type { PairedClient } from "@actana/shared/pairing-store";
+import { PairingStore, type PairedClient } from "@actana/shared/pairing-store";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 const NOW = 1_700_000_000_000;
 
@@ -34,9 +37,17 @@ function client(over: Partial<PairedClient> = {}): PairedClient {
   };
 }
 
-/** A store double, so a test can revoke a row between two reads. */
+/**
+ * A store double, so a test can revoke a row between two reads.
+ *
+ * `readStrict` and not `listClients`, because that is the seam the real
+ * `PairingStore` is injected through — and the difference between the two is
+ * the whole subject of the fail-closed tests below. The suite also drives the
+ * *real* store over a deliberately corrupted file, so the guarantee is not
+ * pinned against a double that behaves differently from the collaborator.
+ */
 function fakeStore(rows: PairedClient[] = []) {
-  return { rows, listClients: () => rows };
+  return { rows, readStrict: () => ({ clients: rows }) };
 }
 
 describe("the bearer subject a pairing speaks for", () => {
@@ -68,14 +79,15 @@ describe("one spelling of a serial", () => {
 describe("the revoked set", () => {
   it("is empty until something is revoked", () => {
     const revocations = new PairingRevocations(fakeStore([client()]));
-    revocations.refresh();
+    expect(revocations.refresh()).toEqual({ ok: true, revoked: [] });
     expect(revocations.isRevoked("0a1b2c")).toBe(false);
+    expect(revocations.isFailClosed()).toBe(false);
   });
 
   it("holds a serial once its row is stamped", () => {
     const store = fakeStore([client({ revokedAt: NOW })]);
     const revocations = new PairingRevocations(store);
-    expect(revocations.refresh()).toEqual(["0a1b2c"]);
+    expect(revocations.refresh()).toEqual({ ok: true, revoked: ["0a1b2c"] });
     expect(revocations.isRevoked("0a1b2c")).toBe(true);
   });
 
@@ -90,8 +102,8 @@ describe("the revoked set", () => {
   it("reports each serial once, so a sweep acts on it once", () => {
     const store = fakeStore([client({ revokedAt: NOW })]);
     const revocations = new PairingRevocations(store);
-    expect(revocations.refresh()).toEqual(["0a1b2c"]);
-    expect(revocations.refresh()).toEqual([]);
+    expect(revocations.refresh()).toEqual({ ok: true, revoked: ["0a1b2c"] });
+    expect(revocations.refresh()).toEqual({ ok: true, revoked: [] });
   });
 
   it("finds a pairing revoked through its bearer's subject", () => {
@@ -102,20 +114,71 @@ describe("the revoked set", () => {
     expect(revocations.isBearerSubjectRevoked(undefined)).toBe(false);
   });
 
-  it("keeps what it knows when the store cannot be read", () => {
-    // The one interpretation that must never be reached is "nobody is
-    // revoked" — that hands a revoked client its access straight back.
+  it("revokes everything when the store cannot be read", () => {
+    // Not "nobody is revoked", and not "whatever we knew last time" — both of
+    // those serve a certificate the operator has taken back.
     let broken = false;
     const revocations = new PairingRevocations({
-      listClients: () => {
-        if (broken) throw new Error("pairing.json is gone");
-        return [client({ revokedAt: NOW })];
+      readStrict: () => {
+        if (broken) throw new Error("pairing.json is not valid JSON");
+        return { clients: [client({ revokedAt: NOW })] };
       },
     });
     revocations.refresh();
+    expect(revocations.isRevoked("never-seen-before")).toBe(false);
+
     broken = true;
-    expect(revocations.refresh()).toEqual([]);
+    expect(revocations.refresh()).toEqual({ ok: false, error: expect.stringContaining("not valid JSON") });
+    expect(revocations.isFailClosed()).toBe(true);
     expect(revocations.isRevoked("0a1b2c")).toBe(true);
+    expect(revocations.isRevoked("never-seen-before")).toBe(true);
+    expect(revocations.isBearerSubjectRevoked(pairingBearerSubject("never-seen-before"))).toBe(true);
+  });
+
+  it("fails closed at boot, where there is no last time to fall back on", () => {
+    // The failure the review named: a truncated write is renamed into place and
+    // the daemon restarts. The seeding read is the first thing that happens, and
+    // if it read "nobody is revoked" every revoked certificate would be served
+    // again from the first request.
+    const revocations = new PairingRevocations({
+      readStrict: () => {
+        throw new Error("pairing.json is not valid JSON");
+      },
+    });
+    revocations.refresh();
+    expect(revocations.isRevoked("0a1b2c")).toBe(true);
+  });
+
+  it("stops failing closed once the store is readable again", () => {
+    // A fact about the store as it is now, not a latch an operator has to reset.
+    let broken = true;
+    const revocations = new PairingRevocations({
+      readStrict: () => {
+        if (broken) throw new Error("unreadable");
+        return { clients: [client()] };
+      },
+    });
+    revocations.refresh();
+    expect(revocations.isRevoked("0a1b2c")).toBe(true);
+    broken = false;
+    expect(revocations.refresh()).toEqual({ ok: true, revoked: [] });
+    expect(revocations.isFailClosed()).toBe(false);
+    expect(revocations.isRevoked("0a1b2c")).toBe(false);
+  });
+
+  it("leaves a bearer that names no pairing alone, even while failing closed", () => {
+    // The hand-carried registration blob's bearer is not a pairing, so no row
+    // about it could have gone unread — and it is the credential the operator's
+    // own Panel is holding while they go and repair the file.
+    const revocations = new PairingRevocations({
+      readStrict: () => {
+        throw new Error("unreadable");
+      },
+    });
+    revocations.refresh();
+    expect(revocations.isBearerSubjectRevoked(undefined)).toBe(false);
+    expect(revocations.isBearerSubjectRevoked("something-else")).toBe(false);
+    expect(revocations.isRevoked(null)).toBe(false);
   });
 
   it("says nothing about a connection with no certificate at all", () => {
@@ -123,6 +186,56 @@ describe("the revoked set", () => {
     revocations.refresh();
     expect(revocations.isRevoked(null)).toBe(false);
     expect(revocations.isRevoked("")).toBe(false);
+  });
+
+  it("reads a real corrupted pairing.json as everything-revoked", () => {
+    // Driven through `PairingStore` itself rather than a double, because the
+    // defect this closes was precisely that the real collaborator never threw:
+    // `read()` swallows a parse failure and answers with an empty store.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-revocation-"));
+    try {
+      const file = path.join(dir, "pairing.json");
+      fs.writeFileSync(file, '{"version":1,"sessions":[],"clients":[{"certSerial":"0a1b2c"');
+      const store = new PairingStore(file);
+      // The lenient reader is what made this invisible — kept here so the two
+      // answers sit side by side.
+      expect(store.read().clients).toEqual([]);
+
+      const revocations = new PairingRevocations(store);
+      expect(revocations.refresh().ok).toBe(false);
+      expect(revocations.isRevoked("0a1b2c")).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a pairing.json that is simply absent as nobody-revoked", () => {
+    // A Core that has never paired anything has no file. Failing closed on its
+    // absence would refuse every client on every fresh Core.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-revocation-"));
+    try {
+      const revocations = new PairingRevocations(new PairingStore(path.join(dir, "pairing.json")));
+      expect(revocations.refresh()).toEqual({ ok: true, revoked: [] });
+      expect(revocations.isRevoked("0a1b2c")).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a row whose shape it does not recognise as everything-revoked", () => {
+    // The lenient reader drops such a row silently, and a dropped row is
+    // exactly what a revoked client's row would look like to a reader that
+    // must not miss one.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-revocation-"));
+    try {
+      const file = path.join(dir, "pairing.json");
+      fs.writeFileSync(file, JSON.stringify({ version: 1, sessions: [], clients: [{ certSerial: 7 }] }));
+      const revocations = new PairingRevocations(new PairingStore(file));
+      expect(revocations.refresh().ok).toBe(false);
+      expect(revocations.isRevoked("anything")).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -134,12 +247,12 @@ describe("the sweep", () => {
     vi.useFakeTimers();
     try {
       const revocations = new PairingRevocations(fakeStore([client({ revokedAt: NOW })]));
-      const closed: string[][] = [];
-      const sweep = startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) });
-      expect(closed).toEqual([]);
+      let closes = 0;
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: () => (closes += 1) });
+      expect(closes).toBe(0);
       expect(revocations.isRevoked("0a1b2c")).toBe(true);
       vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
-      expect(closed).toEqual([]);
+      expect(closes).toBe(0);
       sweep.stop();
     } finally {
       vi.useRealTimers();
@@ -152,16 +265,73 @@ describe("the sweep", () => {
       const row = client();
       const store = fakeStore([row]);
       const revocations = new PairingRevocations(store);
-      const closed: string[][] = [];
-      const sweep = startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) });
+      let closes = 0;
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: () => (closes += 1) });
 
       // What `actana pair revoke` does, in the other process.
       store.rows[0] = client({ revokedAt: NOW });
 
       vi.advanceTimersByTime(REVOCATION_SWEEP_MS);
-      expect(closed).toEqual([["0a1b2c"]]);
+      expect(closes).toBe(1);
       vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
-      expect(closed).toHaveLength(1);
+      expect(closes).toBe(1);
+      sweep.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("calls back when the store becomes unreadable, and only on the crossing", () => {
+    // The change a list of serials could not have expressed: nothing was newly
+    // *named*, but every pairing is now revoked, so the links already open have
+    // to be re-checked.
+    vi.useFakeTimers();
+    try {
+      let broken = false;
+      let closes = 0;
+      const revocations = new PairingRevocations({
+        readStrict: () => {
+          if (broken) throw new Error("unreadable");
+          return { clients: [client()] };
+        },
+      });
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: () => (closes += 1) });
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS);
+      expect(closes).toBe(0);
+
+      broken = true;
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS);
+      expect(closes).toBe(1);
+      // Still unreadable is not a new event — the gates are already refusing.
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
+      expect(closes).toBe(1);
+
+      // And coming back is not one either: nothing became revoked by the file
+      // becoming readable again.
+      broken = false;
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS);
+      expect(closes).toBe(1);
+      sweep.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("seeds fail-closed at boot before the first request is served", () => {
+    vi.useFakeTimers();
+    try {
+      const revocations = new PairingRevocations({
+        readStrict: () => {
+          throw new Error("unreadable");
+        },
+      });
+      let closes = 0;
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: () => (closes += 1) });
+      // Seeded, and no callback: at boot there are no connections to close.
+      expect(revocations.isFailClosed()).toBe(true);
+      expect(closes).toBe(0);
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
+      expect(closes).toBe(0);
       sweep.stop();
     } finally {
       vi.useRealTimers();
@@ -173,11 +343,11 @@ describe("the sweep", () => {
     try {
       const store = fakeStore([client()]);
       const revocations = new PairingRevocations(store);
-      const closed: string[][] = [];
-      startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) }).stop();
+      let closes = 0;
+      startPairingRevocationSweep({ revocations, onRevoked: () => (closes += 1) }).stop();
       store.rows[0] = client({ revokedAt: NOW });
       vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 5);
-      expect(closed).toEqual([]);
+      expect(closes).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/__tests__/core-pairing-revocation.test.ts
+++ b/packages/core/src/__tests__/core-pairing-revocation.test.ts
@@ -1,0 +1,231 @@
+// What a revoked pairing means to the running daemon (#283).
+//
+// `actana pair revoke` runs in another process and can only stamp a row. These
+// tests are about the half that makes the stamp mean something: the set the
+// gates consult, and the sweep that notices a stamp arriving under a daemon
+// that is already running.
+import { describe, expect, it, vi } from "vitest";
+import {
+  PairingRevocations,
+  REVOCATION_SWEEP_MS,
+  certSerialFromBearerSubject,
+  normaliseCertSerial,
+  pairingBearerSubject,
+  startPairingRevocationSweep,
+} from "../core-pairing-revocation";
+import { clientCertGate, coreLinkUpgradeGate } from "../core-preauth-gate";
+import type { PairedClient } from "@actana/shared/pairing-store";
+
+const NOW = 1_700_000_000_000;
+
+function client(over: Partial<PairedClient> = {}): PairedClient {
+  return {
+    certSerial: "0a1b2c",
+    certSubject: "CN=laptop",
+    label: "laptop",
+    sessionId: "ps_1",
+    pairedAt: NOW,
+    certNotAfter: NOW + 1,
+    revokedAt: null,
+    created_by: null,
+    tenant_id: null,
+    auth_method: null,
+    ...over,
+  };
+}
+
+/** A store double, so a test can revoke a row between two reads. */
+function fakeStore(rows: PairedClient[] = []) {
+  return { rows, listClients: () => rows };
+}
+
+describe("the bearer subject a pairing speaks for", () => {
+  it("round-trips", () => {
+    expect(certSerialFromBearerSubject(pairingBearerSubject("0a1b"))).toBe("0a1b");
+  });
+
+  it("reads a bearer with no pairing subject as naming no pairing", () => {
+    // Bearers minted before pairing existed carry `{coreId, exp}` and nothing
+    // else. They are governed by their own expiry, not by a list they are not on.
+    expect(certSerialFromBearerSubject(undefined)).toBe(null);
+    expect(certSerialFromBearerSubject("something-else")).toBe(null);
+    expect(certSerialFromBearerSubject("pair:")).toBe(null);
+  });
+});
+
+describe("one spelling of a serial", () => {
+  it("folds case, separators and leading zeros", () => {
+    expect(normaliseCertSerial("0a:1b:2c")).toBe("A1B2C");
+    expect(normaliseCertSerial("0A1B2C")).toBe("A1B2C");
+    expect(normaliseCertSerial("00a1b2c")).toBe("A1B2C");
+  });
+
+  it("does not fold a serial away to nothing", () => {
+    expect(normaliseCertSerial("00")).toBe("0");
+  });
+});
+
+describe("the revoked set", () => {
+  it("is empty until something is revoked", () => {
+    const revocations = new PairingRevocations(fakeStore([client()]));
+    revocations.refresh();
+    expect(revocations.isRevoked("0a1b2c")).toBe(false);
+  });
+
+  it("holds a serial once its row is stamped", () => {
+    const store = fakeStore([client({ revokedAt: NOW })]);
+    const revocations = new PairingRevocations(store);
+    expect(revocations.refresh()).toEqual(["0a1b2c"]);
+    expect(revocations.isRevoked("0a1b2c")).toBe(true);
+  });
+
+  it("matches however the serial is spelled", () => {
+    const revocations = new PairingRevocations(fakeStore([client({ revokedAt: NOW })]));
+    revocations.refresh();
+    // `@peculiar/x509` issues lower case; Node reports the peer's upper case.
+    expect(revocations.isRevoked("0A1B2C")).toBe(true);
+    expect(revocations.isRevoked("A1B2C")).toBe(true);
+  });
+
+  it("reports each serial once, so a sweep acts on it once", () => {
+    const store = fakeStore([client({ revokedAt: NOW })]);
+    const revocations = new PairingRevocations(store);
+    expect(revocations.refresh()).toEqual(["0a1b2c"]);
+    expect(revocations.refresh()).toEqual([]);
+  });
+
+  it("finds a pairing revoked through its bearer's subject", () => {
+    const revocations = new PairingRevocations(fakeStore([client({ revokedAt: NOW })]));
+    revocations.refresh();
+    expect(revocations.isBearerSubjectRevoked(pairingBearerSubject("0a1b2c"))).toBe(true);
+    expect(revocations.isBearerSubjectRevoked(pairingBearerSubject("ffff"))).toBe(false);
+    expect(revocations.isBearerSubjectRevoked(undefined)).toBe(false);
+  });
+
+  it("keeps what it knows when the store cannot be read", () => {
+    // The one interpretation that must never be reached is "nobody is
+    // revoked" — that hands a revoked client its access straight back.
+    let broken = false;
+    const revocations = new PairingRevocations({
+      listClients: () => {
+        if (broken) throw new Error("pairing.json is gone");
+        return [client({ revokedAt: NOW })];
+      },
+    });
+    revocations.refresh();
+    broken = true;
+    expect(revocations.refresh()).toEqual([]);
+    expect(revocations.isRevoked("0a1b2c")).toBe(true);
+  });
+
+  it("says nothing about a connection with no certificate at all", () => {
+    const revocations = new PairingRevocations(fakeStore([client({ revokedAt: NOW })]));
+    revocations.refresh();
+    expect(revocations.isRevoked(null)).toBe(false);
+    expect(revocations.isRevoked("")).toBe(false);
+  });
+});
+
+describe("the sweep", () => {
+  it("seeds the set at boot without reporting anything to close", () => {
+    // Every revocation already on file at boot was made against a link that
+    // does not exist. Reporting them would ask the server to close connections
+    // that were never opened.
+    vi.useFakeTimers();
+    try {
+      const revocations = new PairingRevocations(fakeStore([client({ revokedAt: NOW })]));
+      const closed: string[][] = [];
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) });
+      expect(closed).toEqual([]);
+      expect(revocations.isRevoked("0a1b2c")).toBe(true);
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
+      expect(closed).toEqual([]);
+      sweep.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a revocation that lands under a running daemon", () => {
+    vi.useFakeTimers();
+    try {
+      const row = client();
+      const store = fakeStore([row]);
+      const revocations = new PairingRevocations(store);
+      const closed: string[][] = [];
+      const sweep = startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) });
+
+      // What `actana pair revoke` does, in the other process.
+      store.rows[0] = client({ revokedAt: NOW });
+
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS);
+      expect(closed).toEqual([["0a1b2c"]]);
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 3);
+      expect(closed).toHaveLength(1);
+      sweep.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops when the daemon does", () => {
+    vi.useFakeTimers();
+    try {
+      const store = fakeStore([client()]);
+      const revocations = new PairingRevocations(store);
+      const closed: string[][] = [];
+      startPairingRevocationSweep({ revocations, onRevoked: (s) => closed.push(s) }).stop();
+      store.rows[0] = client({ revokedAt: NOW });
+      vi.advanceTimersByTime(REVOCATION_SWEEP_MS * 5);
+      expect(closed).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ─── the gates ──────────────────────────────────────────────────────────────
+//
+// A revoked certificate is a *valid* certificate: this Core's CA signed it and
+// TLS has no idea an operator took it back. So `authorized: true` is exactly
+// what a revoked client arrives with, and the order these two checks run in is
+// the whole of whether revocation works at the door.
+
+describe("the client-certificate gate, with revocation", () => {
+  it("refuses a revoked certificate even though the handshake accepted it", () => {
+    expect(clientCertGate({ pathname: "/v1/files", authorized: true, revoked: true })).toBe("refuse");
+  });
+
+  it("still serves an unrevoked one", () => {
+    expect(clientCertGate({ pathname: "/v1/files", authorized: true, revoked: false })).toBe("serve");
+  });
+
+  it("gives revocation no pre-auth exception", () => {
+    // A client here to redeem a code has no certificate to have had revoked, so
+    // nothing legitimate is turned away by refusing this outright.
+    expect(
+      clientCertGate({
+        pathname: "/v1/pair/redeem",
+        authorized: true,
+        revoked: true,
+        isPreAuthPath: (p) => p.startsWith("/v1/pair/"),
+      }),
+    ).toBe("refuse");
+  });
+
+  it("is unchanged for every Core that has revoked nothing", () => {
+    expect(clientCertGate({ pathname: "/v1/files", authorized: true })).toBe("serve");
+    expect(clientCertGate({ pathname: "/v1/files", authorized: false })).toBe("refuse");
+  });
+});
+
+describe("the core-link upgrade gate, with revocation", () => {
+  it("refuses a revoked certificate", () => {
+    expect(coreLinkUpgradeGate(true, true)).toBe("refuse");
+  });
+
+  it("is unchanged otherwise", () => {
+    expect(coreLinkUpgradeGate(true)).toBe("serve");
+    expect(coreLinkUpgradeGate(false)).toBe("refuse");
+  });
+});

--- a/packages/core/src/__tests__/core-revocation-transport.test.ts
+++ b/packages/core/src/__tests__/core-revocation-transport.test.ts
@@ -1,0 +1,338 @@
+// Revocation, over the real transport (#283).
+//
+// Every other revocation assertion in this repository is made either against
+// `clientCertGate` / `coreLinkUpgradeGate` as pure functions, or against a fake
+// WebSocket server that is *handed* a `CoreLinkPeer`. Both are worth having and
+// neither exercises the code that has to produce that peer in the first place:
+// `peerCertSerial` reading `getPeerCertificate()` off a TLS socket,
+// `isRevokedPeer`, the `isRevokedSerial` predicate threaded into
+// `mountHttpRoutes`, and the `wss.on("connection", (ws, req))` extraction in
+// `defaultCreateServer`. Nothing there had a test, so "a revoked certificate is
+// refused on every `/v1/…` request" was asserted at the predicate and never
+// through a server.
+//
+// So this suite pairs a client for real — a code, a CSR, a certificate this
+// Core's CA signed — then revokes it the way `actana pair revoke` does, and
+// dials back with exactly that certificate. The Core is built by its own
+// default factory throughout; overriding `createServer` would test a rig.
+import * as fs from "node:fs";
+import * as https from "node:https";
+import { Server } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { X509Certificate } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { generateCertMaterial, generateClientCsr } from "@actana/shared/core-cert-material";
+import { verifyBearer } from "@actana/shared/core-link-bearer";
+import { generatePairingCode } from "@actana/shared/pairing-code";
+import { createPairingSession } from "@actana/shared/pairing-session";
+import { PairingStore, derivePairingCodeKey, hashPairingCode } from "@actana/shared/pairing-store";
+import { PtyCoreLinkServer } from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+import { createCoreFilesRequestHandler } from "../core-files-routes";
+import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "../core-pairing-wiring";
+import { PairingRevocations } from "../core-pairing-revocation";
+
+const SECRET = "core-revocation-suite-secret-at-least-32-bytes";
+const CORE_UUID = "0b1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
+type Paired = {
+  /** The certificate this Core's CA signed, and the key that never left here. */
+  cert: string;
+  key: string;
+  bearer: string;
+  serial: string;
+};
+
+type Rig = {
+  origin: string;
+  wsUrl: string;
+  caCert: string;
+  store: PairingStore;
+  storeFile: string;
+  revocations: PairingRevocations;
+  server: PtyCoreLinkServer;
+  /** Redeem a fresh code and come back with a usable client credential. */
+  pair(label?: string): Promise<Paired>;
+};
+
+let live: PtyCoreLinkServer | null = null;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  live?.close();
+  live = null;
+  while (tempDirs.length > 0) fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: "pty-1", hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    replay: () => ({ data: "", nextSeq: 0, from: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = new Server();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address && typeof address === "object") {
+        const { port } = address;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+type Response = { status: number; body: string };
+
+function request(
+  rig: Rig,
+  url: string,
+  opts: { method?: string; body?: object; client?: { cert: string; key: string } } = {},
+): Promise<Response> {
+  const payload = opts.body === undefined ? "" : JSON.stringify(opts.body);
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      `${rig.origin}${url}`,
+      {
+        method: opts.method ?? "GET",
+        agent: false,
+        ca: rig.caCert,
+        ...(opts.client ? { cert: opts.client.cert, key: opts.client.key } : {}),
+        headers: payload ? { "content-type": "application/json" } : {},
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => (body += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+/** Dial the core link with this material. Resolves with what the Core did. */
+function dial(
+  rig: Rig,
+  client: { cert: string; key: string },
+  bearer: string,
+): Promise<{ frames: string[]; error: string | null }> {
+  return new Promise((resolve) => {
+    const frames: string[] = [];
+    const socket = new WebSocket(rig.wsUrl, { ca: rig.caCert, cert: client.cert, key: client.key });
+    const done = (error: string | null) => {
+      clearTimeout(timer);
+      try {
+        socket.close();
+      } catch {
+        /* already gone */
+      }
+      resolve({ frames, error });
+    };
+    const timer = setTimeout(() => done("timeout"), 10_000);
+    socket.on("open", () => socket.send(JSON.stringify({ type: "auth", reqId: "a1", bearer })));
+    socket.on("message", (data: unknown) => {
+      const frame = JSON.parse(String(data)) as { type: string };
+      frames.push(frame.type);
+      if (frame.type === "authOk" || frame.type === "authError") done(null);
+    });
+    // A refused upgrade is an `error` here, not a frame: the server writes a 403
+    // and destroys the socket before `ws` ever completes the handshake.
+    socket.on("error", (err: Error) => done(err.message));
+    socket.on("close", () => done(null));
+  });
+}
+
+async function startCore(): Promise<Rig> {
+  const material = await generateCertMaterial({ host: "127.0.0.1" });
+  const port = await freePort();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-revocation-transport-"));
+  tempDirs.push(dir);
+  const storeFile = path.join(dir, "pairing.json");
+  const store = new PairingStore(storeFile);
+  const codeKey = derivePairingCodeKey(SECRET);
+  const revocations = new PairingRevocations(store);
+  revocations.refresh();
+
+  const pairingRoutes = buildCorePairingRoutes({
+    material: {
+      caCert: material.ca.cert,
+      caKey: material.ca.key,
+      bearerSecret: SECRET,
+      coreId: "core_revocation",
+      coreUuid: CORE_UUID,
+    },
+    sessions: store,
+    endpoint: `wss://127.0.0.1:${port}`,
+  });
+  const fileRoutes = createCoreFilesRequestHandler({
+    filesPort: { projectRoot: () => null },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+  });
+
+  const server = new PtyCoreLinkServer(mockCore(), {
+    port,
+    host: "127.0.0.1",
+    tls: { caCert: material.ca.cert, serverCert: material.server.cert, serverKey: material.server.key },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+    httpRoutes: composeCoreHttpRoutes(pairingRoutes, fileRoutes),
+    isPreAuthPath: isPairingPath,
+    revocation: revocations,
+  });
+  live = server;
+
+  const rig: Rig = {
+    origin: `https://127.0.0.1:${port}`,
+    wsUrl: `wss://127.0.0.1:${port}`,
+    caCert: material.ca.cert,
+    store,
+    storeFile,
+    revocations,
+    server,
+    pair: async (label = "laptop") => {
+      const code = generatePairingCode();
+      const sessionId = `ps_${Math.random().toString(16).slice(2, 10)}`;
+      store.createSession(
+        createPairingSession({
+          id: sessionId,
+          label,
+          codeHash: hashPairingCode({ key: codeKey, sessionId, code }),
+          now: Date.now(),
+        }),
+      );
+      const { csrPem, privateKeyPem } = await generateClientCsr(label);
+      const res = await request(rig, "/v1/pair/redeem", {
+        method: "POST",
+        body: { sessionId, code, client: { label, platform: "linux" }, csr: csrPem },
+      });
+      if (res.status !== 200) throw new Error(`pairing failed: ${res.status} ${res.body}`);
+      const issued = JSON.parse(res.body) as Record<string, string>;
+      return {
+        cert: issued.clientCert!,
+        key: privateKeyPem,
+        bearer: issued.bearer!,
+        serial: new X509Certificate(issued.clientCert!).serialNumber,
+      };
+    },
+  };
+
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      await request(rig, "/healthz");
+      return rig;
+    } catch (err) {
+      if (Date.now() > deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+/** What `actana pair revoke` does, in the process that is not this one. */
+function revoke(rig: Rig, serial: string): void {
+  rig.store.revokeClient(serial.toLowerCase(), Date.now());
+  rig.revocations.refresh();
+}
+
+describe("a revoked certificate, over the real transport", () => {
+  it("is refused on the routes it was working on a moment ago", async () => {
+    const rig = await startCore();
+    const client = await rig.pair();
+
+    // The control: the credential works before it is revoked, so the refusal
+    // below is the revocation and not a broken handshake.
+    const before = await request(rig, "/v1/projects/p1/files", { client });
+    expect(before.status).not.toBe(403);
+
+    revoke(rig, client.serial);
+
+    const after = await request(rig, "/v1/projects/p1/files", { client });
+    expect(after.status).toBe(403);
+    expect(after.body).toContain("client-certificate-required");
+  }, 30_000);
+
+  it("is refused at the core-link upgrade", async () => {
+    const rig = await startCore();
+    const client = await rig.pair();
+
+    const before = await dial(rig, client, client.bearer);
+    expect(before.frames).toContain("authOk");
+
+    revoke(rig, client.serial);
+
+    const after = await dial(rig, client, client.bearer);
+    expect(after.frames).not.toContain("authOk");
+  }, 30_000);
+
+  it("does not take another paired client down with it", async () => {
+    const rig = await startCore();
+    const doomed = await rig.pair("doomed");
+    const spared = await rig.pair("spared");
+
+    revoke(rig, doomed.serial);
+
+    expect((await request(rig, "/v1/projects/p1/files", { client: doomed })).status).toBe(403);
+    expect((await request(rig, "/v1/projects/p1/files", { client: spared })).status).not.toBe(403);
+    expect((await dial(rig, spared, spared.bearer)).frames).toContain("authOk");
+  }, 30_000);
+
+  it("can still reach the pairing endpoint, which is how a machine re-pairs", async () => {
+    // Revocation gets no pre-auth exception and needs none: the redemption dial
+    // presents no certificate at all, so there is nothing on it to have been
+    // revoked, and the operator's recovery path stays open.
+    const rig = await startCore();
+    const client = await rig.pair();
+    revoke(rig, client.serial);
+
+    const res = await request(rig, "/v1/pair/redeem", { method: "POST", body: { nonsense: true } });
+    expect(res.status).not.toBe(403);
+  }, 30_000);
+});
+
+describe("an unreadable pairing store, over the real transport", () => {
+  it("refuses every paired client rather than serving them all", async () => {
+    // The fail-closed guarantee, end to end. A half-written document is renamed
+    // into place — which is how `PairingStore` writes, so a truncated write
+    // looks exactly like this — and the daemon re-reads it.
+    const rig = await startCore();
+    const client = await rig.pair();
+    expect((await request(rig, "/v1/projects/p1/files", { client })).status).not.toBe(403);
+
+    fs.writeFileSync(rig.storeFile, '{"version":1,"sessions":[],"clients":[{"certSerial"');
+    expect(rig.revocations.refresh().ok).toBe(false);
+
+    expect((await request(rig, "/v1/projects/p1/files", { client })).status).toBe(403);
+    expect((await dial(rig, client, client.bearer)).frames).not.toContain("authOk");
+  }, 30_000);
+
+  it("serves them again once the store is readable", async () => {
+    const rig = await startCore();
+    const client = await rig.pair();
+    const good = fs.readFileSync(rig.storeFile, "utf8");
+
+    fs.writeFileSync(rig.storeFile, "{ not json");
+    rig.revocations.refresh();
+    expect((await request(rig, "/v1/projects/p1/files", { client })).status).toBe(403);
+
+    fs.writeFileSync(rig.storeFile, good);
+    rig.revocations.refresh();
+    expect((await request(rig, "/v1/projects/p1/files", { client })).status).not.toBe(403);
+  }, 30_000);
+});

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -62,6 +62,11 @@ import { buildCoreFileRoutes, shouldAnnounceFiles } from "./core-files-wiring";
 import { buildCorePairingRoutes, composeCoreHttpRoutes, isPairingPath } from "./core-pairing-wiring";
 import type { CorePairingRoutesOptions } from "./core-pairing-routes";
 import { PairingStore, pairingStorePath } from "@actana/shared/pairing-store";
+import {
+  PairingRevocations,
+  startPairingRevocationSweep,
+  type PairingRevocationSweep,
+} from "./core-pairing-revocation";
 import { createDirectory, listDirectory } from "./directory-browse";
 import { runCoreExec } from "./core-exec";
 import { configureProjectRootsDb } from "./project-roots";
@@ -348,6 +353,10 @@ async function startCore(): Promise<void> {
   // what keeps a loopback Core's TLS posture and route list exactly as they
   // were.
   let pairing: CorePairingRoutesOptions | null = null;
+  // Set beside `pairing`, and for the same reason: a Core with no persisted
+  // material has no pairing store, so there is nothing on this machine that
+  // could have been revoked.
+  let revocations: PairingRevocations | null = null;
 
   const serverOpts: import("./pty-core-link-server").PtyCoreLinkServerOptions = {
     port,
@@ -460,6 +469,7 @@ async function startCore(): Promise<void> {
       // operator's `actana pair new` and this daemon can both see — all three
       // are the persisted material, and a daemon started without one has
       // nowhere for a session to live.
+      const pairingStore = new PairingStore(pairingStorePath(materialFile));
       pairing = {
         material: {
           caCert: material.caCert,
@@ -468,10 +478,18 @@ async function startCore(): Promise<void> {
           coreId: material.coreId,
           coreUuid: material.coreUuid,
         },
-        sessions: new PairingStore(pairingStorePath(materialFile)),
+        sessions: pairingStore,
         endpoint: `wss://${publicHost}:${port}`,
         bearerDays,
       };
+      // The other half of `actana pair revoke` (#283). That command runs in the
+      // CLI and can only stamp a row; this is the process that makes the stamp
+      // mean something — refusing the certificate at the gate, refusing the
+      // bearer at the `auth` frame, and closing the link a revoked client
+      // already has open. Built here, next to the store it reads, and armed
+      // below once there is a server for it to close connections on.
+      revocations = new PairingRevocations(pairingStore);
+      serverOpts.revocation = revocations;
 
       serverOpts.tls = {
         caCert: material.caCert,
@@ -624,6 +642,18 @@ async function startCore(): Promise<void> {
 
   const server = new PtyCoreLinkServer(core, serverOpts);
 
+  // Armed after the server exists, because what it does when it finds a fresh
+  // revocation is close that client's connections. Its first read runs here and
+  // is deliberately not dispatched — see `startPairingRevocationSweep` — so a
+  // Core that boots with revocations already on file refuses them from its
+  // first request rather than from one second in.
+  const revocationSweep: PairingRevocationSweep | null = revocations
+    ? startPairingRevocationSweep({
+        revocations,
+        onRevoked: (certSerials) => server.closeRevoked(certSerials),
+      })
+    : null;
+
   // Alert-only, once a day, into this daemon's log — never a frame the Panel
   // raises and never an update this process applies (ADR 0010).
   //
@@ -653,6 +683,7 @@ async function startCore(): Promise<void> {
     sessionBackstop?.stop();
     availabilityStore.stop();
     updateNotice?.stop();
+    revocationSweep?.stop();
     disposeEventLogStore();
     disposeCoreQueryStore();
     disposeCoreMutationStore();

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -648,10 +648,7 @@ async function startCore(): Promise<void> {
   // Core that boots with revocations already on file refuses them from its
   // first request rather than from one second in.
   const revocationSweep: PairingRevocationSweep | null = revocations
-    ? startPairingRevocationSweep({
-        revocations,
-        onRevoked: (certSerials) => server.closeRevoked(certSerials),
-      })
+    ? startPairingRevocationSweep({ revocations, onRevoked: () => server.closeRevoked() })
     : null;
 
   // Alert-only, once a day, into this daemon's log — never a frame the Panel

--- a/packages/core/src/core-pairing-revocation.ts
+++ b/packages/core/src/core-pairing-revocation.ts
@@ -1,0 +1,168 @@
+// What a revoked pairing means to the running daemon (#283).
+//
+// `actana pair revoke` runs in the `actana` CLI, in a different process, and
+// all it can do there is stamp `revokedAt` on a row in the pairing store. That
+// stamp is a record, not an enforcement: the certificate it names is still one
+// this Core's CA signed, the bearer it issued still verifies against the same
+// secret, and any core link the client already has open is still carrying
+// frames. Nothing about revocation is true until this module makes it true.
+//
+// So there are two halves here, and they answer two different questions:
+//
+//   1. **Is this credential revoked?** — asked at the TLS gate on every request
+//      and every upgrade, and at the `auth` frame. That is what stops a revoked
+//      client coming *back*.
+//   2. **What has just been revoked?** — asked on a timer, so a link that is
+//      already open is closed rather than left running until its next
+//      handshake, which for a healthy Panel is never. {@link
+//      startPairingRevocationSweep} is that timer.
+//
+// **Polling, not watching.** `fs.watch` is per-platform, misses writes behind a
+// rename on some filesystems — and a rename is exactly how `PairingStore`
+// writes — and reports nothing at all on some network mounts. A one-second
+// read of a small JSON file is a cost this Core does not notice, and it is the
+// same code path on every platform. The bound it buys is stated plainly: a
+// revoked client's live link is closed within {@link REVOCATION_SWEEP_MS}, not
+// instantly.
+//
+// The store is reached through a port rather than the class, the way
+// `PairingSessionPort` is in `core-pairing-routes.ts`: this module is driven
+// from tests against an in-memory list, and `PairingStore` satisfies it
+// structurally.
+
+import log from "@actana/shared/log";
+import type { PairedClient } from "@actana/shared/pairing-store";
+
+/** How often the daemon re-reads the store looking for fresh revocations. */
+export const REVOCATION_SWEEP_MS = 1_000;
+
+/** The paired-client rows this module reads. `PairingStore` satisfies it. */
+export interface RevokedClientsPort {
+  listClients(): PairedClient[];
+}
+
+/**
+ * The `sub` claim a paired client's bearer carries — `pair:<serial>`.
+ *
+ * One function for the whole repository. The endpoint mints the claim and this
+ * module takes it apart, and a prefix that two files spelled independently
+ * would fail open the first time either changed it: a `sub` that no longer
+ * parses is a bearer that is never found to be revoked.
+ */
+export function pairingBearerSubject(certSerial: string): string {
+  return `${BEARER_SUBJECT_PREFIX}${certSerial}`;
+}
+
+const BEARER_SUBJECT_PREFIX = "pair:";
+
+/** The serial inside a `pair:<serial>` subject, or `null` for anything else. */
+export function certSerialFromBearerSubject(sub: string | undefined): string | null {
+  if (!sub || !sub.startsWith(BEARER_SUBJECT_PREFIX)) return null;
+  const serial = sub.slice(BEARER_SUBJECT_PREFIX.length);
+  return serial.length > 0 ? serial : null;
+}
+
+/**
+ * One spelling of a certificate serial, so two spellings of one certificate
+ * cannot be one revoked and one not.
+ *
+ * The same serial reaches this module three ways and none of them agree on
+ * presentation: `@peculiar/x509` issues it lower-case, Node's
+ * `getPeerCertificate().serialNumber` reports it upper-case, and a serial that
+ * came back through JSON may have kept a leading zero one of them dropped. Hex
+ * only, upper case, no leading zeros — a comparison on anything less would let
+ * a revoked client back in on a difference of case.
+ */
+export function normaliseCertSerial(serial: string): string {
+  return serial.replace(/[^0-9a-fA-F]/g, "").toUpperCase().replace(/^0+(?=.)/, "");
+}
+
+/**
+ * This Core's revoked serials, re-read from the store on demand.
+ *
+ * Held as a set rather than re-read per question because the questions are
+ * asked on the hot path — every request and every upgrade — and the answers
+ * only change when {@link refresh} says so. The sweep is what calls `refresh`,
+ * so "how stale can this be" has exactly one answer and it is the sweep
+ * interval.
+ */
+export class PairingRevocations {
+  private revoked = new Set<string>();
+
+  constructor(private readonly clients: RevokedClientsPort) {}
+
+  /**
+   * Re-read the store. Returns the serials revoked **since the last read**, in
+   * their stored spelling, so a caller can act on the new ones without acting
+   * on every one it has already handled.
+   *
+   * A store that cannot be read leaves the set exactly as it was and returns
+   * nothing. Failing that way round is deliberate: an unreadable pairing file
+   * must never be read as "nobody is revoked", which is the one interpretation
+   * that hands a revoked client its access back.
+   */
+  refresh(): string[] {
+    let rows: PairedClient[];
+    try {
+      rows = this.clients.listClients();
+    } catch (err) {
+      log.warn("core-pairing.revocation.unreadable", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+    const fresh: string[] = [];
+    for (const row of rows) {
+      if (row.revokedAt === null) continue;
+      const key = normaliseCertSerial(row.certSerial);
+      if (this.revoked.has(key)) continue;
+      this.revoked.add(key);
+      fresh.push(row.certSerial);
+    }
+    return fresh;
+  }
+
+  /** Is this certificate serial revoked? `null` — no peer certificate — is not. */
+  isRevoked(certSerial: string | null | undefined): boolean {
+    if (!certSerial) return false;
+    return this.revoked.has(normaliseCertSerial(certSerial));
+  }
+
+  /** Is the pairing this bearer speaks for revoked? A bearer with no
+   *  `pair:` subject is one this Core minted before pairing existed, and it is
+   *  governed by its own expiry rather than by a list it is not on. */
+  isBearerSubjectRevoked(sub: string | undefined): boolean {
+    return this.isRevoked(certSerialFromBearerSubject(sub));
+  }
+}
+
+/** A running sweep. Stopped with the daemon, like every other Core timer. */
+export type PairingRevocationSweep = { stop(): void };
+
+/**
+ * Poll the store and hand every newly revoked serial to `onRevoked`.
+ *
+ * The first read happens immediately and its results are **not** dispatched:
+ * at boot, every revocation already on file was made against a link that does
+ * not exist any more, and reporting them would ask the server to close
+ * connections that were never opened. What the first read does is seed the set,
+ * so that `isRevoked` is right from the first request rather than from one
+ * second in.
+ */
+export function startPairingRevocationSweep(opts: {
+  revocations: PairingRevocations;
+  onRevoked: (certSerials: string[]) => void;
+  intervalMs?: number;
+}): PairingRevocationSweep {
+  opts.revocations.refresh();
+  const timer = setInterval(() => {
+    const fresh = opts.revocations.refresh();
+    if (fresh.length === 0) return;
+    log.info("pairing.revoked", { certSerials: fresh });
+    opts.onRevoked(fresh);
+  }, opts.intervalMs ?? REVOCATION_SWEEP_MS);
+  // Never the reason this process stays alive: a Core with nothing else to do
+  // should exit, and a one-second timer would keep it running forever.
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
+}

--- a/packages/core/src/core-pairing-revocation.ts
+++ b/packages/core/src/core-pairing-revocation.ts
@@ -36,9 +36,18 @@ import type { PairedClient } from "@actana/shared/pairing-store";
 /** How often the daemon re-reads the store looking for fresh revocations. */
 export const REVOCATION_SWEEP_MS = 1_000;
 
-/** The paired-client rows this module reads. `PairingStore` satisfies it. */
+/**
+ * The paired-client rows this module reads. `PairingStore` satisfies it.
+ *
+ * `readStrict` rather than `listClients`, and the difference is the whole of
+ * {@link PairingRevocations.refresh}'s guarantee. `PairingStore.read` swallows
+ * every failure and answers with an empty store, which makes "this Core has
+ * revoked nobody" and "this Core cannot tell you who it revoked" the same
+ * answer — and the second one must never be served as the first.
+ */
 export interface RevokedClientsPort {
-  listClients(): PairedClient[];
+  /** Every row on file, or throw saying why the file could not be read. */
+  readStrict(): { clients: PairedClient[] };
 }
 
 /**
@@ -77,6 +86,13 @@ export function normaliseCertSerial(serial: string): string {
   return serial.replace(/[^0-9a-fA-F]/g, "").toUpperCase().replace(/^0+(?=.)/, "");
 }
 
+/** What one {@link PairingRevocations.refresh} found. */
+export type RevocationRefresh =
+  /** The store was read. `revoked` is what was newly revoked since last time. */
+  | { ok: true; revoked: string[] }
+  /** The store could not be read, so every pairing is treated as revoked. */
+  | { ok: false; error: string };
+
 /**
  * This Core's revoked serials, re-read from the store on demand.
  *
@@ -85,32 +101,56 @@ export function normaliseCertSerial(serial: string): string {
  * only change when {@link refresh} says so. The sweep is what calls `refresh`,
  * so "how stale can this be" has exactly one answer and it is the sweep
  * interval.
+ *
+ * **When the store cannot be read, everything is revoked.** Not "nothing is",
+ * and not "whatever we happened to know last time": those are both the reading
+ * that hands a revoked client its access straight back, and boot — where there
+ * is no last time — is exactly when the question is asked. See
+ * {@link failClosed}.
  */
 export class PairingRevocations {
   private revoked = new Set<string>();
+  /**
+   * True while the last read failed. Every pairing-issued credential is
+   * revoked for as long as it is set.
+   *
+   * Cleared by the next successful read, so the state is a fact about the
+   * store as it is now rather than a latch an operator has to reset. An
+   * operator recovers by making the file readable again — `actana pair new`
+   * refuses to rewrite an unreadable one precisely so that recovery cannot be
+   * "delete the record of who was revoked".
+   */
+  private failClosed = false;
 
   constructor(private readonly clients: RevokedClientsPort) {}
 
   /**
-   * Re-read the store. Returns the serials revoked **since the last read**, in
-   * their stored spelling, so a caller can act on the new ones without acting
-   * on every one it has already handled.
+   * Re-read the store.
    *
-   * A store that cannot be read leaves the set exactly as it was and returns
-   * nothing. Failing that way round is deliberate: an unreadable pairing file
-   * must never be read as "nobody is revoked", which is the one interpretation
-   * that hands a revoked client its access back.
+   * On success, reports the serials revoked **since the last read**, in their
+   * stored spelling, so a caller can act on the new ones without acting on
+   * every one it has already handled.
+   *
+   * On failure, reports why and switches this Core to refusing every
+   * pairing-issued credential. That is the fail-closed direction, and it is
+   * chosen knowing what it costs: a Core whose `pairing.json` is corrupt stops
+   * serving every client it ever paired. The alternative costs more — a
+   * half-written file, a hand-edit, or a row this build does not recognise
+   * would silently un-revoke every certificate an operator has taken back.
    */
-  refresh(): string[] {
+  refresh(): RevocationRefresh {
     let rows: PairedClient[];
     try {
-      rows = this.clients.listClients();
+      rows = this.clients.readStrict().clients;
     } catch (err) {
-      log.warn("core-pairing.revocation.unreadable", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return [];
+      const error = err instanceof Error ? err.message : String(err);
+      if (!this.failClosed) {
+        log.error("core-pairing.revocation.unreadable", { error, effect: "every pairing refused" });
+      }
+      this.failClosed = true;
+      return { ok: false, error };
     }
+    this.failClosed = false;
     const fresh: string[] = [];
     for (const row of rows) {
       if (row.revokedAt === null) continue;
@@ -119,18 +159,40 @@ export class PairingRevocations {
       this.revoked.add(key);
       fresh.push(row.certSerial);
     }
-    return fresh;
+    return { ok: true, revoked: fresh };
   }
 
-  /** Is this certificate serial revoked? `null` — no peer certificate — is not. */
+  /** Is this Core currently refusing every pairing because it cannot read the store? */
+  isFailClosed(): boolean {
+    return this.failClosed;
+  }
+
+  /**
+   * Is this certificate serial revoked?
+   *
+   * `null` — no peer certificate at all — is not, even while failing closed.
+   * "No certificate" and "a revoked certificate" are different facts and
+   * different gates answer them: `clientCertGate` refuses an uncertificated
+   * caller everywhere but the pairing endpoint, and that endpoint is the one an
+   * operator needs reachable to recover. Answering `true` here would close the
+   * only door out of a corrupt store.
+   */
   isRevoked(certSerial: string | null | undefined): boolean {
     if (!certSerial) return false;
+    if (this.failClosed) return true;
     return this.revoked.has(normaliseCertSerial(certSerial));
   }
 
-  /** Is the pairing this bearer speaks for revoked? A bearer with no
-   *  `pair:` subject is one this Core minted before pairing existed, and it is
-   *  governed by its own expiry rather than by a list it is not on. */
+  /**
+   * Is the pairing this bearer speaks for revoked?
+   *
+   * A bearer with no `pair:` subject is one this Core minted before pairing
+   * existed — the hand-carried registration blob — and it is governed by its
+   * own expiry rather than by a list it is not on. That holds while failing
+   * closed too, and deliberately: such a bearer is not a pairing, so there is
+   * no row about it that could have gone unread, and it is the credential the
+   * operator's own Panel is holding while they go and fix the file.
+   */
   isBearerSubjectRevoked(sub: string | undefined): boolean {
     return this.isRevoked(certSerialFromBearerSubject(sub));
   }
@@ -140,26 +202,42 @@ export class PairingRevocations {
 export type PairingRevocationSweep = { stop(): void };
 
 /**
- * Poll the store and hand every newly revoked serial to `onRevoked`.
+ * Poll the store and call `onRevoked` whenever what is revoked has changed.
  *
- * The first read happens immediately and its results are **not** dispatched:
- * at boot, every revocation already on file was made against a link that does
- * not exist any more, and reporting them would ask the server to close
- * connections that were never opened. What the first read does is seed the set,
- * so that `isRevoked` is right from the first request rather than from one
- * second in.
+ * `onRevoked` takes no arguments and that is deliberate: the caller re-asks
+ * this object about every connection it holds rather than being handed a list.
+ * A list would carry only the *newly named* serials, and the change that most
+ * needs acting on carries no serials at all — switching to fail-closed revokes
+ * every pairing at once, including ones whose rows were never read.
+ *
+ * The first read happens immediately and does **not** call back: at boot, every
+ * revocation already on file was made against a link that does not exist any
+ * more, and reporting them would ask the server to close connections that were
+ * never opened. What the first read does is seed the set — or, if the store is
+ * unreadable, put this Core into fail-closed before it serves its first
+ * request, which is the moment the guarantee has to hold.
  */
 export function startPairingRevocationSweep(opts: {
   revocations: PairingRevocations;
-  onRevoked: (certSerials: string[]) => void;
+  onRevoked: () => void;
   intervalMs?: number;
 }): PairingRevocationSweep {
   opts.revocations.refresh();
+  let wasFailClosed = opts.revocations.isFailClosed();
   const timer = setInterval(() => {
-    const fresh = opts.revocations.refresh();
-    if (fresh.length === 0) return;
-    log.info("pairing.revoked", { certSerials: fresh });
-    opts.onRevoked(fresh);
+    const result = opts.revocations.refresh();
+    const nowFailClosed = !result.ok;
+    // Two things count as a change, and the second is the one a list could not
+    // express: fresh serials, or crossing into fail-closed. Crossing back out
+    // does not — nothing became revoked by the store becoming readable again.
+    const enteredFailClosed = nowFailClosed && !wasFailClosed;
+    wasFailClosed = nowFailClosed;
+    if (result.ok && result.revoked.length > 0) {
+      log.info("pairing.revoked", { certSerials: result.revoked });
+    } else if (!enteredFailClosed) {
+      return;
+    }
+    opts.onRevoked();
   }, opts.intervalMs ?? REVOCATION_SWEEP_MS);
   // Never the reason this process stays alive: a Core with nothing else to do
   // should exit, and a one-second timer would keep it running forever.

--- a/packages/core/src/core-pairing-routes.ts
+++ b/packages/core/src/core-pairing-routes.ts
@@ -51,6 +51,7 @@ import log from "@actana/shared/log";
 import type { CoreHttpRoutes } from "./core-files-routes";
 import { pairingAuditor, type PairingAuditEvent } from "./core-pairing-audit";
 import { PairingRateLimiter } from "./core-pairing-rate-limit";
+import { pairingBearerSubject } from "./core-pairing-revocation";
 
 /** Everything this module answers lives under here. */
 export const CORE_PAIRING_ROUTE_PREFIX = "/v1/pair/";
@@ -350,7 +351,7 @@ export function createCorePairingRequestHandler(opts: CorePairingRoutesOptions):
         // certificate serial because that is what identifies *this pairing* —
         // a label is whatever the operator typed, possibly twice.
         iss: `core:${opts.material.coreId}`,
-        sub: `pair:${issued.serial}`,
+        sub: pairingBearerSubject(issued.serial),
         aud: opts.material.coreUuid,
         jti: randomUUID(),
       },

--- a/packages/core/src/core-pairing-routes.ts
+++ b/packages/core/src/core-pairing-routes.ts
@@ -16,10 +16,12 @@
 // return a key because there is nothing here that has one (#280).
 //
 // **Validation runs in a fixed order** — rate limit, then session lookup and
-// binding, then TTL, then single use, then the attempt cap, and only then the
-// code itself. The order is the design's, not a convenience: every check before
-// the code is one an attacker cannot influence with a guess, so a guess reaches
-// the comparison only after the cheap defences have had their say.
+// binding, then revocation, TTL, single use and the attempt cap, and only then
+// the code itself. The order is the design's, not a convenience: every check
+// before the code is one an attacker cannot influence with a guess, so a guess
+// reaches the comparison only after the cheap defences have had their say — and
+// a guess against a session the operator has already cancelled never costs that
+// session one of its five attempts.
 //
 // **Every refusal is the same refusal.** Expired, consumed, unknown, dead,
 // wrong code — one status, one body, no header that differs. A response that
@@ -39,7 +41,13 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { CsrRejectedError, assertSignableCsr, signClientCsr } from "@actana/shared/core-cert-material";
 import { signBearer } from "@actana/shared/core-link-bearer";
 import { normalisePairingCode } from "@actana/shared/pairing-code";
-import { isConsumed, isDead, isExpired, type PairingSession } from "@actana/shared/pairing-session";
+import {
+  isConsumed,
+  isDead,
+  isExpired,
+  isRevoked,
+  type PairingSession,
+} from "@actana/shared/pairing-session";
 import {
   derivePairingCodeKey,
   hashPairingCode,
@@ -248,17 +256,27 @@ export function createCorePairingRequestHandler(opts: CorePairingRoutesOptions):
       return sendRefusal(res, PAIRING_REFUSED);
     }
 
-    // ── 3. TTL · 4. Single use · 5. Attempt cap ──
+    // ── 3. Revoked · 4. TTL · 5. Single use · 6. Attempt cap ──
     // Written out in the order #282 fixes rather than delegated to `canRedeem`,
     // whose internal order is its own. Nothing observable turns on which of the
-    // three answers first — all three produce the one refusal — but the order a
+    // four answers first — all four produce the one refusal — but the order a
     // reader has to check against the spec is the order it is written in.
+    //
+    // Revocation joins the ladder rather than being left to `consume()` below
+    // (#283). It is caught at the same layer as the rest for two reasons that
+    // are about the operator, not the attacker: a guess against a cancelled
+    // session should not cost that session an attempt it will never use, and
+    // the audit line should say `revoked` rather than `wrong-code` — otherwise
+    // the log does not show that the operator's own cancellation is what
+    // stopped the redemption. `consume()` still refuses it, and must: this is
+    // the reported reason, not the enforcement.
     const at = now();
+    if (isRevoked(session)) return refuse(res, audit, session, peer, "revoked");
     if (isExpired(session, at)) return refuse(res, audit, session, peer, "expired");
     if (isConsumed(session)) return refuse(res, audit, session, peer, "already-consumed");
     if (isDead(session)) return refuse(res, audit, session, peer, "attempts-exhausted");
 
-    // ── 6. The code ──
+    // ── 7. The code ──
     // A code that is not in the alphabet at all is a wrong code, not a protocol
     // error: it is a guess that cannot be right, and treating it as a 400 would
     // hand an attacker a free probe that never costs them an attempt.

--- a/packages/core/src/core-pairing-routes.ts
+++ b/packages/core/src/core-pairing-routes.ts
@@ -49,7 +49,7 @@ import {
 } from "@actana/shared/pairing-store";
 import log from "@actana/shared/log";
 import type { CoreHttpRoutes } from "./core-files-routes";
-import { pairingAuditor, type PairingAuditEvent } from "./core-pairing-audit";
+import { pairingAuditor, type PairingAuditEvent } from "@actana/shared/pairing-audit";
 import { PairingRateLimiter } from "./core-pairing-rate-limit";
 import { pairingBearerSubject } from "./core-pairing-revocation";
 

--- a/packages/core/src/core-preauth-gate.ts
+++ b/packages/core/src/core-preauth-gate.ts
@@ -53,12 +53,23 @@ export const CLIENT_CERT_REFUSAL_MESSAGE =
  * `rejectUnauthorized: true` and never reaches this function with
  * `authorized: false` — but it answers `refuse` if it does, because a gate
  * whose safety depends on a flag set somewhere else is not a gate.
+ *
+ * **`revoked` is checked before anything else, `authorized` included** (#283).
+ * A revoked client's certificate is still signed by this Core's CA and still
+ * completes the handshake — TLS has no idea an operator took it back — so
+ * `authorized: true` is exactly what a revoked client arrives with, and a gate
+ * that read it first would serve every one of them. Revocation is also the one
+ * refusal with no pre-auth exception: a client here to *redeem a code* has no
+ * certificate to have had revoked, so nothing legitimate is turned away.
  */
 export function clientCertGate(opts: {
   pathname: string;
   authorized: boolean;
+  /** Did this connection present a certificate `actana pair revoke` took back? */
+  revoked?: boolean;
   isPreAuthPath?: PreAuthPathPredicate;
 }): ClientCertVerdict {
+  if (opts.revoked) return "refuse";
   if (opts.authorized) return "serve";
   if (!opts.isPreAuthPath) return "refuse";
   return opts.isPreAuthPath(opts.pathname) ? "serve" : "refuse";
@@ -71,8 +82,13 @@ export function clientCertGate(opts: {
  * the path: the core link is the Panel's authenticated session with this Core,
  * and no pairing exception reaches it. A pre-auth WebSocket would be a socket
  * that could ask this Core to spawn a PTY without ever proving who it was.
+ *
+ * `revoked` refuses for the reason spelled out on {@link clientCertGate}: a
+ * revoked certificate is a valid certificate, and this is the layer that knows
+ * the difference.
  */
-export function coreLinkUpgradeGate(authorized: boolean): ClientCertVerdict {
+export function coreLinkUpgradeGate(authorized: boolean, revoked = false): ClientCertVerdict {
+  if (revoked) return "refuse";
   return authorized ? "serve" : "refuse";
 }
 

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -48,11 +48,7 @@ import {
   rejectUnauthorizedAtHandshake,
   type PreAuthPathPredicate,
 } from "./core-preauth-gate";
-import {
-  certSerialFromBearerSubject,
-  normaliseCertSerial,
-  type PairingRevocations,
-} from "./core-pairing-revocation";
+import { certSerialFromBearerSubject, type PairingRevocations } from "./core-pairing-revocation";
 import type { WebSocketServer, WebSocket } from "ws";
 import {
   CORE_LINK_PROTOCOL_VERSION,
@@ -309,6 +305,16 @@ export type PtyCoreLinkServerOptions = {
      * certificate (#282). See {@link PtyCoreLinkServerOptions.isPreAuthPath}.
      */
     isPreAuthPath?: PreAuthPathPredicate;
+    /**
+     * Is this certificate serial one `actana pair revoke` took back (#283)?
+     *
+     * Declared here and not only on the default factory, because a custom
+     * transport is the seam {@link PtyCoreLinkServerOptions.revocation}
+     * explicitly anticipates — and one that had no typed way to receive this
+     * would silently lose both TLS-layer refusals, leaving revocation resting
+     * on the registration check in `onConnection` alone.
+     */
+    isRevokedSerial?: (serial: string) => boolean;
   }) => WebSocketServerLike;
   /**
    * The per-Core event log. When provided, PTY lifecycle events are
@@ -1984,7 +1990,7 @@ export class PtyCoreLinkServer {
   }
 
   /**
-   * Close every link a just-revoked pairing is holding open (#283).
+   * Close every link a revoked pairing is holding open (#283).
    *
    * This is the half of revocation the gates cannot do. A Panel that paired
    * yesterday and has been connected ever since never presents its certificate
@@ -1993,17 +1999,24 @@ export class PtyCoreLinkServer {
    * which for a healthy client is never. `core-entry.ts`'s sweep is what calls
    * this, within a second of the operator's `actana pair revoke`.
    *
+   * **It takes no list and asks the authority instead.** Being handed the
+   * newly-named serials would miss the change that matters most: when the
+   * pairing store cannot be read, `PairingRevocations` revokes *every* pairing
+   * at once and there are no serials to hand over. Re-asking per connection
+   * makes both cases one code path, and makes this method's answer always the
+   * same answer the gates would give the same client at the door.
+   *
    * The listeners come off before the close, for the reason {@link close}
    * gives: a close handshake still delivers whatever is already in flight, and
    * a frame from a revoked client must not be dispatched on the way out.
    */
-  closeRevoked(certSerials: string[]): number {
-    const wanted = new Set(certSerials.map(normaliseCertSerial));
+  closeRevoked(): number {
+    const revocation = this.revocation;
+    if (!revocation) return 0;
     let closed = 0;
     for (const [ws, conn] of [...this.connections]) {
-      const bySerial = conn.certSerial !== null && wanted.has(normaliseCertSerial(conn.certSerial));
-      const subjectSerial = certSerialFromBearerSubject(conn.bearerSubject ?? undefined);
-      const byBearer = subjectSerial !== null && wanted.has(normaliseCertSerial(subjectSerial));
+      const bySerial = revocation.isRevoked(conn.certSerial);
+      const byBearer = revocation.isBearerSubjectRevoked(conn.bearerSubject ?? undefined);
       if (!bySerial && !byBearer) continue;
       try {
         ws.removeAllListeners();

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -48,6 +48,11 @@ import {
   rejectUnauthorizedAtHandshake,
   type PreAuthPathPredicate,
 } from "./core-preauth-gate";
+import {
+  certSerialFromBearerSubject,
+  normaliseCertSerial,
+  type PairingRevocations,
+} from "./core-pairing-revocation";
 import type { WebSocketServer, WebSocket } from "ws";
 import {
   CORE_LINK_PROTOCOL_VERSION,
@@ -446,6 +451,22 @@ export type PtyCoreLinkServerOptions = {
    * `core-preauth-gate.ts` for why the relaxation is scoped this way.
    */
   isPreAuthPath?: PreAuthPathPredicate;
+  /**
+   * This Core's revoked pairings, as `actana pair revoke` leaves them (#283).
+   *
+   * Present, three things become true and none of them is true without it: a
+   * revoked client's certificate stops getting past the upgrade and past the
+   * `/v1/…` routes, a revoked client's bearer stops passing the `auth` frame,
+   * and {@link PtyCoreLinkServer.closeRevoked} has something to be called with.
+   * Absent — a loopback Core, a test, a Core that mounts no pairing endpoint —
+   * nothing here changes: there is no pairing store to have revoked anything
+   * in.
+   *
+   * The seam is a reader, never the sweep itself. Deciding *when* to look is
+   * `core-entry.ts`'s job (`startPairingRevocationSweep`), and a server that
+   * owned a timer would be a server every test had to stop.
+   */
+  revocation?: PairingRevocations;
 };
 
 /**
@@ -456,7 +477,21 @@ export type PtyCoreLinkServerOptions = {
  */
 export type AuthVerifier = (
   bearer: string,
-) => { ok: true; coreId: string; exp: number } | { ok: false; reason: "expired" | "bad-signature" | "malformed" };
+) =>
+  | {
+      ok: true;
+      coreId: string;
+      exp: number;
+      /**
+       * The bearer's `sub` claim, when the Core that signed it minted one
+       * (#282). `pair:<serial>` names the pairing this bearer speaks for, which
+       * is what {@link PtyCoreLinkServerOptions.revocation} needs to answer
+       * whether an operator has taken it back. Optional: bearers minted before
+       * the claim existed verify exactly as they always did.
+       */
+      sub?: string;
+    }
+  | { ok: false; reason: "expired" | "bad-signature" | "malformed" };
 
 /**
  * mTLS material for the core-link server (issue 04). The Core presents
@@ -472,9 +507,23 @@ export type TlsOptions = {
   serverKey: string;
 };
 
+/**
+ * What the transport knows about who is on the other end of one socket (#283).
+ *
+ * Only the certificate serial, and only because revocation names one: an
+ * operator revokes an *issuance*, and the serial is the one field that
+ * identifies an issuance where a subject is whatever the operator typed, twice.
+ * Optional throughout, because a loopback `ws://` Core has no certificates at
+ * all and a fake transport in a test has none either.
+ */
+export type CoreLinkPeer = {
+  /** The client certificate's serial, or `null` when there is no certificate. */
+  certSerial: string | null;
+};
+
 export interface WebSocketServerLike {
   close(cb?: () => void): void;
-  on(event: "connection", cb: (ws: WebSocketLike) => void): void;
+  on(event: "connection", cb: (ws: WebSocketLike, peer?: CoreLinkPeer) => void): void;
   on(event: "error", cb: (err: Error) => void): void;
 }
 
@@ -601,6 +650,8 @@ export class PtyCoreLinkServer {
   private readonly protocolVersion: string;
   private readonly announceMultiConnection: boolean;
   private readonly announceFiles: boolean;
+  /** This Core's revoked pairings, or null when it has no pairing surface. */
+  private readonly revocation: PairingRevocations | null;
   /**
    * The one seam every task-row change goes through — the Panel's
    * `tasksMutate` frame below and the Core's own writers (hook receiver, PTY
@@ -647,12 +698,19 @@ export class PtyCoreLinkServer {
     // them: one https.Server answering a WebSocket upgrade and the `/v1/…`
     // routes, never two listeners (#165 F2, ADR 0028).
     this.announceFiles = opts.announceFiles ?? Boolean(opts.httpRoutes);
+    this.revocation = opts.revocation ?? null;
     this.server = create({
       port: opts.port,
       host,
       tls: opts.tls,
       httpRoutes: opts.httpRoutes,
       ...(opts.isPreAuthPath ? { isPreAuthPath: opts.isPreAuthPath } : {}),
+      // Passed as a predicate rather than the object, so the factory — which
+      // knows about sockets and nothing about pairing — can ask the one
+      // question it needs to ask at the TLS gate.
+      ...(opts.revocation
+        ? { isRevokedSerial: (serial: string) => opts.revocation!.isRevoked(serial) }
+        : {}),
     });
     this.eventLog = opts.eventLog ?? null;
     this.liveEventPollMs = opts.liveEventPollMs ?? DEFAULT_LIVE_EVENT_POLL_MS;
@@ -673,18 +731,38 @@ export class PtyCoreLinkServer {
         queryPort: this.queryPort,
         eventLog: this.eventLog,
       });
-    this.server.on("connection", (ws) => this.onConnection(ws));
+    this.server.on("connection", (ws, peer) => this.onConnection(ws, peer));
     this.server.on("error", (err) => {
       log.error("core-link.server.error", { error: err.message });
     });
   }
 
-  private onConnection(ws: WebSocketLike): void {
+  private onConnection(ws: WebSocketLike, peer?: CoreLinkPeer): void {
+    // A revoked client is turned away here rather than registered and closed
+    // later (#283). The upgrade gate has already refused it on a real `https`
+    // server; this is the same rule at the layer that owns the registry, so a
+    // transport that cannot gate its own upgrade — an injected one, a future
+    // one — cannot hand this Core a connection it has already been told not to
+    // serve. Nothing is sent back: there is no frame in the protocol for it,
+    // and a client whose certificate was revoked is not owed a reason by the
+    // Core that revoked it.
+    const certSerial = peer?.certSerial ?? null;
+    if (this.revocation?.isRevoked(certSerial)) {
+      log.warn("core-link.connection.revoked", { certSerial });
+      try {
+        ws.close();
+      } catch {
+        /* already gone */
+      }
+      return;
+    }
+
     // Many connections at a time (ADR 0024 D1). A new connection — a second
     // Panel tab, the CLI, a reconnecting renderer — is registered alongside
     // whatever is already here, never in place of it. Nothing on `PtyCore`
     // moves as a result.
     const conn = new ActiveConnection(ws);
+    conn.certSerial = certSerial;
     this.connections.set(ws, conn);
     this.ensureEmitTarget();
 
@@ -1874,13 +1952,75 @@ export class PtyCoreLinkServer {
       }
       return;
     }
+    // A bearer that verifies but names a pairing the operator has taken back
+    // (#283). Refused as `expired`, and that is a deliberate choice of an
+    // existing reason rather than a new one: the wire's three reasons live in
+    // `@actana/sdk`, a client that pinned a fourth would be a client this Core
+    // could not talk to, and — more to the point — "expired" is what a revoked
+    // credential *is* from where the client stands. Its validity ended. The
+    // client's own reconnect path takes it to re-pairing, which is exactly
+    // where an operator who revoked it wants it to go. The Core's log is where
+    // the real reason is written, because the operator reading that log is the
+    // person who revoked it.
+    if (this.revocation?.isBearerSubjectRevoked(result.sub)) {
+      log.warn("core-link.auth.revoked", { certSerial: certSerialFromBearerSubject(result.sub) });
+      this.send(ws, { type: "authError", reqId: frame.reqId, reason: "expired" });
+      try {
+        ws.close();
+      } catch {
+        /* already closed */
+      }
+      return;
+    }
+
     conn.authenticated = true;
+    conn.bearerSubject = result.sub ?? null;
     this.send(ws, {
       type: "authOk",
       reqId: frame.reqId,
       coreId: result.coreId,
       exp: result.exp,
     });
+  }
+
+  /**
+   * Close every link a just-revoked pairing is holding open (#283).
+   *
+   * This is the half of revocation the gates cannot do. A Panel that paired
+   * yesterday and has been connected ever since never presents its certificate
+   * again and never re-sends its `auth` frame, so a rule enforced only at the
+   * door would leave it driving this Core until it happened to reconnect —
+   * which for a healthy client is never. `core-entry.ts`'s sweep is what calls
+   * this, within a second of the operator's `actana pair revoke`.
+   *
+   * The listeners come off before the close, for the reason {@link close}
+   * gives: a close handshake still delivers whatever is already in flight, and
+   * a frame from a revoked client must not be dispatched on the way out.
+   */
+  closeRevoked(certSerials: string[]): number {
+    const wanted = new Set(certSerials.map(normaliseCertSerial));
+    let closed = 0;
+    for (const [ws, conn] of [...this.connections]) {
+      const bySerial = conn.certSerial !== null && wanted.has(normaliseCertSerial(conn.certSerial));
+      const subjectSerial = certSerialFromBearerSubject(conn.bearerSubject ?? undefined);
+      const byBearer = subjectSerial !== null && wanted.has(normaliseCertSerial(subjectSerial));
+      if (!bySerial && !byBearer) continue;
+      try {
+        ws.removeAllListeners();
+        ws.close();
+      } catch {
+        /* already gone */
+      }
+      // The listeners are off, so the `close` handler will not run and the
+      // ordinary retirement has to be done by hand — Session locks included.
+      // A revoked client that kept a Session locked on the way out would leave
+      // a Session nobody can write and nobody can release (ADR 0024 D7), which
+      // is the failure a revocation is least entitled to cause.
+      this.dropConnection(ws, conn);
+      closed += 1;
+    }
+    if (closed > 0) log.info("core-link.connections.revoked", { closed });
+    return closed;
   }
 
   /**
@@ -2081,6 +2221,26 @@ class ActiveConnection {
    * commentary on {@link PtyCoreLinkServer.reclaimFor}.
    */
   clientId: string | null = null;
+  /**
+   * The serial of the client certificate this connection presented, or null on
+   * a Core with no mTLS (#283).
+   *
+   * Unlike {@link clientId} this one *is* authority: it is what the CA signed
+   * and what the TLS handshake verified, which is exactly why revocation names
+   * it. It is recorded at registration and never afterwards — a connection
+   * cannot change which certificate it arrived on.
+   */
+  certSerial: string | null = null;
+  /**
+   * The `sub` claim of the bearer this connection authenticated with, or null
+   * (#283).
+   *
+   * The second half of the same question: a client whose certificate this Core
+   * never saw — one behind a terminating proxy, a transport with no peer
+   * certificate — is still identifiable by the pairing its bearer names, and a
+   * revocation has to reach it too.
+   */
+  bearerSubject: string | null = null;
   lastSentEventId = 0;
   /** Last time anything arrived from this client — a frame, or a pong. */
   lastInboundAt = Date.now();
@@ -2137,6 +2297,8 @@ function defaultCreateServer(opts: {
   tls?: TlsOptions;
   httpRoutes?: CoreHttpRoutes;
   isPreAuthPath?: PreAuthPathPredicate;
+  /** Is this certificate serial one `actana pair revoke` took back (#283)? */
+  isRevokedSerial?: (serial: string) => boolean;
 }): WebSocketServerLike {
   // Lazy require so this module stays importable in tests without `ws` at
   // import time.
@@ -2165,7 +2327,7 @@ function defaultCreateServer(opts: {
       // the runtime's default.
       noDelay: true,
     });
-    mountHttpRoutes(tlsServer, opts.httpRoutes, opts.isPreAuthPath);
+    mountHttpRoutes(tlsServer, opts.httpRoutes, opts.isPreAuthPath, opts.isRevokedSerial);
     tlsServer.listen(opts.port, opts.host);
     // `noServer`, so the upgrade is ours to allow or refuse: the core link is
     // never pre-auth, and a WebSocket that reached this Core without a client
@@ -2176,7 +2338,7 @@ function defaultCreateServer(opts: {
     // the caller — so both are forwarded explicitly below.
     const wss = new WebSocketServer({ noServer: true });
     tlsServer.on("upgrade", (req, socket, head) => {
-      if (coreLinkUpgradeGate(clientCertVerified(req)) === "refuse") {
+      if (coreLinkUpgradeGate(clientCertVerified(req), isRevokedPeer(req, opts.isRevokedSerial)) === "refuse") {
         socket.write(
           `HTTP/1.1 ${CLIENT_CERT_REFUSAL_STATUS} Forbidden\r\n` +
             "connection: close\r\n" +
@@ -2193,8 +2355,13 @@ function defaultCreateServer(opts: {
       },
       on: (event, cb) => {
         if (event === "connection") {
-          wss.on("connection", (ws: WebSocket) => {
-            (cb as (ws: WebSocketLike) => void)(adaptWs(ws));
+          // `req` is the upgrade request `handleUpgrade` was given, so the
+          // socket under it is the TLS socket that completed the handshake —
+          // the only place the peer certificate exists.
+          wss.on("connection", (ws: WebSocket, req: import("node:http").IncomingMessage) => {
+            (cb as (ws: WebSocketLike, peer?: CoreLinkPeer) => void)(adaptWs(ws), {
+              certSerial: peerCertSerial(req),
+            });
           });
         } else if (event === "error") {
           wss.on("error", (err: Error) => (cb as (err: Error) => void)(err));
@@ -2264,15 +2431,16 @@ function mountHttpRoutes(
   server: import("node:http").Server | import("node:https").Server,
   routes: CoreHttpRoutes | undefined,
   isPreAuthPath?: PreAuthPathPredicate,
+  isRevokedSerial?: (serial: string) => boolean,
 ): void {
   if (!routes) return;
   server.on("request", (req, res) => {
-    if (!mayServe(req, isPreAuthPath)) return respondClientCertRequired(res);
+    if (!mayServe(req, isPreAuthPath, isRevokedSerial)) return respondClientCertRequired(res);
     if (routes.handle(req, res)) return;
     respondNotFound(res);
   });
   server.on("checkContinue", (req, res) => {
-    if (!mayServe(req, isPreAuthPath)) return respondClientCertRequired(res);
+    if (!mayServe(req, isPreAuthPath, isRevokedSerial)) return respondClientCertRequired(res);
     if (routes.handleContinue(req, res)) return;
     respondNotFound(res);
   });
@@ -2289,14 +2457,46 @@ function mountHttpRoutes(
 function mayServe(
   req: import("node:http").IncomingMessage,
   isPreAuthPath: PreAuthPathPredicate | undefined,
+  isRevokedSerial?: (serial: string) => boolean,
 ): boolean {
   const pathname = new URL(req.url ?? "/", "https://core.invalid").pathname;
   const verdict = clientCertGate({
     pathname,
     authorized: clientCertVerified(req),
+    revoked: isRevokedPeer(req, isRevokedSerial),
     ...(isPreAuthPath ? { isPreAuthPath } : {}),
   });
   return verdict === "serve";
+}
+
+/**
+ * The serial of the client certificate on this request's socket, or null.
+ *
+ * `getPeerCertificate` is a TLS-socket method and this is called on plain
+ * `http` Cores too, so its absence is the ordinary answer rather than an
+ * error. An empty object is what Node returns for a socket that presented no
+ * certificate, and `serialNumber` is absent from it.
+ */
+function peerCertSerial(req: import("node:http").IncomingMessage): string | null {
+  const socket = req.socket as unknown as {
+    getPeerCertificate?: () => { serialNumber?: string } | undefined;
+  };
+  if (typeof socket.getPeerCertificate !== "function") return null;
+  try {
+    return socket.getPeerCertificate()?.serialNumber ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Did this request arrive on a certificate `actana pair revoke` took back? */
+function isRevokedPeer(
+  req: import("node:http").IncomingMessage,
+  isRevokedSerial: ((serial: string) => boolean) | undefined,
+): boolean {
+  if (!isRevokedSerial) return false;
+  const serial = peerCertSerial(req);
+  return serial !== null && isRevokedSerial(serial);
 }
 
 /**

--- a/packages/shared/src/__tests__/core-cert-material.test.ts
+++ b/packages/shared/src/__tests__/core-cert-material.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { X509Certificate, createPublicKey, webcrypto } from "node:crypto";
 import * as x509 from "@peculiar/x509";
-import { generateCertMaterial, generateClientCsr, signClientCsr } from "../core-cert-material";
+import {
+  certFingerprintSha256,
+  generateCertMaterial,
+  generateClientCsr,
+  signClientCsr,
+} from "../core-cert-material";
 
 // Core generates a self-signed CA + server cert + Panel client cert at
 // start (ADR 0002). The Core holds the server cert; the Panel pins the CA
@@ -224,5 +229,41 @@ describe("signing a client CSR against the Core's CA", () => {
     expect(csrPem).toMatch(/-----BEGIN CERTIFICATE REQUEST-----/);
     expect(privateKeyPem).toMatch(/-----BEGIN PRIVATE KEY-----/);
     expect(csrPem).not.toContain("PRIVATE KEY");
+  });
+});
+
+// ─── The CA fingerprint an operator reads out loud (#283) ───────────────────
+//
+// `actana pair new` prints this and the client checks the certificate it is
+// presented against it before it sends the pairing code (#280 step 3). The
+// format is the contract, not a presentation choice: an operator who verifies
+// it against `openssl x509 -fingerprint -sha256` must see the same characters,
+// or the check they just performed proved nothing.
+
+describe("the CA fingerprint", () => {
+  it("is the conventional colon-separated upper-case hex SHA-256", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const fingerprint = certFingerprintSha256(mat.ca.cert);
+    expect(fingerprint).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/);
+  });
+
+  it("agrees with what every other tool prints for the same certificate", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    // Node computes this over the DER too. Asserting against it is what keeps
+    // the hand-rolled version from quietly hashing the PEM — which would still
+    // look like a fingerprint and would match nothing on the client's side.
+    expect(certFingerprintSha256(mat.ca.cert)).toBe(new X509Certificate(mat.ca.cert).fingerprint256);
+  });
+
+  it("is over the DER, so PEM whitespace cannot move it", async () => {
+    const mat = await generateCertMaterial({ host: "127.0.0.1" });
+    const rewrapped = mat.ca.cert.replace(/\n/g, "\r\n").trimEnd() + "\n\n";
+    expect(certFingerprintSha256(rewrapped)).toBe(certFingerprintSha256(mat.ca.cert));
+  });
+
+  it("distinguishes two CAs", async () => {
+    const one = await generateCertMaterial({ host: "127.0.0.1" });
+    const two = await generateCertMaterial({ host: "127.0.0.1" });
+    expect(certFingerprintSha256(one.ca.cert)).not.toBe(certFingerprintSha256(two.ca.cert));
   });
 });

--- a/packages/shared/src/__tests__/pairing-audit.test.ts
+++ b/packages/shared/src/__tests__/pairing-audit.test.ts
@@ -4,7 +4,7 @@
 // written on the failure path, read by people, and outlives the request by
 // however long the log is kept. So the redaction is a function with a test.
 import { describe, expect, it } from "vitest";
-import { pairingAuditor, redactPairingAuditEvent, type PairingAuditEvent } from "../core-pairing-audit";
+import { pairingAuditor, redactPairingAuditEvent, type PairingAuditEvent } from "../pairing-audit";
 
 const attempt: PairingAuditEvent = {
   outcome: "issued",

--- a/packages/shared/src/__tests__/pairing-session.test.ts
+++ b/packages/shared/src/__tests__/pairing-session.test.ts
@@ -8,6 +8,7 @@ import {
   isConsumed,
   isDead,
   isExpired,
+  isRevoked,
   recordWrongAttempt,
   type PairingSession,
 } from "../pairing-session";
@@ -161,6 +162,22 @@ describe("pairing session", () => {
         ok: false,
         reason: "attempts-exhausted",
       });
+    });
+
+    it("refuses a session the operator revoked, ahead of every other reason", () => {
+      // Revocation is the operator's own decision, so it is the answer the
+      // audit log should carry even when the session had also run out of time.
+      const s = session({ revokedAt: MINT + 1 });
+      expect(consumePairingSession(s, s.expiresAt + 1)).toEqual({ ok: false, reason: "revoked" });
+      expect(isRevoked(s)).toBe(true);
+    });
+
+    it("does not read a session written before the field existed as revoked", () => {
+      // Every pending session on a Core would die at the moment it upgraded if
+      // `undefined` counted. This is that regression, written down.
+      const { revokedAt: _absent, ...older } = session();
+      expect(isRevoked(older as PairingSession)).toBe(false);
+      expect(canRedeem(older as PairingSession, MINT)).toEqual({ ok: true });
     });
 
     it("reports consumption ahead of expiry, so a replay reads as a replay", () => {

--- a/packages/shared/src/__tests__/pairing-store.test.ts
+++ b/packages/shared/src/__tests__/pairing-store.test.ts
@@ -271,3 +271,70 @@ describe("cancelling a pending session", () => {
     expect(store.cancelSession("ps_13", NOW + 5_000)?.revokedAt).toBe(NOW);
   });
 });
+
+// ─── Telling "empty" apart from "unreadable" (#283) ─────────────────────────
+//
+// `read()` answers a corrupt file with an empty store, which is right for every
+// writer here — a daemon must not fail to boot because a file it is about to
+// rewrite is malformed — and wrong for anything whose safety depends on the
+// contents. `core-pairing-revocation.ts` is that reader: it treats an unreadable
+// store as *everything is revoked*, and it can only do that if being unable to
+// read is a different outcome from reading nothing.
+
+describe("reading strictly", () => {
+  const file = () => path.join(dir, "pairing.json");
+
+  it("reads a file that is simply not there as empty", () => {
+    // A Core that has never paired anything has no file. Throwing here would
+    // make every fresh Core refuse every client.
+    expect(store.readStrict()).toEqual({ version: 1, sessions: [], clients: [] });
+  });
+
+  it("reads a good file the same way the lenient reader does", () => {
+    store.recordClient(client(), NOW);
+    expect(store.readStrict()).toEqual(store.read());
+  });
+
+  it("throws on a half-written document, where the lenient reader says empty", () => {
+    // A truncated write renamed into place, which is exactly how this store
+    // writes — so this is what an ENOSPC failure leaves behind.
+    fs.writeFileSync(file(), '{"version":1,"sessions":[],"clients":[{"certSerial"');
+    expect(store.read().clients).toEqual([]);
+    expect(() => store.readStrict()).toThrow(/not valid JSON/);
+  });
+
+  it("throws on a document that is not a pairing store at all", () => {
+    fs.writeFileSync(file(), '"a string"');
+    expect(() => store.readStrict()).toThrow(/is not a pairing store/);
+  });
+
+  it("throws on a row whose shape this build does not know", () => {
+    // The lenient reader drops it silently, and a dropped row is exactly what a
+    // revoked client's row would look like to a reader that must not miss one.
+    fs.writeFileSync(file(), JSON.stringify({ version: 1, sessions: [], clients: [{ certSerial: 7 }] }));
+    expect(store.read().clients).toEqual([]);
+    expect(() => store.readStrict()).toThrow(/client 0 is not a client this build knows/);
+  });
+
+  it("leaves the lenient reader salvaging what it can", () => {
+    // The two moods must not have grown apart: `read()` still drops the one bad
+    // row and keeps the good one, which is what a daemon booting on a partly
+    // damaged file needs it to do.
+    fs.writeFileSync(
+      file(),
+      JSON.stringify({ version: 1, sessions: [], clients: [{ certSerial: 7 }, client("beef")] }),
+    );
+    expect(store.read().clients.map((c) => c.certSerial)).toEqual(["beef"]);
+    expect(() => store.readStrict()).toThrow();
+  });
+
+  it("throws when a list is not a list", () => {
+    fs.writeFileSync(file(), JSON.stringify({ version: 1, clients: "none" }));
+    expect(() => store.readStrict()).toThrow(/clients is not a list/);
+  });
+
+  it("names the file in every complaint, since the operator has to go and find it", () => {
+    fs.writeFileSync(file(), "{ not json");
+    expect(() => store.readStrict()).toThrow(new RegExp(file().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  });
+});

--- a/packages/shared/src/__tests__/pairing-store.test.ts
+++ b/packages/shared/src/__tests__/pairing-store.test.ts
@@ -226,3 +226,48 @@ describe("the code digest", () => {
     expect(pairingCodeMatches("", "")).toBe(false);
   });
 });
+
+// ─── Cancelling a pending code (#283) ───────────────────────────────────────
+//
+// `actana pair revoke` pointed at a session, rather than at a paired client.
+// The property is not that the row changed — it is that the endpoint's own
+// gate now refuses the code, which is the only thing that stops a redemption.
+
+describe("cancelling a pending session", () => {
+  it("stops the code being redeemed", () => {
+    const pending = createPairingSession({ id: "ps_9", label: "laptop", codeHash: "h", now: NOW });
+    store.createSession(pending, NOW);
+    expect(store.consume("ps_9", NOW).ok).toBe(true);
+
+    const again = createPairingSession({ id: "ps_10", label: "laptop", codeHash: "h", now: NOW });
+    store.createSession(again, NOW);
+    expect(store.cancelSession("ps_10", NOW)?.revokedAt).toBe(NOW);
+    expect(store.consume("ps_10", NOW)).toEqual({ ok: false, reason: "revoked" });
+  });
+
+  it("survives the round trip through disk", () => {
+    store.createSession(createPairingSession({ id: "ps_11", label: "l", codeHash: "h", now: NOW }), NOW);
+    store.cancelSession("ps_11", NOW);
+    expect(new PairingStore(path.join(dir, "pairing.json")).getSession("ps_11")?.revokedAt).toBe(NOW);
+  });
+
+  it("reports a session that was already redeemed rather than pretending to undo it", () => {
+    store.createSession(createPairingSession({ id: "ps_12", label: "l", codeHash: "h", now: NOW }), NOW);
+    store.consume("ps_12", NOW);
+    const after = store.cancelSession("ps_12", NOW + 1);
+    // There is a certificate in the world for this one. The thing to take back
+    // is the client, and the caller is told so by what comes back unchanged.
+    expect(after?.consumedAt).toBe(NOW);
+    expect(after?.revokedAt).toBe(null);
+  });
+
+  it("answers null for a session this Core does not have", () => {
+    expect(store.cancelSession("ps_nope", NOW)).toBe(null);
+  });
+
+  it("is idempotent — a second cancel changes nothing", () => {
+    store.createSession(createPairingSession({ id: "ps_13", label: "l", codeHash: "h", now: NOW }), NOW);
+    store.cancelSession("ps_13", NOW);
+    expect(store.cancelSession("ps_13", NOW + 5_000)?.revokedAt).toBe(NOW);
+  });
+});

--- a/packages/shared/src/core-cert-material.ts
+++ b/packages/shared/src/core-cert-material.ts
@@ -15,7 +15,7 @@
 
 import selfsigned from "selfsigned";
 import * as x509 from "@peculiar/x509";
-import { randomBytes, webcrypto } from "node:crypto";
+import { createHash, randomBytes, webcrypto } from "node:crypto";
 
 export type CertPem = {
   /** PEM-encoded certificate. */
@@ -525,4 +525,38 @@ function derToPem(label: string, der: Buffer): string {
 
 function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+// ─── The CA fingerprint an operator reads out loud ──────────────────────────
+//
+// `actana pair new` prints this beside the pairing code, and the client's
+// bootstrap dial checks the CA it was presented against it before it sends the
+// code (#280 step 3, #283, #284). It is the whole of what makes that first
+// dial verifiable: the client has no certificate yet, so there is nothing else
+// on the wire it can pin.
+
+/**
+ * SHA-256 over a certificate's DER, rendered colon-separated upper-case hex.
+ *
+ * **The format is the contract**, not a presentation choice. A human compares
+ * these two by eye — one on the Core's terminal, one on the client's — so it is
+ * the conventional form every other tool prints (`openssl x509 -fingerprint
+ * -sha256`, a browser's certificate viewer, `X509Certificate.fingerprint256`),
+ * grouped into byte-sized pairs an eye can chunk. An operator who checks it
+ * against `openssl` must see the same string, character for character, or the
+ * check they just performed proved nothing.
+ *
+ * Over the **DER**, not the PEM: the PEM is base64 of exactly these bytes
+ * wrapped in a header, a footer and line breaks, and hashing that would make
+ * the fingerprint depend on line width and trailing whitespace. The DER is the
+ * certificate; everything else is packaging.
+ *
+ * Computed here rather than read off `node:crypto`'s `X509Certificate` so that
+ * the format lives in code with a test rather than in a property whose spelling
+ * this repository does not own — `core-cert-material.test.ts` asserts the two
+ * agree, which is the check that keeps the convention honest.
+ */
+export function certFingerprintSha256(certPem: string): string {
+  const digest = createHash("sha256").update(pemToDer(certPem)).digest("hex").toUpperCase();
+  return (digest.match(/.{2}/g) ?? []).join(":");
 }

--- a/packages/shared/src/pairing-audit.ts
+++ b/packages/shared/src/pairing-audit.ts
@@ -1,4 +1,12 @@
-// The audit record of every pairing attempt (#280, #282).
+// The audit record of every pairing attempt — and of every revocation (#280,
+// #282, #283).
+//
+// **In `packages/shared` because two processes write it.** The daemon records
+// the attempts at the pre-auth endpoint; the `actana pair revoke` CLI records
+// the revocations, in a different process that never loads `@actana/core`. One
+// shape, one field list and one redaction across both is the whole point of an
+// audit trail — two modules that agreed by convention would drift the first
+// time a field was added to one of them.
 //
 // Pairing is the one thing on a Core that turns knowledge of a short code into
 // a certificate this Core's CA vouches for, so "who asked, when, and what did
@@ -20,7 +28,7 @@
 // event goes; the seam exists so a test can read what was written, and so that
 // a later "ship the audit trail somewhere" has one place to attach.
 
-import log from "@actana/shared/log";
+import log from "./log";
 
 /** What happened to one attempt. */
 export type PairingOutcome =
@@ -33,7 +41,16 @@ export type PairingOutcome =
   /** The request was not shaped like a redemption at all. */
   | "bad-request"
   /** The Core failed — a CA key it could not read, a disk it could not write. */
-  | "core-error";
+  | "core-error"
+  /**
+   * An operator took a pairing back with `actana pair revoke` (#283).
+   *
+   * On this list rather than on a log of its own, because it answers the same
+   * question the others do — *who holds a credential this Core signed, and how
+   * did they get it* — and an operator reading back through a pairing's life
+   * should not have to join two logs to see it end.
+   */
+  | "revoked";
 
 /**
  * One attempt, as the audit log records it.
@@ -60,7 +77,11 @@ export type PairingAuditEvent = {
   sessionId?: string | null;
   /** The operator's label for that session. Display-only, and never a secret. */
   label?: string | null;
-  /** Where the request came from — `req.socket.remoteAddress`. */
+  /**
+   * Where the request came from — `req.socket.remoteAddress`, or
+   * {@link LOCAL_OPERATOR_PEER} for a revocation, which arrives at no socket
+   * at all.
+   */
   peer: string;
   /** Wrong codes counted against the session after this attempt. */
   attempts?: number;
@@ -88,6 +109,16 @@ const LOGGED_FIELDS = [
   "certSerial",
   "at",
 ] as const satisfies readonly (keyof PairingAuditEvent)[];
+
+/**
+ * The `peer` of an event that came from the operator's own shell rather than
+ * over the wire — every `outcome: "revoked"` record.
+ *
+ * A constant rather than an empty string or an omission: `peer` is the field a
+ * reader scans to answer "where did this come from", and a blank one reads as a
+ * record whose origin was lost rather than one that never had a remote origin.
+ */
+export const LOCAL_OPERATOR_PEER = "local-cli";
 
 /** Where an audit record goes. Injectable so a test can read what was written. */
 export type PairingAuditSink = (record: Record<string, unknown>) => void;

--- a/packages/shared/src/pairing-session.ts
+++ b/packages/shared/src/pairing-session.ts
@@ -66,6 +66,18 @@ export type PairingSession = {
   /** Wall-clock ms of the successful redemption, or `null` while pending. A
    *  timestamp rather than a boolean because the audit log wants to say when. */
   consumedAt: number | null;
+  /**
+   * Wall-clock ms of `actana pair revoke` cancelling this session before it was
+   * redeemed, or `null` while it stands (#283).
+   *
+   * Its own field rather than a `consumedAt` stamp, and the difference is not
+   * cosmetic: a cancelled session was never redeemed, so nobody holds a
+   * certificate for it, and an operator reading `actana pair ls` or the audit
+   * log after the fact has to be able to tell "somebody used this code" from "I
+   * took it back". Optional on the type because sessions written before this
+   * field existed are still valid sessions — see {@link isRevoked}.
+   */
+  revokedAt?: number | null;
   /** Inert (#280): the identity that created the session, once there is one. */
   created_by: string | null;
   /** Inert (#280): the tenant the session belongs to, once there are tenants. */
@@ -103,6 +115,7 @@ export function createPairingSession(input: NewPairingSession): PairingSession {
     attempts: 0,
     attemptCap: input.attemptCap ?? PAIRING_ATTEMPT_CAP,
     consumedAt: null,
+    revokedAt: null,
     created_by: null,
     tenant_id: null,
     auth_method: null,
@@ -131,8 +144,20 @@ export function isConsumed(session: PairingSession): boolean {
   return session.consumedAt !== null;
 }
 
+/**
+ * Has the operator taken this session back with `actana pair revoke` (#283)?
+ *
+ * `?? null` rather than `!== null`, because the field is optional: a session
+ * persisted before it existed has no `revokedAt` at all, and `undefined !==
+ * null` would read every one of them as revoked — which would kill every
+ * pending session on a Core the moment it upgraded.
+ */
+export function isRevoked(session: PairingSession): boolean {
+  return (session.revokedAt ?? null) !== null;
+}
+
 /** Why a session would refuse a redemption. Ordered by how it is checked. */
-export type PairingRefusal = "expired" | "attempts-exhausted" | "already-consumed";
+export type PairingRefusal = "expired" | "attempts-exhausted" | "already-consumed" | "revoked";
 
 export type PairingRedeemability =
   | { ok: true }
@@ -146,6 +171,10 @@ export type PairingRedeemability =
  * The caller still has to check the code itself; this is only the state gate.
  */
 export function canRedeem(session: PairingSession, now: number): PairingRedeemability {
+  // Revocation is checked first because it is the operator's own decision, and
+  // it is the answer the audit log should carry when several of these are true
+  // at once — a session revoked and then left to expire was revoked.
+  if (isRevoked(session)) return { ok: false, reason: "revoked" };
   if (isConsumed(session)) return { ok: false, reason: "already-consumed" };
   if (isDead(session)) return { ok: false, reason: "attempts-exhausted" };
   if (isExpired(session, now)) return { ok: false, reason: "expired" };

--- a/packages/shared/src/pairing-store.ts
+++ b/packages/shared/src/pairing-store.ts
@@ -130,27 +130,105 @@ export type PairingConsumeOutcome =
 export class PairingStore {
   constructor(private readonly filePath: string) {}
 
-  /** Everything on disk. A missing, corrupt or wrong-shaped file reads as empty. */
+  /**
+   * Everything on disk. A missing, corrupt or wrong-shaped file reads as empty,
+   * and a single unrecognised row is dropped while the rest are kept.
+   *
+   * That leniency is right for every writer here — a daemon must not fail to
+   * boot because a file it is about to rewrite is malformed — and **wrong for
+   * anything whose safety depends on the contents**, because it makes "this
+   * Core has revoked nobody" and "this Core cannot tell you who it revoked"
+   * the same answer. A reader in that position uses {@link readStrict}.
+   */
   read(): PairingRecords {
+    try {
+      return this.parse(false);
+    } catch {
+      return emptyPairingRecords();
+    }
+  }
+
+  /**
+   * Everything on disk, or throw saying why it could not be read.
+   *
+   * The distinction {@link read} cannot draw, for the one caller that must:
+   * `core-pairing-revocation.ts` treats an unreadable store as *everything is
+   * revoked*, and it can only do that if being unable to read is a different
+   * outcome from reading nothing.
+   *
+   * **A file that is not there is not an error.** A Core that has never paired
+   * anything has no `pairing.json`, and a reader that failed closed on its
+   * absence would refuse every client on every fresh Core. Every *other* read
+   * failure — a permission this process does not have, an I/O error, a
+   * half-written document, a row whose shape this build does not recognise —
+   * throws, because each of them is a state in which a revoked row could be
+   * sitting in this file unseen.
+   */
+  readStrict(): PairingRecords {
+    return this.parse(true);
+  }
+
+  /**
+   * The one reader, in its two moods.
+   *
+   * Written once rather than twice on purpose: the lenient and the strict
+   * reader must agree about what a *good* file contains, and two parsers would
+   * be two chances to disagree — the strict one accepting a document the
+   * lenient one silently trimmed, or the reverse.
+   */
+  private parse(strict: boolean): PairingRecords {
     let raw: string;
     try {
       raw = fs.readFileSync(this.filePath, "utf8");
-    } catch {
-      return emptyPairingRecords();
+    } catch (err) {
+      // Absent is empty in both moods. It is the state of a Core that has
+      // paired nobody, not a failure to read one that has.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyPairingRecords();
+      throw new Error(`${this.filePath} could not be read: ${errorText(err)}`);
     }
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);
-    } catch {
-      return emptyPairingRecords();
+    } catch (err) {
+      throw new Error(`${this.filePath} is not valid JSON: ${errorText(err)}`);
     }
-    if (!parsed || typeof parsed !== "object") return emptyPairingRecords();
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error(`${this.filePath} is not a pairing store`);
+    }
     const o = parsed as Partial<PairingRecords>;
     return {
       version: 1,
-      sessions: Array.isArray(o.sessions) ? o.sessions.filter(isPairingSession) : [],
-      clients: Array.isArray(o.clients) ? o.clients.filter(isPairedClient) : [],
+      sessions: this.rows(o.sessions, isPairingSession, "session", strict),
+      clients: this.rows(o.clients, isPairedClient, "client", strict),
     };
+  }
+
+  /**
+   * One list of rows: filtered when lenient, checked when strict.
+   *
+   * Absent is empty either way — a document that never grew a `clients` key has
+   * no clients. Present and wrong, or one unrecognised row, is where the two
+   * moods part: the lenient reader drops it, and a dropped row is exactly what
+   * a revoked client's row would look like to a reader that must not miss one.
+   */
+  private rows<T>(
+    value: unknown,
+    isRow: (row: unknown) => row is T,
+    what: string,
+    strict: boolean,
+  ): T[] {
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) {
+      if (!strict) return [];
+      throw new Error(`${this.filePath}: ${what}s is not a list`);
+    }
+    if (!strict) return value.filter(isRow);
+    return value.map((row, index) => {
+      if (!isRow(row)) {
+        throw new Error(`${this.filePath}: ${what} ${index} is not a ${what} this build knows`);
+      }
+      return row;
+    });
   }
 
   /** Add a freshly minted session. `actana pair new`'s one write. */
@@ -288,6 +366,10 @@ export class PairingStore {
       /* best effort — non-POSIX filesystems have no mode to set */
     }
   }
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 /** Drop sessions that stopped being interesting a day ago. See the constant. */

--- a/packages/shared/src/pairing-store.ts
+++ b/packages/shared/src/pairing-store.ts
@@ -32,7 +32,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { PairingRefusal, PairingSession } from "./pairing-session";
-import { canRedeem, recordWrongAttempt } from "./pairing-session";
+import { canRedeem, isConsumed, isRevoked, recordWrongAttempt } from "./pairing-session";
 
 /** The filename, beside `material.json` in the same directory. */
 export const PAIRING_STORE_FILENAME = "pairing.json";
@@ -208,6 +208,34 @@ export class PairingStore {
     records.sessions[index] = consumed;
     this.write(records);
     return { ok: true, session: consumed };
+  }
+
+  /**
+   * Cancel a pending session before anybody redeems it — `actana pair revoke`
+   * pointed at a session rather than at a paired client (#283).
+   *
+   * Returns the cancelled row, the row unchanged when it was already cancelled,
+   * or `null` when there is no such session. A session that has already been
+   * *redeemed* is returned unchanged too and reports itself through
+   * `consumedAt`: there is a certificate in the world for it, so the thing to
+   * take back is the client, not the code, and the caller says so rather than
+   * pretending a cancel undid an issuance.
+   *
+   * The stamp is what stops the redemption: `canRedeem` checks `revokedAt`
+   * first, so the endpoint's next look at this session refuses it with the same
+   * body every other refusal gets — a client that had the code cannot tell a
+   * cancelled session from one that never existed.
+   */
+  cancelSession(id: string, now: number): PairingSession | null {
+    const records = this.read();
+    const index = records.sessions.findIndex((session) => session.id === id);
+    if (index === -1) return null;
+    const session = records.sessions[index]!;
+    if (isRevoked(session) || isConsumed(session)) return session;
+    const cancelled: PairingSession = { ...session, revokedAt: now };
+    records.sessions[index] = cancelled;
+    this.write(records);
+    return cancelled;
   }
 
   /** Record an issued client identity. What `pair ls` and `pair revoke` read. */


### PR DESCRIPTION
The Core-side operator's half of short-code enrollment: `actana pair new`, `actana pair ls`, `actana pair revoke`.
Built against the pairing server and store from #282, which are already on this base branch.

**Base is `feat/short-code-pairing`**, the feature branch for #280 — not `main`, not the train.

## What is here

**`actana pair new [--label <name>] [--ttl <duration>]`** mints a pending session and prints three things: the
`XXXX-XXXX` code, this Core's CA fingerprint, and the expiry as both an absolute UTC time and a relative
"in 5 minutes". They go to stdout as labelled lines and every word explaining them goes to stderr, so a `pair new`
being piped stays the facts and nothing else.

The TTL comes from `PAIRING_SESSION_TTL_MS` — the shared constant from #281, never a literal in the CLI — and
`--ttl` requires a unit. A bare `5` is the one input where a wrong guess is invisible: read as seconds it is a code
that dies before the operator finishes reading it out, read as minutes it outlives the phone call by four. The
ceiling is the store's own retention window, so a live session can never be pruned out from under the client
holding its code.

**The fingerprint** is a new `certFingerprintSha256` in `core-cert-material.ts`: SHA-256 over the CA certificate's
DER, colon-separated upper-case hex, computed from `PersistedMaterial.caCert`. The format is the contract, not a
presentation choice — a human compares two of these by eye, so an operator checking it against
`openssl x509 -fingerprint -sha256` must see the same characters. There is a test asserting it equals Node's own
`fingerprint256`, and another that PEM whitespace cannot move it. **#284 verifies its bootstrap dial against this
string**, which is the agreement the two tasks owed each other.

**`actana pair ls`** prints pending codes and paired clients in two labelled sections, each saying "None." rather
than printing an empty table. It cannot print a code, and that is the design working rather than a rule being
obeyed: what the store holds is a keyed digest. The `--json` payload names its fields one at a time for the same
reason the audit record does — a spread would publish whatever the stored shape grows next, and that shape includes
the digest.

**`actana pair revoke <target>`** takes a certificate serial (or a prefix), a session id, or a label matching
exactly one of either. It refuses to guess when a label matches two, because two machines paired under one name is
the ordinary way that happens and revoking the wrong one is not something an operator finds out about until the
machine they meant to keep stops working. Pointed at a pending code it cancels it; pointed at a client it stamps
the row the daemon enforces on.

## Revocation had to reach the daemon

`pair revoke` runs in the CLI, in a different process, and all it can do there is stamp a row. That stamp is a
record, not an enforcement: the certificate it names is still one this Core's CA signed, the bearer still verifies
against the same secret, and any link the client already has open is still carrying frames. So the larger half of
this PR is `packages/core`, in three places:

- **The client certificate** is refused at the gate — every `/v1/…` request and every core-link upgrade. `revoked`
  is checked ahead of `authorized` in both, and the order is the whole mechanism: a revoked certificate is a
  *valid* certificate, TLS has no idea an operator took it back, so `authorized: true` is exactly what a revoked
  client arrives with.
- **The bearer** is refused at the `auth` frame, through the `pair:<serial>` subject #282 mints. It answers
  `expired` rather than a fourth reason: the wire's three reasons live in `@actana/sdk` (**#284's package — not
  touched here**), and from where the client stands a revoked credential is one whose validity ended. Its own
  reconnect path then leads to re-pairing, which is where the operator who revoked it wants it to go. The Core's
  log carries the real reason, read by the person who revoked it.
- **A link already open** is closed, because the first two cannot reach it. A Panel that paired yesterday never
  presents its certificate again and never re-sends `auth`, so a rule enforced only at the door would leave it
  driving this Core until a reconnect that for a healthy client never comes. A one-second sweep of the pairing
  store is what notices.

Polling rather than `fs.watch`: `fs.watch` is per-platform, misses writes behind a rename — and a rename is how
`PairingStore` writes — and reports nothing at all on some network mounts. The bound this buys is stated rather
than implied: **a revoked client's live link closes within a second, not instantly.** An unreadable store leaves
the revoked set as it was, because "nobody is revoked" is the one interpretation that hands a revoked client its
access straight back.

## Two things moved

- **`core-pairing-audit.ts` → `packages/shared/src/pairing-audit.ts`.** It lived in `packages/core` when the daemon
  was its only writer. `pair revoke` is the second writer and runs in the `actana` CLI, which never loads
  `@actana/core`. One shape, one field list and one redaction across both is the point — two modules agreeing by
  convention would drift the first time a field was added to one of them.
- **`PairingSession` gains `revokedAt`**, and `canRedeem` checks it first. Its own field rather than a `consumedAt`
  stamp: a cancelled session was never redeemed, so nobody holds a certificate for it, and an operator reading the
  audit log afterwards has to be able to tell "somebody used this code" from "I took it back". The field is
  optional and read with `?? null` — sessions written before it existed have no `revokedAt`, and `undefined !==
  null` would kill every pending session on a Core the moment it upgraded.

## Notes

- **The verbs live in `packages/cli/src/actana-cli.ts`**, not the `packages/core` path #283's file pointers name.
  #288 unified the two `actana` binaries and moved the operator dispatch; this follows it there.
- **`packages/sdk` is untouched** — that is #284's, and `git diff --stat -- packages/sdk` against the base is empty.
- **The naming trap #283 flags is handled in the help.** `actana pair` is the Core end; `actana core pair` (#285)
  is the client end; since #288 they are one binary, so both help texts open by saying which machine they are for.
  `actana pair --help` answers on a laptop that has never run `actana setup`, because the help is a question about
  this program rather than about this box.
- Full monorepo suite, `pnpm -r typecheck` and `pnpm lint` are green. 88 new tests: 37 in `actana-pair.test.ts`,
  20 in `core-pairing-revocation.test.ts`, 15 in `core-link-revocation.test.ts`, and 16 added to the existing
  machine-CLI, cert-material, pairing-session and pairing-store suites.

Refs #283
Refs #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgVuRvpzdmmUZxjeLYcHA
