### PR TITLE
feat(cli): actana session wait, and send --wait built on it

### DIFF
--- a/.agents/skills/actana-sessions/SKILL.md
+++ b/.agents/skills/actana-sessions/SKILL.md
@@ -88,12 +88,60 @@ also look at it directly:
 ```bash
 actana session logs <id>          # the transcript, rendered, while the harness is running
 actana session send <id> "text"   # write into it; --enter follows with a carriage return
+actana session wait <id>          # block until the Core reports it settled
 actana session kill <id>          # stop the harness running for it
 ```
 
 `actana events tail --json` follows the Core's event log as NDJSON if you want
 to watch state change rather than poll — `session:finished` is the Core's own
 signal that a Session reached a terminal state.
+
+## The multi-turn loop
+
+A Session is a conversation, not a single question. The whole loop:
+
+```bash
+ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
+actana session wait "$ID" --json --wait-timeout 900     # block until it settles
+actana session send "$ID" "<follow-up>" --enter --wait --json --wait-timeout 900
+actana session logs "$ID"                               # or read `screen` off the object
+actana session send "$ID" "<next>" --enter --wait --json
+```
+
+**`actana session wait <id>` blocks until the Core reports the Session settled**
+— `finished`, `needs-input`, `interrupted`, `terminated` or `disconnected`,
+because every one of those is a turn that ended. A Session that is already
+settled answers at once, so a wait that starts after the turn ended is not a
+wait that hangs.
+
+**`actana session send <id> "<text>" --wait` waits for the turn that text
+starts.** The Core stamps the delivery in its event log and the wait resolves on
+the first settling status *after* that stamp, so it can never hand you the
+status the Session was already parked at. With `--json` it prints the **same
+object** `start --wait --json` prints — same keys, same `screen` — so one parser
+reads all three verbs. Two of those keys are `null` on a Session you attached to
+rather than started: `command` and `reportsTurnStart` are answers to a spawn.
+
+Three things to know before you build on it:
+
+1. **Sending into a turn that is already running resolves on *that* turn's
+   end.** A keystroke into a busy Harness is not a new turn. If the Session was
+   mid-turn when your text landed, the wait ends when the current turn ends —
+   possibly before the Harness has read a character of what you sent. Wait for
+   the Session to settle *first*, then send.
+2. **`--enter` is what submits the text.** `send` writes exactly the bytes it
+   was given and appends nothing, so text with no return sits in the Harness's
+   composer and no turn starts — and the wait then runs to your timeout.
+3. **A timeout is this side giving up, not a status.** `--wait-timeout
+   <seconds>` bounds the wait; without it there is no deadline, because a turn
+   takes as long as the work takes. On expiry you get a message saying the wait
+   gave up and a non-zero exit — the Session is still running on the Core, and
+   `session logs`, another `session wait` and `session kill` all still work.
+
+Do not poll `actana session logs` for a sentinel instead. It renders a
+fixed-size screen: lines scroll off the top, so counting occurrences is not
+monotonic, and a marker can match your own echoed prompt rather than the
+Harness's reply.
 
 ## Asking a Session for a machine-readable report
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ routing around it.
 | [0030](adr/0030-the-panel-is-a-dumb-pipe-for-file-bytes.md) | The Panel is a dumb pipe for file bytes, and it is the end that holds the credentials |
 | [0031](adr/0031-the-product-ships-one-skill.md) | The product ships one skill, and installs it into the operator's home — **PROPOSED**, amends 0006 |
 | [0032](adr/0032-one-actana-cli.md) | There is one `actana`, and it is both the Core manager and the client — supersedes #265 §6 and 0031 D8's two-binaries premise |
+| [0033](adr/0033-turn-end-is-the-one-mandatory-harness-signal.md) | Turn-end reporting is the one mandatory harness signal; turn-start, auto-mode flags and resume ids may never gate a feature |
 
 **Two files claim 0018**, as the table shows. It is a pre-existing collision,
 not breakage, and **nothing is renumbered** — every citation in the CI files

--- a/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
+++ b/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
@@ -1,0 +1,78 @@
+# Turn-end reporting is the one mandatory harness signal
+
+A harness family is a row in `HOOK_FAMILIES`
+(`packages/core/src/harness-hooks.ts:267`), and the comment above that table
+says the table is open: *"Keep this open: adding a family is adding a row."*
+What the comment does not say is what a row has to **provide** — so the answer
+was being decided one feature at a time, by whichever field the feature reached
+for.
+
+`reportsTurnStart` is the field it kept reaching for, and half the table answers
+`false`. `claude-code` and `opencode` report a turn's start; `codex` and
+`cursor-cli` do not, and cursor's own comment in that table reads *"The turn's
+end is reported; its start is not."* A feature keyed on turn-start works on half
+the harnesses this project ships today and is a coin flip for every family added
+after it.
+
+#289 met this head-on. Awaiting a follow-up turn looks like it needs two
+signals — the turn started, then the turn ended — and the obvious design waits
+for both. Against `codex` and `cursor-cli` the first signal never comes, so the
+obvious design needs a second mechanism to cover the harnesses the first one
+misses, and then a rule for which mechanism a new family gets. That is machinery
+growing to work around a gap. The design that shipped removes the dependency
+instead: the Core stamps a delivery in its own event log, and the wait resolves
+on the first settling status after that stamp. Turn *start* is never consulted.
+
+## Decisions
+
+**D1 — Turn-end reporting is mandatory.** A harness family may be added to
+`HOOK_FAMILIES` when its hooks move the Session's status on the Core at the end
+of a turn — to `finished`, `needs-input`, `interrupted` or `terminated`. That is
+the whole obligation, and it is the one every family in the table already meets.
+
+**D2 — Turn-start reporting is an optional refinement, and may never gate a
+feature.** `reportsTurnStart` survives as reported information: the
+`hooksReportTurnStart` field on the `spawned` frame
+(`packages/core/src/pty-core-link-server.ts`), the `reportsTurnStart` field on
+`session start --json`, and the Panel's terminal-input fallback
+(`packages/panel/src/lib/task-status-sync.ts`). A client may read it to explain
+what it cannot show. **No wait consults it**, and no feature may be built such
+that a family answering `false` loses the feature rather than losing polish.
+
+**D3 — Auto-mode flags and resume ids are optional on the same terms.** OpenCode
+ships no skip-permissions flag (`HARNESS_SKIP_PERMISSION_FLAGS` says so with
+`null`) and a harness that never reports a session id has nothing to resume
+from. Both degrade a Session; neither makes one unobservable. A feature that
+required either would be a feature that quietly excluded a family already in the
+table.
+
+**D4 — A family that reports nothing degrades into the caller's timeout, and
+says so.** No status is invented, and **nothing infers a turn from the byte
+stream**. #191 deleted a flat quiet-output timer that did exactly that and
+[ADR 0026](0026-prompt-delivery-is-a-core-responsibility.md) D3 records why. A
+wait with no `--wait-timeout` has no deadline; one with a deadline reports, on
+expiry, that *this side gave up* — never a status the Core did not send.
+
+## Consequences
+
+Adding a family is still adding a row, and now the row has a bar to clear. A
+harness whose hooks report a turn's end is drivable by every client: the Panel,
+the CLI's `session wait` and `session send --wait`, and any SDK caller.
+
+A harness whose hooks report **nothing** is not excluded from the table — it is
+spawnable, attachable and killable — but it is not awaitable, and callers meet
+that as a timeout rather than as a wrong answer.
+
+## Out of scope: codex's hook review
+
+Codex refuses to run newly-installed project hooks until an operator reviews
+them with its hooks command; the comment sits on the `codex` row itself
+(`packages/core/src/harness-hooks.ts:269-272`). In a fresh workspace codex may
+therefore report nothing at all, turn-end included — so it can fail D1 for
+reasons that have nothing to do with what its hooks say.
+
+**No wait mechanism can close that.** It is an install-time defect, not a
+waiting defect, and it is filed as its own issue:
+[#290](https://github.com/actana/control/issues/290). It is named here so that
+the next reader meeting a silent codex Session knows which of the two problems
+they have.

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -159,6 +159,8 @@ export function fakeSessionGateway(overrides: Partial<SessionGateway> = {}): Ope
     resume: refuse("resume"),
     logs: refuse("logs"),
     send: refuse("send"),
+    wait: refuse("wait"),
+    sendAndWait: refuse("send --wait"),
     kill: refuse("kill"),
     close: () => {},
     ...overrides,

--- a/packages/cli/src/__tests__/in-process-core-session.test.ts
+++ b/packages/cli/src/__tests__/in-process-core-session.test.ts
@@ -219,6 +219,11 @@ async function coreWithSessions(
     ptyCore: pty.core,
     queryPort,
     mutationPort,
+    // The live-event push, at test speed. A wait resolves when the status event
+    // reaches the client, and the Core's default poll is 500 ms — which is fine
+    // for a person and is most of the wall clock of a suite that waits twice,
+    // on a machine already running five other packages' tests.
+    liveEventPollMs: 25,
     ...(opts.eventLog === false ? {} : { eventLog }),
   });
   fixture = makeCliFixture();
@@ -362,7 +367,10 @@ describe("actana session, against a Core in this process", () => {
     // The transcript rides along, rendered, read while the Session is alive —
     // and it is the Core's replay ring, so it holds what came before the wait.
     expect(String(payload.screen)).toContain("done: 3 files changed");
-  }, 30_000);
+    // A minute, not thirty seconds: this one dials a real Core, runs a CLI
+    // command end to end and waits on a live event push, and `pnpm test` runs it
+    // beside five other packages' suites.
+  }, 60_000);
 
   it("waits as a verb, and refuses to wait on a Session with no harness running", async () => {
     const { eventLog, endTurn } = await coreWithSessions();
@@ -387,7 +395,7 @@ describe("actana session, against a Core in this process", () => {
     const stopped = await fixture!.run(["session", "wait", "task_done", "--json"], withCore());
     expect(stopped.code).toBe(EXIT_FAILURE);
     expect(JSON.parse(stopped.out.join("\n")).error).toContain("no harness running");
-  }, 30_000);
+  }, 60_000);
 
   it("refuses to wait after a delivery the Core did not stamp, rather than answering with the turn before", async () => {
     // The Core here is on this protocol version and still cannot stamp: no
@@ -430,7 +438,7 @@ describe("actana session, against a Core in this process", () => {
       // Read off the archived row rather than lost with it.
       harness: "claude-code",
     });
-  }, 30_000);
+  }, 60_000);
 
   it("says a stopped Session has no transcript rather than printing an empty one", async () => {
     await coreWithSessions();

--- a/packages/cli/src/__tests__/in-process-core-session.test.ts
+++ b/packages/cli/src/__tests__/in-process-core-session.test.ts
@@ -181,7 +181,19 @@ afterEach(() => {
 });
 
 /** A Core holding one live Session and one that has already stopped. */
-async function coreWithSessions(): Promise<{
+async function coreWithSessions(
+  opts: {
+    /**
+     * Wire no event log, which is one of the two ways a Core on this protocol
+     * version still answers a stamped write with no id — the other being an
+     * `appendEvent` that failed. Both are what the gateway's refusal covers,
+     * beyond the version gate that keeps an older Core off the wire entirely.
+     */
+    eventLog?: false;
+    /** Archive a row while its harness keeps running. */
+    archived?: string[];
+  } = {},
+): Promise<{
   writes: string[];
   killed: string[];
   resolutions: string[];
@@ -191,7 +203,7 @@ async function coreWithSessions(): Promise<{
 }> {
   const pty = livePtyCore();
   const tasks = [
-    task(),
+    task({ archived: opts.archived?.includes("task_live") ?? false }),
     task({ taskId: "task_done", title: "ship the changelog", status: "finished" }),
   ];
   // The uncounted lookup: `listSessions` resolves every row's PTY, and counting
@@ -203,7 +215,12 @@ async function coreWithSessions(): Promise<{
   // that id. Without one every write comes back unstamped, which is the
   // older-Core case and not the one these tests are about.
   const eventLog = arrayEventLog();
-  core = await startInProcessCore({ ptyCore: pty.core, queryPort, mutationPort, eventLog });
+  core = await startInProcessCore({
+    ptyCore: pty.core,
+    queryPort,
+    mutationPort,
+    ...(opts.eventLog === false ? {} : { eventLog }),
+  });
   fixture = makeCliFixture();
   await fixture.run(["core", "add", "inproc"], { stdin: core.blobText });
   const endTurn = (taskId: string, status: string): void => {
@@ -370,6 +387,49 @@ describe("actana session, against a Core in this process", () => {
     const stopped = await fixture!.run(["session", "wait", "task_done", "--json"], withCore());
     expect(stopped.code).toBe(EXIT_FAILURE);
     expect(JSON.parse(stopped.out.join("\n")).error).toContain("no harness running");
+  }, 30_000);
+
+  it("refuses to wait after a delivery the Core did not stamp, rather than answering with the turn before", async () => {
+    // The Core here is on this protocol version and still cannot stamp: no
+    // event-log port is wired. Falling through to an uncursored wait would
+    // resolve from the status the Session was already parked at — last turn's
+    // answer, with a zero exit — which is the exact lie the cursor exists to
+    // prevent. It refuses instead.
+    const { writes } = await coreWithSessions({ eventLog: false });
+
+    const run = await fixture!.run(
+      ["session", "send", "task_live", "carry on", "--enter", "--wait", "--json"],
+      withCore(),
+    );
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const error = String(JSON.parse(run.out.join("\n")).error);
+    expect(error).toContain("did not record the delivery");
+    // And it says the text landed, because the next thing an operator does
+    // with this failure must not be to send it a second time.
+    expect(error).toContain("The text was delivered");
+    expect(writes).toEqual(["carry on", "\r"]);
+  }, 30_000);
+
+  it("waits on a Session that was archived while its harness kept running", async () => {
+    // `tasksList` is active rows only by design (ADR 0019), and every other
+    // verb that names a live PTY works on an archived Session. Refusing here
+    // would make `wait` the odd one out over a row it reads two display fields
+    // off.
+    const { endTurn, eventLog } = await coreWithSessions({ archived: ["task_live"] });
+
+    const waiting = fixture!.run(["session", "wait", "task_live", "--json"], withCore());
+    await waitFor(() => eventLog.tailReads > 0, "the wait subscribed to the event log");
+    endTurn("task_live", "finished");
+
+    const settled = await waiting;
+    expect(settled.code, settled.err.join("\n")).toBe(EXIT_OK);
+    expect(JSON.parse(settled.out.join("\n"))).toMatchObject({
+      taskId: "task_live",
+      status: "finished",
+      // Read off the archived row rather than lost with it.
+      harness: "claude-code",
+    });
   }, 30_000);
 
   it("says a stopped Session has no transcript rather than printing an empty one", async () => {

--- a/packages/cli/src/__tests__/in-process-core-session.test.ts
+++ b/packages/cli/src/__tests__/in-process-core-session.test.ts
@@ -30,10 +30,18 @@ import type {
   CoreLinkSessionSnapshot,
   CoreLinkTaskSnapshot,
 } from "@actana/sdk/core-link-frames.ts";
+import { SESSION_DELIVERED_EVENT_KIND } from "@actana/sdk/core-link-frames.ts";
+
 import { openSessionGateway } from "../session-gateway.ts";
 import { EXIT_FAILURE, EXIT_OK } from "../exit-codes.ts";
 import { makeCliFixture, type CliFixture } from "./cli-harness.ts";
-import { startInProcessCore, type InProcessCore } from "./in-process-core.ts";
+import {
+  arrayEventLog,
+  startInProcessCore,
+  waitFor,
+  type ArrayEventLog,
+  type InProcessCore,
+} from "./in-process-core.ts";
 
 const PROJECT: CoreLinkProjectSnapshot = {
   projectId: "proj_web",
@@ -84,13 +92,23 @@ function livePtyCore(): {
   core: unknown;
   writes: string[];
   killed: string[];
+  resolutions: string[];
+  /** The same lookup, uncounted — for the query ports, which are not a verb. */
+  ptyFor: (taskId: string) => string | null;
 } {
   const writes: string[] = [];
   const killed: string[] = [];
+  // Every `findByTask` this Core is asked, so a verb that resolves the PTY
+  // twice — and opens a window between the two — is visible rather than
+  // arguable (#289: one resolution for the write and the wait).
+  const resolutions: string[] = [];
   const ptys = new Map<string, string>([["task_live", "pty_live"]]);
   const core = {
     setEmitTarget: () => {},
-    findByTask: (taskId: string) => ({ ptyId: ptys.get(taskId) ?? null }),
+    findByTask: (taskId: string) => {
+      resolutions.push(taskId);
+      return { ptyId: ptys.get(taskId) ?? null };
+    },
     taskIdForPty: (ptyId: string) =>
       [...ptys.entries()].find(([, id]) => id === ptyId)?.[0] ?? null,
     replay: (ptyId: string) =>
@@ -116,7 +134,13 @@ function livePtyCore(): {
     killLaunchProcesses: () => ({ ptyCount: 0, ports: [] }),
     killPtysUnderPath: () => {},
   };
-  return { core, writes, killed };
+  return {
+    core,
+    writes,
+    killed,
+    resolutions,
+    ptyFor: (taskId: string) => ptys.get(taskId) ?? null,
+  };
 }
 
 /** Task and project reads, answered from memory. */
@@ -157,19 +181,44 @@ afterEach(() => {
 });
 
 /** A Core holding one live Session and one that has already stopped. */
-async function coreWithSessions(): Promise<{ writes: string[]; killed: string[] }> {
+async function coreWithSessions(): Promise<{
+  writes: string[];
+  killed: string[];
+  resolutions: string[];
+  eventLog: ArrayEventLog;
+  /** What the harness's own Stop hook does on the Core: patch the row, say so. */
+  endTurn: (taskId: string, status: string) => void;
+}> {
   const pty = livePtyCore();
   const tasks = [
     task(),
     task({ taskId: "task_done", title: "ship the changelog", status: "finished" }),
   ];
-  const { queryPort, mutationPort } = ports(tasks, (taskId) =>
-    (pty.core as { findByTask(id: string): { ptyId: string | null } }).findByTask(taskId).ptyId,
-  );
-  core = await startInProcessCore({ ptyCore: pty.core, queryPort, mutationPort });
+  // The uncounted lookup: `listSessions` resolves every row's PTY, and counting
+  // those would drown the one thing `resolutions` is watching for — a *verb*
+  // that resolves the same Session twice.
+  const { queryPort, mutationPort } = ports(tasks, pty.ptyFor);
+  // The Core's event log, wired because #289's wait is a cursor into it: the
+  // Core stamps a delivery there and the client counts settling statuses from
+  // that id. Without one every write comes back unstamped, which is the
+  // older-Core case and not the one these tests are about.
+  const eventLog = arrayEventLog();
+  core = await startInProcessCore({ ptyCore: pty.core, queryPort, mutationPort, eventLog });
   fixture = makeCliFixture();
   await fixture.run(["core", "add", "inproc"], { stdin: core.blobText });
-  return { writes: pty.writes, killed: pty.killed };
+  const endTurn = (taskId: string, status: string): void => {
+    const row = tasks.find((t) => t.taskId === taskId);
+    if (row) row.status = status;
+    // The event the Core's task writer appends, with the status the mutation
+    // patched on it — a report about a turn, and legible as one even when the
+    // status it lands on is the status the row already had.
+    eventLog.appendEvent(
+      "task:updated",
+      JSON.stringify({ taskId, projectId: PROJECT.projectId, status }),
+      { taskId },
+    );
+  };
+  return { writes: pty.writes, killed: pty.killed, resolutions: pty.resolutions, eventLog, endTurn };
 }
 
 /** Every session verb dials the Core for real in this suite. */
@@ -248,6 +297,79 @@ describe("actana session, against a Core in this process", () => {
     const again = await fixture!.run(["session", "kill", "task_live", "--json"], withCore());
     expect(again.code).toBe(EXIT_FAILURE);
     expect(JSON.parse(again.out.join("\n")).error).toContain("no harness running");
+  }, 30_000);
+
+  it("sends and awaits the turn in one PTY resolution, and prints the settled screen", async () => {
+    // The whole of #289, against a Core that answers real frames: the write is
+    // stamped in the event log, the wait counts from that id, and the turn that
+    // ends afterwards is the one reported. The Session here is **already
+    // settled** when the text lands — `task_live` is `running`, and the turn
+    // below ends on `finished` — so nothing about this could be satisfied by
+    // the status the Session was sitting at.
+    const { writes, resolutions, eventLog, endTurn } = await coreWithSessions();
+
+    const run = fixture!.run(
+      ["session", "send", "task_live", "carry on", "--enter", "--wait", "--json"],
+      withCore(),
+    );
+    // The turn ends once the delivery has been stamped — which is the ordering
+    // a harness's Stop hook has: it cannot fire before the text arrives.
+    await waitFor(
+      () => eventLog.events.some((e) => e.kind === SESSION_DELIVERED_EVENT_KIND),
+      "the write was stamped",
+    );
+    endTurn("task_live", "finished");
+
+    const result = await run;
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+
+    // Two writes, verbatim, with the return as its own byte (ADR 0026).
+    expect(writes).toEqual(["carry on", "\r"]);
+    // **One resolution for the write and the wait.** A second `findByTask`
+    // between them is the window this design exists to close.
+    expect(resolutions).toEqual(["task_live"]);
+
+    const stamps = eventLog.events.filter((e) => e.kind === SESSION_DELIVERED_EVENT_KIND);
+    expect(stamps).toHaveLength(2);
+    expect(stamps[0]!.taskId).toBe("task_live");
+
+    const payload = JSON.parse(result.out.join("\n")) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      taskId: "task_live",
+      ptyId: "pty_live",
+      harness: "claude-code",
+      waited: true,
+      status: "finished",
+      exited: false,
+    });
+    // The transcript rides along, rendered, read while the Session is alive —
+    // and it is the Core's replay ring, so it holds what came before the wait.
+    expect(String(payload.screen)).toContain("done: 3 files changed");
+  }, 30_000);
+
+  it("waits as a verb, and refuses to wait on a Session with no harness running", async () => {
+    const { eventLog, endTurn } = await coreWithSessions();
+
+    const waiting = fixture!.run(["session", "wait", "task_live", "--json"], withCore());
+    // Nothing was delivered, so there is no cursor — the wait takes the next
+    // settling status this attachment hears about.
+    await waitFor(() => eventLog.tailReads > 0, "the wait subscribed to the event log");
+    endTurn("task_live", "needs-input");
+
+    const settled = await waiting;
+    expect(settled.code, settled.err.join("\n")).toBe(EXIT_OK);
+    expect(JSON.parse(settled.out.join("\n"))).toMatchObject({
+      taskId: "task_live",
+      status: "needs-input",
+      waited: true,
+      // An attach did not spawn, and says so rather than inventing an answer.
+      command: null,
+      reportsTurnStart: null,
+    });
+
+    const stopped = await fixture!.run(["session", "wait", "task_done", "--json"], withCore());
+    expect(stopped.code).toBe(EXIT_FAILURE);
+    expect(JSON.parse(stopped.out.join("\n")).error).toContain("no harness running");
   }, 30_000);
 
   it("says a stopped Session has no transcript rather than printing an empty one", async () => {

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -18,7 +18,11 @@ import {
   sentinelBlobText,
   type CliFixture,
 } from "./cli-harness.ts";
-import { SessionGatewayError, type SessionRow } from "../session-gateway.ts";
+import {
+  SessionGatewayError,
+  type SessionRow,
+  type StartedSession,
+} from "../session-gateway.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 
 let fixture: CliFixture | null = null;
@@ -449,6 +453,174 @@ describe("actana session logs", () => {
       rendered: true,
       screen: "a screen",
     });
+  });
+});
+
+describe("actana session wait, and send --wait (#289)", () => {
+  /** An attached Session, settling on whatever the test says. */
+  function attached(overrides: Partial<StartedSession> = {}): StartedSession {
+    return fakeStartedSession({
+      // The three answers only a spawn gives. An attach did not spawn.
+      command: null,
+      reportsTurnStart: null,
+      ...overrides,
+    });
+  }
+
+  it("is a verb of its own, and takes --wait-timeout without a --wait beside it", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "wait", "task_1", "--wait-timeout", "90"], {
+      sessions: fakeSessionGateway({
+        wait: async () => attached({ wait: async () => ({ status: "finished", exited: false }) }),
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    // The id on stdout, as every other verb leaves it, so `$(…)` still works.
+    expect(run.out).toEqual(["task_1"]);
+    expect(run.err.join("\n")).toContain("finished");
+  });
+
+  it("refuses the flags it does not take, `--wait` included", async () => {
+    await withRegisteredCore();
+    for (const flag of ["--wait", "--enter", "--harness", "--raw"]) {
+      const argv = flag === "--harness" ? ["--harness", "codex"] : [flag];
+      const run = await cli().run(["session", "wait", "task_1", ...argv], {
+        sessions: fakeSessionGateway(),
+      });
+      // `--wait` is refused rather than accepted as a synonym for the verb's
+      // own name: a flag that means nothing here would be a flag somebody
+      // believed they set.
+      expect(run.code, `${flag} was not refused`).toBe(EXIT_USAGE);
+      expect(run.err.join("\n")).toContain(`${flag} does not apply here`);
+    }
+  });
+
+  it("needs a session id, and refuses a second argument", async () => {
+    await withRegisteredCore();
+    const bare = await cli().run(["session", "wait"], { sessions: fakeSessionGateway() });
+    expect(bare.code).toBe(EXIT_USAGE);
+    expect(bare.err.join("\n")).toContain("a session id is required");
+
+    const extra = await cli().run(["session", "wait", "task_1", "task_2"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(extra.code).toBe(EXIT_USAGE);
+    expect(extra.err.join("\n")).toContain('unexpected argument "task_2"');
+  });
+
+  it("says a Session with no harness running has nothing to wait on", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "wait", "task_1"], {
+      sessions: fakeSessionGateway({
+        wait: async () => {
+          throw new SessionGatewayError(
+            "not-running",
+            "session task_1 has no harness running — there is nothing to attach a wait to",
+          );
+        },
+      }),
+    });
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("no harness running");
+  });
+
+  it("accepts `send --wait`, which was a usage error", async () => {
+    await withRegisteredCore();
+    const sent: Array<{ text: string; enter: boolean | undefined }> = [];
+    const run = await cli().run(["session", "send", "task_1", "carry", "on", "--wait"], {
+      sessions: fakeSessionGateway({
+        sendAndWait: async (_taskId, text, opts) => {
+          sent.push({ text, enter: opts?.enter });
+          return attached({ wait: async () => ({ status: "needs-input", exited: false }) });
+        },
+      }),
+    });
+    expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
+    // One call for the write and the wait — the gateway resolves the PTY once
+    // and there is no window between the delivery and the start of the wait.
+    expect(sent).toEqual([{ text: "carry on", enter: false }]);
+    expect(run.err.join("\n")).toContain("Sent 8 characters");
+    expect(run.err.join("\n")).toContain("needs-input");
+  });
+
+  it("prints the same object `start --wait --json` prints", async () => {
+    await withRegisteredCore();
+    const outcome = { status: "finished", exited: true, exitCode: 0 };
+
+    const started = await cli().run(["session", "start", "web", "go", "--wait", "--json"], {
+      sessions: fakeSessionGateway({
+        start: async () => fakeStartedSession({ wait: async () => outcome }),
+      }),
+    });
+    const sent = await cli().run(["session", "send", "task_1", "go on", "--wait", "--json"], {
+      sessions: fakeSessionGateway({
+        sendAndWait: async () => attached({ wait: async () => outcome }),
+      }),
+    });
+    const waited = await cli().run(["session", "wait", "task_1", "--json"], {
+      sessions: fakeSessionGateway({ wait: async () => attached({ wait: async () => outcome }) }),
+    });
+
+    expect(started.code, started.err.join("\n")).toBe(EXIT_OK);
+    expect(sent.code, sent.err.join("\n")).toBe(EXIT_OK);
+    expect(waited.code, waited.err.join("\n")).toBe(EXIT_OK);
+
+    const keys = (run: { out: string[] }) =>
+      Object.keys(JSON.parse(run.out.join("\n")) as Record<string, unknown>).sort();
+    // One result shape across the three commands, so a caller's parser does not
+    // fork on which verb produced the document.
+    expect(keys(sent)).toEqual(keys(started));
+    expect(keys(waited)).toEqual(keys(started));
+    expect(keys(started)).toContain("screen");
+    expect(keys(started)).toContain("waited");
+
+    // And the fields an attach cannot answer are `null` rather than invented.
+    const attachedDoc = JSON.parse(sent.out.join("\n")) as Record<string, unknown>;
+    expect(attachedDoc.command).toBeNull();
+    expect(attachedDoc.reportsTurnStart).toBeNull();
+  });
+
+  it("reports a timeout as this side giving up, never as a status", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(
+      ["session", "send", "task_1", "go on", "--wait", "--wait-timeout", "1", "--json"],
+      {
+        sessions: fakeSessionGateway({
+          sendAndWait: async () =>
+            attached({
+              wait: async () => {
+                throw new Error("session task_1 was still running after 1000ms");
+              },
+            }),
+        }),
+      },
+    );
+    // The existing failure code, not a new one: `exit-codes.ts` belongs to #285
+    // and a wait timeout has always been `EXIT_FAILURE` for `start --wait`.
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n")) as Record<string, unknown>;
+    expect(payload.waited).toBe(true);
+    expect(payload.error).toContain("was still running");
+    expect(payload.status).toBeUndefined();
+  });
+
+  it("refuses --wait-timeout on a send that is not waiting", async () => {
+    await withRegisteredCore();
+    const run = await cli().run(["session", "send", "task_1", "go", "--wait-timeout", "90"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("only means something with --wait");
+  });
+
+  it("states the running-turn limit in the help text", async () => {
+    // #289 C: a keystroke into a busy harness is not a new turn, so a send into
+    // one resolves on *that* turn's end — possibly before the harness has read
+    // the text. It is stated rather than left to be discovered.
+    const help = await cli().run(["session", "--help"]);
+    expect(help.out.join("\n")).toContain("actana session wait <session>");
+    expect(help.out.join("\n")).toContain("resolves on that turn's end");
+    expect(help.out.join("\n")).toContain("this side gave up");
   });
 });
 

--- a/packages/cli/src/orchestration-skill-payload.ts
+++ b/packages/cli/src/orchestration-skill-payload.ts
@@ -108,12 +108,60 @@ also look at it directly:
 \`\`\`bash
 actana session logs <id>          # the transcript, rendered, while the harness is running
 actana session send <id> "text"   # write into it; --enter follows with a carriage return
+actana session wait <id>          # block until the Core reports it settled
 actana session kill <id>          # stop the harness running for it
 \`\`\`
 
 \`actana events tail --json\` follows the Core's event log as NDJSON if you want
 to watch state change rather than poll — \`session:finished\` is the Core's own
 signal that a Session reached a terminal state.
+
+## The multi-turn loop
+
+A Session is a conversation, not a single question. The whole loop:
+
+\`\`\`bash
+ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
+actana session wait "$ID" --json --wait-timeout 900     # block until it settles
+actana session send "$ID" "<follow-up>" --enter --wait --json --wait-timeout 900
+actana session logs "$ID"                               # or read \`screen\` off the object
+actana session send "$ID" "<next>" --enter --wait --json
+\`\`\`
+
+**\`actana session wait <id>\` blocks until the Core reports the Session settled**
+— \`finished\`, \`needs-input\`, \`interrupted\`, \`terminated\` or \`disconnected\`,
+because every one of those is a turn that ended. A Session that is already
+settled answers at once, so a wait that starts after the turn ended is not a
+wait that hangs.
+
+**\`actana session send <id> "<text>" --wait\` waits for the turn that text
+starts.** The Core stamps the delivery in its event log and the wait resolves on
+the first settling status *after* that stamp, so it can never hand you the
+status the Session was already parked at. With \`--json\` it prints the **same
+object** \`start --wait --json\` prints — same keys, same \`screen\` — so one parser
+reads all three verbs. Two of those keys are \`null\` on a Session you attached to
+rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
+
+Three things to know before you build on it:
+
+1. **Sending into a turn that is already running resolves on *that* turn's
+   end.** A keystroke into a busy Harness is not a new turn. If the Session was
+   mid-turn when your text landed, the wait ends when the current turn ends —
+   possibly before the Harness has read a character of what you sent. Wait for
+   the Session to settle *first*, then send.
+2. **\`--enter\` is what submits the text.** \`send\` writes exactly the bytes it
+   was given and appends nothing, so text with no return sits in the Harness's
+   composer and no turn starts — and the wait then runs to your timeout.
+3. **A timeout is this side giving up, not a status.** \`--wait-timeout
+   <seconds>\` bounds the wait; without it there is no deadline, because a turn
+   takes as long as the work takes. On expiry you get a message saying the wait
+   gave up and a non-zero exit — the Session is still running on the Core, and
+   \`session logs\`, another \`session wait\` and \`session kill\` all still work.
+
+Do not poll \`actana session logs\` for a sentinel instead. It renders a
+fixed-size screen: lines scroll off the top, so counting occurrences is not
+monotonic, and a marker can match your own echoed prompt rather than the
+Harness's reply.
 
 ## Asking a Session for a machine-readable report
 

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -5,6 +5,7 @@
 //   actana session logs <session>            the transcript, rendered
 //   actana session resume <session> [prompt] pick a conversation back up
 //   actana session send <session> <text>     type into a running Session
+//   actana session wait <session>            block until it settles (#289)
 //   actana session kill <session>            stop the harness, whoever started it
 //   actana session attach <session>          take the terminal (#163)
 //
@@ -80,6 +81,7 @@ Usage
   actana session logs <session>             print the transcript, rendered
   actana session resume <session> [prompt]  start a Session that continues one
   actana session send <session> <text>      write text into a running Session
+  actana session wait <session>             block until the Core reports it settled
   actana session kill <session>             stop the harness running for it
   actana session attach <session>           watch a Session live, and type into it
 
@@ -87,6 +89,7 @@ Flags
   --core <name>       which registered Core to talk to
   --json              machine-readable output. Only JSON reaches stdout.
   --wait              start/resume: block until the Core reports it settled
+                      send: block until the turn that text starts has ended
   --wait-timeout <s>  give up waiting after this many seconds, and say so
   --harness <name>    start: ${KNOWN_HARNESSES.join(", ")}
   --cwd <path>        start: a directory on the Core, inside the Project
@@ -119,6 +122,28 @@ Attaching, and who is allowed to type
   back, and so does this process dying: the Core releases a dropped connection's
   locks. Ctrl-] detaches; Ctrl-C goes to the harness.
 
+Awaiting a turn
+  \`wait\` blocks until the Core reports the Session settled — \`finished\`,
+  \`needs-input\`, \`interrupted\`, \`terminated\` or \`disconnected\`, because every
+  one of those is a turn that ended. On a Session that is already settled it says
+  so at once.
+
+  \`send <session> <text> --wait\` writes and then waits for **the turn that write
+  starts**: the Core stamps the delivery in its event log and the wait resolves on
+  the first settling status after that stamp, so it can never answer with the
+  status the Session was already sitting at. With \`--json\` it prints the same
+  object \`start --wait --json\` prints.
+
+  **Sending into a turn that is already running resolves on that turn's end.** A
+  keystroke into a busy harness is not a new turn, so if the Session is mid-turn
+  when the text lands, the wait ends when the *current* turn ends — possibly
+  before the harness has read a character of what you sent. Nothing on this side
+  can tell those apart, and nothing here guesses.
+
+  A harness that reports nothing at all runs out the \`--wait-timeout\` and the
+  message says this side gave up — never a status the Core did not send. Without
+  \`--wait-timeout\` there is no deadline: a turn takes as long as the work takes.
+
 Who delivers the prompt
   The Core does (ADR 0026). It waits for the harness to settle, answers the
   dialog it opened, and writes the prompt. This CLI adds no timing of its own,
@@ -149,6 +174,8 @@ export async function runSessionCommand(
       return sessionResume(deps, args, paths, rest);
     case "send":
       return sessionSend(deps, args, paths, rest);
+    case "wait":
+      return sessionWait(deps, args, paths, rest);
     case "kill":
       return sessionKill(deps, args, paths, rest);
     case "attach": {
@@ -162,7 +189,9 @@ export async function runSessionCommand(
     }
     default:
       deps.err(`actana session: unknown verb "${verb}".`);
-      deps.err("Verbs: start, ls, logs, resume, kill, send, attach. `actana session --help` lists them.");
+      deps.err(
+        "Verbs: start, ls, logs, resume, kill, send, wait, attach. `actana session --help` lists them.",
+      );
       return EXIT_USAGE;
   }
 }
@@ -297,50 +326,125 @@ async function reportStartedSession(
       return EXIT_OK;
     }
 
-    deps.err("Waiting for the Core to report this session settled…");
-    let outcome: SessionOutcome;
-    try {
-      outcome = await session.wait(timeoutMs === null ? {} : { timeoutMs });
-    } catch (err) {
-      // The only thing that reaches here is the deadline the operator asked for.
-      // It is reported as what it is — this side gave up — rather than as a
-      // status, because the Core never said one.
-      const message = messageOf(err);
-      if (args.json) deps.out(formatJson({ ...startedFields(session), waited: true, error: message }));
-      deps.err(`actana session: ${message}`);
-      return EXIT_FAILURE;
-    }
-
-    // Read while the Session is alive: a full-screen harness restores the main
-    // buffer when it quits, and the main buffer is where nothing was printed.
-    const screen = session.screen();
-
-    if (args.json) {
-      deps.out(
-        formatJson({
-          ...startedFields(session),
-          waited: true,
-          status: outcome.status,
-          exited: outcome.exited,
-          ...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
-          // The transcript rides along because a `--json` caller has no second
-          // chance at it: the Core's replay ring lives with the PTY, so a
-          // harness that exited takes its output with it and a later
-          // `session logs` has nothing to answer with.
-          screen,
-        }),
-      );
-    } else {
-      deps.out(session.taskId);
-      deps.err(settledLine(outcome));
-      deps.err(`\`actana session logs ${session.taskId}\` prints the transcript while the harness is running.`);
-    }
-    return settledWell(outcome) ? EXIT_OK : EXIT_FAILURE;
+    return await awaitTurn(deps, args, session, timeoutMs);
   } finally {
     // Listeners on the client, released. The harness on the Core is untouched —
     // that is `session kill`.
     session.dispose();
   }
+}
+
+/**
+ * Wait for a turn to end and print how it ended — the half `start`, `resume`,
+ * `wait` and `send --wait` all share (#289 B).
+ *
+ * Shared on purpose, and it is what makes the promise "one result shape across
+ * the commands" true rather than aspirational: there is one place that decides
+ * what a settled Session prints, so a caller's parser cannot need a branch for
+ * which verb produced the object.
+ */
+async function awaitTurn(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  session: StartedSession,
+  timeoutMs: number | null,
+): Promise<number> {
+  deps.err("Waiting for the Core to report this session settled…");
+  let outcome: SessionOutcome;
+  try {
+    outcome = await session.wait(timeoutMs === null ? {} : { timeoutMs });
+  } catch (err) {
+    // The only thing that reaches here is the deadline the operator asked for.
+    // It is reported as what it is — this side gave up — rather than as a
+    // status, because the Core never said one.
+    const message = messageOf(err);
+    if (args.json) deps.out(formatJson({ ...startedFields(session), waited: true, error: message }));
+    deps.err(`actana session: ${message}`);
+    return EXIT_FAILURE;
+  }
+
+  // Read while the Session is alive: a full-screen harness restores the main
+  // buffer when it quits, and the main buffer is where nothing was printed.
+  const screen = session.screen();
+
+  if (args.json) {
+    deps.out(
+      formatJson({
+        ...startedFields(session),
+        waited: true,
+        status: outcome.status,
+        exited: outcome.exited,
+        ...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
+        // The transcript rides along because a `--json` caller has no second
+        // chance at it: the Core's replay ring lives with the PTY, so a
+        // harness that exited takes its output with it and a later
+        // `session logs` has nothing to answer with.
+        screen,
+      }),
+    );
+  } else {
+    deps.out(session.taskId);
+    deps.err(settledLine(outcome));
+    deps.err(`\`actana session logs ${session.taskId}\` prints the transcript while the harness is running.`);
+  }
+  return settledWell(outcome) ? EXIT_OK : EXIT_FAILURE;
+}
+
+/** {@link awaitTurn}, releasing the attachment's listeners on the way out. */
+async function awaitAttachedTurn(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  session: StartedSession,
+  timeoutMs: number | null,
+): Promise<number> {
+  try {
+    return await awaitTurn(deps, args, session, timeoutMs);
+  } finally {
+    // The listeners this attachment holds, released. The harness on the Core is
+    // untouched — waiting for a Session is not owning it.
+    session.dispose();
+  }
+}
+
+/**
+ * `actana session wait <session>` — block until the Core reports it settled.
+ *
+ * **The primitive, and it ships as one** (#289 B). `send --wait` is this with a
+ * write in front of it, and the reason the verb exists rather than only the flag
+ * is ADR 0026 D1: a client sends text and no timing, so timing gets its own verb
+ * instead of being folded into the one that writes.
+ *
+ * With no text delivered there is no cursor to count from, so this answers from
+ * the Session's current status when it is already settled and otherwise on the
+ * next settling status. That is the question the verb asks — "tell me when this
+ * Session is not working" — and it is not the question `send --wait` asks.
+ */
+async function sessionWait(
+  deps: ActanaCliDeps,
+  args: ParsedArgs,
+  paths: RegistryPaths,
+  rest: string[],
+): Promise<number> {
+  const misused = misusedFlag(args, ["--wait-timeout"]);
+  if (misused) return usage(deps, "wait", misused);
+
+  const [taskId, ...extra] = rest;
+  if (taskId === undefined) {
+    return usage(deps, "wait", "a session id is required — `actana session wait <session>`");
+  }
+  if (extra.length > 0) return usage(deps, "wait", `unexpected argument "${extra[0]}"`);
+
+  // The verb *is* the wait, so `--wait-timeout` needs no `--wait` beside it —
+  // and `--wait` is refused above rather than accepted as a synonym for the
+  // verb's own name.
+  const timeout = waitTimeoutMs(args, true);
+  if (timeout.error) return usage(deps, "wait", timeout.error);
+
+  return withGateway(deps, args, paths, "wait", async (gateway) => {
+    deps.verbose(`attaching to session ${taskId} to wait for it to settle`);
+    const session = await gateway.wait(taskId);
+    return awaitAttachedTurn(deps, args, session, timeout.ms);
+  });
 }
 
 /** `actana session ls [project]` — every Session on the Core, newest first. */
@@ -449,6 +553,12 @@ async function sessionLogs(
  * nothing that decides on its own that Enter is due. Both writes go to one PTY
  * resolved once, so the harness cannot move between them. A *starting* prompt
  * goes through `session start`, where the Core owns the schedule.
+ *
+ * `--wait` adds no timing either (#289): it asks the Core to stamp the delivery
+ * in its event log and then waits for the first settling status *after* that
+ * stamp. The text is the same text, written at the same moment, with the same
+ * nothing appended — what `--wait` changes is when this process hangs up, not
+ * what the harness receives.
  */
 async function sessionSend(
   deps: ActanaCliDeps,
@@ -456,13 +566,15 @@ async function sessionSend(
   paths: RegistryPaths,
   rest: string[],
 ): Promise<number> {
-  const misused = misusedFlag(args, ["--enter"]);
+  const misused = misusedFlag(args, ["--enter", "--wait", "--wait-timeout"]);
   if (misused) return usage(deps, "send", misused);
 
   const [taskId, ...words] = rest;
   if (taskId === undefined) {
     return usage(deps, "send", "a session id is required — `actana session send <session> <text>`");
   }
+  const timeout = waitTimeoutMs(args);
+  if (timeout.error) return usage(deps, "send", timeout.error);
   const read = await readText(deps, words);
   if (read.error) return usage(deps, "send", read.error);
   if (read.text === null && !args.enter) {
@@ -485,6 +597,20 @@ async function sessionSend(
 
   return withGateway(deps, args, paths, "send", async (gateway) => {
     const text = read.text ?? "";
+
+    if (args.wait) {
+      // Send-then-wait with **no gap** (#289 B): one attachment resolves the
+      // PTY, writes through it, and waits from the id the Core stamped that
+      // write with. The alternative — send, then attach, then wait — is the
+      // design the issue's landmine is about: the attach would find a Session
+      // sitting at a settled status and answer with last turn's outcome.
+      const andReturn = args.enter ? " and a carriage return" : "";
+      deps.verbose(`sending ${text.length} characters to session ${taskId}${andReturn}, then waiting`);
+      const session = await gateway.sendAndWait(taskId, text, { enter: args.enter });
+      deps.err(`Sent ${text.length} characters to session ${taskId}${andReturn}.`);
+      return awaitAttachedTurn(deps, args, session, timeout.ms);
+    }
+
     // One call, one PTY resolution, both writes (#204 review). The command no
     // longer decides anything about the return beyond passing on the flag.
     const delivered = await gateway.send(taskId, text, { enter: args.enter });
@@ -634,9 +760,14 @@ function misusedFlag(args: ParsedArgs, accepted: readonly string[]): string | nu
  * carried out — and a deadline somebody believes they set is worse than no
  * deadline at all. The wait it bounds is the SDK's; nothing here counts time.
  */
-function waitTimeoutMs(args: ParsedArgs): { ms: number | null; error?: string } {
+function waitTimeoutMs(
+  args: ParsedArgs,
+  waiting: boolean = args.wait,
+): { ms: number | null; error?: string } {
   if (args.waitTimeout === null) return { ms: null };
-  if (!args.wait) return { ms: null, error: "--wait-timeout only means something with --wait" };
+  // `waiting` is for the one verb that *is* a wait: `session wait` takes no
+  // `--wait` (the verb says it), so its deadline cannot be gated on the flag.
+  if (!waiting) return { ms: null, error: "--wait-timeout only means something with --wait" };
   const seconds = Number(args.waitTimeout);
   if (!Number.isFinite(seconds) || seconds <= 0) {
     return { ms: null, error: `--wait-timeout wants a number of seconds, not "${args.waitTimeout}"` };

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -812,9 +812,9 @@ async function readText(
  * because the failure this prevents is an operator reading a stalled `session
  * ls` as a stalled harness and killing a Session that was working.
  */
-function noTurnStartLine(harness: string): string {
+function noTurnStartLine(harness: string | null): string {
   return (
-    `Note: ${harness} does not report the start of a turn, so this session ` +
+    `Note: ${harness ?? "this harness"} does not report the start of a turn, so this session ` +
     `will not show as running until it stops. \`--wait\` and \`session logs\` ` +
     `are unaffected.`
   );

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -528,6 +528,7 @@ class CoreLinkSessionGateway implements SessionGateway {
         // The text **was delivered** and the message says so, because the next
         // thing an operator does with a failure here must not be to send it
         // again.
+        //
         // Guarded on a write having happened at all: a delivery of nothing is
         // not a delivery, and it leaves this exactly where a bare `wait` is —
         // no cursor, because nothing was sent to count from.

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -34,7 +34,11 @@
 // what keeps `session-command.ts` free of the SDK and free of a socket.
 
 import { CoreClient } from "@actana/sdk/core-client.ts";
-import { CoreSession, HARNESS_LAUNCH_COMMANDS } from "@actana/sdk/core-session.ts";
+import {
+  CoreSession,
+  CoreSessionAttachError,
+  HARNESS_LAUNCH_COMMANDS,
+} from "@actana/sdk/core-session.ts";
 import { TerminalScreen, DEFAULT_COLS, DEFAULT_ROWS } from "@actana/sdk/terminal-screen.ts";
 import { harnessResumeCommand } from "./harness-resume.ts";
 import type {
@@ -140,13 +144,25 @@ export type SessionOutcome = {
   exitCode?: number;
 };
 
-/** A Session this invocation started, still connected. */
+/**
+ * A Session this invocation is connected to, and can wait on.
+ *
+ * `start` and `resume` produce one by spawning; `wait` and `send --wait` produce
+ * one by attaching to a harness that is already running (#289). The fields are
+ * the same fields so the two print the same object — and the ones only a spawn
+ * can answer say so with `null` rather than with a plausible value.
+ */
 export type StartedSession = {
   taskId: string;
   ptyId: string;
-  harness: CoreLinkPtySpawnHarness;
-  /** The command the Core was asked to run, after defaulting. */
-  command: string;
+  /** The harness running in it, as the Core spells it. */
+  harness: string;
+  /**
+   * The command the Core was asked to run, after defaulting — `null` on a
+   * Session this invocation attached to rather than started, because the Core
+   * does not publish a running PTY's command.
+   */
+  command: string | null;
   /**
    * Will anything move this Session to `running` when a turn begins?
    *
@@ -162,8 +178,13 @@ export type StartedSession = {
    * working cursor Session shows the status it had before the turn began. An
    * operator told that is reading a quiet table correctly; one who is not has
    * no way to tell it from a harness that never started.
+   *
+   * **`null` on an attached Session** — `session wait` and `send --wait` join a
+   * PTY that is already running, and the Core answers this question on a spawn.
+   * Null is "not asked on this path", not "no", and nothing about waiting reads
+   * it either way (#289 A).
    */
-  reportsTurnStart: boolean;
+  reportsTurnStart: boolean | null;
   projectId: string;
   /** The Project's name, when the start resolved one. */
   project: string | null;
@@ -173,6 +194,12 @@ export type StartedSession = {
    * The SDK's wait, which is the Core's event log — see rule 3 in the header.
    * `timeoutMs` is a deadline the *operator* asked for (`--wait-timeout`) and
    * its expiry is an error, never a status invented here.
+   *
+   * **What "settled" counts from depends on how this Session was reached.** A
+   * spawned one has observed no status, so the first it hears is this turn's. An
+   * attached one carries the delivery stamp the Core answered its write with, so
+   * the status that ends the wait is one reported *after* the text went in — not
+   * the one the Session was already parked at (#289 A).
    */
   wait(opts: { timeoutMs?: number }): Promise<SessionOutcome>;
   /** The rendered transcript, read while the Session is alive. */
@@ -205,6 +232,26 @@ export type SessionGateway = {
    * the text lands and the return is sent somewhere else — or nowhere.
    */
   send(taskId: string, text: string, opts?: { enter?: boolean }): Promise<boolean>;
+  /**
+   * Attach to a running Session and hand back something to wait on — the
+   * primitive `actana session wait` is (#289 B).
+   *
+   * No text goes in, so there is no delivery to count from: the wait it returns
+   * answers from the status the Session is in when it is already settled, and
+   * otherwise on the next settling status. That is the honest answer to "tell me
+   * when this Session is not working", which is what the verb asks.
+   */
+  wait(taskId: string): Promise<StartedSession>;
+  /**
+   * Write text into a running Session and hand back a wait for **the turn that
+   * write starts** — one PTY resolution for both, and no window between them.
+   *
+   * The wait counts from the event id the Core stamped the delivery with, so a
+   * Session that was already settled when the text arrived cannot answer it with
+   * the status it was already sitting at (#289 A, and the `settledNow` landmine
+   * that is the reason the stamp exists).
+   */
+  sendAndWait(taskId: string, text: string, opts?: { enter?: boolean }): Promise<StartedSession>;
   /** Kill the harness running for this Task, whoever started it. */
   kill(taskId: string): Promise<{ ptyId: string; killed: boolean }>;
   close(): void;
@@ -282,7 +329,11 @@ class CoreLinkSessionGateway implements SessionGateway {
       prompt: request.prompt,
       dangerouslySkipPermissions: request.dangerouslySkipPermissions,
     });
-    return wrap(session, project.projectId, project.name);
+    return wrap(session, {
+      projectId: project.projectId,
+      project: project.name,
+      harness,
+    });
   }
 
   async resume(request: SessionResumeRequest): Promise<StartedSession> {
@@ -328,7 +379,11 @@ class CoreLinkSessionGateway implements SessionGateway {
       prompt: request.prompt,
       dangerouslySkipPermissions: request.dangerouslySkipPermissions,
     });
-    return wrap(session, project.projectId, project.name);
+    return wrap(session, {
+      projectId: project.projectId,
+      project: project.name,
+      harness: task.agent,
+    });
   }
 
   async logs(taskId: string): Promise<SessionLogs> {
@@ -359,6 +414,18 @@ class CoreLinkSessionGateway implements SessionGateway {
     return this.client.write(ptyId, "\r");
   }
 
+  async wait(taskId: string): Promise<StartedSession> {
+    return this.attached(taskId, null);
+  }
+
+  async sendAndWait(
+    taskId: string,
+    text: string,
+    opts: { enter?: boolean } = {},
+  ): Promise<StartedSession> {
+    return this.attached(taskId, { text, enter: opts.enter === true });
+  }
+
   async kill(taskId: string): Promise<{ ptyId: string; killed: boolean }> {
     // Resolved through the Core by Task id, which is what makes killing a
     // Session this CLI did not start ordinary rather than special: the PTY
@@ -375,6 +442,79 @@ class CoreLinkSessionGateway implements SessionGateway {
   }
 
   // ─── Shared resolution ─────────────────────────────────────────────────────
+
+  /**
+   * Attach to a running Session, optionally deliver text into it first, and wrap
+   * the result as a {@link StartedSession} to wait on.
+   *
+   * **One PTY resolution covers the write and the wait.** `CoreSession.attach`
+   * resolves the Task's live PTY once and wires the byte stream, the exit and
+   * the event log before this method writes a character; the write goes to that
+   * PTY and the wait counts from the id the Core answered it with. There is no
+   * second `findByTask` between them, so there is no window in which the harness
+   * could move, exit, or finish a turn unobserved.
+   *
+   * The delivery is two writes when `--enter` was asked for — the text, then the
+   * carriage return, exactly as `send` has always done it (ADR 0026: this side
+   * appends nothing on its own). Both are stamped and the wait counts from the
+   * **later** stamp, because the turn starts at the return, not at the text.
+   */
+  private async attached(
+    taskId: string,
+    deliver: { text: string; enter: boolean } | null,
+  ): Promise<StartedSession> {
+    const task = await this.findTask(taskId);
+    const project = await this.projectFor(task.projectId).catch(() => null);
+
+    let session: CoreSession;
+    try {
+      session = await CoreSession.attach(this.client, { taskId });
+    } catch (err) {
+      // A Session with no live PTY is the one failure this path has that the
+      // others do not, and it is `not-running` here for the same reason it is
+      // there: it is a harness that has exited, and the next step is `logs` or
+      // `resume`, not a retry.
+      throw err instanceof CoreSessionAttachError
+        ? new SessionGatewayError("not-running", err.message, { cause: err })
+        : new SessionGatewayError("refused", messageOf(err), { cause: err });
+    }
+
+    let afterEventId = 0;
+    if (deliver !== null) {
+      try {
+        if (deliver.text.length > 0) {
+          const wrote = await session.deliver(deliver.text);
+          if (!wrote.ok) {
+            throw new SessionGatewayError(
+              "not-running",
+              `the Core did not accept the write to session ${taskId}`,
+            );
+          }
+          afterEventId = Math.max(afterEventId, wrote.deliveryEventId);
+        }
+        if (deliver.enter) {
+          const returned = await session.deliver("\r");
+          if (!returned.ok) {
+            throw new SessionGatewayError(
+              "not-running",
+              `the Core did not accept the carriage return for session ${taskId}`,
+            );
+          }
+          afterEventId = Math.max(afterEventId, returned.deliveryEventId);
+        }
+      } catch (err) {
+        session.dispose();
+        throw err;
+      }
+    }
+
+    return wrap(session, {
+      projectId: task.projectId,
+      project: project?.name ?? null,
+      harness: task.agent,
+      afterEventId,
+    });
+  }
 
   /** Start a Session, translating the SDK's refusal into a gateway error. */
   private async begin(opts: {
@@ -473,18 +613,41 @@ class CoreLinkSessionGateway implements SessionGateway {
   }
 }
 
-/** Present one `CoreSession` as a {@link StartedSession}. */
-function wrap(session: CoreSession, projectId: string, project: string | null): StartedSession {
+/**
+ * Present one `CoreSession` as a {@link StartedSession}.
+ *
+ * `harness` is passed in rather than read off the Session: a spawn knows it
+ * because it asked for it, and an attach reads it off the Task row — the Core
+ * publishes no harness for a PTY that is already running, and `CoreSession` says
+ * so with `null` rather than guessing. Same for `command` and `reportsTurnStart`,
+ * which are answers to a `spawn` frame and stay null on the attach path.
+ *
+ * `afterEventId` is the delivery stamp the wait counts from, and 0 — no cursor —
+ * is the spawn path and the bare `session wait`.
+ */
+function wrap(
+  session: CoreSession,
+  opts: {
+    projectId: string;
+    project: string | null;
+    harness: string;
+    afterEventId?: number;
+  },
+): StartedSession {
+  const afterEventId = opts.afterEventId ?? 0;
   return {
     taskId: session.taskId,
     ptyId: session.ptyId,
-    harness: session.harness,
+    harness: opts.harness,
     command: session.command,
     reportsTurnStart: session.reportsTurnStart,
-    projectId,
-    project,
-    wait: async (opts) => {
-      const idle = await session.waitForIdle(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {});
+    projectId: opts.projectId,
+    project: opts.project,
+    wait: async (waitOpts) => {
+      const idle = await session.waitForTurnEnd({
+        ...(afterEventId > 0 ? { afterEventId } : {}),
+        ...(waitOpts.timeoutMs ? { timeoutMs: waitOpts.timeoutMs } : {}),
+      });
       return {
         status: idle.status,
         exited: idle.exited,

--- a/packages/cli/src/session-gateway.ts
+++ b/packages/cli/src/session-gateway.ts
@@ -155,8 +155,14 @@ export type SessionOutcome = {
 export type StartedSession = {
   taskId: string;
   ptyId: string;
-  /** The harness running in it, as the Core spells it. */
-  harness: string;
+  /**
+   * The harness running in it, as the Core spells it — `null` only when this
+   * invocation attached to a Session whose Task row the Core did not list, which
+   * is a row deleted out from under a live PTY. The wait does not need it; it is
+   * on the object because a caller reading the result wants to know what it was
+   * talking to.
+   */
+  harness: string | null;
   /**
    * The command the Core was asked to run, after defaulting — `null` on a
    * Session this invocation attached to rather than started, because the Core
@@ -463,8 +469,14 @@ class CoreLinkSessionGateway implements SessionGateway {
     taskId: string,
     deliver: { text: string; enter: boolean } | null,
   ): Promise<StartedSession> {
-    const task = await this.findTask(taskId);
-    const project = await this.projectFor(task.projectId).catch(() => null);
+    // The archived list as a fallback, because a Session can be archived while
+    // its harness is still running — and `tasksList` is active rows only by
+    // design (ADR 0019). Every other verb that names a live PTY works on such a
+    // Session; refusing it here would make `wait` the odd one out over a row
+    // this only reads two display fields off.
+    const task = await this.findAnyTask(taskId);
+    const project =
+      task === null ? null : await this.projectFor(task.projectId).catch(() => null);
 
     let session: CoreSession;
     try {
@@ -502,6 +514,31 @@ class CoreLinkSessionGateway implements SessionGateway {
           }
           afterEventId = Math.max(afterEventId, returned.deliveryEventId);
         }
+        // **A delivery that was not stamped has no cursor, and an uncursored
+        // wait after a delivery is the lie this whole design exists to
+        // prevent** — it would answer from the status the Session was already
+        // parked at, which is last turn's answer with a zero exit.
+        //
+        // The version gate refuses a Core too old to stamp before a frame goes
+        // out. This covers the ways a Core on this version still answers 0: no
+        // event-log port wired, or an `appendEvent` that failed. Both are
+        // documented on `recordSessionDelivery`, and neither is a reason to
+        // guess.
+        //
+        // The text **was delivered** and the message says so, because the next
+        // thing an operator does with a failure here must not be to send it
+        // again.
+        // Guarded on a write having happened at all: a delivery of nothing is
+        // not a delivery, and it leaves this exactly where a bare `wait` is —
+        // no cursor, because nothing was sent to count from.
+        if ((deliver.text.length > 0 || deliver.enter) && afterEventId === 0) {
+          throw new SessionGatewayError(
+            "refused",
+            `session ${taskId} took the text, but this Core did not record the delivery in its ` +
+              `event log — so there is no cursor to await this turn from, and waiting would report ` +
+              `the turn before it. The text was delivered; \`actana session logs ${taskId}\` shows it`,
+          );
+        }
       } catch (err) {
         session.dispose();
         throw err;
@@ -509,9 +546,9 @@ class CoreLinkSessionGateway implements SessionGateway {
     }
 
     return wrap(session, {
-      projectId: task.projectId,
+      projectId: task?.projectId ?? "",
       project: project?.name ?? null,
-      harness: task.agent,
+      harness: task?.agent ?? null,
       afterEventId,
     });
   }
@@ -556,6 +593,26 @@ class CoreLinkSessionGateway implements SessionGateway {
       );
     }
     return ptyId;
+  }
+
+  /**
+   * The Task row for a Session, active **or archived**, or null when this Core
+   * has neither.
+   *
+   * Null rather than a refusal, because the caller is a verb that acts on a live
+   * PTY and reads this row only for two display fields. `resume` still uses
+   * {@link findTask}, where a missing row is genuinely the end of the road: it
+   * needs the harness and the recorded session id to start anything at all.
+   *
+   * The archived list is asked only when the active one did not have it, so the
+   * ordinary path still costs one round trip.
+   */
+  private async findAnyTask(taskId: string): Promise<CoreLinkTaskSnapshot | null> {
+    const { tasks } = await this.client.tasksList();
+    const active = tasks.find((row) => row.taskId === taskId);
+    if (active) return active;
+    const archived = await this.client.archivedTasksList();
+    return archived.find((row) => row.taskId === taskId) ?? null;
   }
 
   private async findTask(taskId: string): Promise<CoreLinkTaskSnapshot> {
@@ -630,7 +687,7 @@ function wrap(
   opts: {
     projectId: string;
     project: string | null;
-    harness: string;
+    harness: string | null;
     afterEventId?: number;
   },
 ): StartedSession {

--- a/packages/core/src/__tests__/session-delivered-event.test.ts
+++ b/packages/core/src/__tests__/session-delivered-event.test.ts
@@ -1,0 +1,219 @@
+// The Core stamps a delivery in its event log (#289 A).
+//
+// The mechanism the whole ticket hangs off: a client that is about to wait for
+// the turn a write starts needs to know *where in the log the write landed*,
+// because the only other question available — "is this Session settled?" —
+// answers with the status the Session was already sitting at before the write.
+//
+// What is asserted here is the Core's half of that, against the real event-log
+// store rather than a fake: a stamped write appends one `session:delivered`
+// carrying the Task id and answers with its event id; an unstamped write
+// appends nothing; and neither a refused write nor a PTY with no Task behind it
+// produces a cursor, because a cursor for a delivery that did not happen is
+// worse than none.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapCoreDb } from "../core-db-bootstrap";
+import {
+  appendEvent,
+  configureEventLogStore,
+  disposeEventLogStore,
+  getLastEventId,
+  readEventTail,
+} from "../event-log-store";
+import {
+  PtyCoreLinkServer,
+  type EventLogPort,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import type { PtyCore } from "../pty-manager";
+import type { CoreLinkEvent } from "@actana/sdk/core-link-frames";
+import { SESSION_DELIVERED_EVENT_KIND } from "@actana/sdk/core-link-frames";
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(frame: unknown): void {
+    this.emit("message", JSON.stringify(frame));
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike) => void) | null = null;
+
+  connect(ws: FakeWebSocket): void {
+    this.connCb?.(ws as unknown as WebSocketLike);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike) => void;
+  }
+}
+
+/**
+ * One live PTY belonging to `t1`, and a second belonging to nothing.
+ *
+ * The second is not an exotic case: a VM shell Session and a PTY whose Task row
+ * has gone are both PTYs the Core can write to and cannot name a Task for.
+ */
+const writes: string[] = [];
+function mockCore(): PtyCore {
+  return {
+    setEmitTarget: () => {},
+    spawn: async () => ({ ptyId: "pty-1" }),
+    write: (ptyId: string, data: string) => {
+      if (ptyId === "pty-gone") return false;
+      writes.push(data);
+      return true;
+    },
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: "pty-1" }),
+    taskIdForPty: (ptyId: string) => (ptyId === "pty-1" ? "t1" : null),
+    replay: () => ({ data: "", nextSeq: 0 }),
+    killAll: () => {},
+  } as unknown as PtyCore;
+}
+
+const realEventLog: EventLogPort = { appendEvent, getLastEventId, readEventTail };
+
+describe("the Core stamps an accepted write it was asked to stamp (#289 A)", () => {
+  let userDataDir: string;
+  let server: PtyCoreLinkServer;
+  let ws: FakeWebSocket;
+
+  beforeEach(() => {
+    writes.length = 0;
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-session-delivered-"));
+    bootstrapCoreDb(userDataDir);
+    configureEventLogStore(userDataDir);
+
+    const wss = new FakeWebSocketServer();
+    server = new PtyCoreLinkServer(mockCore(), {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      eventLog: realEventLog,
+      liveEventPollMs: 5,
+    });
+    ws = new FakeWebSocket();
+    wss.connect(ws);
+  });
+
+  afterEach(() => {
+    server.close();
+    disposeEventLogStore();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  /** Send a `write` frame and read the `writeResult` it answers with. */
+  async function write(
+    reqId: string,
+    frame: { ptyId: string; data: string; stamp?: boolean },
+  ): Promise<{ ok: boolean; deliveryEventId?: number }> {
+    ws.receive({ type: "write", reqId, ...frame });
+    let answer: { ok: boolean; deliveryEventId?: number } | undefined;
+    await vi.waitFor(() => {
+      answer = ws.sent
+        .map((raw) => JSON.parse(raw) as { reqId?: string; ok?: boolean; deliveryEventId?: number })
+        .find((msg) => msg.reqId === reqId) as typeof answer;
+      expect(answer).toBeDefined();
+    });
+    return answer!;
+  }
+
+  function deliveries(): CoreLinkEvent[] {
+    return readEventTail(0).filter((e) => e.kind === SESSION_DELIVERED_EVENT_KIND);
+  }
+
+  it("appends one delivery event carrying the task id, and answers with its event id", async () => {
+    const answer = await write("w1", { ptyId: "pty-1", data: "carry on", stamp: true });
+
+    expect(answer.ok).toBe(true);
+    const appended = deliveries();
+    expect(appended).toHaveLength(1);
+    expect(appended[0]!.taskId).toBe("t1");
+    expect(appended[0]!.ptyId).toBe("pty-1");
+    // The id on the wire *is* the id in the log. A cursor that named a
+    // different row than the one appended would be a cursor into somebody
+    // else's history.
+    expect(answer.deliveryEventId).toBe(appended[0]!.eventId);
+    // And the bytes went in unchanged — the stamp is a record of a write, not
+    // an instruction added to one (ADR 0026).
+    expect(writes).toEqual(["carry on"]);
+  });
+
+  it("carries the length and not the text, because the log is read by everyone", async () => {
+    await write("w1", { ptyId: "pty-1", data: "the password is hunter2", stamp: true });
+
+    const payload = JSON.parse(deliveries()[0]!.payload) as Record<string, unknown>;
+    expect(payload).toEqual({ taskId: "t1", ptyId: "pty-1", characters: 23 });
+    expect(JSON.stringify(payload)).not.toContain("hunter2");
+  });
+
+  it("stamps nothing for a write that did not ask — which is every keystroke", async () => {
+    // An attached terminal writes a frame per keypress and this log is
+    // append-only for the life of the Core. Stamping unasked would trade a
+    // usable log for a field nobody in that path reads.
+    const answer = await write("w1", { ptyId: "pty-1", data: "j" });
+
+    expect(answer.ok).toBe(true);
+    expect(answer.deliveryEventId).toBeUndefined();
+    expect(deliveries()).toHaveLength(0);
+  });
+
+  it("stamps nothing for a write the PTY refused", async () => {
+    const answer = await write("w1", { ptyId: "pty-gone", data: "anyone there", stamp: true });
+
+    expect(answer.ok).toBe(false);
+    expect(answer.deliveryEventId).toBeUndefined();
+    // A cursor here would have a caller waiting for the end of a turn that no
+    // harness was ever told to start.
+    expect(deliveries()).toHaveLength(0);
+  });
+
+  it("stamps nothing for a PTY it cannot name a Task for", async () => {
+    // The wait is per Session, and the events it counts against carry a task
+    // id. A stamp with none could never be compared with anything.
+    const answer = await write("w1", { ptyId: "pty-shell", data: "ls\r", stamp: true });
+
+    expect(answer.ok).toBe(true);
+    expect(answer.deliveryEventId).toBeUndefined();
+    expect(deliveries()).toHaveLength(0);
+  });
+
+  it("stamps each accepted write of a multi-write delivery, in order", async () => {
+    // `send --enter` is two writes to one PTY — the text, then the carriage
+    // return — and the turn starts at the return. A caller waits from the later
+    // stamp, so both have to be stamped and they have to be ordered.
+    const text = await write("w1", { ptyId: "pty-1", data: "run the tests", stamp: true });
+    const enter = await write("w2", { ptyId: "pty-1", data: "\r", stamp: true });
+
+    expect(deliveries()).toHaveLength(2);
+    expect(enter.deliveryEventId!).toBeGreaterThan(text.deliveryEventId!);
+  });
+});

--- a/packages/core/src/core-task-writer.ts
+++ b/packages/core/src/core-task-writer.ts
@@ -102,7 +102,20 @@ export class CoreTaskWriter {
             : isOnlyPatchedField(mutation, "pinned")
               ? "task:pinnedChanged"
               : "task:updated";
-    const payload = JSON.stringify({ taskId: task.taskId, projectId: task.projectId });
+    // The **patched** status, when the mutation carried one — never the status
+    // the resulting row happens to have (#289 A). That distinction is the whole
+    // value of the field: a rename of a Session sitting at `finished` produces a
+    // `task:updated` whose row still reads `finished`, and a waiter that took
+    // the row's status from it would call the rename the end of a turn. A patch
+    // that sets the status is a report about a turn even when it sets the status
+    // it already had — which is the ordinary case on a harness that never moved
+    // the row to `running`, and the one a follow-up turn depends on.
+    const status = mutation.op === "update" ? mutation.status : undefined;
+    const payload = JSON.stringify({
+      taskId: task.taskId,
+      projectId: task.projectId,
+      ...(status === undefined ? {} : { status }),
+    });
     eventLog.appendEvent(kind, payload, { taskId: task.taskId });
     this.recordSessionFinish(mutation, task, previousStatus);
   }

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -46,10 +46,12 @@ import {
   EXEC_OUTPUT_TOO_LARGE_ERROR_CODE,
   SESSION_LOCKED_ERROR_CODE,
   SESSION_LOCK_CHANGED_EVENT_KIND,
+  SESSION_DELIVERED_EVENT_KIND,
   parseCoreLinkRequestFrame,
   serializeCoreLinkFrame,
   type CoreLinkSessionLock,
   type CoreLinkSessionLockChangedPayload,
+  type CoreLinkSessionDeliveredPayload,
   type CoreLinkSessionLockTransition,
   type CoreLinkHarnessAvailabilityMap,
   type CoreLinkHarnessInstallFailedPayload,
@@ -1245,6 +1247,34 @@ export class PtyCoreLinkServer {
     });
   }
 
+  /**
+   * Stamp an accepted write in the event log and hand back the id (#289 A).
+   *
+   * **The Task id is the whole point.** A wait is per Session, and the cursor it
+   * counts from has to sit in the same log as the status events it is counting
+   * against — so a PTY this Core cannot name a Task for is not stamped at all,
+   * and answers 0. That is honest rather than convenient: a cursor with no Task
+   * on it could never be compared with anything, and a client reading 0 falls
+   * back to waiting with no cursor rather than waiting on a fiction.
+   *
+   * Only stamped writes reach here. Every keystroke of an attached terminal is
+   * a `write` frame too, and this log is append-only for the life of the Core.
+   */
+  private recordSessionDelivery(ptyId: string, data: string): number {
+    if (!this.eventLog) return 0;
+    const taskId = this.core.taskIdForPty(ptyId);
+    if (!taskId) return 0;
+    const payload: CoreLinkSessionDeliveredPayload = {
+      taskId,
+      ptyId,
+      characters: data.length,
+    };
+    return this.eventLog.appendEvent(SESSION_DELIVERED_EVENT_KIND, JSON.stringify(payload), {
+      taskId,
+      ptyId,
+    });
+  }
+
   private async dispatch(conn: ActiveConnection, frame: CoreLinkRequestFrame): Promise<void> {
     const ws = conn.ws;
     switch (frame.type) {
@@ -1303,7 +1333,19 @@ export class PtyCoreLinkServer {
       case "write": {
         if (this.refuseLockedPty(conn, frame.reqId, frame.ptyId)) return;
         const ok = this.core.write(frame.ptyId, frame.data);
-        this.send(ws, { type: "writeResult", reqId: frame.reqId, ok });
+        // The stamp goes in **after** the PTY took the bytes and **before** the
+        // answer goes out, so the id the caller waits from cannot be older than
+        // the delivery it names. A write the PTY refused is not a delivery and
+        // is not stamped: a cursor for something that never arrived would have
+        // the wait sitting on a turn nobody asked for.
+        const deliveryEventId =
+          ok && frame.stamp === true ? this.recordSessionDelivery(frame.ptyId, frame.data) : 0;
+        this.send(ws, {
+          type: "writeResult",
+          reqId: frame.reqId,
+          ok,
+          ...(deliveryEventId > 0 ? { deliveryEventId } : {}),
+        });
         return;
       }
       case "resize": {

--- a/packages/sdk/src/__tests__/core-link-exec-frames.test.ts
+++ b/packages/sdk/src/__tests__/core-link-exec-frames.test.ts
@@ -103,19 +103,27 @@ describe("output past the bound is a named refusal, not a short result", () => {
 describe("the protocol version moved for this frame", () => {
   // The reason is in the test name, so whoever reads this failing after a
   // future bump gets the reason rather than the number.
-  it("is 0.16.0, up from 0.15.0, because `exec` is a new frame and not a ready capability (#266, ADR 0024 D11)", () => {
-    expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.16.0");
+  it("is 0.17.0 — moved for `exec` (#266) and again for the stamped write (#289), neither being a ready capability (ADR 0024 D11)", () => {
+    expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.17.0");
   });
 
   it("marks a Core still on 0.15.0 as incompatible, which is the whole point of moving it", () => {
     // Version-locked, not degraded: the operator is told to update one of the
     // two, once, rather than meeting a per-verb refusal later.
     expect(coreLinkProtocolCompatible("0.15.0")).toBe(false);
-    expect(coreLinkProtocolCompatible("0.16.0")).toBe(true);
+    expect(coreLinkProtocolCompatible("0.17.0")).toBe(true);
   });
 
   it("still ignores patch, so a fix that touches no frame grounds no fleet", () => {
-    expect(coreLinkProtocolCompatible("0.16.4")).toBe(true);
+    expect(coreLinkProtocolCompatible("0.17.4")).toBe(true);
+  });
+
+  it("marks a Core on the previous minor incompatible — an unstamping Core is not a degraded one", () => {
+    // #289: a Core on 0.16.0 answers every frame it always did, and cannot
+    // stamp a delivery. A client that connected anyway would send, get no
+    // cursor, and answer a `--wait` with the status the Session was already
+    // parked at. The gate is what stops that, one sentence before the send.
+    expect(coreLinkProtocolCompatible("0.16.0")).toBe(false);
   });
 
   it("announces no `exec` capability on `ready` — the version is the whole signal", () => {
@@ -123,6 +131,6 @@ describe("the protocol version moved for this frame", () => {
       serializeCoreLinkFrame({ type: "ready", version: CORE_LINK_PROTOCOL_VERSION }),
     ) as Record<string, unknown>;
     expect("exec" in ready).toBe(false);
-    expect(ready.version).toBe("0.16.0");
+    expect(ready.version).toBe("0.17.0");
   });
 });

--- a/packages/sdk/src/__tests__/core-link-frames.test.ts
+++ b/packages/sdk/src/__tests__/core-link-frames.test.ts
@@ -426,11 +426,12 @@ describe("core-link-frames", () => {
     // The reason lives in the test name on purpose: this assertion exists to
     // fail a future edit that bumps the version *for the multiConnection
     // surface*, and whoever reads that failure needs the reason, not the
-    // number. It did not bump for multiConnection and never will; 0.16.0 is
-    // the `exec` frame (issue 266), which is a frame rather than a ready
-    // capability and so is not the additive case D11 carves out.
-    it("is 0.16.0 — moved for the `exec` frame (#266), never for multiConnection, which is a ready capability no Core is marked needs-update for (ADR 0024 D11, issue 143)", () => {
-      expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.16.0");
+    // number. It did not bump for multiConnection and never will; 0.16.0 was
+    // the `exec` frame (issue 266) and 0.17.0 is the stamped write (issue
+    // 289), both frames rather than ready capabilities and so neither the
+    // additive case D11 carves out.
+    it("is 0.17.0 — moved for the `exec` frame (#266) and the stamped write (#289), never for multiConnection, which is a ready capability no Core is marked needs-update for (ADR 0024 D11, issue 143)", () => {
+      expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.17.0");
     });
 
     it("leaves a Core that announces no multiConnection capability fully compatible — absence is a supported state, not drift", () => {

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -35,6 +35,7 @@ import type {
 import { CoreClient } from "../core-client.ts";
 import {
   CoreSession,
+  CoreSessionAttachError,
   CoreSessionStartError,
   HARNESS_LAUNCH_COMMANDS,
   STATUS_READ_RETRIES,
@@ -871,6 +872,77 @@ describe("attaching to a Session that is already running (#289)", () => {
     await new Promise((done) => setTimeout(done, 50));
 
     expect(settled).toBeNull();
+  });
+
+  it("subscribes to the PTY even with the replay off, so an exit still settles a wait", async () => {
+    // Until a connection subscribes, a multi-connection Core fans this PTY out
+    // to somebody else: `onData` and `onExit` never fire, the screen stays
+    // empty, and the "an exit answers every wait" route is dead — so a caller
+    // that attached with `replay: false` to await a harness that then died
+    // would hang to its deadline instead. The subscribe is not part of the
+    // replay, and turning the scrollback off does not make the attachment deaf.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, replay: false });
+    // No scrollback: that is what `replay: false` buys, and all it buys.
+    expect(session.screen().trim()).toBe("");
+
+    const { deliveryEventId } = await session.deliver("carry on");
+    const idle = session.waitForTurnEnd({ afterEventId: deliveryEventId });
+
+    r.ptyCore.emitEvent({ type: "exit", ptyId: "pty-1", exitCode: 4 });
+
+    await expect(idle).resolves.toMatchObject({ exited: true, exitCode: 4 });
+  });
+
+  it("reports a link that blinked mid-attach as a failed attach, not as a dead harness", async () => {
+    // The two are different next steps. "Nothing is running" sends an operator
+    // to `logs` or `resume`; a Core that was busy for a moment wants a retry.
+    // Only the `findByTask` answer decides the first, and it decided before any
+    // of this ran.
+    rig = startRig();
+    const taskId = await runningSession();
+    const r = rig;
+    vi.spyOn(r.client, "sessionsList").mockRejectedValueOnce(new Error("link dropped mid-read"));
+
+    const attaching = CoreSession.attach(r.client, { taskId });
+
+    await expect(attaching).rejects.toThrow(/could not attach/);
+    await expect(attaching).rejects.not.toBeInstanceOf(CoreSessionAttachError);
+  });
+
+  it("gives the PTY subscription back on dispose", async () => {
+    // Removing the listener stops this process reading the bytes; it does not
+    // stop the Core sending them. An orchestrator that attaches to and disposes
+    // many Sessions on one long-lived client would otherwise leave every one of
+    // those streams running at it for the life of the client.
+    rig = startRig();
+    const taskId = await runningSession();
+    const r = rig;
+    const unsubscribe = vi.spyOn(r.client, "ptyUnsubscribe");
+
+    const attached = await CoreSession.attach(r.client, { taskId });
+    expect(unsubscribe).not.toHaveBeenCalled();
+    attached.dispose();
+
+    expect(unsubscribe).toHaveBeenCalledWith("pty-1");
+    // Idempotent: a second dispose is not a second frame.
+    attached.dispose();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not unsubscribe a PTY it never subscribed to — a spawned Session's is the Core's", async () => {
+    // The Core subscribes the connection that spawned a PTY, inside the spawn
+    // (issue 142). Nothing here asked for it, so nothing here gives it back.
+    rig = startRig();
+    const spawned = await startSession(rig);
+    const unsubscribe = vi.spyOn(rig.client, "ptyUnsubscribe");
+
+    spawned.dispose();
+
+    expect(unsubscribe).not.toHaveBeenCalled();
   });
 
   it("resolves a delivered wait when the harness's process exits", async () => {

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -103,9 +103,18 @@ class FakeTaskStore implements CoreMutationPort {
       updatedAt: existing.updatedAt + 1,
     };
     this.tasks.set(next.taskId, next);
-    this.eventLog.appendEvent("task:updated", JSON.stringify({ taskId: next.taskId }), {
-      taskId: next.taskId,
-    });
+    // The **patched** status rides in the payload, as `core-task-writer.ts`
+    // appends it: it is what tells a waiter that this event reported a turn
+    // rather than a rename, and a fake that dropped it would let a wait pass
+    // here and hang against a Core.
+    this.eventLog.appendEvent(
+      "task:updated",
+      JSON.stringify({
+        taskId: next.taskId,
+        ...(mutation.status === undefined ? {} : { status: mutation.status }),
+      }),
+      { taskId: next.taskId },
+    );
     if (next.status === "finished" && previousStatus !== "finished") {
       this.eventLog.appendEvent("session:finished", JSON.stringify({ id: next.taskId }), {
         taskId: next.taskId,
@@ -126,6 +135,26 @@ class FakeTaskStore implements CoreMutationPort {
   /** What the Core's hook pipeline does when a harness reports its lifecycle. */
   setStatus(taskId: string, status: string): void {
     this.mutateTask({ op: "update", taskId, status });
+  }
+
+  /** A row change that is not a turn — what the title generator does (issue 84). */
+  rename(taskId: string, title: string): void {
+    this.mutateTask({ op: "update", taskId, title });
+  }
+
+  /**
+   * A status change the event does not name: the row moves and the event says
+   * only that it moved.
+   *
+   * The shape a Core too old to name the patched status sends (#289 A), and the
+   * one route by which a status still reaches a client through a read rather
+   * than through the event that announced it.
+   */
+  setStatusSilently(taskId: string, status: string): void {
+    const existing = this.tasks.get(taskId);
+    if (!existing) return;
+    this.tasks.set(taskId, { ...existing, status, updatedAt: existing.updatedAt + 1 });
+    this.eventLog.appendEvent("task:updated", JSON.stringify({ taskId }), { taskId });
   }
 }
 
@@ -154,6 +183,12 @@ function startRig(
   if (opts.spawn) ptyCore.spawn = opts.spawn;
   const eventLog = new FakeEventLog();
   const tasks = new FakeTaskStore(eventLog);
+  // The Core stamps a delivery with the Task behind the PTY (#289 A), and the
+  // shared fake answers `null` — every Session in this suite runs on `pty-1`,
+  // so the newest row is the one it belongs to.
+  ptyCore.taskIdForPty = vi.fn((ptyId: string) =>
+    ptyId === "pty-1" ? ([...tasks.tasks.keys()].at(-1) ?? null) : null,
+  ) as unknown as typeof ptyCore.taskIdForPty;
   const wss = new FakeSocketServer();
   const server = new PtyCoreLinkServer(ptyCore, {
     port: 0,
@@ -613,11 +648,12 @@ describe("waiting on the Core's report", () => {
   });
 
   it("asks again when the status read fails, because the event will not come twice", async () => {
-    // `needs-input`, `interrupted` and `terminated` reach this layer as a bare
-    // `task:updated` — the event says a row moved and nothing more, so the
-    // status is read back off the Core, and that event is appended once. A read
-    // swallowed on the transition that mattered leaves `waitForIdle()` waiting
-    // for a report already made, and by design it has no deadline to end on.
+    // Against a Core that does not name the status it patched, a transition
+    // reaches this layer as a bare `task:updated` — the event says a row moved
+    // and nothing more, so the status is read back off the Core, and that event
+    // is appended once. A read swallowed on the transition that mattered leaves
+    // `waitForIdle()` waiting for a report already made, and by design it has no
+    // deadline to end on.
     rig = startRig();
     session = await startSession(rig);
     const r = rig;
@@ -632,7 +668,7 @@ describe("waiting on the Core's report", () => {
     });
     const idle = session.waitForIdle();
 
-    r.tasks.setStatus(session.taskId, "needs-input");
+    r.tasks.setStatusSilently(session.taskId, "needs-input");
 
     await expect(idle).resolves.toEqual({ status: "needs-input", exited: false });
     expect(failed).toBe(1);
@@ -647,7 +683,7 @@ describe("waiting on the Core's report", () => {
     const r = rig;
     vi.spyOn(r.client, "sessionsList").mockRejectedValue(new Error("link dropped"));
 
-    r.tasks.setStatus(session.taskId, "needs-input");
+    r.tasks.setStatusSilently(session.taskId, "needs-input");
 
     const attempts = () => vi.mocked(r.client.sessionsList).mock.calls.length;
     await vi.waitFor(() => expect(attempts()).toBe(1 + STATUS_READ_RETRIES), { timeout: 3000 });
@@ -662,6 +698,231 @@ describe("waiting on the Core's report", () => {
     session = await startSession(rig);
 
     expect(rig.client.isSubscribedToEvents()).toBe(true);
+  });
+});
+
+describe("attaching to a Session that is already running (#289)", () => {
+  /** A Session on the Core, started by somebody else, still on `pty-1`. */
+  async function runningSession(status = "running"): Promise<string> {
+    const r = rig!;
+    await r.client.connect();
+    const created = await r.client.tasksMutate({
+      op: "create",
+      projectId: PROJECT_ID,
+      title: "somebody else's session",
+      agent: "claude-code",
+    });
+    r.tasks.setStatus(created!.taskId, status);
+    return created!.taskId;
+  }
+
+  it("joins a running PTY, paints its scrollback, and names none of the spawn's answers", async () => {
+    rig = startRig();
+    const taskId = await runningSession();
+
+    session = await CoreSession.attach(rig.client, { taskId });
+
+    expect(session.taskId).toBe(taskId);
+    expect(session.ptyId).toBe("pty-1");
+    // The Core's replay ring, so the transcript starts where the conversation
+    // does rather than where this process happened to arrive.
+    expect(session.screen()).toContain("scrollback");
+    // An attach did not spawn, so the three answers a spawn gives are null
+    // rather than plausible. `reportsTurnStart` above all: `false` would read
+    // as "this harness does not report turn starts", which was never asked.
+    expect(session.harness).toBeNull();
+    expect(session.command).toBeNull();
+    expect(session.reportsTurnStart).toBeNull();
+  });
+
+  it("refuses to attach to a Session with no harness running, rather than hanging", async () => {
+    // The failure this replaces is the worst one available: a wait against a
+    // Session nothing is running for has nothing that will ever report a turn,
+    // so it would sit until the caller's deadline and then blame the Core.
+    rig = startRig();
+    const taskId = await runningSession();
+    rig.ptyCore.findByTask = vi.fn(() => ({ ptyId: null })) as unknown as typeof rig.ptyCore.findByTask;
+
+    await expect(CoreSession.attach(rig.client, { taskId })).rejects.toThrow(
+      /has no harness running/,
+    );
+  });
+
+  it("answers a bare wait from the status the Session is already in", async () => {
+    // `actana session wait` with nothing delivered asks "tell me when this
+    // Session is not working". A Session parked on a question is not working,
+    // and saying so at once is the truthful answer — there is no turn in flight
+    // that this could be mistaken for.
+    rig = startRig();
+    const taskId = await runningSession("needs-input");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+
+    await expect(session.waitForIdle()).resolves.toEqual({
+      status: "needs-input",
+      exited: false,
+    });
+  });
+
+  it("does not answer a delivered wait with the status the Session was already in", async () => {
+    // **The `settledNow` landmine, pinned.** This is the failure the delivery
+    // stamp exists to prevent: a Session sitting at `finished`, a write, and a
+    // wait that would otherwise return before the harness had read a character
+    // — reporting the previous turn's answer as this turn's.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    expect(session.status()).toBe("finished");
+
+    const { ok, deliveryEventId } = await session.deliver("carry on");
+    expect(ok).toBe(true);
+    expect(deliveryEventId).toBeGreaterThan(0);
+
+    let settled: unknown = null;
+    void session.waitForTurnEnd({ afterEventId: deliveryEventId }).then((idle) => {
+      settled = idle;
+    });
+    await new Promise((done) => setTimeout(done, 50));
+
+    // The pre-existing status is still `finished` and the wait has not moved.
+    expect(settled).toBeNull();
+    expect(session.status()).toBe("finished");
+
+    // Now the turn this write started ends. The status it lands on is the one
+    // it was already at — which is the ordinary case on a harness that never
+    // moved the row to `running` — and it still ends the wait, because what
+    // the wait is counting is *events after the delivery*, not value changes.
+    r.tasks.setStatus(taskId, "finished");
+
+    await vi.waitFor(() => expect(settled).toEqual({ status: "finished", exited: false }));
+  });
+
+  it("awaits a follow-up turn on a harness that never reports a turn's start", async () => {
+    // `codex` and `cursor-cli` are `reportsTurnStart: false` in `HOOK_FAMILIES`,
+    // so their Sessions never move to `running` and there is no transition to
+    // poll on. The wait is keyed on the turn's *end*, which they do report, and
+    // **no wait path consults `reportsTurnStart`** — the whole point of (A).
+    rig = startRig();
+    const r = rig;
+    await r.client.connect();
+    const created = await r.client.tasksMutate({
+      op: "create",
+      projectId: PROJECT_ID,
+      title: "a codex session",
+      agent: "codex",
+    });
+    const taskId = created!.taskId;
+    // Its first turn ended here, and nothing will move it again until the next
+    // one ends: `ready` → `finished`, and then `finished` → `finished`.
+    r.tasks.setStatus(taskId, "finished");
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("and now the tests\r");
+    const idle = session.waitForTurnEnd({ afterEventId: deliveryEventId });
+
+    r.tasks.setStatus(taskId, "finished");
+
+    await expect(idle).resolves.toEqual({ status: "finished", exited: false });
+  });
+
+  it("resolves on any of the five settled statuses, not on a finish alone", async () => {
+    // A turn that ended on a permission prompt, an escape, a dead harness or a
+    // Core that restarted underneath it *ended*. `session:finished` is appended
+    // for exactly one of the five, so a wait keyed on it waits forever on the
+    // four a caller most needs to hear about.
+    for (const status of ["finished", "needs-input", "interrupted", "terminated", "disconnected"]) {
+      rig = startRig();
+      const r = rig;
+      const taskId = await runningSession();
+      session = await CoreSession.attach(r.client, { taskId });
+      const { deliveryEventId } = await session.deliver("go on");
+      const idle = session.waitForTurnEnd({ afterEventId: deliveryEventId });
+
+      r.tasks.setStatus(taskId, status);
+
+      await expect(idle).resolves.toEqual({ status, exited: false });
+      session.dispose();
+      session = null;
+      r.client.close();
+      r.close();
+      rig = null;
+    }
+  });
+
+  it("does not read a rename as the end of a turn", async () => {
+    // A `task:updated` that patched no status is not a report about a turn. The
+    // title generator renames a Session while it works (issue 84), and a waiter
+    // that took the row's status from that event would call the rename the end
+    // of the turn — with the row still carrying the status it had before.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+    let settled: unknown = null;
+    void session.waitForTurnEnd({ afterEventId: deliveryEventId }).then((idle) => {
+      settled = idle;
+    });
+
+    r.tasks.rename(taskId, "a better title");
+    await new Promise((done) => setTimeout(done, 50));
+
+    expect(settled).toBeNull();
+  });
+
+  it("resolves a delivered wait when the harness's process exits", async () => {
+    // A harness that died is not going to report anything else, cursor or no
+    // cursor. The alternative is a wait that outlives the process it is about.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+    const idle = session.waitForTurnEnd({ afterEventId: deliveryEventId });
+
+    r.ptyCore.emitEvent({ type: "exit", ptyId: "pty-1", exitCode: 3 });
+
+    await expect(idle).resolves.toMatchObject({ exited: true, exitCode: 3 });
+  });
+
+  it("gives up on the caller's deadline and says what it was still doing", async () => {
+    // The honest degradation (#289 D): a harness that reports nothing runs the
+    // deadline out, and what is reported is that this side gave up — never a
+    // status the Core did not send, and never a turn inferred from the bytes.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+
+    await expect(
+      session.waitForTurnEnd({ afterEventId: deliveryEventId, timeoutMs: 30 }),
+    ).rejects.toThrow(/still finished/);
+  });
+});
+
+describe("no wait is keyed on a turn's start (#289 A)", () => {
+  it("mentions reportsTurnStart nowhere in the waiting half of the session layer", () => {
+    // `reportsTurnStart` survives as reported information — the `spawned` frame,
+    // `session start --json`, the Panel's terminal-input fallback — and gates
+    // nothing about waiting. Half the harness families answer `false`, so a wait
+    // that consulted it would work on half of them and be a coin flip for every
+    // family added after it.
+    const source = readFileSync(new URL("../core-session.ts", import.meta.url), "utf8");
+    const waiting = source
+      .slice(source.indexOf("  waitForIdle("), source.indexOf("  // ─── Lifecycle"))
+      // Comments out: the prose there *says* no wait consults the field, and a
+      // check that could not tell that sentence from a call is a check that
+      // punishes writing it down.
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+
+    expect(waiting.length).toBeGreaterThan(200);
+    expect(waiting).not.toContain("reportsTurnStart");
   });
 });
 

--- a/packages/sdk/src/__tests__/files-capability.test.ts
+++ b/packages/sdk/src/__tests__/files-capability.test.ts
@@ -69,8 +69,8 @@ describe("the protocol version does not move for it", () => {
   // not move it and does not: it is a ready capability whose absence yields
   // today's behaviour exactly. What moved it to 0.16.0 is the `exec` frame
   // (#266), which is a frame and therefore not that case.
-  it("is 0.16.0 for the `exec` frame (#266) and not for `files`, which is a ready capability no Core becomes needs-update for (#165 F9, ADR 0024 D11)", () => {
-    expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.16.0");
+  it("is 0.17.0 for the `exec` frame (#266) and the stamped write (#289), and not for `files`, a ready capability no Core becomes needs-update for (#165 F9, ADR 0024 D11)", () => {
+    expect(CORE_LINK_PROTOCOL_VERSION).toBe("0.17.0");
   });
 
   it("serializes the ready frame with the capability when a Core announces it", () => {

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -1114,8 +1114,32 @@ export class CoreClient {
     };
   }
 
-  write(ptyId: string, data: string): Promise<boolean> {
-    return this.rpc({ type: "write", reqId: "", ptyId, data }) as Promise<boolean>;
+  /** Write, unstamped — the one every keystroke goes through. See {@link deliver}. */
+  async write(ptyId: string, data: string): Promise<boolean> {
+    const { ok } = (await this.rpc({ type: "write", reqId: "", ptyId, data })) as {
+      ok: boolean;
+    };
+    return ok;
+  }
+
+  /**
+   * Write, and ask the Core where in its event log the delivery landed (#289 A).
+   *
+   * The same frame `write` sends with one field set, and the same answer with
+   * one field read: `deliveryEventId` is the cursor a turn-end wait counts from,
+   * and it is 0 when the Core did not stamp — an older Core, a write the PTY
+   * refused, a PTY with no Task behind it. A caller that got 0 has no cursor and
+   * must not invent one; what it has is the ordinary `ok`.
+   *
+   * {@link write} is this without the stamp, and stays the one every keystroke
+   * goes through: the log is append-only for the life of a Core, so stamping is
+   * for a caller that is about to wait, not for typing.
+   */
+  async deliver(ptyId: string, data: string): Promise<{ ok: boolean; deliveryEventId: number }> {
+    return (await this.rpc({ type: "write", reqId: "", ptyId, data, stamp: true })) as {
+      ok: boolean;
+      deliveryEventId: number;
+    };
   }
 
   resize(ptyId: string, cols: number, rows: number): Promise<boolean> {
@@ -1409,7 +1433,13 @@ export function unwrapResponse(msg: CoreLinkResponseFrame): unknown {
       };
     case "spawnError":
       throw new Error(msg.message);
+    // The write answers with a pair, because a stamped write has a second thing
+    // to say: where in the event log the delivery landed (#289 A). `ok` alone
+    // would make the cursor unreachable through the typed client, and the two
+    // facts belong to one round trip. Absent `deliveryEventId` reads as 0 — a
+    // Core that does not stamp, never a cursor.
     case "writeResult":
+      return { ok: msg.ok, deliveryEventId: msg.deliveryEventId ?? 0 };
     case "resizeResult":
     case "killResult":
       return msg.ok;

--- a/packages/sdk/src/core-link-frames.ts
+++ b/packages/sdk/src/core-link-frames.ts
@@ -586,6 +586,40 @@ export type CoreLinkSessionLockState = "unlocked" | "held-by-you" | "held-by-ano
 export const SESSION_LOCK_CHANGED_EVENT_KIND = "session:lockChanged";
 
 /**
+ * The kind of the event the Core appends when it accepts a **stamped** write
+ * for a Session (#289 A).
+ *
+ * It exists to be a cursor, not a notification. A client that is about to wait
+ * for the turn a write starts needs one fact the event log could not otherwise
+ * give it: *where in the log the write landed*. With that id in hand the wait is
+ * "the first settling status for this task after event N", which is a question
+ * with one answer — and not "is this Session settled?", which answers with the
+ * status the Session was already sitting at before the write (the `settledNow`
+ * short-circuit in `core-session.ts`, and the reason this event exists).
+ *
+ * Payload is {@link CoreLinkSessionDeliveredPayload}. Appended only for a write
+ * that asked to be stamped and that the PTY accepted, and only when the Core can
+ * name the Task behind the PTY — the id is what the cursor is *for*.
+ */
+export const SESSION_DELIVERED_EVENT_KIND = "session:delivered";
+
+/**
+ * Payload of a {@link SESSION_DELIVERED_EVENT_KIND} event.
+ *
+ * The Task, the PTY and how many characters went in — no text. What was typed
+ * into a Session is the Session's, and this row goes into a log every connection
+ * replays; a length is enough for an operator reading `actana events tail` to
+ * tell a prompt from a keystroke, and carries nothing a transcript would not
+ * already show to somebody entitled to see it.
+ */
+export type CoreLinkSessionDeliveredPayload = {
+  taskId: string;
+  ptyId: string;
+  /** Characters accepted, not bytes on the wire. */
+  characters: number;
+};
+
+/**
  * What happened to a Session's lock, in the vocabulary of the lock rather than
  * of the frame that caused it.
  *
@@ -636,7 +670,25 @@ export type CoreLinkSessionLockChangedPayload = {
 
 export type CoreLinkRequestFrame =
   | { type: "spawn"; reqId: string; opts: CoreLinkPtySpawnOptions }
-  | { type: "write"; reqId: string; ptyId: string; data: string }
+  | {
+      type: "write";
+      reqId: string;
+      ptyId: string;
+      data: string;
+      /**
+       * Ask the Core to **stamp this delivery in its event log** and answer with
+       * the id it got (#289 A). Opt-in, and the opt is what keeps the log
+       * usable: an attached terminal's keystrokes are `write` frames too, and a
+       * log that is append-only for the life of a Core must not carry a row per
+       * keypress. A client that is about to wait for the turn this write starts
+       * sets it; a client that is typing does not.
+       *
+       * Absent on a Core too old to stamp, which answers `writeResult` with no
+       * {@link CoreLinkResponseFrame} `deliveryEventId` — read as 0, "not
+       * stamped", never as a cursor.
+       */
+      stamp?: boolean;
+    }
   | { type: "resize"; reqId: string; ptyId: string; cols: number; rows: number }
   | { type: "kill"; reqId: string; ptyId: string }
   | {
@@ -920,7 +972,23 @@ export type CoreLinkResponseFrame =
       hooksReportTurnStart?: boolean;
     }
   | { type: "spawnError"; reqId: string; message: string }
-  | { type: "writeResult"; reqId: string; ok: boolean }
+  | {
+      type: "writeResult";
+      reqId: string;
+      ok: boolean;
+      /**
+       * The event id of the `session:delivered` this write was stamped with,
+       * when the frame asked for a stamp and the write was accepted (#289 A).
+       *
+       * The cursor a turn-end wait counts from: the wait resolves on the first
+       * settling status for that task at an event id **strictly greater** than
+       * this one, which is what stops it from answering with the status the
+       * Session was already sitting at. 0 or absent means nothing was stamped —
+       * a Core that predates this, a write nothing accepted, or a PTY with no
+       * Task behind it — and 0 is not a cursor.
+       */
+      deliveryEventId?: number;
+    }
   | { type: "resizeResult"; reqId: string; ok: boolean }
   | { type: "killResult"; reqId: string; ok: boolean }
   | {

--- a/packages/sdk/src/core-link-frames.ts
+++ b/packages/sdk/src/core-link-frames.ts
@@ -1460,10 +1460,29 @@ export type CoreLinkServerFrame =
  * tells its operator to update one of the two, in one sentence, before the
  * first `exec` rather than after it.
  *
+ * **Issue 289 moves it to 0.17.0, on the same reasoning and a stronger case.**
+ * The stamped `write` — {@link CoreLinkRequestFrame} `stamp`, answered with
+ * `deliveryEventId` — looks like the additive exception and is not it. The
+ * exception is available only where the capability's absence yields today's
+ * behaviour **exactly**, and here absence yields something worse than today:
+ * `actana session send X --wait` is a clean usage refusal on a Core built
+ * before this, and a client that shipped the flag against an unstamping Core
+ * would send, get no cursor back, and fall through to an uncursored wait that
+ * answers instantly with the status the Session was already parked at — last
+ * turn's answer printed as this turn's, with a zero exit. A silent wrong
+ * answer replacing a hard error is the one degradation the exception exists to
+ * forbid, so the minor moves and no capability is announced for the stamp.
+ *
+ * The cursor is refused rather than approximated in the client as well
+ * ({@link CoreLinkResponseFrame} `deliveryEventId`, and the CLI's session
+ * gateway): the version gate is what an operator meets first, and the refusal
+ * is what covers a Core that is on this version and still could not stamp —
+ * one with no event-log port, or whose append failed.
+ *
  * Patch stays 0 — see {@link coreLinkProtocolCompatible}, which compares
  * major.minor only.
  */
-export const CORE_LINK_PROTOCOL_VERSION = "0.16.0";
+export const CORE_LINK_PROTOCOL_VERSION = "0.17.0";
 
 /**
  * Does a Core advertising `reported` speak this build's core-link?

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -233,6 +233,28 @@ export type CoreSessionStartOptions = {
   subscribeToEvents?: boolean;
 };
 
+export type CoreSessionAttachOptions = {
+  /** The Session to join. It must have a live PTY; see {@link CoreSessionAttachError}. */
+  taskId: string;
+  /** Screen width for the transcript this attachment renders. */
+  cols?: number;
+  /** Screen height. Same. */
+  rows?: number;
+  /** How many scrolled-off lines {@link CoreSession.screen} keeps. */
+  scrollback?: number;
+  /** As {@link CoreSessionStartOptions.subscribeToEvents}. Default true. */
+  subscribeToEvents?: boolean;
+  /**
+   * Paint the Core's replay ring into the screen before returning. Default true.
+   *
+   * On by default because a caller that attaches to read a turn wants the
+   * conversation it lands in the middle of, not the tail of one turn — and the
+   * ring belongs to the PTY, so it is readable now and gone when the harness
+   * exits. Off is for a caller that wants only what this attachment saw.
+   */
+  replay?: boolean;
+};
+
 /** What a Session settled on. */
 export type CoreSessionIdle = {
   /** The Core's status for this Session — one of {@link SETTLED_SESSION_STATUSES}. */
@@ -254,11 +276,39 @@ export type CoreSessionWaitOptions = {
   timeoutMs?: number;
 };
 
+export type CoreSessionTurnWaitOptions = CoreSessionWaitOptions & {
+  /**
+   * Only a settling status learned at an event id **strictly greater** than this
+   * one ends the wait — the id the Core stamped a delivery with
+   * ({@link CoreSession.deliver}).
+   *
+   * 0, the default, is no cursor: any settled status the Session is known to be
+   * in ends the wait, which is what {@link CoreSession.waitForIdle} has always
+   * done.
+   */
+  afterEventId?: number;
+};
+
 /** The Core refused to start this Session. Carries the Core's own reason. */
 export class CoreSessionStartError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = "CoreSessionStartError";
+  }
+}
+
+/**
+ * There is nothing running to attach to.
+ *
+ * Its own kind because it is the one failure an attach has that a start does
+ * not, and because the alternative is worse than an error: a wait against a
+ * Session whose harness has already exited has nothing that will ever report a
+ * turn, so it would hang until the caller's deadline and then blame the Core.
+ */
+export class CoreSessionAttachError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "CoreSessionAttachError";
   }
 }
 
@@ -275,10 +325,20 @@ export class CoreSession {
   readonly taskId: string;
   /** The Core's id for this Session's PTY. */
   readonly ptyId: string;
-  /** The harness running in it. */
-  readonly harness: CoreLinkPtySpawnHarness;
-  /** The command the Core was asked to start, after defaulting. */
-  readonly command: string;
+  /**
+   * The harness running in it, or `null` on a Session this process did not
+   * start — {@link attach} joins a PTY that is already running, and the Core
+   * publishes no harness for one. A caller that needs the name reads it off the
+   * Task row, which is where it lives.
+   */
+  readonly harness: CoreLinkPtySpawnHarness | null;
+  /**
+   * The command the Core was asked to start, after defaulting, or `null` on an
+   * {@link attach} — the command was decided by whoever spawned the PTY and the
+   * Core does not publish it afterwards. Null is "this side does not know",
+   * never "there was none".
+   */
+  readonly command: string | null;
   /**
    * Will anything move this Session to `running` when a turn begins (issue 84,
    * issue 177 finding 4)?
@@ -302,8 +362,14 @@ export class CoreSession {
    *
    * `false` on a Core too old to answer, which is the safe direction: a
    * redundant caveat, never a silently statusless Session.
+   *
+   * `null` on an {@link attach}, which is a different thing again: the Core
+   * answers this question on a **spawn**, so a Session joined after the fact has
+   * no answer rather than a negative one. **No wait consults this field** (#289
+   * A) — turn *end* is reported by every harness family, and that is what every
+   * wait here is waiting for.
    */
-  readonly reportsTurnStart: boolean;
+  readonly reportsTurnStart: boolean | null;
 
   private readonly client: CoreClient;
   private readonly terminal: TerminalScreen;
@@ -312,7 +378,15 @@ export class CoreSession {
   private readonly dataListeners = new Set<(chunk: string) => void>();
   private readonly exitListeners = new Set<(exit: { exitCode: number; signal?: number }) => void>();
   private readonly statusListeners = new Set<(status: string) => void>();
-  private readonly idleWaiters = new Set<(idle: CoreSessionIdle) => void>();
+  /**
+   * Everyone waiting for a turn to end, each with the event id it counts from.
+   * A waiter with `afterEventId: 0` takes any settled status; one carrying a
+   * delivery stamp takes only a status learned after it.
+   */
+  private readonly idleWaiters = new Set<{
+    afterEventId: number;
+    notify: (idle: CoreSessionIdle) => void;
+  }>();
 
   /**
    * The Core's last reported status, or null before one has been *observed*.
@@ -324,6 +398,18 @@ export class CoreSession {
    * event after {@link start} lands here.
    */
   private lastStatus: string | null = null;
+  /**
+   * The event id {@link lastStatus} was learned at, or 0 when it was not learned
+   * from an event — the status {@link attach} seeded from the Task row.
+   *
+   * This is what makes a cursored wait possible (#289 A). "Has this Session
+   * settled?" answers with whatever it is sitting at, including last turn's
+   * answer; "has this Session settled **since event N**?" is the question a
+   * caller that just delivered a prompt is actually asking, and it needs a
+   * *where* as well as a *what*. A seeded status carries 0 on purpose: 0 is
+   * greater than nothing, so it can never satisfy a real cursor.
+   */
+  private lastStatusEventId = 0;
   private exit: { exitCode: number; signal?: number } | null = null;
   private disposed = false;
   /** A status read is in flight; another event arrived while it was. */
@@ -337,9 +423,9 @@ export class CoreSession {
     client: CoreClient;
     taskId: string;
     ptyId: string;
-    harness: CoreLinkPtySpawnHarness;
-    command: string;
-    reportsTurnStart: boolean;
+    harness: CoreLinkPtySpawnHarness | null;
+    command: string | null;
+    reportsTurnStart: boolean | null;
     terminal: TerminalScreen;
   }) {
     this.client = opts.client;
@@ -487,6 +573,101 @@ export class CoreSession {
     return session;
   }
 
+  /**
+   * Join a Session that is **already running**, for the length of a turn (#289).
+   *
+   * The gap this closes: {@link start} is the only way into a `CoreSession`, and
+   * it spawns. Everything this class offers a caller after the first turn — the
+   * screen, the status, the wait — was unreachable for a Session somebody else
+   * started, or that this process started and hung up on. Awaiting a follow-up
+   * turn is therefore SDK work rather than a flag on a command, and this is it.
+   *
+   * What it does, in order, and the order is the point:
+   *
+   *   1. subscribe to the event log, if nothing has, so a status change that
+   *      lands during the rest of this is heard rather than missed;
+   *   2. resolve the Task's live PTY — **once**, and every write and wait made
+   *      through the returned Session uses that resolution, so there is no
+   *      window between delivering text and starting to wait for it;
+   *   3. wire the byte stream, the exit and the events **before** the replay;
+   *   4. seed the screen from the Core's replay ring, and the last known status
+   *      from the Session snapshot.
+   *
+   * **The seeded status carries event id 0**, which is what keeps it honest.
+   * `waitForIdle` will answer from it — that is `actana session wait` on a
+   * Session already sitting at `needs-input`, and answering immediately is
+   * right, because no turn was asked for. {@link waitForTurnEnd} with a delivery
+   * stamp will not: 0 can never be greater than a real cursor, so a wait for the
+   * turn a write starts cannot be answered by the turn before it.
+   *
+   * Rejects with {@link CoreSessionAttachError} when the Task has no live PTY —
+   * a harness that exited, or a Session id that is not one.
+   */
+  static async attach(client: CoreClient, opts: CoreSessionAttachOptions): Promise<CoreSession> {
+    if (opts.subscribeToEvents !== false && !client.isSubscribedToEvents()) {
+      client.subscribeEvents();
+    }
+
+    const { ptyId } = await client.findByTask(opts.taskId);
+    if (ptyId === null) {
+      throw new CoreSessionAttachError(
+        `session ${opts.taskId} has no harness running — there is nothing to attach a wait to`,
+      );
+    }
+
+    const cols = opts.cols ?? DEFAULT_COLS;
+    const rows = opts.rows ?? DEFAULT_ROWS;
+    const terminal = new TerminalScreen({ cols, rows, scrollback: opts.scrollback });
+    const session = new CoreSession({
+      client,
+      taskId: opts.taskId,
+      ptyId,
+      // Three facts about a spawn, and this is not one. The Task row carries the
+      // harness for a caller that needs the name; the command and the turn-start
+      // answer were the Core's answer to a `spawn` frame that happened before
+      // this process was involved, and inventing either would be worse than null.
+      harness: null,
+      command: null,
+      reportsTurnStart: null,
+      terminal,
+    });
+
+    session.unsubscribes.push(
+      client.onData((frame) => {
+        if (frame.ptyId === ptyId) session.ingest(frame.data);
+      }),
+      client.onExit((frame) => {
+        if (frame.ptyId === ptyId) session.ingestExit(frame);
+      }),
+      client.onEvent(({ event }) => session.onCoreEvent(event)),
+    );
+
+    try {
+      if (opts.replay !== false) {
+        // `catchUp` is a promise to read the ring, and the two lines are that
+        // promise kept: the Core holds this PTY's live stream until the replay
+        // has been served, so the bytes either side of it arrive once and in
+        // order. A subscribe with no replay behind it strands the stream.
+        await client.ptySubscribe(ptyId, { catchUp: true });
+        const { data } = await client.replay(ptyId);
+        terminal.write(data);
+      }
+      await session.seedStatus();
+    } catch (err) {
+      session.dispose();
+      throw err instanceof CoreSessionAttachError
+        ? err
+        : new CoreSessionAttachError(
+            `could not attach to session ${opts.taskId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { cause: err },
+          );
+    }
+
+    return session;
+  }
+
   // ─── Programmatic I/O ──────────────────────────────────────────────────────
 
   /**
@@ -508,6 +689,25 @@ export class CoreSession {
    */
   send(text: string): Promise<boolean> {
     return this.client.write(this.ptyId, text);
+  }
+
+  /**
+   * {@link send}, with the Core stamping the delivery in its event log and
+   * answering with the id — the cursor {@link waitForTurnEnd} counts from
+   * (#289 A).
+   *
+   * Exactly the same bytes and exactly as little timing as `send`: the stamp is
+   * a fact recorded about a write that already happened, not a schedule imposed
+   * on one. A caller wanting to await the turn its text starts writes with this
+   * and waits from what it returns, and the two are one round trip apart with no
+   * window between them in which the Session could settle unobserved.
+   *
+   * `deliveryEventId` is 0 when the Core did not stamp — a write the PTY
+   * refused, a Core that predates the stamp, a PTY with no Task behind it. 0 is
+   * not a cursor: a caller that waits from it is waiting with none.
+   */
+  deliver(text: string): Promise<{ ok: boolean; deliveryEventId: number }> {
+    return this.client.deliver(this.ptyId, text);
   }
 
   /**
@@ -601,14 +801,47 @@ export class CoreSession {
    * passes a deadline it chose itself.
    */
   waitForIdle(opts: CoreSessionWaitOptions = {}): Promise<CoreSessionIdle> {
-    const settled = this.settledNow();
+    return this.waitForTurnEnd(opts);
+  }
+
+  /**
+   * Wait for the end of the turn that follows event `afterEventId` — the wait
+   * `session send --wait` is built on (#289 A, B).
+   *
+   * **Why a cursor.** {@link waitForIdle} answers from the status the Session is
+   * already sitting at, and for a Session that was started here that is right:
+   * it has observed no status yet, so anything it hears is this turn's. For a
+   * Session that was **already running** it is a lie waiting to be told — a
+   * harness parked on `needs-input` is settled, so a wait attached to it and
+   * started after a write would return before the harness had read a character,
+   * reporting the previous turn's answer as this one's. Passing the id the Core
+   * stamped the delivery with turns "is it settled?" into "has it settled since
+   * the thing I sent?", and only the second question has a truthful answer.
+   *
+   * `afterEventId: 0` (the default) is no cursor and is {@link waitForIdle}.
+   *
+   * Resolves on **any** of {@link SETTLED_SESSION_STATUSES}, not on `finished`
+   * alone: a turn that ended on a permission prompt, an escape or a dead harness
+   * ended, and a caller waiting for `finished` there waits forever on exactly the
+   * cases it most needs to hear about. A process exit resolves it too.
+   *
+   * Nothing here reads the byte stream, and nothing here consults
+   * {@link reportsTurnStart}. Turn end is reported by every harness family; turn
+   * *start* is not, which is why no wait is keyed on it.
+   */
+  waitForTurnEnd(opts: CoreSessionTurnWaitOptions = {}): Promise<CoreSessionIdle> {
+    const afterEventId = opts.afterEventId ?? 0;
+    const settled = this.settledSince(afterEventId);
     if (settled) return Promise.resolve(settled);
     return new Promise<CoreSessionIdle>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
-      const waiter = (idle: CoreSessionIdle): void => {
-        this.idleWaiters.delete(waiter);
-        if (timer) clearTimeout(timer);
-        resolve(idle);
+      const waiter = {
+        afterEventId,
+        notify: (idle: CoreSessionIdle): void => {
+          this.idleWaiters.delete(waiter);
+          if (timer) clearTimeout(timer);
+          resolve(idle);
+        },
       };
       this.idleWaiters.add(waiter);
       if (opts.timeoutMs && opts.timeoutMs > 0) {
@@ -660,7 +893,12 @@ export class CoreSession {
     // forever. `kill()` disposes, and `await session.kill()` after starting a
     // `waitForIdle()` is an ordinary thing to write.
     for (const waiter of [...this.idleWaiters]) {
-      waiter(this.settledNow() ?? { status: this.lastStatus ?? "disposed", exited: false });
+      waiter.notify(
+        this.settledSince(waiter.afterEventId) ?? {
+          status: this.lastStatus ?? "disposed",
+          exited: false,
+        },
+      );
     }
     this.dataListeners.clear();
     this.exitListeners.clear();
@@ -704,7 +942,17 @@ export class CoreSession {
     // `session:finished` is appended on the transition into `finished` and on
     // nothing else, so it is the one kind that already says what happened.
     if (event.kind === "session:finished") {
-      this.noteStatus("finished");
+      this.noteStatus("finished", event.eventId);
+      return;
+    }
+    // A `task:updated` whose payload names the status the mutation **patched**
+    // is a report about a turn, and it is exact: it needs no round trip, and it
+    // cannot be confused with a rename or an archive of a Session that happens
+    // to be sitting at a settled status. Anything else moves the last known
+    // status but never the cursor — see {@link readStatus}.
+    const patched = patchedStatusOf(event);
+    if (patched !== null) {
+      this.noteStatus(patched, event.eventId);
       return;
     }
     void this.readStatus();
@@ -722,6 +970,13 @@ export class CoreSession {
    * A read that fails is re-asked ({@link STATUS_READ_RETRIES}), because on
    * `needs-input`, `interrupted` and `terminated` there is no second event to
    * carry the news.
+   *
+   * **What it reads never advances the wait cursor** (#289 A). This path is
+   * reached for an event that did not say what it changed — a rename, an
+   * archive, a Core too old to name the patched status — and the row it reads
+   * back may be carrying the status of a turn that ended long before. Answering
+   * a cursored wait from that is the early resolution the cursor exists to
+   * prevent, so a read updates `lastStatus` and leaves the cursor where it was.
    */
   private async readStatus(): Promise<void> {
     if (this.disposed) return;
@@ -756,6 +1011,20 @@ export class CoreSession {
     }
   }
 
+  /**
+   * Read the Core's current status for this Session once, at attach, at event
+   * id 0 — "what it is sitting at", never "what it did".
+   *
+   * A missing row is not an error here: the Session has a live PTY (the attach
+   * proved it), and a Core that does not list it yet will report its status like
+   * any other, through the event log this attachment is already listening to.
+   */
+  private async seedStatus(): Promise<void> {
+    const sessions = await this.client.sessionsList();
+    const mine = sessions.find((s: CoreLinkSessionSnapshot) => s.taskId === this.taskId);
+    if (mine) this.noteStatus(mine.status, 0);
+  }
+
   /** The next re-ask of a read that failed. Cleared by {@link dispose}. */
   private scheduleStatusRetry(): void {
     if (this.statusRetryTimer) return;
@@ -768,14 +1037,27 @@ export class CoreSession {
     this.statusRetryTimer.unref?.();
   }
 
-  private noteStatus(status: string): void {
-    if (status === this.lastStatus) return;
+  /**
+   * Record a status the Core reported, and where in the log it was reported.
+   *
+   * **A repeated status is still news**, which is why the cursor moves even when
+   * the string does not (#289 A). A harness that never moved its Session to
+   * `running` ends its second turn by patching `finished` onto a row that
+   * already said `finished`; the value did not change, but a turn ended, and a
+   * waiter counting from a delivery stamp is waiting for exactly that. What
+   * stays gated on a change is {@link onStatus}, which is about the value.
+   */
+  private noteStatus(status: string, eventId = 0): void {
+    const changed = status !== this.lastStatus;
     this.lastStatus = status;
-    for (const cb of this.statusListeners) {
-      try {
-        cb(status);
-      } catch {
-        /* same */
+    if (eventId > this.lastStatusEventId) this.lastStatusEventId = eventId;
+    if (changed) {
+      for (const cb of this.statusListeners) {
+        try {
+          cb(status);
+        } catch {
+          /* same */
+        }
       }
     }
     this.releaseWaiters();
@@ -783,6 +1065,18 @@ export class CoreSession {
 
   /** What {@link waitForIdle} would answer right now, or null if it must wait. */
   private settledNow(): CoreSessionIdle | null {
+    return this.settledSince(0);
+  }
+
+  /**
+   * What a wait counting from `afterEventId` would answer right now, or null.
+   *
+   * An **exit** answers every wait, cursor or none: a harness whose process is
+   * gone will not report anything else, and a caller left waiting for a status
+   * after that waits forever. A status answers a cursored wait only when it was
+   * learned after the cursor — a seeded status (event id 0) never does.
+   */
+  private settledSince(afterEventId: number): CoreSessionIdle | null {
     if (this.exit) {
       return {
         status: this.lastStatus ?? "terminated",
@@ -790,16 +1084,36 @@ export class CoreSession {
         ...(this.exit.exitCode === undefined ? {} : { exitCode: this.exit.exitCode }),
       };
     }
-    if (this.lastStatus && SETTLED_SESSION_STATUSES.has(this.lastStatus)) {
-      return { status: this.lastStatus, exited: false };
-    }
-    return null;
+    if (!this.lastStatus || !SETTLED_SESSION_STATUSES.has(this.lastStatus)) return null;
+    if (afterEventId > 0 && this.lastStatusEventId <= afterEventId) return null;
+    return { status: this.lastStatus, exited: false };
   }
 
   private releaseWaiters(): void {
-    const settled = this.settledNow();
-    if (!settled) return;
-    for (const waiter of [...this.idleWaiters]) waiter(settled);
+    for (const waiter of [...this.idleWaiters]) {
+      const settled = this.settledSince(waiter.afterEventId);
+      if (settled) waiter.notify(settled);
+    }
+  }
+}
+
+/**
+ * The status a `task:updated` event says its mutation **patched**, or null when
+ * the event does not say (#289 A).
+ *
+ * Null is not "no status": it is "this event did not report a turn". A Core that
+ * names the patched status makes every turn end legible without a round trip; a
+ * Core that does not leaves the caller with `readStatus`, which is a fresher
+ * answer to a different question.
+ */
+function patchedStatusOf(event: CoreLinkEvent): string | null {
+  try {
+    const payload = JSON.parse(event.payload) as { status?: unknown };
+    return typeof payload.status === "string" ? payload.status : null;
+  } catch {
+    // A payload this side cannot parse is a payload this side knows nothing
+    // about — the read path below covers it, which is what it is there for.
+    return null;
   }
 }
 

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -674,11 +674,14 @@ export class CoreSession {
       // until it has been served; it is set exactly when one does, because a
       // hold nobody redeems strands the Session's output on the Core.
       await client.ptySubscribe(ptyId, { catchUp: replay });
+      // Recorded the moment it is owed, not once the rest succeeded: a replay
+      // that throws still leaves this connection subscribed, and the `dispose`
+      // in the catch below is the only thing that will ever give it back.
+      session.subscribedToPty = true;
       if (replay) {
         const { data } = await client.replay(ptyId);
         terminal.write(data);
       }
-      session.subscribedToPty = true;
       await session.seedStatus();
     } catch (err) {
       session.dispose();

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -394,6 +394,14 @@ export class CoreSession {
   }>();
 
   /**
+   * This Session asked the Core for its PTY's stream, so {@link dispose} owes it
+   * a matching `ptyUnsubscribe`. False for a spawned Session: the Core
+   * subscribes the connection that spawned a PTY, inside the spawn, and nothing
+   * here asked for that.
+   */
+  private subscribedToPty = false;
+
+  /**
    * The Core's last reported status, or null before one has been *observed*.
    *
    * Null rather than the status the Task carried when this Session started, and
@@ -402,13 +410,6 @@ export class CoreSession {
    * to end, not being told about the last one. Only a status learned from an
    * event after {@link start} lands here.
    */
-  /**
-   * This Session asked the Core for its PTY's stream, so {@link dispose} owes it
-   * a matching `ptyUnsubscribe`. False for a spawned Session: the Core
-   * subscribes the connection that spawned a PTY, inside the spawn, and nothing
-   * here asked for that.
-   */
-  private subscribedToPty = false;
   private lastStatus: string | null = null;
   /**
    * The event id {@link lastStatus} was learned at, or 0 when it was not learned

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -251,6 +251,11 @@ export type CoreSessionAttachOptions = {
    * conversation it lands in the middle of, not the tail of one turn — and the
    * ring belongs to the PTY, so it is readable now and gone when the harness
    * exits. Off is for a caller that wants only what this attachment saw.
+   *
+   * **It does not turn the PTY subscription off**, which is a separate thing and
+   * is unconditional: without one, `onData` and `onExit` never fire against a
+   * multi-connection Core, and an attachment that could not hear an exit is one
+   * whose wait outlives the process it is about.
    */
   replay?: boolean;
 };
@@ -397,6 +402,13 @@ export class CoreSession {
    * to end, not being told about the last one. Only a status learned from an
    * event after {@link start} lands here.
    */
+  /**
+   * This Session asked the Core for its PTY's stream, so {@link dispose} owes it
+   * a matching `ptyUnsubscribe`. False for a spawned Session: the Core
+   * subscribes the connection that spawned a PTY, inside the spawn, and nothing
+   * here asked for that.
+   */
+  private subscribedToPty = false;
   private lastStatus: string | null = null;
   /**
    * The event id {@link lastStatus} was learned at, or 0 when it was not learned
@@ -589,8 +601,10 @@ export class CoreSession {
    *   2. resolve the Task's live PTY — **once**, and every write and wait made
    *      through the returned Session uses that resolution, so there is no
    *      window between delivering text and starting to wait for it;
-   *   3. wire the byte stream, the exit and the events **before** the replay;
-   *   4. seed the screen from the Core's replay ring, and the last known status
+   *   3. wire the byte stream, the exit and the events **before** subscribing;
+   *   4. subscribe to that PTY, which is what makes the Core send this
+   *      connection its bytes and its exit at all;
+   *   5. seed the screen from the Core's replay ring, and the last known status
    *      from the Session snapshot.
    *
    * **The seeded status carries event id 0**, which is what keeps it honest.
@@ -601,7 +615,11 @@ export class CoreSession {
    * turn a write starts cannot be answered by the turn before it.
    *
    * Rejects with {@link CoreSessionAttachError} when the Task has no live PTY —
-   * a harness that exited, or a Session id that is not one.
+   * a harness that exited, or a Session id that is not one. **Only that.** A
+   * link that blinked during the subscribe, the replay or the status read
+   * rejects with an ordinary `Error`: the two are different next steps, and
+   * reporting a busy Core as a dead harness sends a caller to `resume` for a
+   * Session that is running perfectly well.
    */
   static async attach(client: CoreClient, opts: CoreSessionAttachOptions): Promise<CoreSession> {
     if (opts.subscribeToEvents !== false && !client.isSubscribedToEvents()) {
@@ -642,27 +660,40 @@ export class CoreSession {
       client.onEvent(({ event }) => session.onCoreEvent(event)),
     );
 
+    const replay = opts.replay !== false;
     try {
-      if (opts.replay !== false) {
-        // `catchUp` is a promise to read the ring, and the two lines are that
-        // promise kept: the Core holds this PTY's live stream until the replay
-        // has been served, so the bytes either side of it arrive once and in
-        // order. A subscribe with no replay behind it strands the stream.
-        await client.ptySubscribe(ptyId, { catchUp: true });
+      // **The subscribe is not part of the replay.** Until a connection
+      // subscribes, a multi-connection Core fans this PTY's output to somebody
+      // else and `onData` / `onExit` never fire here — so an attachment that
+      // skipped it would have an empty screen *and* a dead exit route, and the
+      // "an exit answers every wait" case in `settledSince` would never run. A
+      // caller that turns the replay off wants to skip the scrollback, not to
+      // be deaf.
+      //
+      // `catchUp` says a replay follows and the Core must hold the live stream
+      // until it has been served; it is set exactly when one does, because a
+      // hold nobody redeems strands the Session's output on the Core.
+      await client.ptySubscribe(ptyId, { catchUp: replay });
+      if (replay) {
         const { data } = await client.replay(ptyId);
         terminal.write(data);
       }
+      session.subscribedToPty = true;
       await session.seedStatus();
     } catch (err) {
       session.dispose();
-      throw err instanceof CoreSessionAttachError
-        ? err
-        : new CoreSessionAttachError(
-            `could not attach to session ${opts.taskId}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { cause: err },
-          );
+      // **Only "nothing is running" is an attach error.** A link that blinked
+      // during the subscribe, the replay or the status read is a retry, and
+      // reporting it as a harness that has exited sends the operator to
+      // `resume` for a Session that is running perfectly well. The one genuine
+      // case was decided above, before any of this ran.
+      if (err instanceof CoreSessionAttachError) throw err;
+      throw new Error(
+        `could not attach to session ${opts.taskId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
+      );
     }
 
     return session;
@@ -884,6 +915,17 @@ export class CoreSession {
     this.disposed = true;
     for (const off of this.unsubscribes) off();
     this.unsubscribes.length = 0;
+    if (this.subscribedToPty) {
+      this.subscribedToPty = false;
+      // The stream this attachment asked for, given back. Removing the listener
+      // stops this process reading the bytes; it does not stop the Core sending
+      // them, and an orchestrator that attaches to and disposes many Sessions on
+      // one long-lived client would otherwise leave every one of those streams
+      // running at it for the life of the client. Fire and forget on purpose:
+      // `dispose` is synchronous, nothing waits on the answer, and a link that
+      // is already gone has released the subscription by going.
+      void this.client.ptyUnsubscribe(this.ptyId).catch(() => {});
+    }
     if (this.statusRetryTimer) {
       clearTimeout(this.statusRetryTimer);
       this.statusRetryTimer = null;

--- a/packages/shared/src/orchestration-skill-payload.ts
+++ b/packages/shared/src/orchestration-skill-payload.ts
@@ -108,12 +108,60 @@ also look at it directly:
 \`\`\`bash
 actana session logs <id>          # the transcript, rendered, while the harness is running
 actana session send <id> "text"   # write into it; --enter follows with a carriage return
+actana session wait <id>          # block until the Core reports it settled
 actana session kill <id>          # stop the harness running for it
 \`\`\`
 
 \`actana events tail --json\` follows the Core's event log as NDJSON if you want
 to watch state change rather than poll — \`session:finished\` is the Core's own
 signal that a Session reached a terminal state.
+
+## The multi-turn loop
+
+A Session is a conversation, not a single question. The whole loop:
+
+\`\`\`bash
+ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
+actana session wait "$ID" --json --wait-timeout 900     # block until it settles
+actana session send "$ID" "<follow-up>" --enter --wait --json --wait-timeout 900
+actana session logs "$ID"                               # or read \`screen\` off the object
+actana session send "$ID" "<next>" --enter --wait --json
+\`\`\`
+
+**\`actana session wait <id>\` blocks until the Core reports the Session settled**
+— \`finished\`, \`needs-input\`, \`interrupted\`, \`terminated\` or \`disconnected\`,
+because every one of those is a turn that ended. A Session that is already
+settled answers at once, so a wait that starts after the turn ended is not a
+wait that hangs.
+
+**\`actana session send <id> "<text>" --wait\` waits for the turn that text
+starts.** The Core stamps the delivery in its event log and the wait resolves on
+the first settling status *after* that stamp, so it can never hand you the
+status the Session was already parked at. With \`--json\` it prints the **same
+object** \`start --wait --json\` prints — same keys, same \`screen\` — so one parser
+reads all three verbs. Two of those keys are \`null\` on a Session you attached to
+rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
+
+Three things to know before you build on it:
+
+1. **Sending into a turn that is already running resolves on *that* turn's
+   end.** A keystroke into a busy Harness is not a new turn. If the Session was
+   mid-turn when your text landed, the wait ends when the current turn ends —
+   possibly before the Harness has read a character of what you sent. Wait for
+   the Session to settle *first*, then send.
+2. **\`--enter\` is what submits the text.** \`send\` writes exactly the bytes it
+   was given and appends nothing, so text with no return sits in the Harness's
+   composer and no turn starts — and the wait then runs to your timeout.
+3. **A timeout is this side giving up, not a status.** \`--wait-timeout
+   <seconds>\` bounds the wait; without it there is no deadline, because a turn
+   takes as long as the work takes. On expiry you get a message saying the wait
+   gave up and a non-zero exit — the Session is still running on the Core, and
+   \`session logs\`, another \`session wait\` and \`session kill\` all still work.
+
+Do not poll \`actana session logs\` for a sentinel instead. It renders a
+fixed-size screen: lines scroll off the top, so counting occurrences is not
+monotonic, and a marker can match your own echoed prompt rather than the
+Harness's reply.
 
 ## Asking a Session for a machine-readable report
 


### PR DESCRIPTION
## Summary

The first turn of a Session was awaitable and every turn after it was not.
`actana session send X --wait` was a hard usage error, nothing on the send path
waited, and `session resume --wait` refuses a Session that is still running — so
a caller that sent a follow-up prompt had no supported signal for "that turn is
done".

This implements the design decided in #289. The Core stamps an accepted write in
its event log and answers with the id; the wait resolves on the first settling
status for that task at an event id **strictly greater** than that stamp.
`actana session wait <session>` is the primitive and ships here; `session send
<session> <text> --wait` is send-then-wait built on it, with one PTY resolution
covering the write and the wait. No wait consults `reportsTurnStart`, and
nothing infers a turn from the byte stream.

**Base is `feat/await-a-session-turn`, deliberately** — this stacks on the
ticket branch rather than targeting the open train, and it is a draft.

## Related issues

Closes #289

## Type of change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## What changed

**Core** — a `write` frame may ask to be stamped; a stamped write the PTY
accepted appends one `session:delivered` carrying the Task id and answers with
its event id. Opt-in, because every keystroke of an attached terminal is a
`write` frame too and this log is append-only for the life of a Core. Nothing is
stamped for a refused write or a PTY with no Task behind it. `task:updated` now
carries the status its mutation *patched*, so a rename of a Session sitting at
`finished` cannot be read as the end of a turn.

**SDK** — `CoreSession.attach` joins a live PTY (the issue's "no constructor for
an existing PTY" landmine): one resolution, listeners wired before the replay,
screen seeded from the Core's ring, status seeded at event id 0. `deliver`
writes and returns the stamp. `waitForTurnEnd({ afterEventId })` resolves only on
a settling status learned *after* the cursor; `waitForIdle` is that with no
cursor and is unchanged for `start`/`resume`.

**CLI** — the `wait` verb (accepts `--wait-timeout` and `--json`, refuses the
rest, `--wait` included), `send --wait`, one shared reporter so all three verbs
print the same object, and help text stating the running-turn limit and the
timeout behaviour.

**Docs** — ADR 0033, and the orchestration skill now documents the full
multi-turn loop.

## Landmines, and where each is pinned

- **`waitForIdle` short-circuits through `settledNow`.** This is why the stamp
  exists. Pinned by *"does not answer a delivered wait with the status the
  Session was already in"* (`core-session.test.ts`) and end to end against a real
  Core in `in-process-core-session.test.ts`.
- **`CoreSession` has no constructor for an existing PTY.** Done as SDK work:
  `CoreSession.attach`.
- **#191's flat quiet-output timer is not coming back.** No timer, no byte-stream
  inference; `no-prompt-timing.test.ts` still passes.
- **`session logs` is a rendered screen, not a transcript.** Not polled, and the
  skill now says out loud not to poll it for a sentinel.
- **`exit-codes.ts` belongs to #285.** Untouched — a timeout is `EXIT_FAILURE`,
  as it already is for `start --wait`.

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [ ] Manually verified (describe steps below)

`pnpm test` — all six stages green (one Panel file failed in the full run and
passes in isolation: the known flake, #274). `pnpm typecheck` clean, `eslint`
clean (only warnings that predate this branch).

New coverage: `packages/core/src/__tests__/session-delivered-event.test.ts` (6
cases, real event-log store), the attach/cursor suite in
`packages/sdk/src/__tests__/core-session.test.ts` (including all five settled
statuses, the codex/cursor-cli follow-up turn, the rename case, exit, and a grep
that no wait path names `reportsTurnStart`), the CLI surface suite in
`session-command.test.ts` (including a key-set assertion across `start --wait
--json`, `send --wait --json` and `wait --json`), and two end-to-end cases in
`in-process-core-session.test.ts` that count `findByTask` frames to prove one
resolution.

## Checklist

- [ ] This PR targets the **open train** (`beta/x.y.z`), not `main` — **no, on
      purpose**: it stacks on `feat/await-a-session-turn`, per the ticket's
      sequencing behind #282, #283 and #288
- [x] My PR title **and every commit in the branch** follow Conventional Commits
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [x] I updated documentation (ADR 0033, the orchestration skill, help text)
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (or this PR is marked as draft/stacked)
