### PR TITLE
fix(cli): actana update no longer walks a machine off its beta, and the notice fires for its line

### DIFF
--- a/packages/cli/src/__tests__/actana-update.test.ts
+++ b/packages/cli/src/__tests__/actana-update.test.ts
@@ -384,3 +384,110 @@ describe("releases this machine cannot use", () => {
     await expect(update()).rejects.toThrow(/releases\/latest|no release/i);
   });
 });
+
+// #322. `/releases/latest` cannot see a prerelease, so on a machine installed
+// from a beta a bare `actana update` resolves the *previous* release. Before
+// the guard, "0.4.0" !== "0.4.1-beta" waved straight past the already-current
+// check and the machine was stopped, swapped and restarted onto an older
+// version — and told it had been updated.
+describe("a machine running a beta", () => {
+  const BETA = "0.4.1-beta";
+
+  beforeEach(() => {
+    existingInstall(BETA);
+  });
+
+  describe("when the newest release is older than the beta", () => {
+    beforeEach(() => {
+      writeRelease({ dir: releaseDir, version: "0.4.0", target: TARGET });
+    });
+
+    it("does not replace the tree", async () => {
+      const service = fakeService();
+      const result = await update({ service });
+
+      expect(result.updated).toBe(false);
+      expect(result.version).toBe(BETA);
+      expect(fs.realpathSync(layout.currentLink)).toBe(
+        fs.realpathSync(installDirFor(layout, BETA)),
+      );
+      expect(fs.existsSync(installDirFor(layout, "0.4.0"))).toBe(false);
+      expect(readActanaConfig(layout.configDir)!.version).toBe(BETA);
+      // The daemon never noticed: no stop, no restart.
+      expect(service.verbs).toEqual([]);
+      expect(service.stops).toBe(0);
+    });
+
+    it("says what it is on, what the release is, and what to do about it", async () => {
+      await update();
+      const said = out.join("\n");
+      expect(said).toContain(BETA);
+      expect(said).toContain("prerelease");
+      // The line, in ADR 0036 D1's vocabulary — the release this machine is
+      // actually waiting for is its own line's.
+      expect(said).toContain("0.4.1 line");
+      expect(said).toContain("0.4.0");
+      expect(said).toContain("actana update --version 0.4.0");
+    });
+
+    it("downloads nothing — the refusal is a decision, not a failed attempt", async () => {
+      const fetcher = fixtureFetcher(releaseDir, CHANNEL);
+      await update({ fetcher });
+      expect(fetcher.asked.some((url) => url.endsWith(".tar.gz"))).toBe(false);
+      expect(fetcher.asked.some((url) => url.endsWith("SHA256SUMS"))).toBe(false);
+    });
+
+    // An explicit pin is an operator's decision and is not second-guessed:
+    // this is how a Panel↔Core version lock is recovered.
+    it("still installs an older release when the operator pins it", async () => {
+      const result = await update({ requestedVersion: "0.4.0" });
+
+      expect(result.updated).toBe(true);
+      expect(result.version).toBe("0.4.0");
+      expect(result.previousVersion).toBe(BETA);
+      expect(fs.realpathSync(layout.currentLink)).toBe(
+        fs.realpathSync(installDirFor(layout, "0.4.0")),
+      );
+      expect(readActanaConfig(layout.configDir)!.version).toBe("0.4.0");
+    });
+  });
+
+  // The other direction, and the reason the guard is a comparison rather than
+  // "never move off a prerelease": the beta's own line releasing is exactly
+  // what this machine is waiting for, and it must not be stranded.
+  it("takes its own line's release the day it exists", async () => {
+    writeRelease({ dir: releaseDir, version: "0.4.0", target: TARGET });
+    writeRelease({ dir: releaseDir, version: "0.4.1", target: TARGET });
+
+    const result = await update();
+    expect(result.updated).toBe(true);
+    expect(result.previousVersion).toBe(BETA);
+    expect(result.version).toBe("0.4.1");
+    expect(readActanaConfig(layout.configDir)!.version).toBe("0.4.1");
+  });
+
+  it("takes a later line's release too", async () => {
+    writeRelease({ dir: releaseDir, version: "0.4.2", target: TARGET });
+    expect((await update()).version).toBe("0.4.2");
+  });
+});
+
+// The guard is about ordering, not about prereleases: a `latest` that has been
+// moved backwards would walk a release-running machine back just as silently.
+describe("a bare update that would move any machine backwards", () => {
+  beforeEach(() => {
+    existingInstall("0.5.0");
+    writeRelease({ dir: releaseDir, version: "0.4.0", target: TARGET });
+  });
+
+  it("refuses, and does not call the installed version a prerelease", async () => {
+    const result = await update();
+    expect(result.updated).toBe(false);
+    expect(result.version).toBe("0.5.0");
+    const said = out.join("\n");
+    expect(said).toContain("0.5.0");
+    expect(said).toContain("0.4.0");
+    expect(said).not.toContain("prerelease");
+    expect(said).toContain("actana update --version 0.4.0");
+  });
+});

--- a/packages/cli/src/actana-release.ts
+++ b/packages/cli/src/actana-release.ts
@@ -30,12 +30,19 @@ import type { ReleaseFetcher } from "@actana/shared/actana-release-fetch";
 export { nodeReleaseFetcher, type ReleaseFetcher } from "@actana/shared/actana-release-fetch";
 
 export {
+  BETA_SUFFIX,
+  betaVersionForLine,
   DEFAULT_API_BASE,
   DEFAULT_DOWNLOAD_BASE,
   DEFAULT_REPO,
+  isBetaVersion,
   latestReleaseUrl,
+  lineOf,
   parseLatestTag,
   releaseChannel,
+  releaseTagUrl,
+  resolveLine,
+  type LineResolution,
   type ReleaseChannel,
 } from "@actana/shared/actana-release-channel";
 
@@ -106,6 +113,19 @@ export function sha256OfFile(filePath: string): string {
  * A pinned version costs no API call — an update that still asked what the
  * latest release was would be one API change away from quietly installing
  * something else than the operator named.
+ *
+ * **`/releases/latest` cannot see a prerelease**, by GitHub's definition of
+ * that endpoint, so on a machine installed from a beta this answers with the
+ * *previous* release — `0.4.0` for a machine running `0.4.1-beta`. That is not
+ * corrected here, because it is the right answer to the question this function
+ * asks ("what is the newest release?"). Deciding that installing it would move
+ * the machine backwards is a different question, and it is answered by
+ * `runActanaUpdate`'s downgrade guard in `actana-update.ts` (#322).
+ *
+ * Resolving a *line* to its release or its beta is a third question again —
+ * ADR 0036 D2's rule, spelled as `resolveLine` in the shared channel module
+ * and re-exported above. `actana update` does not use it yet: teaching it a
+ * beta channel of its own is explicitly not #322.
  */
 export async function resolveReleaseVersion(
   fetcher: ReleaseFetcher,

--- a/packages/cli/src/actana-update.ts
+++ b/packages/cli/src/actana-update.ts
@@ -30,11 +30,13 @@ import { writeActanaConfig, type ActanaConfig } from "./actana-config.ts";
 import { installDirFor, type ActanaLayout } from "./actana-layout.ts";
 import type { CoreManifest } from "./actana-manifest.ts";
 import {
+  lineOf,
   releaseTargetFor,
   resolveReleaseVersion,
   type ReleaseChannel,
   type ReleaseFetcher,
 } from "./actana-release.ts";
+import { isNewerSemver, isPrereleaseVersion } from "@actana/shared/semver";
 import { fetchVerifiedRelease } from "./actana-fetch-release.ts";
 import type { ActanaServiceManager } from "./actana-service.ts";
 import type { ActanaSystem } from "./actana-system.ts";
@@ -95,6 +97,34 @@ export async function runActanaUpdate(opts: UpdateOptions): Promise<UpdateResult
   }
 
   const version = await resolveReleaseVersion(opts.fetcher, opts.channel, opts.requestedVersion);
+
+  // The downgrade guard (#322). A bare update resolves `/releases/latest`,
+  // which excludes prereleases, so a machine installed from `0.4.1-beta` is
+  // answered with `0.4.0` — an older version, and one the already-current
+  // guard below waves straight through because the two strings simply differ.
+  // What followed was a stop, a tree swap and a restart, reported to the
+  // operator as an update.
+  //
+  // Nothing is changed and nothing is downloaded: the refusal is a sentence on
+  // stdout and `updated: false`, which is the same shape "already current"
+  // returns and which `actana update` renders as exit 0. Silence was the other
+  // option and is worse — an operator who ran `update` is owed the reason it
+  // did nothing.
+  //
+  // An explicit `--version` is never second-guessed. Pinning an older version
+  // is how a Panel↔Core version lock is recovered, and an operator who named
+  // one has already made this decision.
+  if (!opts.requestedVersion && isNewerSemver(config.version, version)) {
+    opts.out(refusedDowngrade(config.version, version));
+    return {
+      updated: false,
+      version: config.version,
+      previousVersion: config.version,
+      installDir: config.installDir,
+      listening: null,
+    };
+  }
+
   const installDir = installDirFor(layout, version);
 
   // "Already current" is about the tree, not just the recorded version: an
@@ -167,4 +197,30 @@ export async function runActanaUpdate(opts: UpdateOptions): Promise<UpdateResult
     installDir,
     listening: await opts.system.waitForPort(config.port, LISTEN_TIMEOUT_MS),
   };
+}
+
+/**
+ * What the operator is told when a bare update would move them backwards.
+ *
+ * The prerelease case gets its own opening sentence because it is the one an
+ * operator has no other way to make sense of: they installed a beta on
+ * purpose, ran `update`, and it did nothing. Naming the line — `0.4.1-beta` is
+ * the beta of the 0.4.1 line (ADR 0036 D1, D2) — is what makes the next
+ * sentence land, because the release they are waiting for is that line's, and
+ * `actana update` will take it the day it exists.
+ */
+function refusedDowngrade(installed: string, resolved: string): string {
+  const opening = isPrereleaseVersion(installed)
+    ? `This Core is on ${installed}, a prerelease of the ${lineOf(installed)} line, and the ` +
+      `newest release is ${resolved} — older than what is installed.`
+    : `This Core is on ${installed} and the newest release is ${resolved} — older than what ` +
+      "is installed.";
+  return [
+    `${opening} Nothing was changed: updating would move this machine backwards.`,
+    isPrereleaseVersion(installed)
+      ? `A bare \`actana update\` will move this Core as soon as ${lineOf(installed)} is ` +
+        "released."
+      : "A bare `actana update` will move this Core again as soon as a newer release exists.",
+    `To install ${resolved} anyway, pin it: \`actana update --version ${resolved}\`.`,
+  ].join(" ");
 }

--- a/packages/core/src/__tests__/core-update-notice.test.ts
+++ b/packages/core/src/__tests__/core-update-notice.test.ts
@@ -140,3 +140,53 @@ describe("the daemon's update notice", () => {
     expect(logged).toHaveLength(2);
   });
 });
+
+// #322. A Core installed from a beta is a prerelease of a line (ADR 0036 D1),
+// and the release it is waiting for is that same line's. The old comparison
+// compared only the numeric core, called `0.4.1` and `0.4.1-beta` equal, and
+// so said nothing to the population most in need of the notice.
+describe("a Core running a beta", () => {
+  const BETA = "0.4.1-beta";
+
+  it("is told when its own line's release lands", async () => {
+    await notice({ current: BETA, fetcher: answering("0.4.1") });
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("Actana 0.4.1 is available");
+    expect(logged[0]).toContain(`on ${BETA}`);
+    expect(logged[0]).toContain("actana update");
+  });
+
+  it("is told once, on the same throttle as everyone else", async () => {
+    await notice({ current: BETA, fetcher: answering("0.4.1") });
+    await notice({ current: BETA, fetcher: answering("0.4.1"), now: () => NOW + 60_000 });
+    await notice({
+      current: BETA,
+      fetcher: answering("0.4.1"),
+      now: () => NOW + UPDATE_CHECK_TTL_MS - 1,
+    });
+
+    expect(logged).toHaveLength(1);
+  });
+
+  // The channel's newest release is the *previous* line's while a beta is out
+  // ahead of it — `/releases/latest` excludes prereleases. Announcing it would
+  // be telling an operator that an older version is available.
+  it("says nothing about a release older than the beta it is running", async () => {
+    await notice({ current: BETA, fetcher: answering("0.4.0") });
+    expect(logged).toEqual([]);
+  });
+
+  // A beta tag is re-cut at a new commit per cut and publishes the same
+  // version string (ADR 0036 D7). Nothing may read that as news.
+  it("says nothing when the channel answers with the beta's own version", async () => {
+    await notice({ current: BETA, fetcher: answering(BETA) });
+    expect(logged).toEqual([]);
+  });
+
+  it("is still told about a later line's release", async () => {
+    await notice({ current: BETA, fetcher: answering("0.5.0") });
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("Actana 0.5.0 is available");
+  });
+});

--- a/packages/core/src/core-update-notice.ts
+++ b/packages/core/src/core-update-notice.ts
@@ -11,6 +11,18 @@
 // and shared with the CLI — so a Core that reboots hourly still asks GitHub
 // once. Nothing here runs an update; the line names the command its operator
 // runs (ADR 0016 D16 decides which one).
+//
+// **A Core running a beta is inside this, not outside it.** `0.4.1-beta` is a
+// prerelease of the 0.4.1 line (ADR 0036 D1, D2), and the release it is
+// waiting for is that same line's — `0.4.1`. Until #322 the comparison
+// underneath compared only the numeric core, called `0.4.1` and `0.4.1-beta`
+// equal, and so said nothing to the one population that most needed telling:
+// the operators who had installed a beta on metal. Nothing in this file
+// special-cases them; `isNewerSemver` learning semver §11.4 is the whole fix,
+// and it reaches here through `checkForUpdate`. The throttle below is
+// unchanged and applies to that line exactly as to any other — the release of
+// your own line is a *different* release from the last one announced, so it
+// speaks once and then holds for a day.
 
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/shared/src/__tests__/actana-release-channel.test.ts
+++ b/packages/shared/src/__tests__/actana-release-channel.test.ts
@@ -1,0 +1,144 @@
+// The channel's shapes, and the line vocabulary ADR 0036 D6 puts beside them.
+//
+// The two are tested in one file on purpose: the point of D6 is that a
+// `ReleaseChannel` — which repository, which hosts — and a *line* — `x.y.z`,
+// resolving to its release or its beta — are different things that live next
+// to each other, and a reader who sees them tested together is less likely to
+// collapse them back into one.
+
+import { describe, expect, it } from "vitest";
+import {
+  BETA_SUFFIX,
+  betaVersionForLine,
+  DEFAULT_API_BASE,
+  DEFAULT_DOWNLOAD_BASE,
+  DEFAULT_REPO,
+  isBetaVersion,
+  latestReleaseUrl,
+  lineOf,
+  parseLatestTag,
+  releaseChannel,
+  releaseTagUrl,
+  resolveLine,
+} from "../actana-release-channel";
+
+describe("releaseChannel", () => {
+  it("defaults to the public repository and GitHub's two hosts", () => {
+    expect(releaseChannel({})).toEqual({
+      repo: DEFAULT_REPO,
+      apiBase: DEFAULT_API_BASE,
+      downloadBase: DEFAULT_DOWNLOAD_BASE,
+    });
+  });
+
+  it("points both hosts at one baseUrl, as install.sh's --base-url does", () => {
+    expect(releaseChannel({ repo: "me/fork", baseUrl: "http://releases.test/" })).toEqual({
+      repo: "me/fork",
+      apiBase: "http://releases.test",
+      downloadBase: "http://releases.test",
+    });
+  });
+});
+
+describe("release URLs", () => {
+  const channel = releaseChannel({ baseUrl: "http://releases.test" });
+
+  it("names the latest-release endpoint", () => {
+    expect(latestReleaseUrl(channel)).toBe(
+      "http://releases.test/repos/actana/control/releases/latest",
+    );
+  });
+
+  it("names one release by its tag, release and beta alike", () => {
+    expect(releaseTagUrl(channel, "0.4.1")).toBe(
+      "http://releases.test/repos/actana/control/releases/tags/v0.4.1",
+    );
+    expect(releaseTagUrl(channel, "0.4.1-beta")).toBe(
+      "http://releases.test/repos/actana/control/releases/tags/v0.4.1-beta",
+    );
+  });
+});
+
+describe("parseLatestTag", () => {
+  it("reads the bare version out of a release payload", () => {
+    expect(parseLatestTag(JSON.stringify({ tag_name: "v0.4.1" }))).toBe("0.4.1");
+  });
+
+  it("answers null for anything that is not a release", () => {
+    expect(parseLatestTag("not json")).toBe(null);
+    expect(parseLatestTag(JSON.stringify({ message: "Not Found" }))).toBe(null);
+    expect(parseLatestTag(JSON.stringify({ tag_name: "" }))).toBe(null);
+  });
+});
+
+describe("a line and its beta", () => {
+  it("spells a line's beta as exactly x.y.z-beta", () => {
+    expect(BETA_SUFFIX).toBe("-beta");
+    expect(betaVersionForLine("0.4.1")).toBe("0.4.1-beta");
+  });
+
+  it("recognises a beta, and nothing else", () => {
+    expect(isBetaVersion("0.4.1-beta")).toBe(true);
+    expect(isBetaVersion("0.4.1")).toBe(false);
+    // A counter is not a shape this project publishes (ADR 0036 D7 — the tag
+    // moves per cut instead), so it is not a beta by this name either.
+    expect(isBetaVersion("0.4.1-beta.1")).toBe(false);
+    expect(isBetaVersion("-beta")).toBe(false);
+  });
+
+  it("reads a version back to the line it belongs to", () => {
+    expect(lineOf("0.4.1-beta")).toBe("0.4.1");
+    expect(lineOf("0.4.1")).toBe("0.4.1");
+    expect(lineOf("v0.4.1-beta")).toBe("0.4.1");
+    expect(lineOf("1.2.4-rc.1")).toBe("1.2.4");
+  });
+});
+
+// ADR 0036 D2, step by step. The inputs are existence answers about two named
+// tags and nothing else — there is no listing here to order or to mis-read.
+describe("resolveLine", () => {
+  it("takes an explicit pin over everything, and strips its v", () => {
+    const pinned = { line: "0.4.1", releaseExists: true, betaExists: true };
+    expect(resolveLine({ ...pinned, requested: "0.3.0" })).toEqual({
+      kind: "pinned",
+      version: "0.3.0",
+    });
+    expect(resolveLine({ ...pinned, requested: "v0.3.0" })).toEqual({
+      kind: "pinned",
+      version: "0.3.0",
+    });
+  });
+
+  it("takes the line's release when that Release exists — main after promotion", () => {
+    expect(resolveLine({ line: "0.4.1", releaseExists: true, betaExists: true })).toEqual({
+      kind: "release",
+      version: "0.4.1",
+    });
+  });
+
+  it("takes the line's beta when only that exists — a train", () => {
+    expect(resolveLine({ line: "0.4.1", releaseExists: false, betaExists: true })).toEqual({
+      kind: "beta",
+      version: "0.4.1-beta",
+    });
+  });
+
+  it("falls back to /releases/latest for a line that has published nothing", () => {
+    expect(resolveLine({ line: "0.4.1", releaseExists: false, betaExists: false })).toEqual({
+      kind: "latest",
+    });
+  });
+
+  // The rule is per line by construction: it is told about `v<line>` and
+  // `v<line>-beta` and can never reach another line's beta, which is exactly
+  // what enumerating releases newest-first across all lines would risk.
+  it("never resolves to a version outside the line it was given", () => {
+    for (const releaseExists of [true, false]) {
+      for (const betaExists of [true, false]) {
+        const resolved = resolveLine({ line: "0.4.1", releaseExists, betaExists });
+        if (resolved.kind === "latest") continue;
+        expect(lineOf(resolved.version)).toBe("0.4.1");
+      }
+    }
+  });
+});

--- a/packages/shared/src/__tests__/semver.test.ts
+++ b/packages/shared/src/__tests__/semver.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isNewerSemver, stripVersionPrefix, versionCore } from "../semver";
+import {
+  isNewerSemver,
+  isPrereleaseVersion,
+  stripVersionPrefix,
+  versionCore,
+} from "../semver";
 
 describe("stripVersionPrefix", () => {
   it("removes a leading v prefix", () => {
@@ -20,10 +25,114 @@ describe("versionCore", () => {
   });
 });
 
+describe("isPrereleaseVersion", () => {
+  it("is true for a beta and for a release candidate", () => {
+    expect(isPrereleaseVersion("0.4.1-beta")).toBe(true);
+    expect(isPrereleaseVersion("v0.4.1-beta")).toBe(true);
+    expect(isPrereleaseVersion("1.2.4-rc.1")).toBe(true);
+  });
+
+  it("is false for a release, and for anything that does not parse", () => {
+    expect(isPrereleaseVersion("0.4.1")).toBe(false);
+    expect(isPrereleaseVersion("v0.4.1")).toBe(false);
+    expect(isPrereleaseVersion("not-a-version")).toBe(false);
+    expect(isPrereleaseVersion("")).toBe(false);
+  });
+});
+
 describe("isNewerSemver", () => {
   it("compares normalized semver triplets", () => {
     expect(isNewerSemver("v0.49.0", "0.48.4")).toBe(true);
     expect(isNewerSemver("0.48.4", "0.48.4")).toBe(false);
     expect(isNewerSemver("0.48.3", "0.48.4")).toBe(false);
+  });
+
+  // Every pair the ticket names, and only pairs that can actually occur: a beta
+  // version is exactly `x.y.z-beta`, with no counter, no `.N` and no suffix
+  // (ADR 0036 D1, D7 — the tag moves per cut, so the string never changes).
+  describe("a beta and its line", () => {
+    it("ranks a release above its own beta, and never the other way round", () => {
+      expect(isNewerSemver("0.4.1", "0.4.1-beta")).toBe(true);
+      expect(isNewerSemver("0.4.1-beta", "0.4.1")).toBe(false);
+    });
+
+    it("ranks a beta above the previous release — the downgrade this stops", () => {
+      expect(isNewerSemver("0.4.1-beta", "0.4.0")).toBe(true);
+      expect(isNewerSemver("0.4.0", "0.4.1-beta")).toBe(false);
+    });
+
+    it("still lets the next line's release win", () => {
+      expect(isNewerSemver("0.4.2", "0.4.1-beta")).toBe(true);
+    });
+
+    // A beta tag is re-cut at a new commit on every beta cut of the line, and
+    // the version string it publishes is the same one. Nothing in this
+    // comparison may read that as an upgrade — the machine would reinstall on
+    // every check, forever.
+    it("does not call a re-cut beta newer than itself", () => {
+      expect(isNewerSemver("0.4.1-beta", "0.4.1-beta")).toBe(false);
+    });
+  });
+
+  // A `-beta` string has one identifier and no second field to compare, so the
+  // numeric branch of §11.4 needs a shape that does. The backport release
+  // candidate ADR 0023 D30 publishes is that shape.
+  describe("numeric identifier precedence (semver §11.4)", () => {
+    it("compares identifiers numerically rather than as strings", () => {
+      expect(isNewerSemver("1.2.4-rc.2", "1.2.4-rc.10")).toBe(false);
+      expect(isNewerSemver("1.2.4-rc.10", "1.2.4-rc.2")).toBe(true);
+    });
+
+    it("ranks a numeric identifier below an alphanumeric one", () => {
+      expect(isNewerSemver("1.2.4-alpha", "1.2.4-1")).toBe(true);
+      expect(isNewerSemver("1.2.4-1", "1.2.4-alpha")).toBe(false);
+    });
+
+    it("ranks a shorter run of otherwise equal identifiers lower", () => {
+      expect(isNewerSemver("1.2.4-rc.2.1", "1.2.4-rc.2")).toBe(true);
+      expect(isNewerSemver("1.2.4-rc.2", "1.2.4-rc.2.1")).toBe(false);
+    });
+
+    it("orders alphanumeric identifiers by ASCII", () => {
+      expect(isNewerSemver("1.2.4-beta", "1.2.4-alpha")).toBe(true);
+      expect(isNewerSemver("1.2.4-alpha", "1.2.4-beta")).toBe(false);
+    });
+  });
+
+  // The answers this function has always given, kept: the prerelease clause is
+  // an addition below the numeric comparison, not a replacement for it.
+  describe("plain x.y.z pairs answer exactly as they did", () => {
+    it("orders major, then minor, then patch", () => {
+      expect(isNewerSemver("1.0.0", "0.99.99")).toBe(true);
+      expect(isNewerSemver("0.99.99", "1.0.0")).toBe(false);
+      expect(isNewerSemver("0.5.0", "0.4.99")).toBe(true);
+      expect(isNewerSemver("0.4.99", "0.5.0")).toBe(false);
+      expect(isNewerSemver("0.4.1", "0.4.0")).toBe(true);
+      expect(isNewerSemver("0.4.0", "0.4.1")).toBe(false);
+      expect(isNewerSemver("0.4.0", "0.4.0")).toBe(false);
+    });
+
+    it("compares components numerically, not as strings", () => {
+      expect(isNewerSemver("0.10.0", "0.9.0")).toBe(true);
+      expect(isNewerSemver("0.9.0", "0.10.0")).toBe(false);
+    });
+
+    it("ignores build metadata, as semver §10 says to", () => {
+      expect(isNewerSemver("1.0.1+build.42", "1.0.0")).toBe(true);
+      expect(isNewerSemver("1.0.0+build.42", "1.0.0")).toBe(false);
+    });
+  });
+
+  describe("anything unparseable", () => {
+    it("answers false rather than throwing", () => {
+      expect(isNewerSemver("not-a-version", "0.4.0")).toBe(false);
+      expect(isNewerSemver("0.4.0", "not-a-version")).toBe(false);
+      expect(isNewerSemver("1.2", "1.1")).toBe(false);
+      expect(isNewerSemver("1.2.3.4", "1.2.3")).toBe(false);
+      expect(isNewerSemver("", "")).toBe(false);
+      // The Panel and the daemon both call this on a background path; an
+      // exception there would be a crash nobody asked for.
+      expect(() => isNewerSemver(undefined as unknown as string, "0.4.0")).not.toThrow();
+    });
   });
 });

--- a/packages/shared/src/actana-release-channel.ts
+++ b/packages/shared/src/actana-release-channel.ts
@@ -65,3 +65,93 @@ export function parseLatestTag(json: string): string | null {
   if (typeof tag !== "string" || tag === "") return null;
   return tag.replace(/^v/, "");
 }
+
+// -- Lines ---------------------------------------------------------------------
+//
+// A **line** is `x.y.z`, and it resolves to either its release or its beta
+// (ADR 0036 D1, D2). It is deliberately not a second meaning for
+// {@link ReleaseChannel} above: that type already means *which repository and
+// which hosts releases are read from*, and overloading it with
+// stable-versus-beta would make the two meanings indistinguishable in exactly
+// the code that resolves both (ADR 0036 D6).
+//
+// This half is created here and consumed twice — by the CLI through
+// `actana-release.ts`, and by `install.sh`, which mirrors the same rule in
+// POSIX sh (#317). The module's own header rule is why they live together:
+// an installer that resolved releases differently from the CLI would be a
+// second, subtly different front door.
+
+/**
+ * The suffix a beta version carries. Exactly `-beta`, and never a counter.
+ *
+ * A beta tag *moves* — it is re-cut at a new commit on every beta cut of the
+ * line (ADR 0036 D7) — so the version string stays the same across cuts and
+ * there is no `.N` to order. Nothing that compares versions may be built
+ * around ordering counters, because there are none to order.
+ */
+export const BETA_SUFFIX = "-beta";
+
+/** `0.4.1` → `0.4.1-beta`. The one beta version a line can have. */
+export function betaVersionForLine(line: string): string {
+  return `${line}${BETA_SUFFIX}`;
+}
+
+/** Whether a version is a line's beta — `0.4.1-beta`, and nothing else. */
+export function isBetaVersion(version: string): boolean {
+  return version.endsWith(BETA_SUFFIX) && version.length > BETA_SUFFIX.length;
+}
+
+/** The line a version belongs to: `0.4.1-beta` → `0.4.1`, `0.4.1` → `0.4.1`. */
+export function lineOf(version: string): string {
+  return version.replace(/^v/i, "").split(/[-+]/)[0];
+}
+
+/** The releases-API URL for one named tag — `/releases/tags/v<version>`. */
+export function releaseTagUrl(channel: ReleaseChannel, version: string): string {
+  return `${channel.apiBase}/repos/${channel.repo}/releases/tags/v${version}`;
+}
+
+/**
+ * How a line resolved, and to what.
+ *
+ * The kind is carried rather than inferred from the string so a caller can say
+ * *why* it is installing what it is installing — "this line has no release yet,
+ * so you are getting its beta" is a different sentence from "this is the
+ * release", and an operator on a train deserves the difference.
+ */
+export type LineResolution =
+  | { kind: "pinned"; version: string }
+  | { kind: "release"; version: string }
+  | { kind: "beta"; version: string }
+  | { kind: "latest" };
+
+/**
+ * ADR 0036 D2's resolution rule, as a decision over answers already gathered.
+ *
+ * In order: an explicit pin wins; then the release `v<line>` if that Release
+ * exists; then `v<line>-beta` if that one does; otherwise `/releases/latest`,
+ * which is what the installer and `actana update` read today and which stays
+ * the terminal fallback for a line that has published nothing at all.
+ *
+ * **No step enumerates releases, and this signature is what makes that
+ * structural.** `GET /repos/<repo>/releases` returns every release across
+ * *all* lines newest-first, so "the newest prerelease" would hand a machine
+ * installing one line's beta the beta of another. The two inputs here are
+ * existence answers about two *named* tags, so there is no listing to be
+ * tempted by and no ordering to get wrong — which is also why this is pure and
+ * lives beside the URL builders rather than behind a fetcher.
+ */
+export function resolveLine(opts: {
+  line: string;
+  /** An explicit `--version` / `ACTANA_VERSION`, unchanged and never second-guessed. */
+  requested?: string;
+  /** Whether the Release `v<line>` exists. */
+  releaseExists: boolean;
+  /** Whether the Release `v<line>-beta` exists. */
+  betaExists: boolean;
+}): LineResolution {
+  if (opts.requested) return { kind: "pinned", version: opts.requested.replace(/^v/i, "") };
+  if (opts.releaseExists) return { kind: "release", version: opts.line };
+  if (opts.betaExists) return { kind: "beta", version: betaVersionForLine(opts.line) };
+  return { kind: "latest" };
+}

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -1,3 +1,29 @@
+// Version precedence — "is that version newer than this one?", answered the
+// way semver §11 answers it, prereleases included.
+//
+// **This rule exists twice in the repository and the two must agree.**
+// `scripts/lib/release-latest.mjs` implements it for the release workflows
+// (`compareReleaseVersions`, `comparePrereleaseIdentifiers`); this module
+// implements it for the two product surfaces — `actana update` and the update
+// check both surfaces read (ADR 0036 D8). They cannot share a file: the script
+// half is plain `.mjs` run by `node` inside a workflow step with no build, and
+// the TypeScript half ships inside the Core tarball and the Panel bundle. So
+// they share a *test* instead — `scripts/__tests__/version-rule-agreement.test.mjs`
+// runs both over the same table and fails when they answer differently.
+//
+// The clause that made this necessary is a prerelease being below its own
+// release: `0.4.1-beta` < `0.4.1`. Comparing only the numeric core called those
+// two equal, and that single answer was two bugs (#322) — a Core installed
+// from a beta was never told its own line's release existed, and a bare
+// `actana update` resolved `/releases/latest`, which excludes prereleases, and
+// walked the machine backwards to the previous release.
+//
+// On the vocabulary: a **line** is `x.y.z` and resolves to either its release
+// or its beta (ADR 0036 D1, D2). A beta version string is exactly `x.y.z-beta`
+// on every surface and carries no counter — nothing here is built around
+// ordering counters, and `-beta` is compared as the ordinary alphanumeric
+// identifier it is.
+
 /** Strip a leading `v`/`V` prefix from a version string (e.g. release tags). */
 export function stripVersionPrefix(version: string): string {
   return version.trim().replace(/^v/i, "");
@@ -8,21 +34,109 @@ export function versionCore(version: string): string {
   return stripVersionPrefix(version).split(/[-+]/)[0];
 }
 
-function parse(v: string): [number, number, number] | null {
-  const parts = versionCore(v).split(".");
-  if (parts.length !== 3) return null;
-  const nums = parts.map((p) => Number(p));
-  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
-  return [nums[0], nums[1], nums[2]];
+/**
+ * `1.2.4`, `1.2.4-rc.1`, `0.4.1-beta`, optionally `v`-prefixed.
+ *
+ * Mirrors `parseReleaseVersion`'s regex in `scripts/lib/release-latest.mjs`,
+ * with two deliberate differences, both of them about what reaches each half:
+ * this one accepts the `v` prefix, because the strings here come from release
+ * tags and from `core-manifest.json` rather than from a caller that already
+ * normalised them; and it accepts `+build` metadata, which the script half
+ * rejects because `+` is not a legal Docker tag character. Build metadata is
+ * then *ignored* for precedence, which is semver §10 and is what this function
+ * has always done.
+ */
+const VERSION = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+type ParsedVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  /** The `-` suffix's identifiers, or null for a release. */
+  prerelease: string | null;
+};
+
+function parse(version: string): ParsedVersion | null {
+  const match = VERSION.exec(stripVersionPrefix(String(version ?? "")));
+  if (!match) return null;
+  const [, major, minor, patch, prerelease] = match;
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prerelease === undefined ? null : prerelease,
+  };
 }
 
+/**
+ * Whether a version string is a prerelease — `0.4.1-beta`, `1.2.4-rc.1`.
+ *
+ * The Core's own version is the caller that matters: a machine installed from
+ * a beta is *ahead* of `/releases/latest`, which excludes prereleases, and
+ * that is what `actana update`'s downgrade guard turns into a sentence rather
+ * than a silent walk backwards. Unparseable is not a prerelease.
+ */
+export function isPrereleaseVersion(version: string): boolean {
+  return parse(version)?.prerelease != null;
+}
+
+/**
+ * Semver §11.4 identifier precedence: field by field, numeric fields compared
+ * numerically and ranking below alphanumeric ones, and a shorter run of
+ * otherwise equal fields ranking lower — `rc.1` < `rc.2` < `rc.2.1`.
+ *
+ * `rc.2` < `rc.10` is the property this exists for: as strings it is the other
+ * way round. A `-beta` string never reaches the numeric branch — it has one
+ * identifier and no counter — so the branch is exercised by the backport
+ * release candidates ADR 0023 D30 publishes.
+ */
+function comparePrereleaseIdentifiers(a: string, b: string): number {
+  const left = a.split(".");
+  const right = b.split(".");
+  const numeric = /^\d+$/;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    if (left[i] === undefined) return -1;
+    if (right[i] === undefined) return 1;
+    const isNumericLeft = numeric.test(left[i]);
+    const isNumericRight = numeric.test(right[i]);
+    if (isNumericLeft && isNumericRight) {
+      if (Number(left[i]) !== Number(right[i])) return Number(left[i]) < Number(right[i]) ? -1 : 1;
+      continue;
+    }
+    if (isNumericLeft !== isNumericRight) return isNumericLeft ? -1 : 1;
+    if (left[i] !== right[i]) return left[i] < right[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Semver precedence for two parsed versions: `-1`, `0` or `1`.
+ *
+ * Line by line the same decision as `compareReleaseVersions` in
+ * `scripts/lib/release-latest.mjs`, including the clause both bugs turned on:
+ * a prerelease is below its own release, so `0.4.1-beta` < `0.4.1`.
+ */
+function compare(left: ParsedVersion, right: ParsedVersion): number {
+  for (const field of ["major", "minor", "patch"] as const) {
+    if (left[field] !== right[field]) return left[field] < right[field] ? -1 : 1;
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  if (left.prerelease === null) return 1;
+  if (right.prerelease === null) return -1;
+  return comparePrereleaseIdentifiers(left.prerelease, right.prerelease);
+}
+
+/**
+ * Whether `remote` is a strictly newer version than `local`.
+ *
+ * Unparseable on either side answers `false` rather than throwing: every
+ * caller is a background check or an update guard, and neither has anywhere
+ * useful to put an exception. `false` means "say nothing, change nothing",
+ * which is the safe answer for both.
+ */
 export function isNewerSemver(remote: string, local: string): boolean {
   const r = parse(remote);
   const l = parse(local);
   if (!r || !l) return false;
-  for (let i = 0; i < 3; i++) {
-    if (r[i] > l[i]) return true;
-    if (r[i] < l[i]) return false;
-  }
-  return false;
+  return compare(r, l) > 0;
 }

--- a/scripts/__tests__/version-rule-agreement.test.mjs
+++ b/scripts/__tests__/version-rule-agreement.test.mjs
@@ -1,0 +1,118 @@
+// One version-precedence rule, implemented twice, pinned together here.
+//
+// `scripts/lib/release-latest.mjs` decides the tag ladder inside the release
+// workflows; `packages/shared/src/semver.ts` decides what `actana update` and
+// the in-product update check do on an operator's machine. They cannot share a
+// file — the script half is plain `.mjs` that `node` runs in a workflow step
+// with no build in front of it, and the TypeScript half is compiled into the
+// Core tarball and the Panel bundle — so ADR 0036 D8's requirement that the
+// version parsers agree is held by this test instead.
+//
+// This is the only suite that can see both: the root vitest project is the one
+// that spans `scripts/**` and `packages/**`. If the two rules ever answer
+// differently for any ordered pair below, this goes red and names the pair.
+
+import { describe, expect, it } from "vitest";
+
+import { compareReleaseVersions, isPrerelease } from "../lib/release-latest.mjs";
+import { isNewerSemver, isPrereleaseVersion } from "../../packages/shared/src/semver.ts";
+
+/**
+ * The strings both halves accept, spanning every branch of §11.4 that either
+ * one can reach.
+ *
+ * Deliberately bare and `+`-free: the script half rejects `+build` metadata
+ * outright, because `+` is not a legal Docker tag character, while the product
+ * half ignores it for precedence per semver §10. That is the one place the two
+ * accepted domains differ by design, and it is asserted by name at the bottom
+ * rather than left for this table to trip over.
+ */
+const VERSIONS = [
+  "0.4.0",
+  "0.4.1-beta",
+  "0.4.1",
+  "0.4.2-beta",
+  "0.4.2",
+  "0.5.0",
+  "1.0.0",
+  "1.2.4-alpha",
+  "1.2.4-alpha.1",
+  "1.2.4-rc.1",
+  "1.2.4-rc.2",
+  "1.2.4-rc.2.1",
+  "1.2.4-rc.10",
+  "1.2.4",
+  "1.10.0",
+  "2.0.0",
+];
+
+/** `isNewerSemver` read back as the `-1`/`0`/`1` the script half returns. */
+const productSign = (a, b) => (isNewerSemver(a, b) ? 1 : isNewerSemver(b, a) ? -1 : 0);
+
+describe("the two version rules agree (ADR 0036 D8)", () => {
+  it("answers identically for every ordered pair", () => {
+    const disagreements = [];
+    for (const a of VERSIONS) {
+      for (const b of VERSIONS) {
+        const script = Math.sign(compareReleaseVersions(a, b));
+        const product = productSign(a, b);
+        if (script !== product) {
+          disagreements.push(`${a} vs ${b}: release-latest ${script}, semver.ts ${product}`);
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  it("agrees on which versions are prereleases", () => {
+    for (const version of VERSIONS) {
+      expect([version, isPrereleaseVersion(version)]).toEqual([version, isPrerelease(version)]);
+    }
+  });
+
+  // The clause both bugs in #322 turned on, asserted on both halves rather
+  // than only through the cross-product above, so a reader looking for it
+  // finds it stated.
+  it("puts a beta below its own line's release, on both sides", () => {
+    expect(compareReleaseVersions("0.4.1-beta", "0.4.1")).toBe(-1);
+    expect(isNewerSemver("0.4.1", "0.4.1-beta")).toBe(true);
+    expect(isNewerSemver("0.4.1-beta", "0.4.1")).toBe(false);
+  });
+
+  // A guard on the guard: the cross-product only means something if a change
+  // to either rule could actually move an answer in this table. Two versions
+  // whose order is decided by each distinct branch, so no branch is untested.
+  it("covers the branches a divergence would hide in", () => {
+    // major/minor/patch, numerically rather than as strings
+    expect(productSign("1.10.0", "1.2.4")).toBe(1);
+    // prerelease below its own release
+    expect(productSign("1.2.4-rc.1", "1.2.4")).toBe(-1);
+    // numeric identifiers numerically
+    expect(productSign("1.2.4-rc.2", "1.2.4-rc.10")).toBe(-1);
+    // numeric identifier below alphanumeric
+    expect(productSign("1.2.4-alpha", "1.2.4-rc.1")).toBe(-1);
+    // a shorter run of otherwise equal identifiers is lower
+    expect(productSign("1.2.4-rc.2", "1.2.4-rc.2.1")).toBe(-1);
+  });
+});
+
+describe("where the two accepted domains differ, on purpose", () => {
+  it("the script half rejects build metadata; the product half ignores it", () => {
+    expect(() => compareReleaseVersions("1.0.0+build.42", "1.0.0")).toThrow(/not a version/);
+    expect(isNewerSemver("1.0.0+build.42", "1.0.0")).toBe(false);
+    expect(isNewerSemver("1.0.1+build.42", "1.0.0")).toBe(true);
+  });
+
+  it("the product half accepts a v prefix, and answers the same either way", () => {
+    expect(isNewerSemver("v0.4.1", "0.4.1-beta")).toBe(true);
+    expect(isNewerSemver("0.4.1", "v0.4.1-beta")).toBe(true);
+  });
+
+  // Unparseable throws on the script half — a release workflow wants to stop —
+  // and answers `false` on the product half, because a background update check
+  // has nowhere useful to put an exception.
+  it("differs on how each half refuses a string neither can parse", () => {
+    expect(() => compareReleaseVersions("nightly", "1.0.0")).toThrow(/not a version/);
+    expect(isNewerSemver("nightly", "1.0.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #322.

**Base is `fix/update-channel-awareness`** — the feature branch for #314, not `main` and not the
beta train. This is the only ticket in the 0.4.1 milestone on that branch; ADR 0036 lives on
`feat/release-pipeline` and is read from there, not from this base.

## The bug

`isNewerSemver` compared only the numeric core, so `0.4.1` and `0.4.1-beta` were *equal*. One
answer, two bugs:

1. **The update notice never fired for a beta's own release.** `checkForUpdate` asked the channel
   for the latest release, got `0.4.1`, and `isNewerSemver("0.4.1", "0.4.1-beta")` was `false`. The
   operators who had installed a beta on metal — the population most in need of the notice — were
   never told the real release existed.
2. **`actana update` silently downgraded.** A bare update resolves `/releases/latest`, which
   excludes prereleases, so it answered `0.4.0`. The already-current guard compares two strings for
   equality, `"0.4.0" !== "0.4.1-beta"`, so it waved that straight through: a stop, a tree swap and
   a restart onto an older version, reported to the operator as an update.

## What changed

**`packages/shared/src/semver.ts`** learns semver §11.4 precedence — a prerelease is below its own
release, and identifiers compare numerically rather than as strings. Build metadata is ignored for
precedence (semver §10), which keeps every answer the function gave for a plain `x.y.z` pair, and
an unparseable string still answers `false` rather than throwing.

**`scripts/__tests__/version-rule-agreement.test.mjs`** is new, and is what stops the two
implementations of this one rule drifting apart (ADR 0036 D8). They cannot share a file — one is
`.mjs` that node runs inside a workflow step with no build, the other ships in the Core tarball and
the Panel bundle — so they share a test. The root suite is the only project that spans both
`scripts/**` and `packages/**`. It runs `compareReleaseVersions` and `isNewerSemver` over every
ordered pair of a 16-version table and names any pair they answer differently. Verified by
mutation: reverting either half of the rule turns it red with the offending pairs listed.

**`packages/shared/src/actana-release-channel.ts`** gains the *line* vocabulary, which ADR 0036 D6
assigns to this ticket. A **line** is `x.y.z` and resolves to either its release or its beta (D1,
D2). It is deliberately not a second meaning for `ReleaseChannel`, which already means *which
repository and which hosts releases are read from*. `resolveLine` is D2's rule — a pin, then
`v<line>`, then `v<line>-beta`, then `/releases/latest` as the terminal fallback. Its inputs are
existence answers about two *named* tags, so no step enumerates releases and it cannot hand a
machine installing one line's beta the beta of another. D6: **#322 creates, #317 consumes.**

**`packages/cli/src/actana-update.ts`** gains the downgrade guard. A bare update refuses a resolved
version older than the installed one, downloads nothing, and says what the machine is on, what the
newest release is, and that a bare update will take its own line's release the day that exists. An
explicit `--version` is never second-guessed — pinning an older release is how a Panel↔Core version
lock is recovered. The guard is an ordering comparison, not a rule about prereleases, so a `latest`
moved backwards is caught for a machine on a release too, and a beta machine is not *stranded*.

**`packages/core/src/core-update-notice.ts`** needed no behaviour change: the semver fix reaches it
through `checkForUpdate`. Nothing special-cases a beta, which is the property worth pinning, so it
gains the coverage and a header note saying so.

## On the version shape

A beta version string is exactly `x.y.z-beta` on every surface and carries no counter (ADR 0036 D1,
D7 — the tag *moves* per cut, so the string never changes). Nothing here is built around ordering
counters. The numeric-identifier branch of §11.4 is therefore covered by the backport release
candidates ADR 0023 D30 publishes (`rc.2` vs `rc.10`), not by beta-shaped fixtures.

## Boundaries

Touches only this ticket's surfaces: `semver.ts`, `actana-release-channel.ts`, `actana-update.ts`,
`actana-release.ts`, `core-update-notice.ts`, their tests, and the new root-suite agreement test.
No `install.sh` (#316, #317), no `.github/workflows` (#325), no CLI install/setup/layout/tree
modules (#316). Nothing merged, `main` untouched, and this stays a draft.
