### PR TITLE
feat(cli): pairing — actana core pair replaces the blob paste

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,8 @@ release is attested to the workflow and the commit that built it.
 ## Cores this machine can reach
 
 ```sh
+actana core pair laptop core.example:8443 ABCD-2345 \
+  --session <id> --fingerprint AA:BB:…  # enroll this machine on a Core
 actana core add laptop ~/blob.txt   # register a Core from its blob, or stdin
 actana core ls --json               # what this machine knows
 actana core use laptop              # point `current` at one
@@ -33,6 +35,14 @@ actana core status                  # reach it, and report what it says
 actana core shell                   # an interactive shell on that machine
 actana core exec -- df -h /         # one command on it, no terminal
 ```
+
+`core pair` is the enrollment gesture: somebody on the Core runs `actana pair
+new`, reads out an eight-character code and that Core's CA fingerprint, and this
+machine generates its own key pair, checks the fingerprint **before** it sends
+the code, and stores the credential the Core signs. The private half never
+leaves this machine, and the code is never sent to a certificate authority
+nobody confirmed — with no `--fingerprint` and no terminal to confirm one on,
+the command refuses.
 
 `core exec` is the non-interactive half of `core shell`, and the reason it
 exists is that a script cannot use a terminal. It returns the command's real

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -23,6 +23,9 @@ import type {
   SessionAttachment,
 } from "../session-attach-channel.ts";
 import type { CoreConnectFn, CoreConnectOptions, CoreLinkClient } from "../core-connection.ts";
+import type { CorePairingPort } from "../core-pair.ts";
+import { CorePairingError, type CorePairingFailure } from "@actana/sdk/core-pairing.ts";
+import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
 import type { OpenSessionGateway, SessionGateway, StartedSession } from "../session-gateway.ts";
 import { projectFilesErrorFrom } from "../project-files-gateway.ts";
 import type {
@@ -80,6 +83,8 @@ export type RunOptions = {
   probe?: CoreProbeFn;
   /** What every other noun gets when it dials, or a throw. */
   connect?: CoreConnectFn;
+  /** What `core pair` gets back from the SDK, or a throw. */
+  pairing?: CorePairingPort;
   /** What the `session` noun's verbs get back, or a throw. */
   sessions?: OpenSessionGateway;
   /** What `project cp` and `project files` get back, or a throw. */
@@ -165,6 +170,83 @@ export function fakeSessionGateway(overrides: Partial<SessionGateway> = {}): Ope
   });
 }
 
+/** What a {@link fakePairing} was asked, and what it answered. */
+export type FakePairing = CorePairingPort & {
+  /** Every `identify`, by the address it was given. */
+  identified: string[];
+  /**
+   * Every `pair`, with the options it carried — **including the code**.
+   *
+   * Recorded so a suite can assert what crossed the seam: that the code handed
+   * to the SDK is the normalised one, that the fingerprint is the confirmed
+   * one, and that a refusal happened without `pair` ever being reached.
+   */
+  paired: Array<Parameters<CorePairingPort["pair"]>[0]>;
+};
+
+/**
+ * The SDK's pairing surface, without a Core.
+ *
+ * `identify` answers with the fingerprint the test says the Core presents;
+ * `pair` hands back a credential or throws the `CorePairingError` the suite is
+ * about. Both are recorded, because half of what this verb has to get right is
+ * *not* reaching the second one.
+ */
+export function fakePairing(
+  opts: {
+    fingerprint?: string;
+    identifyFails?: unknown;
+    blob?: CoreRegistrationBlob;
+    fails?: CorePairingFailure;
+    failsWith?: unknown;
+    detail?: ConstructorParameters<typeof CorePairingError>[2];
+  } = {},
+): FakePairing {
+  const fingerprint = opts.fingerprint ?? PAIRED_FINGERPRINT;
+  const state: FakePairing = {
+    identified: [],
+    paired: [],
+    identify: async ({ address }) => {
+      state.identified.push(address);
+      if (opts.identifyFails) throw opts.identifyFails;
+      return {
+        fingerprint,
+        caCert: SENTINEL_CA,
+        host: address.split(":")[0] ?? address,
+        port: 8443,
+        httpsOrigin: `https://${address}`,
+      };
+    },
+    pair: async (pairOpts) => {
+      state.paired.push(pairOpts);
+      if (opts.failsWith) throw opts.failsWith;
+      if (opts.fails) {
+        throw new CorePairingError(opts.fails, `the fake Core answered ${opts.fails}`, opts.detail ?? {});
+      }
+      return opts.blob ?? sentinelPairedBlob();
+    },
+  };
+  return state;
+}
+
+/** The fingerprint {@link fakePairing} presents unless a test says otherwise. */
+export const PAIRED_FINGERPRINT =
+  "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+
+/**
+ * The credential a successful pair hands back: the same sentinels every other
+ * suite sweeps for, so `never-logs-a-blob.test.ts` covers this path too.
+ */
+export function sentinelPairedBlob(endpoint = "wss://core.test:8443"): CoreRegistrationBlob {
+  return {
+    endpoint,
+    caCert: SENTINEL_CA,
+    clientCert: SENTINEL_CERT,
+    clientKey: SENTINEL_KEY,
+    bearer: SENTINEL_BEARER,
+  };
+}
+
 /** A probe that answers like a healthy Core on the current protocol. */
 export function healthyProbe(overrides: Partial<CoreProbe> = {}): CoreProbeFn {
   return async () => ({
@@ -233,6 +315,15 @@ export function makeCliFixture(): CliFixture {
           (async () => {
             throw new Error("this test did not expect to dial a Core");
           }),
+        pairing:
+          opts.pairing ?? {
+            identify: async () => {
+              throw new Error("this test did not expect to identify a Core");
+            },
+            pair: async () => {
+              throw new Error("this test did not expect to pair with a Core");
+            },
+          },
         openSessions:
           opts.sessions ??
           (async () => {

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -223,7 +223,14 @@ export function fakePairing(
       if (opts.fails) {
         throw new CorePairingError(opts.fails, `the fake Core answered ${opts.fails}`, opts.detail ?? {});
       }
-      return opts.blob ?? sentinelPairedBlob();
+      // **The label is echoed, because `pairWithCore` echoes it.** The real
+      // function copies `opts.label` straight into the blob it returns — the
+      // one field where what the caller passed in comes back out — and a fake
+      // that answered with a fixed blob instead would make every assertion
+      // about what is *stored* vacuous, which is exactly how a client hostname
+      // reached the column that means the Core's own alias.
+      const issued = opts.blob ?? sentinelPairedBlob();
+      return { ...issued, ...(pairOpts.label === undefined ? {} : { label: pairOpts.label }) };
     },
   };
   return state;

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -1,0 +1,456 @@
+// `actana core pair` — enrollment from the client's side, end to end through
+// `runActanaCli` (#285).
+//
+// The verb has three jobs and this suite is organised as those three. It has to
+// *get* a credential the way #280 says (a fingerprint confirmed before a code
+// moves, and a code the operator may type in any of the shapes a human types
+// one in); it has to *store* that credential exactly where and how `core add`
+// does, so that every verb downstream is unchanged; and it has to *refuse*
+// legibly — one sentence, one next step and one exit code per failure the SDK
+// distinguishes.
+//
+// The SDK is behind `deps.pairing`, so no test here opens a socket. What is
+// deliberately real is the filesystem: file modes, the cores directory and the
+// `current` pointer are the subject of half these assertions, and a stubbed
+// filesystem would assert nothing about any of them.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, statSync } from "node:fs";
+import { coreBlobPath, readCurrentCore } from "../blob-registry.ts";
+import { resolveCore } from "../core-resolution.ts";
+import { CorePairingError, type CorePairingFailure } from "@actana/sdk/core-pairing.ts";
+import {
+  EXIT_FAILURE,
+  EXIT_OK,
+  EXIT_PAIR_CERTIFICATE_INVALID,
+  EXIT_PAIR_CORE_ERROR,
+  EXIT_PAIR_FINGERPRINT_MISMATCH,
+  EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+  EXIT_PAIR_HOSTNAME_MISMATCH,
+  EXIT_PAIR_MALFORMED_RESPONSE,
+  EXIT_PAIR_NO_CA,
+  EXIT_PAIR_NOT_PAIRABLE,
+  EXIT_PAIR_RATE_LIMITED,
+  EXIT_PAIR_REFUSED,
+  EXIT_PAIR_REJECTED,
+  EXIT_PAIR_UNREACHABLE,
+  EXIT_USAGE,
+} from "../exit-codes.ts";
+import {
+  fakePairing,
+  healthyProbe,
+  makeCliFixture,
+  PAIRED_FINGERPRINT,
+  sentinelPairedBlob,
+  SENTINELS,
+  type CliFixture,
+  type FakePairing,
+} from "./cli-harness.ts";
+import { fakeSystem } from "./machine-fixture.ts";
+
+let fixture: CliFixture | null = null;
+function cli(): CliFixture {
+  fixture ??= makeCliFixture();
+  return fixture;
+}
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+});
+
+/** The pairing session `actana pair new` printed, as this suite spells it. */
+const SESSION = "5f2a1c0e-0000-4000-8000-0123456789ab";
+
+/** The code, as it was read out loud. */
+const CODE = "ABCD-2345";
+
+/** The three arguments plus the flags a scripted pair carries. */
+function pairArgv(extra: string[] = []): string[] {
+  return [
+    "core",
+    "pair",
+    "prod",
+    "core.test:8443",
+    CODE,
+    "--session",
+    SESSION,
+    "--fingerprint",
+    PAIRED_FINGERPRINT,
+    ...extra,
+  ];
+}
+
+describe("actana core pair — coming by the credential", () => {
+  it("stores what the SDK issued, at 0600, where `core-resolution.ts` finds it", async () => {
+    // The acceptance criterion in full: a successful pair is indistinguishable
+    // downstream from a pasted blob. `resolveCore` is the module every other
+    // noun reaches a Core through, so resolving through it — rather than
+    // re-reading the file this test just watched being written — is what
+    // actually proves "no change" for `ls`, `use`, `rm`, `status`, `shell` and
+    // `exec`.
+    const pairing = fakePairing();
+    const run = await cli().run(pairArgv(), { pairing });
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(run.out.join("\n")).toContain('Paired Core "prod" → wss://core.test:8443');
+    expect(statSync(coreBlobPath(cli().paths, "prod")).mode & 0o777).toBe(0o600);
+
+    const resolved = resolveCore({
+      paths: cli().paths,
+      env: { XDG_CONFIG_HOME: cli().configHome },
+      home: cli().home,
+      coreFlag: null,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    // `label: ""` because the decoder fills one in and the Core's redemption
+    // answer carries none — see `encodeRegistrationBlobText`.
+    expect(resolved.core.blob).toEqual({ ...sentinelPairedBlob(), label: "" });
+    expect(resolved.core.source).toBe("current");
+  });
+
+  it("hands the SDK the normalised code, however the operator typed it", async () => {
+    // Hyphen and case are the operator's business; what crosses the seam is one
+    // shape. The normaliser is #281's, reached through the SDK's public surface
+    // — this package has no copy of it and no opinion about the alphabet.
+    for (const typed of ["abcd2345", "AbCd-2345", " abcd 2345 ", "ABCD-2345"]) {
+      const pairing = fakePairing();
+      const run = await cli().run(
+        ["core", "pair", "prod", "core.test:8443", typed, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+        { pairing },
+      );
+      expect(run.code, `"${typed}" was refused`).toBe(EXIT_OK);
+      expect(pairing.paired[0]?.code).toBe("ABCD-2345");
+      expect(pairing.paired[0]?.sessionId).toBe(SESSION);
+    }
+  });
+
+  it("takes the session joined to the code, as `<session>:<code>`", async () => {
+    const pairing = fakePairing();
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", `${SESSION}:${CODE}`, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing },
+    );
+    expect(run.code).toBe(EXIT_OK);
+    expect(pairing.paired[0]?.sessionId).toBe(SESSION);
+    expect(pairing.paired[0]?.code).toBe(CODE);
+  });
+
+  it("says which machine it is, so the Core's `pair ls` has a name for it", async () => {
+    const byDefault = fakePairing();
+    await cli().run(pairArgv(), { pairing: byDefault, machine: { hostname: "laptop-7" } });
+    expect(byDefault.paired[0]?.label).toBe("laptop-7");
+    expect(byDefault.paired[0]?.platform).toBe("linux");
+
+    const named = fakePairing();
+    await cli().run(pairArgv(["--label", "the-build-box"]), { pairing: named });
+    expect(named.paired[0]?.label).toBe("the-build-box");
+  });
+
+  it("does not put that label in the stored blob, because it is not the Core's", async () => {
+    // A blob from `actana setup` carries the *Core's* alias, which is what the
+    // LABEL column of `core ls` means. A paired credential carries none — the
+    // redemption answer has no field for one — and inventing one out of this
+    // machine's hostname would make that column disagree with itself.
+    await cli().run(pairArgv(["--label", "the-build-box"]), { pairing: fakePairing() });
+    const listed = await cli().run(["core", "ls", "--json"]);
+    const rows = JSON.parse(listed.out.join("\n")) as Array<Record<string, unknown>>;
+    expect(rows).toEqual([
+      {
+        name: "prod",
+        current: true,
+        endpoint: "wss://core.test:8443",
+        label: "",
+        insecureMode: false,
+        error: null,
+      },
+    ]);
+  });
+});
+
+describe("actana core pair — the fingerprint, which is the whole security argument", () => {
+  it("refuses with no fingerprint and no terminal, and sends no code", async () => {
+    const pairing = fakePairing();
+    const run = await cli().run(["core", "pair", "prod", "core.test:8443", CODE, "--session", SESSION], {
+      pairing,
+    });
+    expect(run.code).toBe(EXIT_PAIR_FINGERPRINT_UNCONFIRMED);
+    expect(pairing.paired).toEqual([]);
+    expect(pairing.identified).toEqual([]);
+    expect(run.err.join("\n")).toContain("--fingerprint");
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+  });
+
+  it("shows the presented fingerprint and pairs when the operator confirms it", async () => {
+    const system = fakeSystem();
+    system.answers = [true];
+    const pairing = fakePairing();
+    const run = await cli().run(["core", "pair", "prod", "core.test:8443", CODE, "--session", SESSION], {
+      pairing,
+      machine: { interactive: true, system },
+    });
+
+    expect(run.out.join("\n")).toContain(PAIRED_FINGERPRINT);
+    expect(pairing.identified).toEqual(["core.test:8443"]);
+    // What was confirmed is what is enforced: the fingerprint handed to `pair`
+    // is the one the operator was shown, not an absence that would waive it.
+    expect(pairing.paired[0]?.expectedCaFingerprint).toBe(PAIRED_FINGERPRINT);
+    expect(run.code).toBe(EXIT_OK);
+  });
+
+  it("writes nothing when the operator says the fingerprint does not match", async () => {
+    const system = fakeSystem();
+    system.answers = [false];
+    const pairing = fakePairing();
+    const run = await cli().run(["core", "pair", "prod", "core.test:8443", CODE, "--session", SESSION], {
+      pairing,
+      machine: { interactive: true, system },
+    });
+
+    expect(run.code).toBe(EXIT_PAIR_FINGERPRINT_MISMATCH);
+    expect(pairing.paired).toEqual([]);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+    expect(run.err.join("\n")).toContain("the pairing code was not sent");
+  });
+
+  it("writes nothing when the SDK reports a mismatch", async () => {
+    // The other half of the same rule: the human check can be skipped with
+    // `--fingerprint`, and then the comparison is the SDK's. A credential must
+    // not land, and neither must a half-written file.
+    const pairing = fakePairing({ fails: "fingerprint-mismatch" });
+    const run = await cli().run(pairArgv(), { pairing });
+
+    expect(run.code).toBe(EXIT_PAIR_FINGERPRINT_MISMATCH);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+    expect(readCurrentCore(cli().paths)).toBe(null);
+    expect(run.err.join("\n")).toContain("Do not retry until you know why");
+  });
+});
+
+describe("actana core pair — refusals", () => {
+  it("writes nothing and exits non-zero when the Core refuses the code", async () => {
+    const pairing = fakePairing({ fails: "refused" });
+    const run = await cli().run(pairArgv(), { pairing });
+
+    expect(run.code).toBe(EXIT_PAIR_REFUSED);
+    expect(run.code).not.toBe(EXIT_OK);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+    expect(run.err.join("\n")).toContain("`actana pair new` on the Core");
+  });
+
+  it("gives every failure the SDK distinguishes its own exit code and next step", async () => {
+    // The table is the acceptance criterion, and it is a table rather than
+    // fifteen `it`s because what is being asserted is that the *set* is covered
+    // and that no two members answer with the same number.
+    const expected: Array<[CorePairingFailure, number]> = [
+      ["bad-address", EXIT_USAGE],
+      ["unreachable", EXIT_PAIR_UNREACHABLE],
+      ["not-pairable", EXIT_PAIR_NOT_PAIRABLE],
+      ["no-ca-presented", EXIT_PAIR_NO_CA],
+      ["fingerprint-unconfirmed", EXIT_PAIR_FINGERPRINT_UNCONFIRMED],
+      ["fingerprint-mismatch", EXIT_PAIR_FINGERPRINT_MISMATCH],
+      ["hostname-mismatch", EXIT_PAIR_HOSTNAME_MISMATCH],
+      ["certificate-invalid", EXIT_PAIR_CERTIFICATE_INVALID],
+      ["refused", EXIT_PAIR_REFUSED],
+      ["rate-limited", EXIT_PAIR_RATE_LIMITED],
+      ["rejected", EXIT_PAIR_REJECTED],
+      ["core-error", EXIT_PAIR_CORE_ERROR],
+      ["malformed-response", EXIT_PAIR_MALFORMED_RESPONSE],
+    ];
+
+    const seen = new Set<number>();
+    for (const [failure, code] of expected) {
+      const run = await cli().run(pairArgv(), { pairing: fakePairing({ fails: failure }) });
+      expect(run.code, `${failure} exited ${run.code}`).toBe(code);
+      // Two lines: what happened, and what to do about it. The second is what
+      // an operator at three in the morning is actually reading.
+      expect(run.err.length, `${failure} said nothing about what to do next`).toBeGreaterThanOrEqual(2);
+      expect(run.err.at(-1)?.length, `${failure}'s next step is empty`).toBeGreaterThan(20);
+      seen.add(code);
+    }
+    // Every code distinct, bar the three input-shape failures that are all
+    // `EXIT_USAGE` on purpose — see the block comment in `exit-codes.ts`.
+    expect(seen.size).toBe(expected.length);
+  });
+
+  it("says how long to wait when the Core said so", async () => {
+    const pairing = fakePairing({ fails: "rate-limited", detail: { retryAfterSeconds: 42 } });
+    const run = await cli().run(pairArgv(), { pairing });
+    expect(run.code).toBe(EXIT_PAIR_RATE_LIMITED);
+    expect(run.err.join("\n")).toContain("Wait 42 seconds");
+  });
+
+  it("reports a failure on the unverified dial the same way, with nothing sent", async () => {
+    const system = fakeSystem();
+    const pairing = fakePairing({
+      identifyFails: new CorePairingError("unreachable", "https://core.test:8443 could not be reached"),
+    });
+    const run = await cli().run(["core", "pair", "prod", "core.test:8443", CODE, "--session", SESSION], {
+      pairing,
+      machine: { interactive: true, system },
+    });
+    expect(run.code).toBe(EXIT_PAIR_UNREACHABLE);
+    expect(pairing.paired).toEqual([]);
+  });
+
+  it("treats anything that is not a CorePairingError as a defect, not an operator error", async () => {
+    const pairing = fakePairing({ failsWith: new TypeError("cannot read properties of undefined") });
+    const run = await cli().run(pairArgv(), { pairing });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+  });
+});
+
+describe("actana core pair — the command line", () => {
+  it("needs a name, an address and a code", async () => {
+    for (const argv of [
+      ["core", "pair"],
+      ["core", "pair", "prod"],
+      ["core", "pair", "prod", "core.test:8443"],
+    ]) {
+      const run = await cli().run(argv, { pairing: fakePairing() });
+      expect(run.code).toBe(EXIT_USAGE);
+      expect(run.err.join("\n")).toContain("a name, an address and a code are required");
+    }
+  });
+
+  it("refuses a fourth argument without echoing it", async () => {
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("too many arguments");
+    expect(run.all).not.toContain("WXYZ-6789");
+  });
+
+  it("rejects a name that could become a different path, exactly as `add` does", async () => {
+    const run = await cli().run(
+      ["core", "pair", "../escape", "core.test:8443", CODE, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("Core name");
+  });
+
+  it("asks for the session when the code does not name one, before dialling anything", async () => {
+    const pairing = fakePairing();
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--session");
+    expect(pairing.identified).toEqual([]);
+    expect(pairing.paired).toEqual([]);
+  });
+
+  it("refuses a code that is not one, without printing it back", async () => {
+    const pairing = fakePairing();
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", "NOT-A-REAL-CODE", "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("eight characters");
+    expect(run.all).not.toContain("NOT-A-REAL-CODE");
+    // And the Core was never dialled, so the operator's session still has all
+    // five of its attempts.
+    expect(pairing.paired).toEqual([]);
+  });
+
+  it("refuses two session ids that disagree", async () => {
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("they have to agree");
+  });
+});
+
+describe("actana core pair — the registry, unchanged", () => {
+  it("makes the first Core `current` and leaves the pointer alone after that", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    expect(readCurrentCore(cli().paths)).toBe("prod");
+
+    const second = await cli().run(
+      ["core", "pair", "spare", "core.test:8443", CODE, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(readCurrentCore(cli().paths)).toBe("prod");
+    expect(second.out.join("\n")).toContain('`current` is still "prod"');
+  });
+
+  it("replaces a name already registered, which is what re-pairing is", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    const again = await cli().run(pairArgv(), {
+      pairing: fakePairing({ blob: sentinelPairedBlob("wss://moved.test:8443") }),
+    });
+    expect(again.code).toBe(EXIT_OK);
+    expect(again.out.join("\n")).toContain('Replaced Core "prod"');
+    expect(again.out.join("\n")).toContain("wss://moved.test:8443");
+  });
+
+  it("leaves every other verb working against what it wrote", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+
+    const listed = await cli().run(["core", "ls"]);
+    expect(listed.out.join("\n")).toContain("prod");
+    expect(listed.out.join("\n")).toContain("wss://core.test:8443");
+
+    const status = await cli().run(["core", "status"], { probe: healthyProbe() });
+    expect(status.code).toBe(EXIT_OK);
+    expect(status.out.join("\n")).toContain("core_test");
+
+    const used = await cli().run(["core", "use", "prod"]);
+    expect(used.code).toBe(EXIT_OK);
+
+    const removed = await cli().run(["core", "rm", "prod"]);
+    expect(removed.code).toBe(EXIT_OK);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+  });
+});
+
+describe("actana core pair — what it says", () => {
+  it("explains the steps under --verbose without printing the code or the key", async () => {
+    const system = fakeSystem();
+    system.answers = [true];
+    const pairing: FakePairing = fakePairing();
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--session", SESSION, "--verbose"],
+      { pairing, machine: { interactive: true, system } },
+    );
+
+    expect(run.code).toBe(EXIT_OK);
+    const verbose = run.err.join("\n");
+    expect(verbose).toContain("with nothing trusted yet");
+    expect(verbose).toContain("mode 0600");
+    expect(verbose).toContain(`pairing session ${SESSION}`);
+
+    // The two rules, asserted as absence — the only assertion that survives the
+    // output being rewritten.
+    for (const secret of SENTINELS) {
+      expect(run.all, "the credential reached an output sink").not.toContain(secret);
+    }
+    expect(run.all, "the pairing code reached an output sink").not.toContain(CODE);
+    // In either case, and without its hyphen: a code echoed back in any of the
+    // shapes it is accepted in is a code in a shell history.
+    expect(run.all.toUpperCase(), "the pairing code reached an output sink").not.toContain("ABCD");
+  });
+
+  it("is listed in `actana core --help`, and says which machine it runs on", async () => {
+    const help = await cli().run(["core", "--help"]);
+    expect(help.code).toBe(EXIT_OK);
+    const text = help.out.join("\n");
+    expect(text).toContain("actana core pair <name> <address> <code>");
+    expect(text).toContain("runs on the machine being paired");
+    expect(text).toContain("actana pair new");
+  });
+
+  it("is named in the verb list an unknown verb prints", async () => {
+    const run = await cli().run(["core", "wat"]);
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("Verbs: pair, add");
+  });
+});

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -359,6 +359,51 @@ describe("actana core pair — the command line", () => {
     expect(pairing.paired).toEqual([]);
   });
 
+  it("does not blame the session when the ids agree and the code is malformed", async () => {
+    // The overlap the two cases either side of this one each miss. Both spellings
+    // of the session are present and they agree; what is wrong is the code. An
+    // operator told to drop `--session` here would be sent after a mistake they
+    // did not make, and dropping it would not help.
+    const run = await cli().run(
+      [
+        "core",
+        "pair",
+        "prod",
+        "core.test:8443",
+        `${SESSION}:ABCD-234`,
+        "--session",
+        SESSION,
+        "--fingerprint",
+        PAIRED_FINGERPRINT,
+      ],
+      { pairing: fakePairing() },
+    );
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("eight characters");
+    expect(run.err.join("\n")).not.toContain("--session");
+    expect(run.all).not.toContain("ABCD-234");
+  });
+
+  it("writes its own sentence for a code the SDK refuses, rather than relaying one that quotes it", async () => {
+    // The second door onto `bad-code`: `pairWithCore` parses the ticket again,
+    // so a shape this file accepted and the SDK did not arrives through the
+    // failure path instead. Its message ends `— "…" is not`, and relaying it
+    // would put the code on stderr through the one route the header's rule does
+    // not cover.
+    const pairing = fakePairing({
+      failsWith: new CorePairingError(
+        "bad-code",
+        `a pairing code is eight characters, written XXXX-XXXX — "${CODE}" is not`,
+      ),
+    });
+    const run = await cli().run(pairArgv(), { pairing });
+
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("eight characters");
+    expect(run.all, "the SDK's sentence was relayed with the code in it").not.toContain(CODE);
+    expect(existsSync(coreBlobPath(cli().paths, "prod"))).toBe(false);
+  });
+
   it("refuses two session ids that disagree", async () => {
     const run = await cli().run(
       ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],

--- a/packages/cli/src/__tests__/machine-fixture.ts
+++ b/packages/cli/src/__tests__/machine-fixture.ts
@@ -167,6 +167,7 @@ export type ClientHalf = Pick<
   | "stdinIsTty"
   | "probe"
   | "connect"
+  | "pairing"
   | "openSessions"
   | "openFiles"
   | "now"
@@ -190,6 +191,7 @@ export function stubClientHalf(
     stdinIsTty: false,
     probe: refuse("dial a Core"),
     connect: refuse("dial a Core"),
+    pairing: { identify: refuse("identify a Core"), pair: refuse("pair with a Core") },
     openSessions: refuse("open a session gateway"),
     openFiles: refuse("open a file gateway"),
     now,

--- a/packages/cli/src/__tests__/never-logs-a-blob.test.ts
+++ b/packages/cli/src/__tests__/never-logs-a-blob.test.ts
@@ -17,6 +17,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   fakeAttachment,
+  fakePairing,
   fakeTerminal,
   fakeCore,
   fakeProjectFiles,
@@ -80,6 +81,62 @@ describe("no verb prints a blob, with --verbose on", () => {
     for (const [what, argv] of runs) {
       const run = await cli().run(argv, { probe: healthyProbe() });
       expectNoSecrets(what, run.all);
+    }
+  });
+
+  it("sweeps `core pair`, which is handed a credential rather than reading one (#285)", async () => {
+    // The verb the sweep would miss if it were only ever run against a registry
+    // that already had a blob in it: `core pair` receives one from the SDK and
+    // writes it, so every line it prints — the success, the `--verbose` steps,
+    // the fingerprint prompt and every refusal — has the material in scope.
+    //
+    // The pairing **code** is swept alongside the credential here, because this
+    // is the one verb that is handed one. It is a bearer secret for as long as
+    // its session is open and it must not reach a terminal, a CI log or a shell
+    // history any more than the key does.
+    const code = "CODE-SENTINEL-VVV";
+    const session = "session-1";
+    const argv = (extra: string[] = []) => [
+      "core",
+      "pair",
+      "paired",
+      "core.test:8443",
+      code,
+      "--session",
+      session,
+      "--verbose",
+      ...extra,
+    ];
+    const fingerprint = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+
+    const runs: Array<[string, string[], Parameters<CliFixture["run"]>[1]]> = [
+      // A shape that is refused before anything is dialled.
+      ["core pair (bad code)", argv(["--fingerprint", fingerprint]), { pairing: fakePairing() }],
+      // The interactive confirmation, which prints a fingerprint beside a code
+      // it was given.
+      [
+        "core pair (confirmed)",
+        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose"],
+        { pairing: fakePairing({ fingerprint }), machine: { interactive: true } },
+      ],
+      // The success, which has the issued credential in hand.
+      [
+        "core pair (issued)",
+        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose", "--fingerprint", fingerprint],
+        { pairing: fakePairing({ fingerprint }) },
+      ],
+      // And a refusal, where a diagnostic would reach for its input.
+      [
+        "core pair (refused)",
+        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose", "--fingerprint", fingerprint],
+        { pairing: fakePairing({ fingerprint, fails: "refused" }) },
+      ],
+    ];
+
+    for (const [what, args, opts] of runs) {
+      const run = await cli().run(args, opts);
+      expectNoSecrets(what, run.all);
+      expect(run.all, `${what} printed the pairing code`).not.toContain("SENTINEL-VVV");
     }
   });
 

--- a/packages/cli/src/__tests__/never-logs-a-blob.test.ts
+++ b/packages/cli/src/__tests__/never-logs-a-blob.test.ts
@@ -13,6 +13,7 @@
 // exactly the line somebody adds without thinking.
 
 import { describe, it, expect, afterEach } from "vitest";
+import { CorePairingError } from "@actana/sdk/core-pairing.ts";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
@@ -94,9 +95,19 @@ describe("no verb prints a blob, with --verbose on", () => {
     // is the one verb that is handed one. It is a bearer secret for as long as
     // its session is open and it must not reach a terminal, a CI log or a shell
     // history any more than the key does.
-    const code = "CODE-SENTINEL-VVV";
+    //
+    // **The sentinel is a code the shape check accepts.** An unmistakable
+    // string that could not be a pairing code only ever reaches the one path
+    // that refuses it, which would leave the absence assertion vacuous on the
+    // three runs that matter most — the confirmed dial, the issued credential
+    // and the Core's refusal. So the well-formed sentinel goes through all
+    // four, and the malformed one shares its first four characters so a single
+    // absence check covers both.
+    const CODE = "ZZVV-QQWW";
+    const MALFORMED = "ZZVVQQWWXX";
     const session = "session-1";
-    const argv = (extra: string[] = []) => [
+    const fingerprint = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+    const argv = (code: string, extra: string[] = []) => [
       "core",
       "pair",
       "paired",
@@ -107,37 +118,63 @@ describe("no verb prints a blob, with --verbose on", () => {
       "--verbose",
       ...extra,
     ];
-    const fingerprint = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
 
     const runs: Array<[string, string[], Parameters<CliFixture["run"]>[1]]> = [
       // A shape that is refused before anything is dialled.
-      ["core pair (bad code)", argv(["--fingerprint", fingerprint]), { pairing: fakePairing() }],
+      ["core pair (bad code)", argv(MALFORMED, ["--fingerprint", fingerprint]), { pairing: fakePairing() }],
       // The interactive confirmation, which prints a fingerprint beside a code
       // it was given.
       [
         "core pair (confirmed)",
-        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose"],
+        argv(CODE),
         { pairing: fakePairing({ fingerprint }), machine: { interactive: true } },
       ],
       // The success, which has the issued credential in hand.
       [
         "core pair (issued)",
-        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose", "--fingerprint", fingerprint],
+        argv(CODE, ["--fingerprint", fingerprint]),
         { pairing: fakePairing({ fingerprint }) },
       ],
       // And a refusal, where a diagnostic would reach for its input.
       [
         "core pair (refused)",
-        ["core", "pair", "paired", "core.test:8443", "ABCD-2345", "--session", session, "--verbose", "--fingerprint", fingerprint],
+        argv(CODE, ["--fingerprint", fingerprint]),
         { pairing: fakePairing({ fingerprint, fails: "refused" }) },
+      ],
+      // And the second door onto `bad-code`: a shape this package accepted and
+      // the SDK did not, whose own message ends with the code in quotes.
+      [
+        "core pair (SDK refused the shape)",
+        argv(CODE, ["--fingerprint", fingerprint]),
+        {
+          pairing: fakePairing({
+            fingerprint,
+            failsWith: new CorePairingError(
+              "bad-code",
+              `a pairing code is eight characters, written XXXX-XXXX — "${CODE}" is not`,
+            ),
+          }),
+        },
       ],
     ];
 
     for (const [what, args, opts] of runs) {
       const run = await cli().run(args, opts);
       expectNoSecrets(what, run.all);
-      expect(run.all, `${what} printed the pairing code`).not.toContain("SENTINEL-VVV");
+      // Both spellings, and the prefix they share: a code echoed back without
+      // its hyphen is a code in a shell history.
+      for (const shape of [CODE, MALFORMED, "ZZVV"]) {
+        expect(run.all, `${what} printed the pairing code`).not.toContain(shape);
+      }
     }
+
+    // The guard on the guard: the well-formed sentinel really is one the shape
+    // check takes, so the four runs above reached the paths they name rather
+    // than all landing on the refusal that rejects a malformed code.
+    const issued = await cli().run(argv(CODE, ["--fingerprint", fingerprint]), {
+      pairing: fakePairing({ fingerprint }),
+    });
+    expect(issued.code, "the sentinel code was refused, so three of these runs proved nothing").toBe(0);
   });
 
   it("sweeps the nouns that dial with the credential in hand", async () => {

--- a/packages/cli/src/__tests__/registration-blob-file.test.ts
+++ b/packages/cli/src/__tests__/registration-blob-file.test.ts
@@ -9,7 +9,11 @@
 // time somebody improves an error message.
 
 import { describe, it, expect } from "vitest";
-import { decodeRegistrationBlobText, summarizeBlob } from "../registration-blob-file.ts";
+import {
+  decodeRegistrationBlobText,
+  encodeRegistrationBlobText,
+  summarizeBlob,
+} from "../registration-blob-file.ts";
 import { SENTINELS, sentinelBlobText } from "./cli-harness.ts";
 
 /** The blob shape, as an object, before it is encoded. */
@@ -143,3 +147,55 @@ describe("what it says when a blob is wrong", () => {
     }
   });
 });
+
+describe("encodeRegistrationBlobText", () => {
+  // The other direction, which #285 needs: `actana core pair` is handed a blob
+  // *object* by the SDK and the registry stores text. What matters is that the
+  // two halves of this module are each other's inverse — a credential that
+  // encoded but did not decode would land on disk as an entry `core ls` reports
+  // as corrupt, on a machine that has just been told pairing worked.
+  it("round-trips a blob through the decoder", () => {
+    const blob = {
+      endpoint: "wss://core.test:9444",
+      caCert: "ca",
+      clientCert: "cert",
+      clientKey: "key",
+      bearer: "bearer",
+    };
+    const result = decodeRegistrationBlobText(encodeRegistrationBlobText(blob));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.blob).toEqual({ ...blob, label: "" });
+  });
+
+  it("keeps a label when there is one, and writes no key for one there is not", () => {
+    const withLabel = encodeRegistrationBlobText({
+      endpoint: "wss://core.test:9444",
+      label: "the-test-core",
+      caCert: "ca",
+      clientCert: "cert",
+      clientKey: "key",
+      bearer: "bearer",
+    });
+    expect(summarizeBlob(unwrap(withLabel)).label).toBe("the-test-core");
+
+    // A paired credential has no alias, because the Core's redemption answer
+    // has no field for one. An empty string written here would put a blank
+    // LABEL column in `core ls` on the strength of a field nobody set.
+    const without = encodeRegistrationBlobText({
+      endpoint: "wss://core.test:9444",
+      caCert: "ca",
+      clientCert: "cert",
+      clientKey: "key",
+      bearer: "bearer",
+    });
+    expect(JSON.parse(Buffer.from(without, "base64").toString("utf8"))).not.toHaveProperty("label");
+  });
+});
+
+/** Decode text this suite just encoded, failing loudly if it will not. */
+function unwrap(text: string) {
+  const result = decodeRegistrationBlobText(text);
+  if (!result.ok) throw new Error(`the encoder wrote something the decoder refuses: ${result.error}`);
+  return result.blob;
+}

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -43,6 +43,7 @@ import { probeCore } from "./core-probe.ts";
 import { openCoreShell } from "./core-shell-channel.ts";
 import { terminalFromProcess } from "./cli-terminal.ts";
 import { connectCore } from "./core-connection.ts";
+import { sdkCorePairing } from "./core-pair.ts";
 import { openSessionGateway } from "./session-gateway.ts";
 import { openProjectFiles } from "./project-files-gateway.ts";
 import { openSessionAttach } from "./session-attach-channel.ts";
@@ -145,6 +146,9 @@ async function main(): Promise<void> {
     stdinIsTty: Boolean(process.stdin.isTTY),
     probe: probeCore,
     connect: connectCore,
+    // The one dial that starts with nothing trusted: `core pair` enrolls this
+    // machine on a Core it has no credential for yet (#285).
+    pairing: sdkCorePairing,
     openSessions: openSessionGateway,
     // The file surface, which is the one thing in this program that does not
     // cross the core link: `project cp` and `project files` reach the Core's

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -162,7 +162,7 @@ Usage:
   actana <noun> <verb> [flags]
 
 Cores this machine can reach
-  core       Register, select and inspect them
+  core       Pair with a Core, register, select and inspect them
   project    The Projects a Core owns: ls, add, browse, files, cp
   harness    The coding agents a Core can run: ls, install, skills
   events     Follow a Core's event log: tail

--- a/packages/cli/src/cli-args.ts
+++ b/packages/cli/src/cli-args.ts
@@ -67,6 +67,27 @@ export type ParsedArgs = {
   enter: boolean;
   /** `--dangerously-skip-permissions`: start the harness without permission prompts. */
   skipPermissions: boolean;
+  // ─── `core pair`'s flags (#285) ───
+  /**
+   * `--fingerprint <sha256>` — the CA fingerprint the operator was read out by
+   * `actana pair new`, in any form a human copies it in.
+   *
+   * Raw, like `--since` and `--limit`: what shape a fingerprint has is the
+   * SDK's business, and the verb that hands it over is the one that can say
+   * what a bad one means without this parser mirroring a format it does not
+   * own.
+   */
+  fingerprint: string | null;
+  /**
+   * `--session <id>` — the pairing session the code belongs to, when the code
+   * the operator was given does not already carry it as `<session>:<XXXX-XXXX>`.
+   *
+   * A code names a session and the Core will not go looking for which one
+   * (#282), so one of the two spellings has to supply it.
+   */
+  session: string | null;
+  /** `--label <name>` — what this machine calls itself in the Core's `pair ls`. */
+  label: string | null;
   /**
    * `--read-only`: attach without claiming the Session's write lock (#163).
    *
@@ -93,6 +114,9 @@ const VALUE_FLAGS = new Set([
   "--harness",
   "--cwd",
   "--title",
+  "--fingerprint",
+  "--session",
+  "--label",
 ]);
 
 /** Parse `process.argv.slice(2)`. Never throws; malformed input is reported in the result. */
@@ -114,6 +138,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
     harness: null,
     cwd: null,
     title: null,
+    fingerprint: null,
+    session: null,
+    label: null,
     raw: false,
     enter: false,
     skipPermissions: false,
@@ -160,6 +187,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       else if (name === "--harness") parsed.harness = value;
       else if (name === "--cwd") parsed.cwd = value;
       else if (name === "--title") parsed.title = value;
+      else if (name === "--fingerprint") parsed.fingerprint = value;
+      else if (name === "--session") parsed.session = value;
+      else if (name === "--label") parsed.label = value;
       continue;
     }
 

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -17,6 +17,7 @@ import type { CoreProbeFn } from "./core-probe.ts";
 import type { CliTerminal } from "./cli-terminal.ts";
 import type { OpenCoreShellFn } from "./core-shell-channel.ts";
 import type { CoreConnectFn } from "./core-connection.ts";
+import type { CorePairingPort } from "./core-pair.ts";
 import type { OpenSessionGateway } from "./session-gateway.ts";
 import type { OpenProjectFilesFn } from "./project-files-gateway.ts";
 import type { OpenSessionAttachFn } from "./session-attach-channel.ts";
@@ -85,6 +86,16 @@ export type ActanaCliDeps = {
    * that refuses to hand it a client when the Core is on another train.
    */
   connect: CoreConnectFn;
+  /**
+   * How `core pair` reaches a Core it has **no credential for yet** (#285).
+   *
+   * Its own port rather than a verb on {@link connect}, because it is the one
+   * client call made before there is anything to authenticate with: the dial is
+   * unverified by construction, what pins it is a fingerprint a human read out
+   * loud, and what comes back is the credential every other field here already
+   * assumes exists. See `core-pair.ts`.
+   */
+  pairing: CorePairingPort;
   /** How the `session` noun reaches a Core. See `session-gateway.ts`. */
   openSessions: OpenSessionGateway;
   /**

--- a/packages/cli/src/core-command.ts
+++ b/packages/cli/src/core-command.ts
@@ -1,5 +1,6 @@
 // `actana core` — the Cores this machine can reach (#129 D10).
 //
+//   actana core pair <name> <address> <code>   enroll this machine on a Core
 //   actana core add <name> [file]   register a Core from a blob file, or stdin
 //   actana core ls [--json]         what this machine knows, without dialling
 //   actana core use <name>          point `current` at one of them
@@ -18,6 +19,15 @@
 // need one; and it turns "paste this once" into a privilege the CLI holds
 // forever. `packages/cli` imports nothing that can start a process, and
 // `src/__tests__/no-local-escape.test.ts` is what keeps that true.
+//
+// **`pair` is how a machine comes by a credential now (#280, #285).** The
+// operator types an address and an eight-character code somebody read out to
+// them, the SDK generates a key pair here and gets a certificate signed, and
+// what lands is the same file `add` writes at the same mode — so every verb
+// below is unchanged and cannot tell the two apart. It runs on the *client*;
+// `actana pair new`, which mints the code, runs on the Core. `core-pair.ts`
+// has the reasoning, and `add` stays until #287 removes the paste path
+// everywhere at once.
 //
 // **`exec` is the same argument one verb further along (#266).** A maintenance
 // script that needs to run something on a Core used to have to reach for
@@ -39,6 +49,7 @@ import {
   type RegistryPaths,
 } from "./blob-registry.ts";
 import { decodeRegistrationBlobText } from "./registration-blob-file.ts";
+import { runCorePair } from "./core-pair.ts";
 import { resolveCore } from "./core-resolution.ts";
 import { runCoreShell } from "./core-shell.ts";
 import { runCoreExec } from "./core-exec.ts";
@@ -54,6 +65,8 @@ const STATUS_TIMEOUT_MS = 15_000;
 export const CORE_HELP = `actana core — the Cores this machine can reach
 
 Usage
+  actana core pair <name> <address> <code>
+                                  enroll THIS machine on a Core
   actana core add <name> [file]   register a Core from a blob file, or stdin
   actana core ls                  list the Cores this machine knows
   actana core use <name>          point \`current\` at a Core
@@ -66,7 +79,30 @@ Flags
   --core <name>   which Core \`status\` (and every later noun) talks to
   --cwd <dir>     a directory on the **Core's** machine — \`exec\`
   --json          machine-readable output — \`ls\`, \`status\` and \`exec\`
-  --verbose       explain the steps. Never prints a blob.
+  --verbose       explain the steps. Never prints a blob, a code or a key.
+  --fingerprint <sha256>   the Core's CA fingerprint — \`pair\`
+  --session <id>  the pairing session the code belongs to — \`pair\`
+  --label <name>  what to call this machine on the Core — \`pair\`
+
+Pairing with a Core
+  \`pair\` runs on the machine being paired — **this one**. On the Core, an
+  operator runs \`actana pair new\`, which prints a code, that Core's CA
+  fingerprint and the pairing session. Then, here:
+
+    actana core pair prod core.example:8443 ABCD-2345 \\
+      --session 0f6d… --fingerprint AA:BB:CC:…
+
+  The fingerprint is not optional. Without \`--fingerprint\` this prints the
+  fingerprint the Core presents and asks you to compare it with the one on the
+  Core's terminal; with no terminal to ask on, it refuses. Either way the code
+  is never sent to a certificate authority nobody confirmed.
+
+  The code is one-time, expires, and is spent by a wrong guess. A fresh one is
+  \`actana pair new\` again — it cannot be recovered, only re-minted.
+
+  What lands is the same credential file \`add\` writes, at the same mode, so
+  \`ls\`, \`use\`, \`rm\`, \`status\`, \`shell\` and \`exec\` work against it
+  unchanged.
 
 Running one command
   \`exec\` is the non-interactive half of \`shell\`: no terminal, stdout and
@@ -105,8 +141,11 @@ export async function runCoreCommand(
 
   // Only the verbs with flags of their own take `args`. `add`, `use` and `rm`
   // have none — passing it to them anyway made every verb look like it read the
-  // flag set, which is the one thing a reader checks a dispatch for.
+  // flag set, which is the one thing a reader checks a dispatch for. `pair`
+  // does: `--fingerprint`, `--session` and `--label` are all its.
   switch (verb) {
+    case "pair":
+      return runCorePair(deps, args, paths, rest);
     case "add":
       return coreAdd(deps, paths, rest);
     case "ls":
@@ -125,7 +164,7 @@ export async function runCoreCommand(
       return runCoreExec(deps, args, paths, rest);
     default:
       deps.err(`actana core: unknown verb "${verb}".`);
-      deps.err("Verbs: add, ls, use, rm, status, shell, exec. `actana core --help` lists them.");
+      deps.err("Verbs: pair, add, ls, use, rm, status, shell, exec. `actana core --help` lists them.");
       return EXIT_USAGE;
   }
 }

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -217,31 +217,53 @@ type TicketResult = { ok: true; sessionId: string; code: string } | { ok: false;
  * accepts both for the same reason.
  */
 function readTicket(deps: ActanaCliDeps, code: string, session: string | null): TicketResult {
-  const carried = code.includes(":");
-  if (!carried && (session === null || session.trim() === "")) {
+  // The two session ids, read the way `parsePairingTicket` reads them. Split
+  // out here rather than inferred from `code.includes(":")`, because a
+  // `bad-code` covers two different mistakes and the operator has to be told
+  // which of them they made: "the ids disagree" and "that is not a code" have
+  // opposite fixes, and sending somebody to drop a `--session` that was right
+  // all along is worse than saying nothing.
+  const separator = code.indexOf(":");
+  const carried = separator === -1 ? "" : code.slice(0, separator).trim();
+  const explicit = session?.trim() ?? "";
+
+  if (carried === "" && explicit === "") {
     deps.err("actana core pair: a pairing code names the pairing session it belongs to.");
     deps.err("Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.");
     return { ok: false, exit: EXIT_USAGE };
   }
+  if (carried !== "" && explicit !== "" && carried !== explicit) {
+    deps.err("actana core pair: the code names one pairing session and `--session` names another.");
+    deps.err("Drop `--session`, or pass the bare code beside it — they have to agree.");
+    return { ok: false, exit: EXIT_USAGE };
+  }
+
   try {
     const ticket = parsePairingTicket(code, session ?? undefined);
     return { ok: true, sessionId: ticket.sessionId, code: ticket.code };
   } catch (err) {
-    if (err instanceof CorePairingError && err.failure === "bad-code") {
-      // Worded here rather than relayed: the SDK's sentence quotes the code it
-      // was handed, and a pairing code is a secret for as long as its session
-      // is open. Which of the two mistakes it was is knowable without it.
-      if (carried && session !== null && session.trim() !== "") {
-        deps.err("actana core pair: the code names one pairing session and `--session` names another.");
-        deps.err("Drop `--session`, or pass the bare code beside it — they have to agree.");
-      } else {
-        deps.err("actana core pair: that is not a pairing code — it is eight characters, written XXXX-XXXX.");
-        deps.err("Hyphen and case do not matter. `actana pair new` on the Core prints a fresh one.");
-      }
-      return { ok: false, exit: EXIT_USAGE };
-    }
+    // Every remaining `bad-code` is a shape, the ids having been checked above.
+    if (err instanceof CorePairingError && err.failure === "bad-code") return { ok: false, exit: badCode(deps) };
     throw err;
   }
+}
+
+/**
+ * The one sentence this package writes about a code that is not one.
+ *
+ * It is written here rather than relayed from the SDK, whose message ends
+ * `— "ABCD-2345" is not`: correct for a library whose caller decides where text
+ * goes, and wrong for a CLI whose stderr is a terminal, a CI log and a shell
+ * history at once. One function for it because there are two ways to arrive —
+ * the ticket read here, and a `bad-code` raised inside `pairWithCore`, which
+ * parses the ticket again — and a rule kept in one of two places is a rule that
+ * holds until somebody touches the other.
+ */
+function badCode(deps: ActanaCliDeps): number {
+  const outcome = corePairingOutcome("bad-code");
+  deps.err("actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.");
+  deps.err(outcome.next);
+  return outcome.exit;
 }
 
 /** A fingerprint the operator stands behind, or the exit code for the refusal. */
@@ -321,6 +343,14 @@ function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
     deps.err(`actana core pair: pairing failed — ${message}`);
     return EXIT_FAILURE;
   }
+  // `bad-code` is the one failure whose message is not relayed, because the
+  // SDK's quotes the code — see {@link badCode}. Reaching it from here means
+  // `pairWithCore` refused a ticket this file had already normalised, which
+  // nothing does today and something will the moment the SDK tightens its shape
+  // check (it says as much, and calls the stop deliberate). The rule should not
+  // wait for that.
+  if (err.failure === "bad-code") return badCode(deps);
+
   const outcome = corePairingOutcome(err.failure, err.detail);
   deps.err(`actana core pair: ${err.message}`);
   deps.err(outcome.next);

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -184,7 +184,14 @@ export async function runCorePair(
   // already exist: the private key was generated locally and the Core never had
   // it. What is left is the part `core add` also does.
   const replacing = coreExists(paths, name);
-  writeCoreBlob(paths, name, encodeRegistrationBlobText(blob));
+  // The label goes to the Core and stops there. `pairWithCore` copies whatever
+  // label it was handed straight into the blob it returns, and the LABEL column
+  // of `actana core ls` means *the Core's* own alias — the one `actana setup`
+  // puts in a blob it prints. Storing this machine's name there would put the
+  // client's hostname in a column about the other end of the link, so a paired
+  // credential is stored with no alias at all and the column stays empty until
+  // a Core has something to say for itself.
+  writeCoreBlob(paths, name, encodeRegistrationBlobText({ ...blob, label: "" }));
   deps.verbose(`stored at ${paths.coresDir}/${name}.txt, mode 0600`);
 
   const current = readCurrentCore(paths);

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -1,0 +1,424 @@
+// `actana core pair <name> <address> <code>` — enrollment from the client's
+// side (#280, #285).
+//
+// **You are on the machine being paired.** Somebody on the Core ran `actana
+// pair new` and read out three things: a pairing code, that Core's CA
+// fingerprint, and the session the code belongs to. This is what this machine
+// does with them, and it is the exact counterpart of `actana-pair.ts`, which is
+// the *Core* end of the same exchange and lives in the same binary (#288). The
+// help text on each says which machine it runs on, because the only thing
+// separating the two commands is which words the operator types.
+//
+// **What this verb is, structurally: `actana core add` with a different way of
+// coming by the credential.** Everything after the credential lands is
+// deliberately unchanged — the same `writeCoreBlob` at mode 0600 under the same
+// cores directory, the same `current` pointer rule, the same name validation,
+// the same replace-in-place behaviour. `core-resolution.ts`, `core-connection.ts`
+// and every verb built on them cannot tell a paired credential from a pasted
+// one, and that is the whole design: this ticket replaces a *gesture*, not a
+// storage format. (The paste path is still here; #287 removes it everywhere at
+// once.)
+//
+// **No crypto happens in this file.** The key pair is born inside the SDK call,
+// on this machine, and its private half never crosses the wire — see
+// `@actana/sdk/core-pairing.ts`, which is also where the fingerprint comparison
+// and the pinned second connection live. This module supplies an address, a
+// code and an expected fingerprint, and turns whatever comes back into a
+// registry entry, a sentence and an exit code. The one piece of parsing it does
+// reach for is the SDK's own `parsePairingTicket`, which is the normaliser from
+// #281 as a client sees it: hyphens and case are the operator's business and
+// the Core's alphabet is nobody's business here.
+//
+// **The fingerprint is never assumed.** Either the operator passes
+// `--fingerprint`, or — on a terminal — this prints the one the Core presents
+// and asks them to compare it with what `actana pair new` printed. There is no
+// third path and no flag that skips it: an unconfirmed fingerprint refuses with
+// {@link EXIT_PAIR_FINGERPRINT_UNCONFIRMED} and, as the SDK's own contract puts
+// it, **absent is not waived**. The code is not sent in either refusal.
+//
+// **Nothing secret reaches an output sink, `--verbose` included** — not the
+// credential, not the private key, and not the pairing code. The code is the
+// one addition to that rule this ticket makes: it is a bearer secret for as
+// long as its session is open, so it is not echoed back in a confirmation, not
+// quoted in a diagnostic, and not written into a verbose line. That is why the
+// two shape errors below are worded here rather than relayed from the SDK,
+// whose `bad-code` message quotes what it was handed — correct for a library
+// whose caller decides where text goes, wrong for a CLI whose stderr is a
+// terminal, a CI log and a shell history at once.
+
+import {
+  CorePairingError,
+  fetchCorePairingIdentity,
+  pairWithCore,
+  parsePairingTicket,
+  type CorePairingErrorDetail,
+  type CorePairingFailure,
+  type CorePairingIdentity,
+  type PairWithCoreOptions,
+} from "@actana/sdk/core-pairing.ts";
+import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
+import {
+  coreExists,
+  coreNameError,
+  readCurrentCore,
+  writeCoreBlob,
+  writeCurrentCore,
+  type RegistryPaths,
+} from "./blob-registry.ts";
+import { encodeRegistrationBlobText } from "./registration-blob-file.ts";
+import {
+  EXIT_FAILURE,
+  EXIT_OK,
+  EXIT_PAIR_CERTIFICATE_INVALID,
+  EXIT_PAIR_CORE_ERROR,
+  EXIT_PAIR_FINGERPRINT_MISMATCH,
+  EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+  EXIT_PAIR_HOSTNAME_MISMATCH,
+  EXIT_PAIR_MALFORMED_RESPONSE,
+  EXIT_PAIR_NO_CA,
+  EXIT_PAIR_NOT_PAIRABLE,
+  EXIT_PAIR_RATE_LIMITED,
+  EXIT_PAIR_REFUSED,
+  EXIT_PAIR_REJECTED,
+  EXIT_PAIR_UNREACHABLE,
+  EXIT_USAGE,
+} from "./exit-codes.ts";
+import type { ActanaCliDeps } from "./cli-deps.ts";
+import type { ParsedArgs } from "./cli-args.ts";
+
+/**
+ * How this verb reaches a Core it has no credential for yet. Injected, for the
+ * same reason `probe` and `connect` are: the surface — flags, prompts, output,
+ * exit codes, what lands in the registry — is exercised without a Core.
+ *
+ * One port with two calls rather than two ports, because the two calls are one
+ * exchange and the SDK is explicit that they must agree: the fingerprint an
+ * operator confirms through {@link CorePairingPort.identify} has to be computed
+ * by the same code that later enforces it inside {@link CorePairingPort.pair},
+ * and a fake that answered one without the other would be testing a flow that
+ * cannot happen.
+ */
+export type CorePairingPort = {
+  /** Dial with nothing trusted and report the CA presented. Sends no code. */
+  identify: (opts: { address: string; timeoutMs?: number }) => Promise<CorePairingIdentity>;
+  /** Verify the fingerprint, then redeem the code. Returns the issued credential. */
+  pair: (opts: PairWithCoreOptions) => Promise<CoreRegistrationBlob>;
+};
+
+/** The real port: the SDK's two functions, bound and nothing else. */
+export const sdkCorePairing: CorePairingPort = {
+  identify: fetchCorePairingIdentity,
+  pair: pairWithCore,
+};
+
+/**
+ * `actana core pair <name> <address> <code>`.
+ *
+ * `rest` is the positionals after `pair`. The order is the order it is read
+ * out: what this machine will call the Core, where the Core is, and the code.
+ */
+export async function runCorePair(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const [name, address, code, ...extra] = rest;
+  if (name === undefined || address === undefined || code === undefined) {
+    deps.err("actana core pair: a name, an address and a code are required.");
+    deps.err("  actana core pair <name> <host:port> <code> --fingerprint <sha256>");
+    deps.err("`actana pair new` on the Core prints the code and the fingerprint.");
+    return EXIT_USAGE;
+  }
+  if (extra.length > 0) {
+    // Never the value: an operator who typed the code twice, or put it after
+    // the address a second time, would have it echoed back at them.
+    deps.err("actana core pair: too many arguments — expected <name> <address> <code>.");
+    return EXIT_USAGE;
+  }
+
+  // The same validation `core add` does, in the same order and with the same
+  // wording: a name this registry will not take is a name none of `ls`, `use`,
+  // `rm`, `status`, `shell` or `exec` could reach afterwards.
+  const nameError = coreNameError(name);
+  if (nameError) {
+    deps.err(`actana core pair: ${nameError}.`);
+    return EXIT_USAGE;
+  }
+
+  // The ticket first, before anything is dialled and before an operator is
+  // asked to compare a fingerprint: a code that cannot be a code will not
+  // become one after a round trip, and failing here means it never spends one
+  // of the five attempts the Core's session has.
+  const ticket = readTicket(deps, code, args.session);
+  if (!ticket.ok) return ticket.exit;
+  deps.verbose(`pairing session ${ticket.sessionId}`);
+
+  const confirmed = await confirmFingerprint(deps, args, address);
+  if (!confirmed.ok) return confirmed.exit;
+
+  let blob: CoreRegistrationBlob;
+  try {
+    deps.verbose(`redeeming the code at ${address} over a connection pinned to that certificate authority`);
+    blob = await deps.pairing.pair({
+      address,
+      // The normalised code, not what was typed: `parsePairingTicket` is the
+      // SDK's public door onto #281's normaliser, and passing its answer back
+      // in is what makes "hyphenated or not, upper or lower case" one rule
+      // rather than two implementations of one.
+      code: ticket.code,
+      sessionId: ticket.sessionId,
+      expectedCaFingerprint: confirmed.fingerprint,
+      // What this machine will be called in the operator's `actana pair ls`.
+      // The hostname is the honest default: the Core lists it beside a
+      // certificate serial, and "unnamed" beside three of them is a list an
+      // operator cannot revoke from.
+      label: args.label ?? deps.hostname,
+      platform: deps.platform,
+    });
+  } catch (err) {
+    return reportPairingFailure(deps, err);
+  }
+
+  // Past here the credential exists on this machine and nowhere else it did not
+  // already exist: the private key was generated locally and the Core never had
+  // it. What is left is the part `core add` also does.
+  const replacing = coreExists(paths, name);
+  writeCoreBlob(paths, name, encodeRegistrationBlobText(blob));
+  deps.verbose(`stored at ${paths.coresDir}/${name}.txt, mode 0600`);
+
+  const current = readCurrentCore(paths);
+  if (current === null) writeCurrentCore(paths, name);
+
+  deps.out(`${replacing ? "Replaced" : "Paired"} Core "${name}" → ${blob.endpoint}`);
+  if (current === null) deps.out(`\`current\` now points at "${name}".`);
+  else if (current !== name) {
+    deps.out(`\`current\` is still "${current}" — \`actana core use ${name}\` to switch.`);
+  }
+  return EXIT_OK;
+}
+
+/** A ticket that parsed, or the exit code for the sentence already printed. */
+type TicketResult = { ok: true; sessionId: string; code: string } | { ok: false; exit: number };
+
+/**
+ * Read the code and the session it names — without ever printing either.
+ *
+ * Two spellings, because #283 prints the session id on its own line and an
+ * operator may be handed either it or a joined `<session>:<XXXX-XXXX>` string.
+ * Which of the two they get is #280's to settle; both work here, and the SDK
+ * accepts both for the same reason.
+ */
+function readTicket(deps: ActanaCliDeps, code: string, session: string | null): TicketResult {
+  const carried = code.includes(":");
+  if (!carried && (session === null || session.trim() === "")) {
+    deps.err("actana core pair: a pairing code names the pairing session it belongs to.");
+    deps.err("Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.");
+    return { ok: false, exit: EXIT_USAGE };
+  }
+  try {
+    const ticket = parsePairingTicket(code, session ?? undefined);
+    return { ok: true, sessionId: ticket.sessionId, code: ticket.code };
+  } catch (err) {
+    if (err instanceof CorePairingError && err.failure === "bad-code") {
+      // Worded here rather than relayed: the SDK's sentence quotes the code it
+      // was handed, and a pairing code is a secret for as long as its session
+      // is open. Which of the two mistakes it was is knowable without it.
+      if (carried && session !== null && session.trim() !== "") {
+        deps.err("actana core pair: the code names one pairing session and `--session` names another.");
+        deps.err("Drop `--session`, or pass the bare code beside it — they have to agree.");
+      } else {
+        deps.err("actana core pair: that is not a pairing code — it is eight characters, written XXXX-XXXX.");
+        deps.err("Hyphen and case do not matter. `actana pair new` on the Core prints a fresh one.");
+      }
+      return { ok: false, exit: EXIT_USAGE };
+    }
+    throw err;
+  }
+}
+
+/** A fingerprint the operator stands behind, or the exit code for the refusal. */
+type FingerprintResult = { ok: true; fingerprint: string } | { ok: false; exit: number };
+
+/**
+ * Get the fingerprint the operator was read out — from the flag, or from them.
+ *
+ * The flag is the scriptable path and the prompt is the interactive one, and
+ * there is no third. With neither, this refuses rather than pairing: the SDK
+ * would refuse too, and refusing here costs an operator on a pipe one dial less
+ * and says the same thing.
+ *
+ * The prompt is a comparison, not a decision: what is printed is the
+ * fingerprint *this Core presents*, and the question is whether it matches the
+ * one on the Core's terminal. An operator who answers yes has done the check
+ * that makes the first dial verifiable; one who answers no has caught either an
+ * impersonation or a Core that has been reissued since they wrote the
+ * fingerprint down, and either way no code has been sent.
+ */
+async function confirmFingerprint(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  address: string,
+): Promise<FingerprintResult> {
+  if (args.fingerprint !== null) {
+    deps.verbose("checking the certificate authority against the fingerprint given on the command line");
+    return { ok: true, fingerprint: args.fingerprint };
+  }
+  if (!deps.interactive) {
+    deps.err("actana core pair: no fingerprint was given and there is no terminal to confirm one on.");
+    deps.err(corePairingOutcome("fingerprint-unconfirmed").next);
+    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED };
+  }
+
+  let identity: CorePairingIdentity;
+  try {
+    deps.verbose(`dialling ${address} with nothing trusted yet, to read the certificate authority it presents`);
+    identity = await deps.pairing.identify({ address });
+  } catch (err) {
+    // Nothing has been sent on this connection and nothing was going to be:
+    // the failure is the same failure `pair` would have reported one dial
+    // later, so it is reported the same way.
+    return { ok: false, exit: reportPairingFailure(deps, err) };
+  }
+
+  deps.out(`${identity.httpsOrigin} presents a certificate authority with this fingerprint:`);
+  deps.out(`  ${identity.fingerprint}`);
+  const matches = await deps.system.confirm(
+    "Is that the fingerprint `actana pair new` printed on the Core?",
+    false,
+  );
+  if (!matches) {
+    deps.err("actana core pair: the fingerprint was not confirmed, so the pairing code was not sent.");
+    deps.err(corePairingOutcome("fingerprint-mismatch").next);
+    // A human comparing two strings and saying they differ is a mismatch, and
+    // it exits as one: the operator has performed exactly the check the SDK
+    // performs when it is given a fingerprint to hold the Core to.
+    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_MISMATCH };
+  }
+  // The confirmed value is handed back to `pair`, which dials again and
+  // re-computes it: what the operator agreed to is enforced on the connection
+  // the code actually crosses, not merely on the one they were shown.
+  return { ok: true, fingerprint: identity.fingerprint };
+}
+
+/**
+ * Turn a failed pairing into one sentence, one next step and one exit code.
+ *
+ * Everything but a `CorePairingError` is a defect rather than an operator
+ * error, and it is reported as {@link EXIT_FAILURE} without a next step to
+ * offer: there is nothing for an operator to do differently about a bug here.
+ */
+function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
+  if (!(err instanceof CorePairingError)) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.err(`actana core pair: pairing failed — ${message}`);
+    return EXIT_FAILURE;
+  }
+  const outcome = corePairingOutcome(err.failure, err.detail);
+  deps.err(`actana core pair: ${err.message}`);
+  deps.err(outcome.next);
+  return outcome.exit;
+}
+
+/** What an operator should do next about a failure, and what this process exits with. */
+export type CorePairingOutcome = {
+  /** The code from `exit-codes.ts`. Contract: a script may branch on it. */
+  exit: number;
+  /** One line saying what to do next. Never quotes the code or any credential. */
+  next: string;
+};
+
+/**
+ * Every failure the SDK distinguishes, given a number and a next step.
+ *
+ * One `switch` with no `default`, so a failure added to `CorePairingFailure`
+ * stops this file compiling until somebody decides what an operator should do
+ * about it — which is the only way a list like this stays honest.
+ */
+export function corePairingOutcome(
+  failure: CorePairingFailure,
+  detail: CorePairingErrorDetail = {},
+): CorePairingOutcome {
+  switch (failure) {
+    case "bad-address":
+      return {
+        exit: EXIT_USAGE,
+        next: "An address is host:port — the Core's TLS port, the one `actana status` reports on the Core.",
+      };
+    case "bad-code":
+      return {
+        exit: EXIT_USAGE,
+        next: "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
+      };
+    case "bad-fingerprint":
+      return {
+        exit: EXIT_USAGE,
+        next: "A fingerprint is 32 bytes of hex, as AA:BB:… — copy the line `actana pair new` printed.",
+      };
+    case "unreachable":
+      return {
+        exit: EXIT_PAIR_UNREACHABLE,
+        next: "Check the Core is running and that address reaches it — `actana status` on the Core says where it listens.",
+      };
+    case "not-pairable":
+      return {
+        exit: EXIT_PAIR_NOT_PAIRABLE,
+        next: "Something answered there but it has no pairing endpoint — check it is a Core, and update it if it is old.",
+      };
+    case "no-ca-presented":
+      return {
+        exit: EXIT_PAIR_NO_CA,
+        next: "Nothing was presented to compare against the fingerprint — check the address is the Core's own TLS port.",
+      };
+    case "fingerprint-unconfirmed":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+        next: "Pass `--fingerprint <sha256>` — the code is never sent to a certificate authority nobody confirmed.",
+      };
+    case "fingerprint-mismatch":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
+        next:
+          "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
+          "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
+      };
+    case "hostname-mismatch":
+      return {
+        exit: EXIT_PAIR_HOSTNAME_MISMATCH,
+        next: "That is the right Core on an address its certificate does not cover — dial the one it was set up for.",
+      };
+    case "certificate-invalid":
+      return {
+        exit: EXIT_PAIR_CERTIFICATE_INVALID,
+        next: "The right Core, with a certificate that cannot be used — check the clock on both machines, then reissue it.",
+      };
+    case "refused":
+      return {
+        exit: EXIT_PAIR_REFUSED,
+        next: "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
+      };
+    case "rate-limited":
+      return {
+        exit: EXIT_PAIR_RATE_LIMITED,
+        next:
+          detail.retryAfterSeconds === undefined
+            ? "Wait, then try again with a fresh code."
+            : `Wait ${detail.retryAfterSeconds} seconds, then try again with a fresh code.`,
+      };
+    case "rejected":
+      return {
+        exit: EXIT_PAIR_REJECTED,
+        next: "The Core would not accept the request itself — that is a bug on this side. Please report it.",
+      };
+    case "core-error":
+      return {
+        exit: EXIT_PAIR_CORE_ERROR,
+        next: "The Core failed while handling this — `actana logs` on the Core has the reason; nothing here does.",
+      };
+    case "malformed-response":
+      return {
+        exit: EXIT_PAIR_MALFORMED_RESPONSE,
+        next: "Something answered that is not a Core, or is not one this build understands. Check the address.",
+      };
+  }
+}

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -65,3 +65,105 @@ export const EXIT_UNIMPLEMENTED = 3;
  * `$?`. The sentence on stderr says which happened either way.
  */
 export const EXIT_LINK_LOST = 125;
+
+// ─── Pairing (#285) ─────────────────────────────────────────────────────────
+//
+// `actana core pair` is the one client verb whose failures an operator has to
+// tell apart *without reading English*. A wrong code, a code somebody already
+// spent, a Core that is not answering and a certificate authority that is not
+// the one they were read out are four different situations with four different
+// next actions — and the enrollment script that runs this across a fleet is not
+// going to grep stderr to decide which of them happened.
+//
+// So every failure `@actana/sdk/core-pairing.ts` distinguishes gets a code of
+// its own here, in one block, and `corePairingExit` in `core-pair.ts` switches
+// over the SDK's union exhaustively — a failure added there stops compiling
+// until it is given a number here, rather than quietly collapsing into
+// {@link EXIT_FAILURE}.
+//
+// **10 upward, as a block.** It leaves 4–9 free for whatever the next
+// *general* code turns out to be (the four above it are general facts about any
+// verb), keeps well clear of the shell's own reservations at 126, 127 and
+// 128+n, and clear of {@link EXIT_LINK_LOST}. Numbers here are contract: a
+// script that branches on 14 must keep meaning "that was not the Core you were
+// told about" forever.
+//
+// **What is deliberately NOT in this block**: a code, an address or a
+// fingerprint that is malformed. Those never leave the machine and they are the
+// command line being wrong, which is what {@link EXIT_USAGE} already means —
+// giving them numbers here would be inventing a second answer to a question
+// this CLI has answered the same way since #129.
+
+/**
+ * Nothing answered at the address, or the dial timed out.
+ *
+ * The one failure that is usually not about pairing at all: a Core that is
+ * stopped, a port that is closed, a host that is somebody's typo.
+ */
+export const EXIT_PAIR_UNREACHABLE = 10;
+
+/** Something answered, but it has no pairing endpoint — check it is a Core, and its version. */
+export const EXIT_PAIR_NOT_PAIRABLE = 11;
+
+/** The chain presented had no certificate authority in it, so there was nothing to compare. */
+export const EXIT_PAIR_NO_CA = 12;
+
+/**
+ * No fingerprint was given and there was no terminal to confirm one on. **The
+ * code was not sent.**
+ *
+ * Distinct from a mismatch because it is not an alarm: nobody has been
+ * impersonated, the operator simply has not said what they expect yet. A script
+ * that hits this is missing `--fingerprint`, not under attack.
+ */
+export const EXIT_PAIR_FINGERPRINT_UNCONFIRMED = 13;
+
+/**
+ * The certificate authority presented is not the one the operator was read out.
+ * **The code was not sent.**
+ *
+ * The loud one, and the reason the whole exchange is shaped the way it is: this
+ * is what a machine-in-the-middle on the first dial looks like from here. It is
+ * also what a stale fingerprint from a Core that has been reissued looks like,
+ * which is why the message says both.
+ */
+export const EXIT_PAIR_FINGERPRINT_MISMATCH = 14;
+
+/**
+ * The right certificate authority, on an address its certificate does not cover.
+ *
+ * Its own code rather than a mismatch, because it is not an attack and reporting
+ * one would send an operator hunting for something that is not there: a Core's
+ * certificate covers the host it was set up for plus loopback, so reaching it
+ * over a second interface, a tunnel or a DNS name added later lands here with
+ * the fingerprint matching perfectly.
+ */
+export const EXIT_PAIR_HOSTNAME_MISMATCH = 15;
+
+/** The right certificate authority, and a certificate that is expired or otherwise unusable. */
+export const EXIT_PAIR_CERTIFICATE_INVALID = 16;
+
+/**
+ * The Core refused the code: wrong, expired, already redeemed, or out of
+ * attempts.
+ *
+ * One code for four situations because the *Core* answers all four with one
+ * status and one body on purpose (#282, "every refusal is the same refusal") —
+ * telling them apart on the wire would tell an attacker whether a session
+ * exists and whether their last guess was closer. A CLI that exported four
+ * codes here would be inventing three of them. The distinction is in the Core's
+ * audit log, where #282 put it deliberately.
+ */
+export const EXIT_PAIR_REFUSED = 17;
+
+/** Too many attempts from here, too fast. The message says how long to wait. */
+export const EXIT_PAIR_RATE_LIMITED = 18;
+
+/** The Core would not accept the request itself — a bug on this side, not an operator error. */
+export const EXIT_PAIR_REJECTED = 19;
+
+/** The Core failed while handling the redemption. Its logs have the reason; this side does not. */
+export const EXIT_PAIR_CORE_ERROR = 20;
+
+/** A 200 that was not a redemption response — something is answering that is not a Core. */
+export const EXIT_PAIR_MALFORMED_RESPONSE = 21;

--- a/packages/cli/src/registration-blob-file.ts
+++ b/packages/cli/src/registration-blob-file.ts
@@ -110,6 +110,43 @@ export function decodeRegistrationBlobText(raw: string): BlobDecodeResult {
 }
 
 /**
+ * Write a blob down, in exactly the form {@link decodeRegistrationBlobText}
+ * reads back.
+ *
+ * The other direction of the same one file, and it exists because #285 gives
+ * this package a second way to *come by* a credential: `actana core pair` gets
+ * a `CoreRegistrationBlob` object back from the SDK, and the registry stores
+ * text. Encoding it anywhere else would be a second opinion about the format at
+ * rest — the thing this module's header says it is the only place for — and the
+ * round trip is asserted rather than assumed (`registration-blob-file.test.ts`).
+ *
+ * **`label` is written only when there is one.** A blob from `actana setup`
+ * carries the *Core's* own alias in it; a paired credential carries no alias at
+ * all, because the Core's redemption answer has no field for one (#284). An
+ * empty string here would put a blank LABEL column in `actana core ls` on the
+ * strength of a field nobody set, so the key is left out instead and the
+ * decoder's `?? ""` answers for it.
+ *
+ * The result is base64 of compact JSON and has no trailing newline: the file
+ * `actana core add` writes has whatever the operator's paste had, and the
+ * decoder trims either way.
+ */
+export function encodeRegistrationBlobText(blob: CoreRegistrationBlob): string {
+  const label = blob.label ?? "";
+  return Buffer.from(
+    JSON.stringify({
+      endpoint: blob.endpoint,
+      ...(label === "" ? {} : { label }),
+      caCert: blob.caCert,
+      clientCert: blob.clientCert,
+      clientKey: blob.clientKey,
+      bearer: blob.bearer,
+    }),
+    "utf8",
+  ).toString("base64");
+}
+
+/**
  * The parts of a blob that are safe to print, name, sort by and log.
  *
  * This exists so that "never log the blob" is something the code can be *read*


### PR DESCRIPTION
Closes #285. Part of #280.

Base is `feat/short-code-pairing`, the feature branch for #280 — not `main` and not the train. This sits on top of the
pairing server (#282), the `actana pair` verbs (#283) and the SDK's client pairing (#284).

## What this is

`actana core add <name> [file]` reads a base64 credential off a file, a pipe or a paste. This replaces that gesture with
`actana core pair <name> <address> <code>`: the operator types an address and the eight-character code somebody read out
to them, the SDK generates a key pair on this machine and gets a certificate signed, and what lands is the same file, in
the same place, at the same mode.

**Everything after the credential lands is unchanged.** `core-resolution.ts`, `core-connection.ts` and every verb built
on them cannot tell a paired credential from a pasted one — the test resolves the stored entry through `resolveCore`
rather than re-reading the file it just watched being written, because resolution is what `ls`, `use`, `rm`, `status`,
`shell` and `exec` actually go through. **The paste path is untouched**; #287 removes it everywhere at once.

## The fingerprint, which is the whole security argument

Either `--fingerprint` carries the one `actana pair new` printed, or — on a terminal — the command prints the
fingerprint the Core presents and asks the operator to compare the two. With neither, it refuses. Absent is not waived.

What the operator confirms is handed back to `pairWithCore`, which dials again and recomputes it, so the value they
agreed to is enforced on the connection the code actually crosses and not merely on the one they were shown. Every
refusal happens with the code unsent, and the tests assert that at the seam — `pair` is never reached — rather than by
reading the prose.

## No crypto here

The key pair is born inside the SDK call and its private half never crosses the wire. This package supplies an address,
a code and an expected fingerprint, and turns what comes back into a registry entry, a sentence and an exit code. The
one parser it reaches for is the SDK's own `parsePairingTicket` — #281's normaliser through a published door, so the
CLI imports nothing from `@actana/shared` for it and has no copy of the Core's alphabet.

## Exit codes

Every failure `@actana/sdk/core-pairing.ts` distinguishes gets a code of its own in `exit-codes.ts`, from 10 upward, and
the mapping switches over the SDK's union exhaustively — a failure added there stops this compiling until it is given a
number. A malformed code, address or fingerprint stays `EXIT_USAGE`: it never leaves the machine, and it is the command
line being wrong, which is what that code has meant since #129.

## The pairing code is a secret

It joins the credential under the "never reaches an output sink" rule: not echoed in a confirmation, not quoted in a
diagnostic, not written into a `--verbose` line. That is why the two shape errors are worded in this package rather than
relayed — the SDK's `bad-code` message quotes what it was handed. `never-logs-a-blob.test.ts` sweeps this verb for the
code as well as for the four credential sentinels.

## Scope

`packages/cli` only, plus its README. `packages/panel` belongs to #286 and is untouched.

- `pnpm -r typecheck` — clean
- `pnpm lint` — 0 errors (46 pre-existing warnings, none in `packages/cli`)
- `packages/cli` suite — 981 passed, 3 skipped, including 26 new
