### PR TITLE
feat(panel): pair a Core by address and short code, with the fingerprint shown first

### DIFF
--- a/packages/panel/src/components/views/AddCoreByPairing.tsx
+++ b/packages/panel/src/components/views/AddCoreByPairing.tsx
@@ -1,0 +1,444 @@
+import { useState } from "react";
+import { Btn } from "~/components/ui/Btn";
+import { TextField } from "~/components/ui/TextField";
+import { api, ApiError } from "~/lib/api";
+import {
+  fingerprintCheck,
+  normalizePairingCode,
+  pairingFailureMessage,
+  type CorePairingIdentity,
+  type CorePairingRefusal,
+  type FingerprintCheck,
+} from "~/shared/core-pairing";
+import type { CoreWithDial } from "~/shared/cores";
+
+/**
+ * Adding a Core by short code (#280, #286) — address, then fingerprint, then
+ * code, in that order and never in another.
+ *
+ * The Panel is the one client that can *show* the operator a fingerprint rather
+ * than make them type one into a terminal, so this is a two-step: the first
+ * request carries no code and comes back with the certificate authority the
+ * machine presents, and the second is only reachable once what the operator was
+ * read out and what the machine presented are the same string.
+ *
+ * **The comparison here is a gate, not the enforcement.** The Panel server runs
+ * it again inside `pairWithCore`, against the certificate on the connection it
+ * is about to send the code over, and refuses there too. What this component
+ * owns is that an operator is never *asked* for a code before they have looked
+ * at a fingerprint, and that a mismatch stops rather than warns.
+ *
+ * **Nothing secret is kept.** The code lives in this component's state for as
+ * long as it takes to post it and nowhere else — no preference store, no URL,
+ * no toast, no error message. The credential the pairing returns never comes
+ * back to the browser at all: the server seals it and answers with a registry
+ * row.
+ */
+
+/** What each fingerprint state looks like, and what it is called out loud. */
+const FINGERPRINT_STATES: Record<
+  FingerprintCheck,
+  { label: string; color: string; border: string }
+> = {
+  unchecked: { label: "Not checked", color: "var(--text-dim)", border: "var(--border)" },
+  verified: { label: "Verified", color: "var(--accent-ink)", border: "var(--accent)" },
+  mismatch: { label: "Mismatch", color: "var(--danger, #e5484d)", border: "var(--danger, #e5484d)" },
+};
+
+export function AddCoreByPairing({ onPaired }: { onPaired: (core: CoreWithDial) => Promise<void> }) {
+  const [address, setAddress] = useState("");
+  const [identity, setIdentity] = useState<CorePairingIdentity | null>(null);
+  const [inspecting, setInspecting] = useState(false);
+
+  const [expected, setExpected] = useState("");
+  const [sessionId, setSessionId] = useState("");
+  const [code, setCode] = useState("");
+  const [name, setName] = useState("");
+  const [pairing, setPairing] = useState(false);
+
+  const [refusal, setRefusal] = useState<CorePairingRefusal | null>(null);
+
+  const check = fingerprintCheck(expected, identity?.fingerprint ?? null);
+  const verified = check === "verified";
+  const codeReady = normalizePairingCode(code) !== null && sessionId.trim() !== "";
+
+  /**
+   * Retyping the address drops the fingerprint that was read off the old one.
+   *
+   * Without this, an operator who checked one machine and then pointed the box
+   * at another would be looking at a "verified" badge earned by a Core they are
+   * no longer talking to — the exact confusion the fingerprint exists to
+   * prevent.
+   */
+  const changeAddress = (next: string) => {
+    setAddress(next);
+    setIdentity(null);
+    setRefusal(null);
+  };
+
+  const handleInspect = async () => {
+    if (!address.trim()) return;
+    setInspecting(true);
+    setRefusal(null);
+    setIdentity(null);
+    try {
+      const { identity: next } = await api.inspectCoreForPairing(address.trim());
+      setIdentity(next);
+    } catch (err) {
+      setRefusal(refusalOf(err));
+    } finally {
+      setInspecting(false);
+    }
+  };
+
+  const handlePair = async () => {
+    if (!verified || !codeReady) return;
+    setPairing(true);
+    setRefusal(null);
+    try {
+      const { core } = await api.pairCore({
+        address: address.trim(),
+        code,
+        sessionId: sessionId.trim(),
+        expectedFingerprint: expected,
+        label: name.trim(),
+      });
+      reset();
+      await onPaired(core);
+    } catch (err) {
+      const next = refusalOf(err);
+      setRefusal(next);
+      // A code the Core has already looked at is spent, dead, or was never
+      // right: keeping it in the box invites a second attempt that can only
+      // burn another of the session's five, and keeps a secret in memory that
+      // has no further use.
+      if (next.failure === "refused") setCode("");
+    } finally {
+      setPairing(false);
+    }
+  };
+
+  const reset = () => {
+    setAddress("");
+    setIdentity(null);
+    setExpected("");
+    setSessionId("");
+    setCode("");
+    setName("");
+    setRefusal(null);
+  };
+
+  return (
+    <div
+      style={{
+        padding: "14px 16px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: 7,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+      }}
+    >
+      <div style={{ fontFamily: "var(--mono)", fontSize: 11.5, color: "var(--text-dim)" }}>
+        On the machine, run <code>actana pair new</code>. It prints a one-time pairing code, this
+        Core&apos;s CA fingerprint, and a session id. Enter the address first and compare the
+        fingerprint — the Panel does not send the code until they match.
+      </div>
+
+      {/* Step 1 — reach the machine. Nothing secret is sent by this. */}
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <TextField
+            label="Core address"
+            value={address}
+            onChange={changeAddress}
+            placeholder="prod-vm-1.internal:7777"
+            hint="Host and TLS port, as the Core was set up. Pairing needs the TLS port."
+            mono
+            autoComplete="off"
+            spellCheck={false}
+            disabled={inspecting || pairing}
+          />
+        </div>
+        <Btn
+          variant="frame"
+          size="md"
+          onClick={() => void handleInspect()}
+          disabled={inspecting || pairing || !address.trim()}
+        >
+          {inspecting ? "Checking…" : "Check fingerprint"}
+        </Btn>
+      </div>
+
+      {/* Step 2 — the three states, told apart by colour, by wording, and by
+          whether step 3 exists at all. */}
+      <FingerprintPanel
+        check={check}
+        identity={identity}
+        expected={expected}
+        onExpectedChange={(next) => {
+          setExpected(next);
+          if (refusal?.failure === "fingerprint-mismatch") setRefusal(null);
+        }}
+        busy={inspecting || pairing}
+      />
+
+      {/* Step 3 — the code, reachable only past a verified fingerprint. */}
+      {verified && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <TextField
+            label="Session"
+            value={sessionId}
+            onChange={setSessionId}
+            placeholder="the Session line from `actana pair new`"
+            mono
+            autoComplete="off"
+            spellCheck={false}
+            disabled={pairing}
+          />
+          <TextField
+            label="Pairing code"
+            value={code}
+            onChange={(next) => {
+              setCode(next);
+              if (refusal) setRefusal(null);
+            }}
+            placeholder="XXXX-XXXX"
+            hint="Eight characters. Hyphen and case are yours to get wrong."
+            mono
+            autoComplete="off"
+            spellCheck={false}
+            disabled={pairing}
+          />
+          <TextField
+            label="Name in this Panel (optional)"
+            value={name}
+            onChange={setName}
+            placeholder="the machine's host, if you leave this empty"
+            autoComplete="off"
+            disabled={pairing}
+          />
+        </div>
+      )}
+
+      {refusal && refusal.failure !== "fingerprint-mismatch" && (
+        <RefusalBox refusal={refusal} />
+      )}
+
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <Btn
+          variant="primary"
+          size="sm"
+          icon="plus"
+          onClick={() => void handlePair()}
+          disabled={pairing || !verified || !codeReady}
+        >
+          {pairing ? "Pairing…" : "Pair Core"}
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Where the operator stands against the fingerprint they were read out.
+ *
+ * All three states render here rather than one of them being an absence: an
+ * operator who has not checked yet should see that they have not checked yet,
+ * in the same place a verified check would appear, so the badge is read as an
+ * answer rather than as chrome that failed to load.
+ */
+function FingerprintPanel({
+  check,
+  identity,
+  expected,
+  onExpectedChange,
+  busy,
+}: {
+  check: FingerprintCheck;
+  identity: CorePairingIdentity | null;
+  expected: string;
+  onExpectedChange: (next: string) => void;
+  busy: boolean;
+}) {
+  const state = FINGERPRINT_STATES[check];
+  return (
+    <div
+      data-fingerprint-state={check}
+      role={check === "mismatch" ? "alert" : "status"}
+      aria-label={`Fingerprint ${state.label}`}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        padding: "12px 14px",
+        background: "var(--surface-1)",
+        border: `1px solid ${state.border}`,
+        borderRadius: 7,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: "0.05em",
+            textTransform: "uppercase",
+            color: state.color,
+            border: `1px solid ${state.border}`,
+            borderRadius: 4,
+            padding: "2px 6px",
+          }}
+        >
+          {state.label}
+        </span>
+        <span style={{ fontSize: 12, color: "var(--text-dim)" }}>
+          {identity === null
+            ? "No machine checked yet — enter an address and check its fingerprint."
+            : check === "unchecked"
+              ? "Now type the CA fingerprint `actana pair new` printed on that machine."
+              : check === "verified"
+                ? "This is the machine you were read a fingerprint for."
+                : "This is NOT the machine you were read a fingerprint for."}
+        </span>
+      </div>
+
+      {identity !== null && (
+        <>
+          <Fingerprint
+            caption={`Presented by ${identity.httpsOrigin}`}
+            value={identity.fingerprint}
+            color={state.color}
+          />
+          <TextField
+            label="CA fingerprint from `actana pair new`"
+            value={expected}
+            onChange={onExpectedChange}
+            placeholder="AA:BB:CC:…"
+            mono
+            autoComplete="off"
+            spellCheck={false}
+            ariaInvalid={check === "mismatch"}
+            disabled={busy}
+          />
+        </>
+      )}
+
+      {check === "mismatch" && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            padding: "10px 12px",
+            background: "var(--surface-0)",
+            border: `1px solid ${state.border}`,
+            borderRadius: 6,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+              color: state.color,
+              lineHeight: 1.5,
+            }}
+          >
+            {pairingFailureMessage("fingerprint-mismatch")}
+          </div>
+          <Fingerprint caption="Expected" value={expected} color={state.color} />
+          <Fingerprint
+            caption="Presented"
+            value={identity?.fingerprint ?? ""}
+            color={state.color}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One fingerprint, wrapped rather than truncated — every byte is the point. */
+function Fingerprint({
+  caption,
+  value,
+  color,
+}: {
+  caption: string;
+  value: string;
+  color: string;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          fontWeight: 500,
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          color: "var(--text-dim)",
+        }}
+      >
+        {caption}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 11.5,
+          color,
+          wordBreak: "break-all",
+          lineHeight: 1.5,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+/** A refusal that is not a mismatch — one sentence, and what to do next. */
+function RefusalBox({ refusal }: { refusal: CorePairingRefusal }) {
+  return (
+    <div
+      role="alert"
+      data-pairing-failure={refusal.failure}
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: "var(--danger, #e5484d)",
+        padding: "8px 12px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: 7,
+      }}
+    >
+      {pairingFailureMessage(refusal.failure, refusal)}
+    </div>
+  );
+}
+
+/**
+ * Read a refusal out of whatever the call threw.
+ *
+ * A `CorePairingRefusal` body is the expected shape; anything else — a proxy
+ * in the way, a Panel that fell over — is reported as `core-error`, which is
+ * the arm whose advice ("nothing was paired, try again") is true of every
+ * failure that never reached the pairing endpoint.
+ */
+function refusalOf(err: unknown): CorePairingRefusal {
+  if (err instanceof ApiError && isRefusal(err.body)) return err.body;
+  return { failure: "core-error", error: pairingFailureMessage("core-error") };
+}
+
+function isRefusal(body: unknown): body is CorePairingRefusal {
+  return (
+    !!body &&
+    typeof body === "object" &&
+    typeof (body as { failure?: unknown }).failure === "string" &&
+    typeof (body as { error?: unknown }).error === "string"
+  );
+}

--- a/packages/panel/src/components/views/AddCoreByPairing.tsx
+++ b/packages/panel/src/components/views/AddCoreByPairing.tsx
@@ -35,6 +35,18 @@ import type { CoreWithDial } from "~/shared/cores";
  * row.
  */
 
+/**
+ * What the panel says when *this* comparison failed.
+ *
+ * Its own string rather than `pairingFailureMessage("fingerprint-mismatch")`,
+ * because this is the one place that can promise the code has not moved: no
+ * request has been made with it, and the button that would make one is not
+ * rendered. The shared sentence has to cover a mismatch the server returned,
+ * where the code may already have been spent, so it cannot promise that.
+ */
+const LOCAL_MISMATCH_MESSAGE =
+  "That machine is not the Core you were read a fingerprint for. The pairing code has not been sent and will not be — find out why the two differ before going any further.";
+
 /** What each fingerprint state looks like, and what it is called out loud. */
 const FINGERPRINT_STATES: Record<
   FingerprintCheck,
@@ -63,16 +75,28 @@ export function AddCoreByPairing({ onPaired }: { onPaired: (core: CoreWithDial) 
   const codeReady = normalizePairingCode(code) !== null && sessionId.trim() !== "";
 
   /**
-   * Retyping the address drops the fingerprint that was read off the old one.
+   * Retyping the address drops everything that was true of the old one — the
+   * fingerprint read off it, the fingerprint typed against it, **and the code**.
    *
-   * Without this, an operator who checked one machine and then pointed the box
-   * at another would be looking at a "verified" badge earned by a Core they are
-   * no longer talking to — the exact confusion the fingerprint exists to
-   * prevent.
+   * The badge is the obvious half: an operator who checked one machine and then
+   * pointed the box at another would otherwise be looking at a "verified" badge
+   * earned by a Core they are no longer talking to. The code is the half that
+   * matters. It lives on this component rather than on the `{verified && …}`
+   * subtree, so unmounting step 3 does not clear it, and without this an
+   * operator could check machine A, type A's code, point the box at machine B,
+   * verify B's fingerprint, and find A's still-redeemable code waiting in a
+   * re-enabled form — one click from posting A's pairing secret to B, which
+   * could then spend it against A.
+   *
+   * A code is minted for one machine and is a secret to every other. Nothing
+   * about it survives a change of address.
    */
   const changeAddress = (next: string) => {
     setAddress(next);
     setIdentity(null);
+    setExpected("");
+    setSessionId("");
+    setCode("");
     setRefusal(null);
   };
 
@@ -177,10 +201,11 @@ export function AddCoreByPairing({ onPaired }: { onPaired: (core: CoreWithDial) 
         check={check}
         identity={identity}
         expected={expected}
-        onExpectedChange={(next) => {
-          setExpected(next);
-          if (refusal?.failure === "fingerprint-mismatch") setRefusal(null);
-        }}
+        // Editing what was typed does not clear a refusal. A server-returned
+        // mismatch is a statement about the certificate that machine presented,
+        // and retyping the expected fingerprint does not change it — the
+        // warning stands until the next attempt or the next address.
+        onExpectedChange={setExpected}
         busy={inspecting || pairing}
       />
 
@@ -222,9 +247,17 @@ export function AddCoreByPairing({ onPaired }: { onPaired: (core: CoreWithDial) 
         </div>
       )}
 
-      {refusal && refusal.failure !== "fingerprint-mismatch" && (
-        <RefusalBox refusal={refusal} />
-      )}
+      {/* The refusal box is suppressed for exactly one reason: `FingerprintPanel`
+          is already showing this refusal, in more detail, with both
+          fingerprints side by side. That is true when the *local* comparison
+          failed — and only then. A `fingerprint-mismatch` the server returned
+          while the local check says verified is a different animal: the CA on
+          the pairing dial was not the CA the inspect dial presented, or the CA
+          in the response was not the one in the handshake. Neither is visible
+          here, and a suppression keyed on the failure code rather than on the
+          local state would leave the operator with a green badge and silence —
+          on the one refusal in this flow that must never be quiet. */}
+      {refusal && check !== "mismatch" && <RefusalBox refusal={refusal} />}
 
       <div style={{ display: "flex", justifyContent: "flex-end" }}>
         <Btn
@@ -346,7 +379,7 @@ function FingerprintPanel({
               lineHeight: 1.5,
             }}
           >
-            {pairingFailureMessage("fingerprint-mismatch")}
+            {LOCAL_MISMATCH_MESSAGE}
           </div>
           <Fingerprint caption="Expected" value={expected} color={state.color} />
           <Fingerprint
@@ -416,7 +449,13 @@ function RefusalBox({ refusal }: { refusal: CorePairingRefusal }) {
         borderRadius: 7,
       }}
     >
-      {pairingFailureMessage(refusal.failure, refusal)}
+      {/* The server's own sentence first. `~/shared/core-pairing` fills `error`
+          in precisely so a caller reading only that field still gets prose, and
+          it is the only text that can be right for a refusal the renderer's
+          compiled-in union does not know about — where `pairingFailureMessage`,
+          an exhaustive switch with no default, would return nothing and paint
+          an empty red box. */}
+      {refusal.error || pairingFailureMessage(refusal.failure, refusal)}
     </div>
   );
 }
@@ -424,13 +463,29 @@ function RefusalBox({ refusal }: { refusal: CorePairingRefusal }) {
 /**
  * Read a refusal out of whatever the call threw.
  *
- * A `CorePairingRefusal` body is the expected shape; anything else — a proxy
- * in the way, a Panel that fell over — is reported as `core-error`, which is
- * the arm whose advice ("nothing was paired, try again") is true of every
- * failure that never reached the pairing endpoint.
+ * Three cases, in order of how much the server managed to tell us:
+ *
+ *   1. A `CorePairingRefusal` body — the pairing endpoint's own answer, with a
+ *      failure code to switch on and fingerprints where there are any.
+ *   2. Any other `ApiError`. Most often the registry refusing an endpoint it
+ *      already holds, which `pairCore` deliberately lets past its own catch so
+ *      that the registry gets to explain itself. `ApiError.message` is carrying
+ *      that explanation, and it is used verbatim: writing a pairing sentence
+ *      over it would tell an operator whose code was redeemed perfectly well
+ *      that the Core failed and to mint a fresh one — four false claims in one
+ *      sentence, and the exact outcome the server went out of its way to avoid.
+ *   3. Anything else — a proxy in the way, a socket that hung up, a Panel that
+ *      fell over. `core-error` is the arm whose advice is true of every failure
+ *      that never got an answer out of the Panel.
+ *
+ * `core-error` is the failure code in case 2 as well, because there is no
+ * pairing failure to name; only the sentence comes from the server.
  */
 function refusalOf(err: unknown): CorePairingRefusal {
-  if (err instanceof ApiError && isRefusal(err.body)) return err.body;
+  if (err instanceof ApiError) {
+    if (isRefusal(err.body)) return err.body;
+    if (err.message.trim() !== "") return { failure: "core-error", error: err.message };
+  }
   return { failure: "core-error", error: pairingFailureMessage("core-error") };
 }
 

--- a/packages/panel/src/components/views/CoresSettingsPage.tsx
+++ b/packages/panel/src/components/views/CoresSettingsPage.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Btn } from "~/components/ui/Btn";
 import { ConfirmDialog } from "~/components/ui/ConfirmDialog";
-import { Textarea } from "~/components/ui/Textarea";
 import { Field, SettingsSection } from "~/components/views/SettingsParts";
+import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import { CoreNeedsUpdateNotice } from "~/components/views/CoreNeedsUpdate";
 import { api } from "~/lib/api";
 import { formatRelativeTime } from "~/lib/format-relative-time";
@@ -12,6 +12,12 @@ import { coreOrder, type CoreDialStatus, type CoreWithDial } from "~/shared/core
 /**
  * Cores settings — the operator's view of the fleet, and the one place a Core
  * is paired or forgotten.
+ *
+ * Pairing is a short code and an address (#286): `actana pair new` on the
+ * machine prints a code, that Core's CA fingerprint and a session id, and
+ * `AddCoreByPairing` walks the operator through comparing the fingerprint
+ * before the code goes anywhere. The Panel server does the pairing itself —
+ * key generation and a TLS dial are not a browser's work.
  *
  * The link state shown here belongs to the Panel *service*: it dials every Core
  * whether or not this page is open, so all this page does is poll for the
@@ -26,10 +32,6 @@ export function CoresSettingsPage() {
   const [cores, setCores] = useState<CoreWithDial[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const [registrationBlob, setRegistrationBlob] = useState("");
-  const [registering, setRegistering] = useState(false);
-  const [registerError, setRegisterError] = useState<string | null>(null);
 
   const [pendingRemoval, setPendingRemoval] = useState<CoreWithDial | null>(null);
   const [removing, setRemoving] = useState(false);
@@ -65,23 +67,14 @@ export function CoresSettingsPage() {
     return () => clearInterval(timer);
   }, [refresh]);
 
-  const handleRegister = async () => {
-    const blob = registrationBlob.trim();
-    if (!blob) return;
-    setRegistering(true);
-    setRegisterError(null);
-    try {
-      const { core } = await api.addCore(blob);
-      setRegistrationBlob("");
-      await refresh();
-      toast.success(`Core "${core.label}" paired.`);
-    } catch (err) {
-      // Inline rather than a toast: a rejected paste is something the operator
-      // has to correct in the box that is still in front of them.
-      setRegisterError(err instanceof Error ? err.message : "Could not pair that Core.");
-    } finally {
-      setRegistering(false);
-    }
+  /**
+   * A Core that just paired. The list is re-read rather than appended to, so
+   * the new row arrives with the service's own view of its link rather than
+   * the one the pairing response happened to be born with.
+   */
+  const handlePaired = async (core: CoreWithDial) => {
+    await refresh();
+    toast.success(`Core "${core.label}" paired.`);
   };
 
   /**
@@ -128,7 +121,7 @@ export function CoresSettingsPage() {
   return (
     <SettingsSection
       title="Cores"
-      subtitle="The machines this Panel manages. Pair one by pasting the token its Core printed at install; the Panel keeps the link up from the server, so your fleet stays connected with no browser open. Credentials are encrypted in the Panel's data directory."
+      subtitle="The machines this Panel manages. Pair one with the short code `actana pair new` prints on the machine; the Panel keeps the link up from the server, so your fleet stays connected with no browser open. Credentials are encrypted in the Panel's data directory."
       headingLevel="h1"
     >
       {loading ? (
@@ -152,7 +145,8 @@ export function CoresSettingsPage() {
                   borderRadius: 7,
                 }}
               >
-                No Cores yet. Install the Core on a machine and paste the token it prints below.
+                No Cores yet. Install the Core on a machine, run `actana pair new` there, and
+                pair it below.
               </div>
             ) : (
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -171,47 +165,7 @@ export function CoresSettingsPage() {
           </Field>
 
           <Field label="Add a Core">
-            <div
-              style={{
-                padding: "14px 16px",
-                background: "var(--surface-0)",
-                border: "1px solid var(--border)",
-                borderRadius: 7,
-                display: "flex",
-                flexDirection: "column",
-                gap: 12,
-              }}
-            >
-              <div style={{ fontFamily: "var(--mono)", fontSize: 11.5, color: "var(--text-dim)" }}>
-                Run <code>core install</code> on the machine and paste the single line it prints.
-                It carries the endpoint, the pinned CA and client certificate, and the signed bearer
-                — everything the Panel needs to dial that Core, and nothing it can reach without.
-              </div>
-              <Textarea
-                label="Pairing token"
-                value={registrationBlob}
-                onChange={(v) => {
-                  setRegistrationBlob(v);
-                  if (registerError) setRegisterError(null);
-                }}
-                placeholder="paste the pairing token here…"
-                rows={3}
-                mono
-                disabled={registering}
-              />
-              {registerError && <ErrorBox>{registerError}</ErrorBox>}
-              <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                <Btn
-                  variant="primary"
-                  size="sm"
-                  icon="plus"
-                  onClick={handleRegister}
-                  disabled={registering || !registrationBlob.trim()}
-                >
-                  {registering ? "Pairing…" : "Add Core"}
-                </Btn>
-              </div>
-            </div>
+            <AddCoreByPairing onPaired={handlePaired} />
           </Field>
         </>
       )}
@@ -226,7 +180,8 @@ export function CoresSettingsPage() {
       >
         The Panel stops dialing this Core and forgets its credentials and its place in the event
         log. Nothing on the machine itself is touched — its projects, tasks, and running sessions
-        keep going. To manage it again you&apos;ll need a fresh pairing token.
+        keep going. To manage it again, run <code>actana pair new</code> on the machine and pair it
+        here with the code it prints.
       </ConfirmDialog>
     </SettingsSection>
   );
@@ -267,8 +222,8 @@ function endpointHost(endpoint: string): string {
 /**
  * One Core in the list. The alias is editable in place — it is the only field
  * here that is the Panel's to change, and the operator's read of the fleet
- * depends on it. Endpoint and credentials are what the pairing token said they
- * were; changing those means a fresh token.
+ * depends on it. Endpoint and credentials are what the pairing produced;
+ * changing those means pairing again with a fresh code.
  */
 function CoreRow({
   core,
@@ -476,7 +431,7 @@ function badgeTitle(dial: CoreDialStatus): string {
     case "unreachable":
       return `${dial.detail ?? "The Panel can't reach this Core"} — ${lastSeen}. It keeps retrying.`;
     case "auth-error":
-      return `This Core rejected the Panel's credentials (${dial.detail ?? "rejected"}). Reissue a pairing token on the machine and add it again.`;
+      return `This Core rejected the Panel's credentials (${dial.detail ?? "rejected"}). Run \`actana pair new\` on the machine and pair it again.`;
     case "needs-update":
       return `${dial.detail ?? "This Core speaks a different core-link protocol"}. Its data is suppressed until the Core on that machine is updated.`;
   }

--- a/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
+++ b/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
@@ -208,6 +208,31 @@ describe("adding a Core by short code (#286)", () => {
       expect(state()).toBe("unchecked");
       expect(screen.queryByLabelText("Pairing code")).toBeNull();
     });
+
+    it("drops the code with it — a code minted for one machine is a secret to every other", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_machine_a");
+      type("Pairing code", "k7rp-9x4t");
+
+      // Point the box at a second machine and verify *its* fingerprint. The
+      // form comes back; what must not come back with it is machine A's
+      // still-redeemable code, one click from being posted to machine B.
+      await act(async () => {
+        type("Core address", "machine-b.internal:7777");
+      });
+      await click("Check fingerprint");
+      await act(async () => {
+        type("CA fingerprint from `actana pair new`", PRESENTED);
+      });
+      expect(state()).toBe("verified");
+
+      expect((screen.getByLabelText("Pairing code") as HTMLInputElement).value).toBe("");
+      expect((screen.getByLabelText("Session") as HTMLInputElement).value).toBe("");
+      expect(document.body.textContent).not.toContain("k7rp-9x4t");
+      expect(document.body.textContent).not.toContain("ps_machine_a");
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", true);
+    });
   });
 
   describe("sending the code", () => {
@@ -274,6 +299,7 @@ describe("adding a Core by short code (#286)", () => {
       "unreachable",
       "no-ca-presented",
       "fingerprint-unconfirmed",
+      "fingerprint-mismatch",
       "hostname-mismatch",
       "certificate-invalid",
       "refused",
@@ -328,6 +354,81 @@ describe("adding a Core by short code (#286)", () => {
       expect((screen.getByLabelText("Pairing code") as HTMLInputElement).value).toBe("");
       expect(document.body.textContent).not.toContain("k7rp-9x4t");
       expect(document.body.textContent).not.toContain("K7RP-9X4T");
+    });
+
+    it("shows a mismatch the server found even though the local check passed", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      // The certificate on the pairing dial was not the one the inspect dial
+      // saw — a rotation between the two calls, an address that moved, or the
+      // SDK's post-redemption check. The panel is still green, because the
+      // panel only knows what `inspect` reported, so the refusal box is the
+      // only thing that can say so. Silence here would be the worst outcome in
+      // the whole flow.
+      api.pairCore.mockRejectedValueOnce(
+        refusalOf("fingerprint-mismatch", {
+          expectedFingerprint: PRESENTED,
+          presentedFingerprint: OTHER,
+        }),
+      );
+
+      await click("Pair Core");
+
+      expect(state()).toBe("verified");
+      const box = document.querySelector('[data-pairing-failure="fingerprint-mismatch"]');
+      expect(box).toBeTruthy();
+      expect(box!.textContent).toContain("treat the code as spent");
+    });
+
+    it("still hides the box when the panel beside it is already showing the mismatch", async () => {
+      await openPage();
+      await checkFingerprint();
+      await act(async () => {
+        type("CA fingerprint from `actana pair new`", OTHER);
+      });
+
+      // Suppression is keyed on the local comparison, not on the failure code:
+      // this is the one case where the panel says it better, with both
+      // fingerprints side by side.
+      expect(state()).toBe("mismatch");
+      expect(document.querySelector("[data-pairing-failure]")).toBeNull();
+    });
+
+    it("keeps the server's own sentence for a refusal that is not a pairing one", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      // The registry refusing an endpoint it already holds. The server writes a
+      // true sentence for it; a fabricated `core-error` would say the Core
+      // failed, that nothing was paired, and to mint a fresh code — none of
+      // which is true, and the last of which sends the operator in a circle.
+      const stated = "A Core at wss://prod-vm-1.internal:7777 is already registered.";
+      api.pairCore.mockRejectedValueOnce(new ApiError(stated, 400, { error: stated }));
+
+      await click("Pair Core");
+
+      const box = screen.getByRole("alert");
+      expect(box.textContent).toBe(stated);
+      expect(box.textContent).not.toContain("actana pair new");
+    });
+
+    it("renders the sentence the server sent rather than recomputing one", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      // A failure code this build does not know about: `pairingFailureMessage`
+      // is an exhaustive switch with no default and would paint an empty box.
+      const stated = "This Core wants something newer than this Panel knows how to say.";
+      api.pairCore.mockRejectedValueOnce(
+        new ApiError(stated, 400, { failure: "some-future-failure", error: stated }),
+      );
+
+      await click("Pair Core");
+      expect(screen.getByRole("alert").textContent).toBe(stated);
     });
 
     it("falls back to something true when the failure is not a refusal at all", async () => {

--- a/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
+++ b/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
@@ -1,0 +1,357 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CoreWithDial } from "~/shared/cores";
+import type { CorePairingFailureCode, CorePairingRefusal } from "~/shared/core-pairing";
+
+/**
+ * Adding a Core from Settings → Cores, by short code (#286).
+ *
+ * The page's job here is a sequence, not a form: an address, then a fingerprint
+ * the operator looks at, and only then a code. What these tests hold it to is
+ * the part a server-side suite cannot see — that the three fingerprint states
+ * are visibly three, that a mismatch has nothing to click past, and that a
+ * "verified" badge is never worn on behalf of a machine the box is no longer
+ * pointed at.
+ */
+
+const PRESENTED = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+const OTHER = `11:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99`;
+const ORIGIN = "https://prod-vm-1.internal:7777";
+
+/** The client's error type, as `~/lib/api` declares it — the mock stands in for the module. */
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+function paired(label = "prod-vm-1"): CoreWithDial {
+  return {
+    id: "core_new",
+    endpoint: "wss://prod-vm-1.internal:7777",
+    label,
+    lastEventId: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    dial: { coreId: "core_new", state: "connecting", lastSeenAt: null },
+  };
+}
+
+const api = {
+  listCores: vi.fn(async (): Promise<{ cores: CoreWithDial[] }> => ({ cores: CORES })),
+  inspectCoreForPairing: vi.fn(async (_address: string) => ({
+    identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+  })),
+  pairCore: vi.fn(async (_body: unknown): Promise<{ core: CoreWithDial }> => ({ core: paired() })),
+  renameCore: vi.fn(),
+  removeCore: vi.fn(async () => undefined),
+  addCore: vi.fn(),
+  getKeybindings: vi.fn(async () => ({ bindings: {} })),
+};
+
+const toasts = { success: vi.fn(), error: vi.fn() };
+
+vi.mock("~/lib/api", () => ({ api, ApiError }));
+vi.mock("sonner", () => ({ toast: toasts }));
+
+const { CoresSettingsPage } = await import("../CoresSettingsPage");
+const { KeybindingsProvider } = await import("~/lib/keybindings/store");
+const { pairingFailureMessage } = await import("~/shared/core-pairing");
+
+let CORES: CoreWithDial[] = [];
+
+async function openPage(): Promise<void> {
+  render(
+    <KeybindingsProvider>
+      <CoresSettingsPage />
+    </KeybindingsProvider>,
+  );
+  await act(async () => {});
+}
+
+function fingerprintPanel(): HTMLElement {
+  const el = document.querySelector("[data-fingerprint-state]");
+  if (!el) throw new Error("no fingerprint panel rendered");
+  return el as HTMLElement;
+}
+
+function state(): string | null {
+  return fingerprintPanel().getAttribute("data-fingerprint-state");
+}
+
+function type(label: string | RegExp, value: string): void {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+async function click(name: string | RegExp): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+/** Address in, fingerprint read off the Core. Stops short of confirming it. */
+async function checkFingerprint(address = "prod-vm-1.internal:7777"): Promise<void> {
+  type("Core address", address);
+  await click("Check fingerprint");
+}
+
+/** The whole way to a verified fingerprint, which is what unlocks the code. */
+async function verify(): Promise<void> {
+  await checkFingerprint();
+  await act(async () => {
+    type("CA fingerprint from `actana pair new`", PRESENTED);
+  });
+}
+
+function refusalOf(failure: CorePairingFailureCode, extra: Partial<CorePairingRefusal> = {}): ApiError {
+  const refusal: CorePairingRefusal = {
+    failure,
+    error: pairingFailureMessage(failure, extra),
+    ...extra,
+  };
+  return new ApiError(refusal.error, 400, refusal);
+}
+
+describe("adding a Core by short code (#286)", () => {
+  beforeEach(() => {
+    CORES = [];
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    api.inspectCoreForPairing.mockImplementation(async () => ({
+      identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+    }));
+    api.pairCore.mockImplementation(async () => ({ core: paired() }));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("asks for an address and a code, not for a blob to paste", async () => {
+    await openPage();
+    expect(screen.getByLabelText("Core address")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("paste the pairing token here…")).toBeNull();
+    expect(screen.queryByLabelText("Pairing token")).toBeNull();
+  });
+
+  describe("the three fingerprint states", () => {
+    it("starts not-yet-checked, with nowhere to type a code", async () => {
+      await openPage();
+      expect(state()).toBe("unchecked");
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", true);
+    });
+
+    it("stays not-yet-checked once the Core has answered but nothing is compared", async () => {
+      await openPage();
+      await checkFingerprint();
+      // The fingerprint is on screen to be compared — and until it has been,
+      // this is still the unchecked state and there is still no code field.
+      expect(screen.getByText(PRESENTED)).toBeTruthy();
+      expect(state()).toBe("unchecked");
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+    });
+
+    it("reads verified when the two strings are the same, and opens the code", async () => {
+      await openPage();
+      await verify();
+      expect(state()).toBe("verified");
+      expect(screen.getByLabelText("Pairing code")).toBeTruthy();
+      expect(screen.getByLabelText("Session")).toBeTruthy();
+    });
+
+    it("reads mismatched, shows both, and has nothing to click past", async () => {
+      await openPage();
+      await checkFingerprint();
+      await act(async () => {
+        type("CA fingerprint from `actana pair new`", OTHER);
+      });
+
+      expect(state()).toBe("mismatch");
+      expect(fingerprintPanel().getAttribute("role")).toBe("alert");
+      // Both halves of the disagreement are on screen.
+      expect(screen.getByText("Expected")).toBeTruthy();
+      expect(screen.getByText("Presented")).toBeTruthy();
+      expect(screen.getAllByText(OTHER).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(PRESENTED).length).toBeGreaterThan(0);
+      // A refusal, not a warning: there is no code box and no way to send one.
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", true);
+      expect(api.pairCore).not.toHaveBeenCalled();
+    });
+
+    it("takes the fingerprint the way a human copies it off a terminal", async () => {
+      await openPage();
+      await checkFingerprint();
+      await act(async () => {
+        type("CA fingerprint from `actana pair new`", `  sha256:${PRESENTED.replace(/:/g, "").toLowerCase()}  `);
+      });
+      expect(state()).toBe("verified");
+    });
+
+    it("drops a verified fingerprint when the address changes under it", async () => {
+      await openPage();
+      await verify();
+      expect(state()).toBe("verified");
+
+      await act(async () => {
+        type("Core address", "other-box.internal:7777");
+      });
+
+      // A badge earned by one machine must not be worn by another.
+      expect(state()).toBe("unchecked");
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+    });
+  });
+
+  describe("sending the code", () => {
+    it("posts what the operator was read out, and reports the paired Core", async () => {
+      await openPage();
+      await verify();
+      type("Session", " ps_abc ");
+      type("Pairing code", "k7rp-9x4t");
+      type("Name in this Panel (optional)", " prod-vm-1 ");
+
+      await click("Pair Core");
+
+      expect(api.pairCore).toHaveBeenCalledWith({
+        address: "prod-vm-1.internal:7777",
+        code: "k7rp-9x4t",
+        sessionId: "ps_abc",
+        expectedFingerprint: PRESENTED,
+        label: "prod-vm-1",
+      });
+      expect(toasts.success).toHaveBeenCalledWith('Core "prod-vm-1" paired.');
+    });
+
+    it("takes a code typed without its hyphen, in whatever case", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp9x4t");
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", false);
+
+      await click("Pair Core");
+      expect(api.pairCore).toHaveBeenCalledWith(expect.objectContaining({ code: "k7rp9x4t" }));
+    });
+
+    it("will not send a code that could not be one, or one with no session", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp");
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", true);
+
+      type("Pairing code", "k7rp9x4t");
+      type("Session", "  ");
+      expect(screen.getByRole("button", { name: "Pair Core" })).toHaveProperty("disabled", true);
+    });
+
+    it("clears the form once the Core is in the fleet", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      await click("Pair Core");
+
+      expect((screen.getByLabelText("Core address") as HTMLInputElement).value).toBe("");
+      expect(state()).toBe("unchecked");
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+    });
+  });
+
+  describe("failures the operator has to tell apart", () => {
+    const FAILURES: CorePairingFailureCode[] = [
+      "bad-address",
+      "bad-code",
+      "bad-fingerprint",
+      "unreachable",
+      "no-ca-presented",
+      "fingerprint-unconfirmed",
+      "hostname-mismatch",
+      "certificate-invalid",
+      "refused",
+      "rate-limited",
+      "rejected",
+      "not-pairable",
+      "core-error",
+      "malformed-response",
+    ];
+
+    it.each(FAILURES)("renders a message of its own for %s", async (failure) => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      api.pairCore.mockRejectedValueOnce(refusalOf(failure));
+
+      await click("Pair Core");
+
+      const box = document.querySelector(`[data-pairing-failure="${failure}"]`);
+      expect(box).toBeTruthy();
+      expect(box!.textContent).toBe(pairingFailureMessage(failure));
+    });
+
+    it("says something different for each of them", async () => {
+      const said = new Set(FAILURES.map((failure) => pairingFailureMessage(failure)));
+      expect(said.size).toBe(FAILURES.length);
+    });
+
+    it("names the wait when the Core asked for one", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      api.pairCore.mockRejectedValueOnce(refusalOf("rate-limited", { retryAfterSeconds: 42 }));
+
+      await click("Pair Core");
+      expect(screen.getByRole("alert").textContent).toContain("42s");
+    });
+
+    it("empties the box on a refusal, and never prints the code that was in it", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      api.pairCore.mockRejectedValueOnce(refusalOf("refused"));
+
+      await click("Pair Core");
+
+      // Spent, dead or wrong — a second attempt could only burn another of the
+      // session's five, and the code has no reason to still be in memory.
+      expect((screen.getByLabelText("Pairing code") as HTMLInputElement).value).toBe("");
+      expect(document.body.textContent).not.toContain("k7rp-9x4t");
+      expect(document.body.textContent).not.toContain("K7RP-9X4T");
+    });
+
+    it("falls back to something true when the failure is not a refusal at all", async () => {
+      await openPage();
+      await verify();
+      type("Session", "ps_abc");
+      type("Pairing code", "k7rp-9x4t");
+      api.pairCore.mockRejectedValueOnce(new Error("socket hang up"));
+
+      await click("Pair Core");
+
+      const box = document.querySelector('[data-pairing-failure="core-error"]');
+      expect(box).toBeTruthy();
+      expect(box!.textContent).toContain("Nothing was paired");
+    });
+
+    it("reports a first-contact dial that failed, without offering a code box", async () => {
+      await openPage();
+      api.inspectCoreForPairing.mockRejectedValueOnce(refusalOf("unreachable"));
+      await checkFingerprint();
+
+      expect(document.querySelector('[data-pairing-failure="unreachable"]')).toBeTruthy();
+      expect(state()).toBe("unchecked");
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+    });
+  });
+});

--- a/packages/panel/src/lib/api.ts
+++ b/packages/panel/src/lib/api.ts
@@ -2,6 +2,7 @@ import type { Group, Project, ProjectPresentation, Task, UserTerminal } from "~/
 import type { Harness, TaskStatus } from "@actana/shared/domain";
 import type { ProjectPathStatus, ProjectWithCounts } from "~/shared/projects";
 import type { CoreListResponse, CoreWithDial } from "~/shared/cores";
+import type { CorePairingIdentityResponse } from "~/shared/core-pairing";
 import { DEV_SERVER_ORIGIN } from "~/shared/dev-server";
 import type { Binding, BindingMap, HotkeyAction } from "~/lib/keybindings/types";
 import type { UsageSummary } from "~/shared/token-usage";
@@ -175,6 +176,38 @@ export const api = {
     req<{ core: CoreWithDial }>(`/api/cores/${id}`, {
       method: "PATCH",
       body: JSON.stringify({ label }),
+    }),
+  /**
+   * Ask the Panel server what certificate authority a Core presents (#286).
+   *
+   * No code goes in this request, which is what makes it safe to make against
+   * an address nobody has verified yet: the answer is the fingerprint the
+   * operator compares against what `actana pair new` printed, and the dial
+   * that produced it sent nothing.
+   */
+  inspectCoreForPairing: (address: string) =>
+    req<CorePairingIdentityResponse>("/api/cores/pairing/inspect", {
+      method: "POST",
+      body: JSON.stringify({ address }),
+    }),
+  /**
+   * Pair with a Core by short code. The server dials, checks the fingerprint
+   * again, redeems the code and registers what comes back — the key it now
+   * holds was generated there and never crossed the wire, in either direction.
+   *
+   * A refusal is an ApiError whose `body` is a `CorePairingRefusal`: switch on
+   * `failure` to say what to do next rather than rendering `message` alone.
+   */
+  pairCore: (body: {
+    address: string;
+    code: string;
+    sessionId?: string;
+    expectedFingerprint: string;
+    label?: string;
+  }) =>
+    req<{ core: CoreWithDial }>("/api/cores/pairing", {
+      method: "POST",
+      body: JSON.stringify(body),
     }),
   removeCore: (id: string) => req<void>(`/api/cores/${id}`, { method: "DELETE" }),
 

--- a/packages/panel/src/server/__tests__/cores-pairing-api.test.ts
+++ b/packages/panel/src/server/__tests__/cores-pairing-api.test.ts
@@ -366,13 +366,17 @@ describe("a code redeemed against a Core the operator verified", () => {
     expect(listed).not.toContain(code);
   }, 40_000);
 
-  it("refuses a second Core at an endpoint already registered", async () => {
+  it("refuses a second Core at an endpoint already registered, without spending the code", async () => {
     const rig = await startCore();
     const first = rig.openSession();
-    expect(
-      (await pair({ address: rig.address, code: first.code, sessionId: first.sessionId, expectedFingerprint: rig.fingerprint }))
-        .status,
-    ).toBe(201);
+    const created = await pair({
+      address: rig.address,
+      code: first.code,
+      sessionId: first.sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(created.status).toBe(201);
+    const firstId = ((await created.json()) as { core: { id: string } }).core.id;
 
     const second = rig.openSession();
     const response = await pair({
@@ -384,6 +388,43 @@ describe("a code redeemed against a Core the operator verified", () => {
     expect(response.status).toBe(400);
     expect(((await response.json()) as { error: string }).error).toContain("already registered");
     expect(registryCounts()).toEqual({ cores: 1, secrets: 1 });
+
+    // The collision was seen *before* the redemption, so the operator still has
+    // their code: remove the Core that was in the way and the same code pairs.
+    // Discovering this after the fact would have cost them the code and left
+    // this Core holding a signed certificate for a client nobody stored.
+    expect((await call(`/api/cores/${firstId}`, { method: "DELETE" })).status).toBe(204);
+    expect(
+      (await pair({
+        address: rig.address,
+        code: second.code,
+        sessionId: second.sessionId,
+        expectedFingerprint: rig.fingerprint,
+      })).status,
+    ).toBe(201);
+  }, 40_000);
+
+  it("says so plainly, without telling the operator to mint a code they still hold", async () => {
+    const rig = await startCore();
+    const first = rig.openSession();
+    await pair({ address: rig.address, code: first.code, sessionId: first.sessionId, expectedFingerprint: rig.fingerprint });
+
+    const second = rig.openSession();
+    const body = (await (
+      await pair({
+        address: rig.address,
+        code: second.code,
+        sessionId: second.sessionId,
+        expectedFingerprint: rig.fingerprint,
+      })
+    ).json()) as { error: string; failure?: string };
+
+    // Not a pairing refusal — the registry's own, so it carries no `failure`
+    // and the renderer must show this sentence rather than write one of its
+    // own over it.
+    expect(body.failure).toBeUndefined();
+    expect(body.error).toContain("has not been used");
+    expect(body.error).not.toContain("actana pair new");
   }, 40_000);
 
   it("requires an Operator session", async () => {

--- a/packages/panel/src/server/__tests__/cores-pairing-api.test.ts
+++ b/packages/panel/src/server/__tests__/cores-pairing-api.test.ts
@@ -1,0 +1,506 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as https from "node:https";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Server } from "node:net";
+import { X509Certificate } from "node:crypto";
+import { generateCertMaterial } from "@actana/shared/core-cert-material";
+import { verifyBearer } from "@actana/shared/core-link-bearer";
+import { generatePairingCode } from "@actana/shared/pairing-code";
+import { createPairingSession } from "@actana/shared/pairing-session";
+import { PairingStore, derivePairingCodeKey, hashPairingCode } from "@actana/shared/pairing-store";
+import { createCoreFilesRequestHandler } from "@actana/core/core-files-routes";
+import {
+  buildCorePairingRoutes,
+  composeCoreHttpRoutes,
+  isPairingPath,
+} from "@actana/core/core-pairing-wiring";
+import { PtyCoreLinkServer } from "@actana/core/pty-core-link-server";
+import { fingerprintOf } from "@actana/sdk/core-pairing";
+import type { PtyCore } from "@actana/core/pty-manager";
+import type { EventLogPort } from "@actana/core/pty-core-link-server";
+
+/**
+ * The Panel's pairing surface, driven the way a browser drives it (#286).
+ *
+ * The Core here is real: the Core's own `PtyCoreLinkServer` with the Core's own
+ * pairing routes mounted through the Core's own wiring, behind a real TLS
+ * socket, with sessions in the `PairingStore` that `actana pair new` writes. So
+ * "the code was redeemed" means a CSR was signed by that CA, and "the Panel can
+ * dial what it paired" means an mTLS handshake and a bearer both actually
+ * worked — not that a fake resolved a promise.
+ *
+ * What this suite is really watching for is the three ways this endpoint could
+ * be wrong in a way nothing downstream would notice: a mismatch that stores
+ * something, a Core paired by code that is not dialable the way a pasted one
+ * is, and a code or a private key finding its way into a response.
+ */
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ac-cores-pairing-test-"));
+process.env.AC_USER_DATA_DIR = path.join(tmpRoot, "app");
+process.env.AC_PANEL_DATA_DIR = path.join(tmpRoot, "panel");
+
+const { handleApiRequest } = await import("../api-router");
+const { closePanelDb, getPanelDb } = await import("../panel-db");
+const { operatorSessionCookie } = await import("./_operator-session");
+const { resetCoreLinkManagerForTests } = await import("../services/core-link-manager");
+
+const ORIGIN = "http://panel.example.test";
+const SECRET = "panel-pairing-suite-secret-at-least-32-bytes";
+const CORE_UUID = "3b7c0d61-9a2e-4f10-8c5b-7d1e2a4f6b90";
+
+async function call(
+  pathname: string,
+  init: RequestInit & { json?: unknown; anonymous?: boolean } = {},
+): Promise<Response> {
+  const { json, anonymous, ...rest } = init;
+  const headers: Record<string, string> = { ...(rest.headers as Record<string, string>) };
+  if (!anonymous) headers.cookie = operatorSessionCookie();
+  if (json !== undefined) headers["content-type"] = "application/json";
+  const response = await handleApiRequest(
+    new Request(`${ORIGIN}${pathname}`, {
+      ...rest,
+      headers,
+      body: json !== undefined ? JSON.stringify(json) : rest.body,
+    }),
+  );
+  if (!response) throw new Error(`no API response for ${pathname}`);
+  return response;
+}
+
+// ─── A real Core, with a real pairing endpoint ────────────────────────────
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = new Server();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address && typeof address === "object") {
+        const { port } = address;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close();
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: () => {},
+    spawn: async () => ({ ptyId: "pty-1" }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    killPtysUnderPath: async () => ({ ptyCount: 0 }),
+    findByTask: () => ({ ptyId: null }),
+    taskIdForPty: () => null,
+    replay: () => ({ data: "", nextSeq: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+function emptyEventLog(): EventLogPort {
+  return { appendEvent: () => 0, getLastEventId: () => 0, readEventTail: () => [] };
+}
+
+type Rig = {
+  address: string;
+  origin: string;
+  fingerprint: string;
+  caCert: string;
+  openSession(label?: string): { sessionId: string; code: string };
+};
+
+const running: PtyCoreLinkServer[] = [];
+const tempDirs: string[] = [];
+
+async function startCore(): Promise<Rig> {
+  const material = await generateCertMaterial({ host: "127.0.0.1" });
+  const port = await freePort();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-panel-pairing-store-"));
+  tempDirs.push(dir);
+  const store = new PairingStore(path.join(dir, "pairing.json"));
+  const codeKey = derivePairingCodeKey(SECRET);
+
+  const pairingRoutes = buildCorePairingRoutes({
+    material: {
+      caCert: material.ca.cert,
+      caKey: material.ca.key,
+      bearerSecret: SECRET,
+      coreId: "core_paired",
+      coreUuid: CORE_UUID,
+    },
+    sessions: store,
+    endpoint: `wss://127.0.0.1:${port}`,
+  });
+  const fileRoutes = createCoreFilesRequestHandler({
+    filesPort: { projectRoot: () => null },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+  });
+
+  const server = new PtyCoreLinkServer(mockCore(), {
+    eventLog: emptyEventLog(),
+    port,
+    host: "127.0.0.1",
+    tls: {
+      caCert: material.ca.cert,
+      serverCert: material.server.cert,
+      serverKey: material.server.key,
+    },
+    authVerifier: (bearer) => verifyBearer(bearer, SECRET),
+    httpRoutes: composeCoreHttpRoutes(pairingRoutes, fileRoutes),
+    isPreAuthPath: isPairingPath,
+  });
+  running.push(server);
+
+  await waitForListening(port, material.ca.cert);
+
+  return {
+    address: `127.0.0.1:${port}`,
+    origin: `https://127.0.0.1:${port}`,
+    fingerprint: fingerprintOf(new X509Certificate(material.ca.cert).raw),
+    caCert: material.ca.cert,
+    openSession: (label = "the-panel") => {
+      const code = generatePairingCode();
+      const sessionId = `ps_${running.length}_${Date.now().toString(16)}`;
+      store.createSession(
+        createPairingSession({
+          id: sessionId,
+          label,
+          codeHash: hashPairingCode({ key: codeKey, sessionId, code }),
+          now: Date.now(),
+        }),
+        Date.now(),
+      );
+      return { sessionId, code };
+    },
+  };
+}
+
+/**
+ * Readiness, observed on a route that is not the pairing one — a probe there
+ * would spend a rate-limit attempt before a test had started.
+ */
+async function waitForListening(port: number, caCert: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = https.request(
+          { host: "127.0.0.1", port, path: "/healthz", method: "GET", ca: caCert, agent: false },
+          (res) => {
+            res.resume();
+            res.on("end", () => resolve());
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+      return;
+    } catch (err) {
+      if (Date.now() > deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+afterEach(() => {
+  resetCoreLinkManagerForTests();
+  for (const server of running.splice(0)) server.close();
+  while (tempDirs.length > 0) fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  const db = getPanelDb();
+  db.prepare("DELETE FROM core_secrets").run();
+  db.prepare("DELETE FROM cores").run();
+});
+
+afterAll(() => {
+  closePanelDb();
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+type Refusal = { failure: string; error: string; expectedFingerprint?: string; presentedFingerprint?: string };
+
+async function inspect(address: string): Promise<Response> {
+  return call("/api/cores/pairing/inspect", { method: "POST", json: { address } });
+}
+
+async function pair(body: Record<string, unknown>): Promise<Response> {
+  return call("/api/cores/pairing", { method: "POST", json: body });
+}
+
+function registryCounts(): { cores: number; secrets: number } {
+  const db = getPanelDb();
+  const cores = (db.prepare("SELECT COUNT(*) AS n FROM cores").get() as { n: number }).n;
+  const secrets = (db.prepare("SELECT COUNT(*) AS n FROM core_secrets").get() as { n: number }).n;
+  return { cores, secrets };
+}
+
+async function dialOf(id: string): Promise<{ state: string; lastSeenAt: number | null }> {
+  const body = (await (await call("/api/cores")).json()) as {
+    cores: { id: string; dial: { state: string; lastSeenAt: number | null } }[];
+  };
+  const core = body.cores.find((c) => c.id === id);
+  if (!core) throw new Error(`core ${id} not listed`);
+  return core.dial;
+}
+
+describe("first contact: what the Core presents, before anything is sent", () => {
+  it("reports the CA fingerprint an operator can compare", async () => {
+    const rig = await startCore();
+    const response = await inspect(rig.address);
+    expect(response.status).toBe(200);
+    expect((await response.json()) as unknown).toEqual({
+      identity: { fingerprint: rig.fingerprint, httpsOrigin: rig.origin },
+    });
+  }, 30_000);
+
+  it("does not hand the browser the certificate itself — only what it must compare", async () => {
+    const rig = await startCore();
+    const raw = await (await inspect(rig.address)).text();
+    expect(raw).not.toContain("BEGIN CERTIFICATE");
+  }, 30_000);
+
+  it("refuses an address that is not one, and one nothing answers at", async () => {
+    expect(((await (await inspect("http://plain.example:80")).json()) as Refusal).failure).toBe(
+      "bad-address",
+    );
+    const dead = await inspect(`127.0.0.1:${await freePort()}`);
+    expect(((await dead.json()) as Refusal).failure).toBe("unreachable");
+  }, 30_000);
+
+  it("requires an Operator session", async () => {
+    const response = await call("/api/cores/pairing/inspect", {
+      method: "POST",
+      anonymous: true,
+      json: { address: "127.0.0.1:1" },
+    });
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("a code redeemed against a Core the operator verified", () => {
+  it("registers a Core the Panel then reaches over mTLS", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+
+    const response = await pair({
+      address: rig.address,
+      code,
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+      label: "prod-vm-1",
+    });
+    expect(response.status).toBe(201);
+    const { core } = (await response.json()) as { core: { id: string; label: string; endpoint: string } };
+    expect(core.label).toBe("prod-vm-1");
+    expect(core.endpoint).toBe(`wss://127.0.0.1:${new URL(rig.origin).port}`);
+
+    // The registry row and the sealed secrets are both there, and the dialer
+    // gets all the way to an authenticated core-link with them.
+    expect(registryCounts()).toEqual({ cores: 1, secrets: 1 });
+    await vi.waitFor(async () => expect((await dialOf(core.id)).state).toBe("connected"), {
+      timeout: 10_000,
+    });
+  }, 40_000);
+
+  it("takes the code hyphenated or not, and in any case", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const mangled = code.replace("-", "").toLowerCase();
+    expect(mangled).not.toBe(code);
+
+    const response = await pair({
+      address: rig.address,
+      code: mangled,
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(response.status).toBe(201);
+  }, 40_000);
+
+  it("takes the fingerprint the way a human copies it — no colons, any case", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const response = await pair({
+      address: rig.address,
+      code,
+      sessionId,
+      expectedFingerprint: rig.fingerprint.replace(/:/g, "").toLowerCase(),
+    });
+    expect(response.status).toBe(201);
+  }, 40_000);
+
+  it("names the machine, not this Panel, when no alias is typed", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const response = await pair({
+      address: rig.address,
+      code,
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+      label: "",
+    });
+    // The label the Panel sends the Core describes the Panel; letting it come
+    // back round as the alias would name every row after this Panel.
+    expect(((await response.json()) as { core: { label: string } }).core.label).toBe("127.0.0.1");
+  }, 40_000);
+
+  it("never lets the code or the issued key back into a response", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const created = await (
+      await pair({ address: rig.address, code, sessionId, expectedFingerprint: rig.fingerprint })
+    ).text();
+    expect(created).not.toContain("PRIVATE KEY");
+    expect(created).not.toContain("BEGIN CERTIFICATE");
+    expect(created).not.toContain(code);
+    expect(created).not.toContain(code.replace("-", ""));
+
+    const listed = await (await call("/api/cores")).text();
+    expect(listed).not.toContain("PRIVATE KEY");
+    expect(listed).not.toContain(code);
+  }, 40_000);
+
+  it("refuses a second Core at an endpoint already registered", async () => {
+    const rig = await startCore();
+    const first = rig.openSession();
+    expect(
+      (await pair({ address: rig.address, code: first.code, sessionId: first.sessionId, expectedFingerprint: rig.fingerprint }))
+        .status,
+    ).toBe(201);
+
+    const second = rig.openSession();
+    const response = await pair({
+      address: rig.address,
+      code: second.code,
+      sessionId: second.sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { error: string }).error).toContain("already registered");
+    expect(registryCounts()).toEqual({ cores: 1, secrets: 1 });
+  }, 40_000);
+
+  it("requires an Operator session", async () => {
+    const response = await call("/api/cores/pairing", {
+      method: "POST",
+      anonymous: true,
+      json: { address: "127.0.0.1:1", code: "AAAA-BBBB", sessionId: "ps_x", expectedFingerprint: "x" },
+    });
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("a fingerprint that does not match", () => {
+  it("stores nothing, and shows both fingerprints", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const wrong = rig.fingerprint.startsWith("AA")
+      ? `BB${rig.fingerprint.slice(2)}`
+      : `AA${rig.fingerprint.slice(2)}`;
+
+    const response = await pair({
+      address: rig.address,
+      code,
+      sessionId,
+      expectedFingerprint: wrong,
+    });
+    expect(response.status).toBe(400);
+    const refusal = (await response.json()) as Refusal;
+    expect(refusal.failure).toBe("fingerprint-mismatch");
+    expect(refusal.expectedFingerprint).toBe(wrong);
+    expect(refusal.presentedFingerprint).toBe(rig.fingerprint);
+
+    // Nothing was written, and — the part that matters — the code was not
+    // spent, so the same session still redeems.
+    expect(registryCounts()).toEqual({ cores: 0, secrets: 0 });
+    expect(
+      (await pair({ address: rig.address, code, sessionId, expectedFingerprint: rig.fingerprint }))
+        .status,
+    ).toBe(201);
+  }, 40_000);
+
+  it("refuses to send a code with no fingerprint to compare at all", async () => {
+    const rig = await startCore();
+    const { sessionId, code } = rig.openSession();
+    const response = await pair({ address: rig.address, code, sessionId, expectedFingerprint: "" });
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as Refusal).failure).toBe("fingerprint-unconfirmed");
+    expect(registryCounts()).toEqual({ cores: 0, secrets: 0 });
+    // Still redeemable: an unconfirmed fingerprint costs the session nothing.
+    expect(
+      (await pair({ address: rig.address, code, sessionId, expectedFingerprint: rig.fingerprint }))
+        .status,
+    ).toBe(201);
+  }, 40_000);
+});
+
+describe("the failures an operator has to tell apart", () => {
+  it("distinguishes a wrong code from a bad address, a bad code and an unreachable Core", async () => {
+    const rig = await startCore();
+    const { sessionId } = rig.openSession();
+
+    const wrongCode = await pair({
+      address: rig.address,
+      code: "AAAA-BBBB",
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(((await wrongCode.json()) as Refusal).failure).toBe("refused");
+
+    const badShape = await pair({
+      address: rig.address,
+      code: "nope",
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(((await badShape.json()) as Refusal).failure).toBe("bad-code");
+
+    const badAddress = await pair({
+      address: "ws://plain.example:80",
+      code: "AAAA-BBBB",
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(((await badAddress.json()) as Refusal).failure).toBe("bad-address");
+
+    const unreachable = await pair({
+      address: `127.0.0.1:${await freePort()}`,
+      code: "AAAA-BBBB",
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    expect(((await unreachable.json()) as Refusal).failure).toBe("unreachable");
+
+    expect(registryCounts()).toEqual({ cores: 0, secrets: 0 });
+  }, 40_000);
+
+  it("never quotes the code back, even when the code is what was wrong", async () => {
+    const rig = await startCore();
+    const { sessionId } = rig.openSession();
+    // The SDK's own message for this failure quotes the string it was handed.
+    // The Panel writes its sentence from the failure code instead, and this is
+    // what stops a mistyped code landing in an error box, a log, or a report.
+    const typed = "hunter2-secretish";
+    const response = await pair({
+      address: rig.address,
+      code: typed,
+      sessionId,
+      expectedFingerprint: rig.fingerprint,
+    });
+    const raw = await response.text();
+    expect(raw).toContain("bad-code");
+    expect(raw).not.toContain(typed);
+    expect(raw).not.toContain("HUNTER2");
+  }, 40_000);
+
+  it("rejects a body that is missing the fields the flow depends on", async () => {
+    expect((await pair({ address: "127.0.0.1:1" })).status).toBe(400);
+    expect((await pair({ code: "AAAA-BBBB" })).status).toBe(400);
+  });
+});

--- a/packages/panel/src/server/api-router.ts
+++ b/packages/panel/src/server/api-router.ts
@@ -212,6 +212,16 @@ async function dispatch(
     if (method === "GET") return coresController.list();
     if (method === "POST") return coresController.add(request);
   }
+  // Pairing (#286). Literal paths, and matched before CORE_PATH so `pairing`
+  // is never read as a Core id. Both are Node-side work the browser cannot do:
+  // a TLS chain is read here, a key pair is born here, and a code is spent
+  // here — see `services/core-pairing.ts`.
+  if (pathname === "/api/cores/pairing/inspect" && method === "POST") {
+    return coresController.inspect(request);
+  }
+  if (pathname === "/api/cores/pairing" && method === "POST") {
+    return coresController.pair(request);
+  }
   // A Project's files, on the Core that owns them (#129 F6/F11, #169). The
   // Panel is a dumb pipe here: these three lines resolve a Core and forward a
   // stream, and every decision about what a path means is the Core's.

--- a/packages/panel/src/server/controllers/cores.controller.ts
+++ b/packages/panel/src/server/controllers/cores.controller.ts
@@ -1,26 +1,43 @@
 import { z } from "zod";
 import { json, noContent, notFound, parseJsonBody } from "./_helpers";
-import { HTTP_CREATED } from "~/shared/http-status";
+import { HTTP_BAD_REQUEST, HTTP_CREATED } from "~/shared/http-status";
 import {
   listCores,
   registerCoreFromRegistrationBlob,
   removeCore,
   renameCore,
 } from "../services/cores";
+import {
+  CorePairingRefusedError,
+  inspectCoreForPairing,
+  pairCore,
+} from "../services/core-pairing";
 import { coreLinkManager } from "../services/core-link-manager";
 import type { Core, CoreWithDial } from "~/shared/cores";
 
 /**
- * The Cores surface: list the fleet with live link state, register a new Core
- * from a registration blob, rename one, forget one.
+ * The Cores surface: list the fleet with live link state, add a Core — by
+ * pairing code, or from the registration blob #287 removes — rename one,
+ * forget one.
  *
  * Note what is absent — there is no endpoint that returns a Core's secrets, and
- * none that takes them piecemeal. The credentials enter once, inside the blob,
- * and from then on only the dialer reads them.
+ * none that takes them piecemeal. The credentials enter once, inside a
+ * credential the service assembles, and from then on only the dialer reads
+ * them. The pairing routes hold that line from the other side too: a code goes
+ * in, a Core comes back, and the key the Panel now holds was never in either
+ * direction of the exchange.
  */
 
 const addBody = z.object({ registrationBlob: z.string() });
 const renameBody = z.object({ label: z.string() });
+const inspectBody = z.object({ address: z.string() });
+const pairBody = z.object({
+  address: z.string(),
+  code: z.string(),
+  sessionId: z.string().optional(),
+  expectedFingerprint: z.string(),
+  label: z.string().optional(),
+});
 
 function withDial(core: Core): CoreWithDial {
   return { ...core, dial: coreLinkManager().status(core.id) };
@@ -45,6 +62,67 @@ export async function add(request: Request): Promise<Response> {
   const core = registerCoreFromRegistrationBlob(body.data.registrationBlob);
   coreLinkManager().dial(core.id);
   return json({ core: withDial(core) }, { status: HTTP_CREATED });
+}
+
+/**
+ * Report the certificate authority a Core presents, with no code in the
+ * request to leak (#286).
+ *
+ * The first half of the Panel's two-step: the operator is shown this
+ * fingerprint beside the one `actana pair new` printed, and only a confirmed
+ * comparison moves on to {@link pair}. Answering it costs an unverified dial
+ * and nothing else — the connection carries no secret and is dropped as soon
+ * as the chain has been read.
+ */
+export async function inspect(request: Request): Promise<Response> {
+  const body = await parseJsonBody(request, inspectBody);
+  if (!body.ok) return body.response;
+  try {
+    return json({ identity: await inspectCoreForPairing(body.data.address) });
+  } catch (err) {
+    return refusal(err);
+  }
+}
+
+/**
+ * Pair with a Core by short code and register the credential it issues.
+ *
+ * The dial starts here rather than waiting for a poll, exactly as it does for
+ * {@link add}, so the row the operator just paired is already reaching for its
+ * Core by the time the response paints.
+ *
+ * A refusal is a 400 whatever kind it is — including a rate limit. The status
+ * describes *this* request to the Panel, which was well-formed; what the Core
+ * said is in `failure`, which is the field the page switches on.
+ */
+export async function pair(request: Request): Promise<Response> {
+  const body = await parseJsonBody(request, pairBody);
+  if (!body.ok) return body.response;
+  let core: Core;
+  try {
+    core = await pairCore({
+      address: body.data.address,
+      code: body.data.code,
+      ...(body.data.sessionId === undefined ? {} : { sessionId: body.data.sessionId }),
+      expectedFingerprint: body.data.expectedFingerprint,
+      ...(body.data.label === undefined ? {} : { label: body.data.label }),
+    });
+  } catch (err) {
+    return refusal(err);
+  }
+  coreLinkManager().dial(core.id);
+  return json({ core: withDial(core) }, { status: HTTP_CREATED });
+}
+
+/**
+ * A pairing refusal, as the browser reads it: the sentence under `error` so a
+ * generic client shows something useful, and the machine-readable `failure`
+ * beside it so the page can say what to do next. Anything that is not a
+ * refusal is rethrown for the router to handle.
+ */
+function refusal(err: unknown): Response {
+  if (!(err instanceof CorePairingRefusedError)) throw err;
+  return json(err.refusal, { status: HTTP_BAD_REQUEST });
 }
 
 /**

--- a/packages/panel/src/server/services/__tests__/cores.test.ts
+++ b/packages/panel/src/server/services/__tests__/cores.test.ts
@@ -10,6 +10,7 @@ process.env.AC_PANEL_DATA_DIR = path.join(tmpRoot, "panel");
 const { getPanelDb } = await import("../../panel-db");
 const { createOperator, operatorExists } = await import("../operator");
 const {
+  CoreRegistryError,
   RegistrationBlobError,
   advanceCoreCursor,
   getCore,
@@ -134,10 +135,14 @@ describe("Core registry", () => {
     expect(coreRowCount()).toBe(0);
   });
 
+  // `CoreRegistryError`, not `RegistrationBlobError`: an endpoint already spoken
+  // for is the registry's invariant rather than the codec's, and pairing (#286)
+  // hits it through a door that never sees a blob. Same refusal, same 400, same
+  // nothing written — only the name says whose rule it is.
   it("refuses a second registration of the same endpoint, leaving the first intact", () => {
     const first = registerCoreFromRegistrationBlob(registrationBlob());
     expect(() => registerCoreFromRegistrationBlob(registrationBlob({ label: "duplicate" }))).toThrow(
-      RegistrationBlobError,
+      CoreRegistryError,
     );
     expect(listCores().map((c) => c.id)).toEqual([first.id]);
     expect(getCore(first.id)?.label).toBe("prod-vm-1");

--- a/packages/panel/src/server/services/core-pairing.ts
+++ b/packages/panel/src/server/services/core-pairing.ts
@@ -3,9 +3,10 @@ import {
   CorePairingError,
   fetchCorePairingIdentity,
   pairWithCore,
+  parseCoreAddress,
   type CorePairingFailure,
 } from "@actana/sdk/core-pairing";
-import { registerCoreFromCredential } from "./cores";
+import { CoreRegistryError, coreRegisteredAt, registerCoreFromCredential } from "./cores";
 import {
   pairingFailureMessage,
   type CorePairingFailureCode,
@@ -125,6 +126,8 @@ export type PairCoreInput = {
  * `core-link-manager.ts` dials the result unchanged.
  */
 export async function pairCore(input: PairCoreInput): Promise<Core> {
+  refuseIfAlreadyRegistered(input.address);
+
   let credential;
   try {
     credential = await pairWithCore({
@@ -142,6 +145,37 @@ export async function pairCore(input: PairCoreInput): Promise<Core> {
   // the registry's to explain, and wrapping it as a pairing failure would tell
   // the operator to mint a code they do not need.
   return registerCoreFromCredential(credential, { label: input.label ?? "" });
+}
+
+/**
+ * Refuse a collision this Panel can already see, before the code is spent.
+ *
+ * A pairing code is one-time. Redeeming it and *then* discovering the endpoint
+ * is taken costs the operator that code and leaves the Core holding a signed
+ * certificate for a client this Panel never stored — a credential nobody can
+ * use and nobody has revoked. The check inside
+ * {@link registerCoreFromCredential} still runs and is still the authority,
+ * because a Core reports its own endpoint and that need not be the address it
+ * was reached on. This one only moves the ordinary case — an operator pairing a
+ * machine that is already in the fleet — to before the irreversible step.
+ *
+ * A bad address falls through to `pairWithCore`, which owns that failure and
+ * words it. Nothing here dials, so nothing here is slow.
+ */
+function refuseIfAlreadyRegistered(address: string): void {
+  let endpoint: string;
+  try {
+    // Via `httpsOrigin` rather than by reassembling host and port: it keeps the
+    // brackets an IPv6 authority needs, which a `${host}:${port}` would lose.
+    endpoint = `wss://${parseCoreAddress(address).httpsOrigin.slice("https://".length)}`;
+  } catch {
+    return;
+  }
+  if (coreRegisteredAt(endpoint)) {
+    throw new CoreRegistryError(
+      `A Core at ${endpoint} is already registered. Remove it first — your pairing code has not been used.`,
+    );
+  }
 }
 
 /**

--- a/packages/panel/src/server/services/core-pairing.ts
+++ b/packages/panel/src/server/services/core-pairing.ts
@@ -1,0 +1,168 @@
+import { hostname } from "node:os";
+import {
+  CorePairingError,
+  fetchCorePairingIdentity,
+  pairWithCore,
+  type CorePairingFailure,
+} from "@actana/sdk/core-pairing";
+import { registerCoreFromCredential } from "./cores";
+import {
+  pairingFailureMessage,
+  type CorePairingFailureCode,
+  type CorePairingIdentity,
+  type CorePairingRefusal,
+  type CorePairingRefusalDetail,
+} from "~/shared/core-pairing";
+import type { Core } from "~/shared/cores";
+
+/**
+ * Adding a Core by short code, on the side of the Panel that can do it (#286).
+ *
+ * Pairing is Node-side work — an RSA key pair is generated, a TLS chain is read
+ * before anything is trusted, a code is spent — so it runs here, next to the
+ * other Core-side services, and the renderer posts an address, a fingerprint
+ * and a code to it. That is the division the whole file surface already runs
+ * on: the Panel server holds the mTLS credentials because no browser can
+ * present a client certificate (CONTEXT.md "Dumb pipe", ADR 0030).
+ *
+ * **There is no second implementation.** The dial, the fingerprint comparison
+ * and the redemption are `@actana/sdk/core-pairing` — the same function
+ * `actana core pair` calls (#285) — and this module adds an address, a label
+ * and a registry write around it. A behaviour that differs between the Panel
+ * and the CLI would be a bug in one of them, not a choice.
+ *
+ * **What this module refuses to say.** Nothing here logs, and nothing here
+ * forwards an SDK error message. Both are deliberate: `parsePairingTicket`
+ * quotes the string it was given back at the caller, so an SDK message can
+ * carry the code an operator typed. Every sentence the browser gets is written
+ * from the failure *code* by `~/shared/core-pairing`, so the code, the CSR and
+ * the private key have no path into a response body or a log line.
+ */
+
+/**
+ * What the Core is told this client is called — the Panel, and which host it
+ * runs on, because that is what an operator reads in `actana pair ls`.
+ *
+ * Not the Core's alias in this Panel's registry: that names the machine being
+ * added and is the operator's to type. {@link pairCore} keeps the two apart.
+ */
+export const PANEL_PAIRING_CLIENT_LABEL = `actana-panel ${hostname()}`;
+
+/**
+ * Compile-time proof that the browser-facing union is exactly the SDK's.
+ *
+ * `~/shared/core-pairing` restates the failure list rather than importing it,
+ * so that a browser bundle never reaches into a module that opens `node:tls`.
+ * This is the seam where the copy is held to the original: a member added,
+ * removed or renamed in the SDK fails the Panel's typecheck here, which is the
+ * only place that can see both.
+ */
+type SameUnion<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _failureUnionsMatch: SameUnion<CorePairingFailure, CorePairingFailureCode> = true;
+void _failureUnionsMatch;
+
+/**
+ * A pairing attempt that produced no Core.
+ *
+ * Carries the whole {@link CorePairingRefusal} rather than only a message: the
+ * page switches on `failure` to say what to do next, and a mismatch has to show
+ * both fingerprints to be a refusal instead of a shrug. `expose` is the
+ * fallback for a path that lets it reach the router's catch-all — the message
+ * is already operator-facing and already free of anything secret.
+ */
+export class CorePairingRefusedError extends Error {
+  readonly expose = true;
+  readonly refusal: CorePairingRefusal;
+  constructor(refusal: CorePairingRefusal) {
+    super(refusal.error);
+    this.name = "CorePairingRefusedError";
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * Dial a Core and report the certificate authority it presents — with no code
+ * to send.
+ *
+ * This is the first half of the two-step the Panel exists to offer: the Panel
+ * is the one client that can *show* the operator a fingerprint rather than make
+ * them type it into a terminal. Nothing secret has been handed over at this
+ * point, and nothing can be, because this call was never given a code.
+ */
+export async function inspectCoreForPairing(address: string): Promise<CorePairingIdentity> {
+  try {
+    const identity = await fetchCorePairingIdentity({ address });
+    // Deliberately narrower than what the SDK returns: the browser needs a
+    // fingerprint to show and an origin to name, and has no use for the CA
+    // certificate itself.
+    return { fingerprint: identity.fingerprint, httpsOrigin: identity.httpsOrigin };
+  } catch (err) {
+    throw refusalFrom(err);
+  }
+}
+
+export type PairCoreInput = {
+  /** `host:port`, `https://host:port` or `wss://host:port`. */
+  address: string;
+  /** The eight-character code, hyphenated or not, in any case. */
+  code: string;
+  /** The pairing session the code belongs to, when the code does not carry it. */
+  sessionId?: string;
+  /** The fingerprint the operator confirmed against the presented one. */
+  expectedFingerprint: string;
+  /** The Panel's alias for the machine. Empty falls back to the endpoint host. */
+  label?: string;
+};
+
+/**
+ * Redeem a code against a Core and register what comes back.
+ *
+ * The credential the SDK returns is `CoreRegistrationBlob`-shaped with a
+ * `clientKey` that was born on this machine and never crossed the wire, so it
+ * goes into the registry and the sealed store through
+ * {@link registerCoreFromCredential} — the same door a decoded blob walks
+ * through today. Nothing downstream can tell the two apart, which is the point:
+ * `core-link-manager.ts` dials the result unchanged.
+ */
+export async function pairCore(input: PairCoreInput): Promise<Core> {
+  let credential;
+  try {
+    credential = await pairWithCore({
+      address: input.address,
+      code: input.code,
+      ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+      expectedCaFingerprint: input.expectedFingerprint,
+      label: PANEL_PAIRING_CLIENT_LABEL,
+      platform: process.platform,
+    });
+  } catch (err) {
+    throw refusalFrom(err);
+  }
+  // Outside the catch: a registry refusal — an endpoint already spoken for — is
+  // the registry's to explain, and wrapping it as a pairing failure would tell
+  // the operator to mint a code they do not need.
+  return registerCoreFromCredential(credential, { label: input.label ?? "" });
+}
+
+/**
+ * Turn whatever the SDK threw into the shape the browser is allowed to see.
+ *
+ * Built field by field rather than by serialising the error: the SDK's message
+ * can quote what the caller typed, and `detail` can carry the CA certificate.
+ * Neither has any business in a response, so neither is copied.
+ */
+function refusalFrom(err: unknown): CorePairingRefusedError {
+  if (!(err instanceof CorePairingError)) throw err;
+  const failure: CorePairingFailureCode = err.failure;
+  const detail: CorePairingRefusalDetail = {};
+  if (err.detail.expectedFingerprint) detail.expectedFingerprint = err.detail.expectedFingerprint;
+  if (err.detail.presentedFingerprint) detail.presentedFingerprint = err.detail.presentedFingerprint;
+  if (typeof err.detail.retryAfterSeconds === "number") {
+    detail.retryAfterSeconds = err.detail.retryAfterSeconds;
+  }
+  return new CorePairingRefusedError({
+    ...detail,
+    failure,
+    error: pairingFailureMessage(failure, detail),
+  });
+}

--- a/packages/panel/src/server/services/cores.ts
+++ b/packages/panel/src/server/services/cores.ts
@@ -137,6 +137,26 @@ export function listCores(): Core[] {
   return rows.map(rowToCore);
 }
 
+/**
+ * Is a Core already registered at this endpoint?
+ *
+ * The same question {@link registerCoreFromCredential} asks inside its
+ * transaction, exposed so a caller holding something expensive and perishable
+ * can ask it *first*. Pairing does (#286): discovering the collision after the
+ * redemption costs the operator their one-time code and leaves the Core holding
+ * a signed certificate for a client this Panel never stored.
+ *
+ * An answer here is advice, not a decision — the endpoint a Core reports is its
+ * own, and need not be the address it was reached on. The check inside the
+ * transaction stays the authority.
+ */
+export function coreRegisteredAt(endpoint: string): boolean {
+  return (
+    getPanelDb().prepare("SELECT id FROM cores WHERE endpoint = ?").get(endpoint.trim()) !==
+    undefined
+  );
+}
+
 export function getCore(id: string): Core | null {
   const row = getPanelDb().prepare("SELECT * FROM cores WHERE id = ?").get(id) as
     | CoreRow

--- a/packages/panel/src/server/services/cores.ts
+++ b/packages/panel/src/server/services/cores.ts
@@ -9,12 +9,22 @@ import type { Core } from "~/shared/cores";
  * The Core registry — the Panel's list of Cores it can talk to, plus the
  * sealed credentials it dials them with.
  *
- * Registration is one paste: the operator hands over the registration blob
- * that `core install` printed ("pairing token" in what the UI says), the
- * endpoint and label land in `cores`, and the secret half is sealed into
- * `core_secrets`. There is no other way in; the Panel does not accept a
- * hand-typed endpoint, because a Core without pinned mTLS material is a Core
- * it cannot safely dial.
+ * A registration is one credential: an endpoint, the mTLS material and the
+ * bearer. The endpoint and label land in `cores` and the secret half is sealed
+ * into `core_secrets`. The Panel does not accept a hand-typed endpoint,
+ * because a Core without pinned mTLS material is a Core it cannot safely dial.
+ *
+ * Two doors lead here and they meet at {@link registerCoreFromCredential}:
+ *
+ *   • the pasted registration blob `core install` printed, decoded by
+ *     {@link registerCoreFromRegistrationBlob} — the path #287 removes;
+ *   • a short pairing code redeemed against the Core by
+ *     `services/core-pairing.ts` (#286), which hands back the same
+ *     `CoreRegistrationBlob` shape with a key that never crossed the wire.
+ *
+ * Everything past that function is one path, so a Core added by pairing is
+ * indistinguishable downstream from one added by paste: same registry row,
+ * same sealed secrets, same `core-link-manager.ts` dial.
  */
 
 /** The secret half of a registration. Never leaves the service. */
@@ -42,6 +52,39 @@ export class RegistrationBlobError extends Error {
     this.name = "RegistrationBlobError";
   }
 }
+
+/**
+ * A credential the registry itself won't take — an endpoint already spoken
+ * for, or material with a field missing. Caller-facing for the same reason
+ * {@link RegistrationBlobError} is, and worded without reference to how the
+ * credential arrived, because both doors throw it.
+ */
+export class CoreRegistryError extends Error {
+  readonly expose = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "CoreRegistryError";
+  }
+}
+
+/**
+ * What a registration is made of, whichever door it came through.
+ *
+ * Structurally `CoreRegistrationBlob` from `@actana/sdk` and `RegistrationBlob`
+ * from `@actana/shared` — declared here rather than imported from either so
+ * the registry depends on the *shape* of a credential and not on the codec
+ * #287 deletes.
+ */
+export type CoreCredential = {
+  /** `wss://host:port` — the core-link endpoint the dialer will use. */
+  endpoint: string;
+  /** The name the credential carried, if any. Overridden by an explicit one. */
+  label?: string;
+  caCert: string;
+  clientCert: string;
+  clientKey: string;
+  bearer: string;
+};
 
 type CoreRow = {
   id: string;
@@ -102,12 +145,9 @@ export function getCore(id: string): Core | null {
 }
 
 /**
- * Register a Core from a pasted registration blob.
- *
- * Both rows go in under one transaction: a Core in the registry that the
- * dialer has no credentials for would sit in the fleet showing "unreachable"
- * forever with no way to fix it but a manual delete. Either the Core is
- * registered and dialable, or nothing happened.
+ * Register a Core from a pasted registration blob — the hand-carry path #287
+ * removes. It decodes, checks what the codec does not, and hands the result to
+ * {@link registerCoreFromCredential} like every other door.
  */
 export function registerCoreFromRegistrationBlob(raw: unknown): Core {
   if (typeof raw !== "string" || !raw.trim()) {
@@ -123,15 +163,45 @@ export function registerCoreFromRegistrationBlob(raw: unknown): Core {
       "That isn't a valid pairing token. Copy the whole line `core install` printed and paste it again.",
     );
   }
+  return registerCoreFromCredential(blob);
+}
 
-  const endpoint = blob.endpoint.trim();
+/**
+ * Register a Core from a credential, whichever door produced it.
+ *
+ * Both rows go in under one transaction: a Core in the registry that the
+ * dialer has no credentials for would sit in the fleet showing "unreachable"
+ * forever with no way to fix it but a manual delete. Either the Core is
+ * registered and dialable, or nothing happened.
+ *
+ * `label` is the Panel's alias for the *machine* and is passed explicitly by a
+ * caller that has one — pairing does, because the label it sent the Core names
+ * this Panel rather than the machine, and letting that come back round as the
+ * alias would fill the fleet list with the Panel's own name.
+ */
+export function registerCoreFromCredential(
+  credential: CoreCredential,
+  opts: { label?: string } = {},
+): Core {
+  if (
+    !credential.caCert.trim() ||
+    !credential.clientCert.trim() ||
+    !credential.clientKey.trim() ||
+    !credential.bearer.trim()
+  ) {
+    throw new CoreRegistryError("That credential is missing material the Panel needs to dial the Core.");
+  }
+
+  const endpoint = credential.endpoint.trim();
+  if (!endpoint) throw new CoreRegistryError("That credential names no Core endpoint.");
+
   const id = newCoreId();
   const now = Date.now();
   const secrets: CoreSecrets = {
-    caCert: blob.caCert,
-    clientCert: blob.clientCert,
-    clientKey: blob.clientKey,
-    bearer: blob.bearer,
+    caCert: credential.caCert,
+    clientCert: credential.clientCert,
+    clientKey: credential.clientKey,
+    bearer: credential.bearer,
   };
   // Sealed before the transaction opens: a misconfigured AC_SECRETS_KEY should
   // fail the registration outright, not leave a half-written one to roll back.
@@ -140,12 +210,12 @@ export function registerCoreFromRegistrationBlob(raw: unknown): Core {
   const db = getPanelDb();
   const insert = db.transaction(() => {
     if (db.prepare("SELECT id FROM cores WHERE endpoint = ?").get(endpoint)) {
-      throw new RegistrationBlobError(`A Core at ${endpoint} is already registered.`);
+      throw new CoreRegistryError(`A Core at ${endpoint} is already registered.`);
     }
     db.prepare(
       `INSERT INTO cores (id, operator_id, endpoint, label, last_event_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, 0, ?, ?)`,
-    ).run(id, OPERATOR_ID, endpoint, labelFor(blob.label ?? "", endpoint), now, now);
+    ).run(id, OPERATOR_ID, endpoint, labelFor(opts.label ?? credential.label ?? "", endpoint), now, now);
     db.prepare("INSERT INTO core_secrets (core_id, sealed, updated_at) VALUES (?, ?, ?)").run(
       id,
       sealed,

--- a/packages/panel/src/shared/core-pairing.ts
+++ b/packages/panel/src/shared/core-pairing.ts
@@ -1,0 +1,180 @@
+// Pairing, as the browser half of the Panel sees it (#280, #286).
+//
+// The pairing call itself is Node-side work — a key pair is born, a TLS chain
+// is read, a code is spent — so it runs on the Panel server beside the other
+// Core-side services and never in a tab (CONTEXT.md "Dumb pipe", ADR 0030).
+// What crosses to the renderer is exactly what this module declares: an
+// address to dial, a fingerprint to look at, a failure to explain. No key, no
+// certificate, no code.
+//
+// Two things here look like copies of `@actana/sdk/core-pairing` and are
+// deliberately not:
+//
+//   • {@link CorePairingFailureCode} restates the SDK's failure union so that a
+//     browser bundle never reaches into a module that opens `node:tls`. The
+//     server asserts the two are the same union at compile time
+//     (`server/services/core-pairing.ts`), so a member added to the SDK fails
+//     the typecheck here rather than silently rendering as "unknown".
+//   • {@link normalizeFingerprint} and {@link normalizePairingCode} are *input
+//     tidying*, not enforcement. The comparison that decides whether a code is
+//     sent is the SDK's, re-run on the server against the certificate the Core
+//     presented — a browser that skipped everything below still cannot get a
+//     code past a fingerprint that does not match.
+
+/**
+ * Why a pairing attempt did not produce a Core.
+ *
+ * Structurally the SDK's `CorePairingFailure`. Switch on it to write a
+ * sentence; the message that comes with it is already written for the
+ * operator, and neither ever carries the code or the key.
+ */
+export type CorePairingFailureCode =
+  | "bad-address"
+  | "bad-code"
+  | "bad-fingerprint"
+  | "unreachable"
+  | "no-ca-presented"
+  | "fingerprint-unconfirmed"
+  | "fingerprint-mismatch"
+  | "hostname-mismatch"
+  | "certificate-invalid"
+  | "refused"
+  | "rate-limited"
+  | "rejected"
+  | "not-pairable"
+  | "core-error"
+  | "malformed-response";
+
+/**
+ * What a refused pairing tells the browser.
+ *
+ * Fingerprints are in here because a mismatch has to *show* both halves to be
+ * a refusal an operator can act on rather than a shrug (#286). Everything a
+ * refusal could have carried and does not — the code, the CSR, the issued
+ * certificate, the key — is absent by construction: the server builds this
+ * shape field by field rather than serialising an error it caught.
+ */
+export type CorePairingRefusalDetail = {
+  /** On a mismatch: the fingerprint the operator said to expect. */
+  expectedFingerprint?: string;
+  /** On a mismatch: the fingerprint the Core actually presented. */
+  presentedFingerprint?: string;
+  /** On `rate-limited`: how long the Core asked us to wait. */
+  retryAfterSeconds?: number;
+};
+
+export type CorePairingRefusal = CorePairingRefusalDetail & {
+  failure: CorePairingFailureCode;
+  /**
+   * Operator-facing, and the same string {@link pairingFailureMessage} would
+   * write: the server fills it in so that a caller reading only `error` — the
+   * generic API client, a log of a failed request — still gets the sentence
+   * rather than a bare code.
+   */
+  error: string;
+};
+
+/** What a bootstrap dial learned about a Core, as the browser is told it. */
+export type CorePairingIdentity = {
+  /** SHA-256 over the CA's DER, colon-separated uppercase hex. */
+  fingerprint: string;
+  /** `https://host:port` — the surface that was dialled. */
+  httpsOrigin: string;
+};
+
+export type CorePairingIdentityResponse = { identity: CorePairingIdentity };
+
+/** Where the operator stands against the fingerprint they were read out. */
+export type FingerprintCheck = "unchecked" | "verified" | "mismatch";
+
+/**
+ * Compare what the operator typed with what the Core presented.
+ *
+ * `unchecked` is the answer for an empty box *and* for a half-typed one: a
+ * fingerprint is 32 bytes or it is nothing, and calling a prefix "mismatched"
+ * would paint the box red for every operator on their way to typing it.
+ */
+export function fingerprintCheck(expected: string, presented: string | null): FingerprintCheck {
+  if (presented === null) return "unchecked";
+  const normalized = normalizeFingerprint(expected);
+  if (normalized === null) return "unchecked";
+  return normalized === normalizeFingerprint(presented) ? "verified" : "mismatch";
+}
+
+/**
+ * A SHA-256 fingerprint in the one form this Panel compares them in:
+ * colon-separated uppercase hex, which is what `actana pair new` prints.
+ *
+ * Null for anything that is not 32 bytes of hex. Whitespace, colons, case and
+ * a leading `sha256:` are all things a human copying off a terminal brings
+ * along, and none of them is a mismatch.
+ */
+export function normalizeFingerprint(input: string): string | null {
+  const hex = input.trim().replace(/^sha-?256[:=]/i, "").replace(/[\s:]/g, "").toUpperCase();
+  if (!/^[0-9A-F]{64}$/.test(hex)) return null;
+  return (hex.match(/../g) ?? []).join(":");
+}
+
+/**
+ * A pairing code as `actana pair new` printed it — `XXXX-XXXX`, uppercase.
+ *
+ * Null when what was typed could not be a code whatever the Core's alphabet
+ * is. Hyphens, spaces and case are the operator's to get wrong: eight
+ * characters is the only thing asserted here, and the Core is the only thing
+ * that knows whether they are the right eight.
+ */
+export function normalizePairingCode(input: string): string | null {
+  const stripped = input.replace(/[\s-]/g, "").toUpperCase();
+  if (!/^[A-Z0-9]{8}$/.test(stripped)) return null;
+  return `${stripped.slice(0, 4)}-${stripped.slice(4)}`;
+}
+
+/**
+ * What to tell the operator, and what to do about it.
+ *
+ * Every arm names the next action, because a pairing failure is always
+ * somebody's move: mint a new code on the Core, fix the address, wait, or stop
+ * and find out why a machine is presenting a certificate authority nobody read
+ * out. The Core answers a wrong, expired, spent and exhausted code with one
+ * indistinguishable refusal on purpose (#282), so `refused` names all four and
+ * points at the Core's audit log rather than guessing between them.
+ */
+export function pairingFailureMessage(
+  failure: CorePairingFailureCode,
+  detail: CorePairingRefusalDetail = {},
+): string {
+  switch (failure) {
+    case "bad-address":
+      return "That is not a Core address. Use the machine's host and TLS port, as host:port — pairing needs the TLS port, not a plaintext one.";
+    case "bad-code":
+      return "That is not a pairing code. `actana pair new` prints eight characters as XXXX-XXXX, and the session id on the line below it.";
+    case "bad-fingerprint":
+      return "That is not a SHA-256 fingerprint. Copy the whole `CA fingerprint` line from `actana pair new`.";
+    case "unreachable":
+      return "Nothing answered at that address. Check the Core is running and that this Panel can reach its TLS port, then try again.";
+    case "no-ca-presented":
+      return "That machine presented no certificate authority, so there is nothing to compare the fingerprint against. It is not a Core, or not the one you meant.";
+    case "fingerprint-unconfirmed":
+      return "The fingerprint was not confirmed, so the pairing code was not sent. Compare the Core's fingerprint with the one `actana pair new` printed.";
+    case "fingerprint-mismatch":
+      return "That machine is not the Core you were given a fingerprint for. The pairing code was NOT sent. Do not retry until you know why they differ.";
+    case "hostname-mismatch":
+      return "The right Core, on an address its certificate does not cover. Reach it on the host it was set up for, or reissue its certificate for this one.";
+    case "certificate-invalid":
+      return "The Core's certificate is expired or otherwise unusable, so the pairing dial could not be pinned to it. Fix the certificate on the machine first.";
+    case "refused":
+      return "The Core refused this code: wrong, expired, already used, or out of attempts. Run `actana pair new` on the machine and pair again with the fresh code.";
+    case "rate-limited":
+      return detail.retryAfterSeconds === undefined
+        ? "The Core is rate-limiting pairing attempts. Wait a moment and try again."
+        : `The Core is rate-limiting pairing attempts. Wait ${detail.retryAfterSeconds}s and try again.`;
+    case "rejected":
+      return "The Core would not accept the pairing request. Check the Panel and the Core are on the same release, and report it if they are.";
+    case "not-pairable":
+      return "That Core has no pairing endpoint. Update the Core on that machine, then run `actana pair new` there.";
+    case "core-error":
+      return "The Core failed while redeeming the code. Nothing was paired — check the Core's logs, then run `actana pair new` and try again.";
+    case "malformed-response":
+      return "That address answered, but not like a Core. Check the address, and that nothing is proxying the Core's TLS port.";
+  }
+}

--- a/packages/panel/src/shared/core-pairing.ts
+++ b/packages/panel/src/shared/core-pairing.ts
@@ -157,7 +157,12 @@ export function pairingFailureMessage(
     case "fingerprint-unconfirmed":
       return "The fingerprint was not confirmed, so the pairing code was not sent. Compare the Core's fingerprint with the one `actana pair new` printed.";
     case "fingerprint-mismatch":
-      return "That machine is not the Core you were given a fingerprint for. The pairing code was NOT sent. Do not retry until you know why they differ.";
+      // Deliberately silent on whether the code moved. Reached before the code
+      // is sent when the presented CA is wrong, and *after* it is spent when the
+      // CA in the response is not the one from the handshake — and a client
+      // cannot tell those apart from the outside. "Treat the code as spent" is
+      // the one instruction that is safe under both.
+      return "That machine is not the Core you were read a fingerprint for. Stop: do not retry, treat the code as spent, and find out why the two differ.";
     case "hostname-mismatch":
       return "The right Core, on an address its certificate does not cover. Reach it on the host it was set up for, or reissue its certificate for this one.";
     case "certificate-invalid":


### PR DESCRIPTION
## Summary

Replaces the Panel's "paste the pairing token here…" textarea with **address plus code** (#280 task 6). The
add-Core flow is now three steps in order: an address, a fingerprint the operator looks at, and only then
a code.

The pairing call itself runs on the **Panel server** — key generation and a TLS dial are not a browser's
work, and the Panel server is where the mTLS credentials already live (CONTEXT.md "Dumb pipe", ADR 0030).
It is `pairWithCore` from task 4's `packages/sdk/src/core-pairing.ts`, the same function `actana core pair`
(#285) calls, with an address and a registry write around it — no second implementation and no crypto in
the renderer. What comes back is `CoreRegistrationBlob`-shaped, so it goes into the Core registry and the
encrypted store through the same door a decoded blob walks through today; `core-link-manager.ts` dials it
unchanged.

The middle step is the thing only a Panel can offer: a terminal client can only ask an operator to type a
fingerprint in, but a Panel can put the one the machine presented on screen beside the one `actana pair new`
printed. Three states — **not checked**, **verified**, **mismatch** — told apart by colour, by wording, and
by whether the code fields exist at all. A mismatch renders no code box, so there is nothing to click past.

## Related issues

Closes #286

Part of #280. Depends on #284 (already on this base). Sibling of #285, which does the same job for the CLI
through the same SDK function. #287 depends on this landing before it deletes the paste path.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [x] ♻️ Refactor (no functional change)
- [ ] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## What is in it

**`packages/panel/src/shared/core-pairing.ts`** — the browser-facing vocabulary: the failure union, the
refusal shape, the fingerprint comparison, and one operator-facing sentence per distinguishable failure.
It restates the SDK's failure union rather than importing it, so a browser bundle never reaches into a
module that opens `node:tls`; the service holds the copy to the original with a compile-time union-equality
assertion, in the one place that can see both.

**`packages/panel/src/server/services/core-pairing.ts`** — the pairing call, and the two things it refuses
to do. Nothing here logs, and nothing forwards an SDK error message: `parsePairingTicket` quotes the string
it was handed back at its caller, so an SDK message can carry the code an operator typed. Every sentence
the browser gets is written from the failure *code*.

**Two routes.** `POST /api/cores/pairing/inspect` carries no code, which is what makes it safe against an
address nobody has verified yet. `POST /api/cores/pairing` is only reachable once the operator has confirmed.

**`registerCoreFromCredential`** — split out of `registerCoreFromRegistrationBlob`, so both doors meet at one
insert, one transaction, one sealing step. That is what makes "indistinguishable downstream" structural
rather than a promise. **The blob-paste path itself is untouched and stays** — #287 removes it everywhere
at once.

## Security properties this holds

- The code is **not sent** until the presented fingerprint matches the expected one — and the browser's
  comparison is a gate, not the enforcement: the server re-runs it inside `pairWithCore` against the
  certificate on the connection it is about to send the code over.
- A mismatch and an unconfirmed fingerprint both leave the pairing session **still redeemable**, which is
  the assertion that proves the code was never sent rather than merely not stored.
- The private key is born on the Panel server and never crosses the wire in either direction; it never
  reaches the renderer at all, because the pairing response is a registry row.
- The code is never persisted, never logged, never in a URL, and never in an error message. A code the Core
  has already refused is cleared from the box.
- Retyping the address drops the fingerprint read off the old one, so a "verified" badge cannot be worn by a
  Core the box is no longer pointed at.

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [ ] Manually verified (describe steps below)

`packages/panel/src/server/__tests__/cores-pairing-api.test.ts` (16 tests) drives the API the way a browser
does, against a **real Core**: the Core's own `PtyCoreLinkServer` with the Core's own pairing routes mounted
through the Core's own wiring, behind a real TLS socket, with sessions in the `PairingStore` that
`actana pair new` writes. So "the code was redeemed" means a CSR was signed by that CA, and "the Panel can
dial what it paired" means an mTLS handshake and a bearer both actually worked. It covers a successful pair
producing a registry row plus encrypted secrets that reach `connected`, a mismatch storing nothing, the
failure taxonomy, and a deliberately mistyped code never appearing in a response.

`packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx` (30 tests) covers what a
server-side suite cannot see: the three fingerprint states, that a mismatch renders no code box, that a
changed address drops a verified badge, and that all fourteen distinguishable failures render fourteen
different sentences.

Full workspace run — `pnpm typecheck`, `pnpm lint`, `pnpm test` (all 6 stages, 144 panel test files),
`pnpm scan:secrets` — all green.

## Screenshots / recordings

None — the change is exercised by the component suite rather than by hand. Happy to add a recording if a
reviewer wants one.

## Checklist

- [x] This PR targets the **feature branch for #280** (`feat/short-code-pairing`), not `main` and not the train — per #286's Branching section, sub-branches PR into the feature branch
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [ ] I updated documentation (README, docs/, changelog entry) where relevant — CONTEXT.md's "pairing token" / Registration blob vocabulary is #287's to settle, per #286
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (#284 is on this base), and this PR is a draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYa7TtuZy8Kjcha4bFTgpa
