### PR TITLE
refactor(install-sh): install.sh installs and stops activating — setup is the operator's next command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,10 @@
 # Core Installation Guide
 
 This guide covers turning a **Linux or macOS** machine into a **Core**:
-installing the Core bundle, running `actana setup` — a separate command,
-because installing is not activating — and pairing the machine with your Panel. The Core is the stateful daemon that runs harnesses and owns
-the PTY layer; the Panel is the web app you drive it from.
+installing the Core bundle, running `actana setup` — a separate command, because
+installing is not activating — and pairing the machine with your Panel. The Core
+is the stateful daemon that runs harnesses and owns the PTY layer; the Panel is
+the web app you drive it from.
 
 **There is one `actana`.** The command that installs and operates a Core is the
 same command that drives Cores — `actana core ls`, `actana session start` and
@@ -303,23 +304,27 @@ actana core pair prod <public-host>:<port> XXXX-XXXX \
 
 ## macOS, on the machine itself
 
-A Mac with Apple silicon is a Core like any other: the one-liner at the top of
-this page installs it, `actana setup` runs without sudo, and the machine pairs
-with your Panel the same way. What differs is the auto-start mechanism, and
-one property that follows from it.
+A Mac with Apple silicon is a Core like any other: the same two commands at the
+top of this page install it, both run without sudo, and the machine pairs with
+your Panel the same way. What differs is the auto-start mechanism, and one
+property that follows from it.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash
+actana setup
 ```
 
-The installer maps the machine to the `mac-arm64` release asset and hands over
-to `actana setup`, which writes a **LaunchAgent** at
+The first command maps the machine to the `mac-arm64` release asset, places the
+bundle and links the launcher — and stops. Nothing is running yet. Run the
+`actana setup` line it printed; that is what writes the **LaunchAgent** at
 `~/Library/LaunchAgents/com.actana.core.plist`, labelled `com.actana.core`, and
-loads it.
+loads it. On a Mac that has never had `~/.local/bin` on its `PATH`, the printed
+line is an absolute path rather than a bare `actana` — run it as printed.
 
 **An Intel Mac stops here, deliberately.** There is no `mac-x64` build and
-there will not be one; the installer refuses at detection and points you at the
-container image, which is the supported way to run a Core on that machine.
+there will not be one; the installer refuses at detection — before it downloads
+anything — and points you at the container image, which is the supported way to
+run a Core on that machine.
 
 ### The LaunchAgent is tied to your login session
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
 # Core Installation Guide
 
 This guide covers turning a **Linux or macOS** machine into a **Core**:
-downloading the Core bundle, running `actana setup`, and pairing the machine
-with your Panel. The Core is the stateful daemon that runs harnesses and owns
+installing the Core bundle, running `actana setup` — a separate command,
+because installing is not activating — and pairing the machine with your Panel. The Core is the stateful daemon that runs harnesses and owns
 the PTY layer; the Panel is the web app you drive it from.
 
 **There is one `actana`.** The command that installs and operates a Core is the
@@ -36,12 +36,28 @@ automatic login, or leave the session open.
 
 ## Install in one command
 
+Two commands, and the first one prints the second:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash
+actana setup
 ```
 
-**Or, if you already have the CLI**, the same three steps without the shell
-script:
+**Installing is not activating.** `install.sh` puts the Core bundle and the
+`actana` CLI on this machine and stops. `actana setup` is what turns the machine
+into a Core: it generates the mTLS material, writes the auto-start service,
+offers to enable lingering, offers the harness CLIs, starts the daemon, and
+registers the Core with this machine's own `actana`. They are two different acts
+with two different audiences, and there is no flag that fuses them back into
+one.
+
+The installer prints the exact `actana setup` line to run — **run the line it
+printed**. On a machine where `~/.local/bin` was not yet on your `PATH` when the
+shell started, that line is an absolute path rather than a bare `actana`, and it
+is the one that will actually be found.
+
+**Or, if you already have the CLI**, `actana install` does both halves in one
+go — it is the CLI's own front door, not the shell script's:
 
 ```bash
 npm i -g @actana/cli
@@ -50,15 +66,16 @@ actana install
 
 `install.sh` stays the door for a machine with no Node — the tarball carries its
 own pinned runtime, so the script cannot be replaced by the CLI it installs.
-Both do the same work: resolve the release, download it, check it against the
-release's `SHA256SUMS`, extract it, then set up. A failed check leaves nothing
-installed either way.
+Both fetch the same way: resolve the release, download it, check it against the
+release's `SHA256SUMS`, extract it. A failed check leaves nothing installed
+either way.
 
-That detects the machine's OS and CPU, downloads the matching Core tarball
-from the latest GitHub Release, **checks it against the release's `SHA256SUMS`
-before extracting or running anything**, and hands over to `actana setup` —
-which installs, writes the auto-start unit, starts the daemon, and tells you how
-to pair a client with it.
+The one-liner detects the machine's OS and CPU, downloads the matching Core
+tarball from the latest GitHub Release, **checks it against the release's
+`SHA256SUMS` before extracting or running anything**, copies the bundle to
+`~/.local/share/actana/versions/<version>`, points `~/.local/share/actana/current`
+at it, and links `~/.local/bin/actana` — unless something else already answers
+to `actana`, in which case it leaves that one alone and says so.
 
 The checksum catches a corrupted or truncated download: it proves the tarball
 is the one that release's own checksum file describes. Releases are not signed
@@ -66,12 +83,11 @@ is the one that release's own checksum file describes. Releases are not signed
 release workflow), so it is not a proof of origin — use `https` URLs, which the
 defaults do.
 
-Piped like that, the run is non-interactive: nothing prompts, and every choice
-comes from a flag. Flags the installer does not own are passed straight through
-to `actana setup`:
+Piped like that, the run is non-interactive — it asks nothing, because it
+decides nothing. The four options it takes are its own:
 
 ```bash
-curl -fsSL <install-script-url> | bash -s -- --version 0.1.0 --public-host core1.example.com --yes
+curl -fsSL <install-script-url> | bash -s -- --version 0.1.0
 ```
 
 | Flag | Meaning |
@@ -79,18 +95,35 @@ curl -fsSL <install-script-url> | bash -s -- --version 0.1.0 --public-host core1
 | `--version <v>` | Install this exact release instead of the latest |
 | `--repo <slug>` | Install from another GitHub repository |
 | `--base-url <url>` | Fetch releases from somewhere else — how the tests run hermetically |
-| *anything else* | Passed to `actana setup` (see the table below) |
+| `--help` | Show what the script does and the options it owns |
+
+**Anything else is refused, not ignored.** `--yes`, `--port`, `--public-host`,
+`--label`, `--with-<harness>` and `--no-harnesses` are `actana setup`'s options
+and belong on the second command — an installer that accepted `--public-host`
+and then did nothing with it would silently drop the one setting that decides
+whether your Panel can reach this machine.
+
+```bash
+curl -fsSL <install-script-url> | bash
+~/.local/bin/actana setup --public-host core1.example.com --yes
+```
 
 `ACTANA_VERSION`, `ACTANA_REPO` and `ACTANA_BASE_URL` set the same three
-options, for provisioning systems where flags are awkward.
+installer options, for provisioning systems where flags are awkward.
+`ACTANA_HOME`, `ACTANA_BIN_DIR`, `ACTANA_CONFIG_DIR`, `ACTANA_DATA_DIR` and the
+XDG variables move where things land; the script does not read them itself — the
+CLI does — so the installer and `actana setup` cannot disagree about where
+anything is.
 
-**Re-running the one-liner on a machine that already has a Core upgrades it
+**Re-running both commands on a machine that already has a Core upgrades it
 in place** — same install, same identity, one unit, and every paired client
 stays paired. It is always safe to paste again.
 
 If anything fails — an unsupported platform, a release without a build for it,
 a checksum that does not match — the installer stops before extracting or
-running a single byte of the download, and says what to do about it.
+running a single byte of the download, and says what to do about it. A failed
+run leaves the machine as it found it: nothing under the install root, no
+launcher, no half-placed tree.
 
 The rest of this page is the same install done by hand, and how to operate a
 Core afterwards.
@@ -143,25 +176,45 @@ shasum -a 256 --ignore-missing -c SHA256SUMS
 
 That must print `OK`. If it does not, stop — do not extract or run anything.
 
-### Step 2 — Extract and run setup
+### Step 2 — Extract, place the bundle, and run setup
 
 ```bash
 tar -xzf actana-core-0.1.0-linux-x64.tar.gz
 ```
 
 ```bash
-./actana-core-0.1.0-linux-x64/bin/actana setup
+./actana-core-0.1.0-linux-x64/bin/actana place
 ```
 
-`setup` does all of it:
+```bash
+actana setup
+```
+
+**These are the same two commands the one-liner runs** — the only difference is
+who downloaded the tarball. `place` copies the extracted tree into the install
+layout and links the launcher; `setup` activates the machine. Run the
+`actana setup` line `place` printed, for the same reason as above: on a machine
+where `~/.local/bin` is not on your `PATH` it is an absolute path.
+
+`place` does the install half:
 
 - copies the tree to `~/.local/share/actana/versions/<version>` and points
   `~/.local/share/actana/current` at it,
-- links the launcher into `~/.local/bin/actana` (and tells you if that
-  directory is not on your `PATH`) — **unless something else already answers to
-  `actana` there or earlier on your `PATH`**, in which case it leaves that one
-  alone and says so. Whoever installed a CLI owns its path; since there is one
-  `actana` program, the one already there runs this Core's verbs too,
+- links the launcher into `~/.local/bin/actana` — **unless something else
+  already answers to `actana` there or earlier on your `PATH`**, in which case
+  it leaves that one alone and says so. Whoever installed a CLI owns its path;
+  since there is one `actana` program, the one already there runs this Core's
+  verbs too,
+- prints the `actana setup` command to run next, and stops. Nothing is running
+  and nothing is configured until you run it.
+
+You can skip `place` and run `setup` straight out of the extracted directory —
+`setup` places the tree it is standing in before it activates anything, which
+is what it has always done. `place` exists so that installing and activating
+can be two separate decisions.
+
+`setup` does the rest:
+
 - generates the mTLS material and persists it to `~/.config/actana/material.json`,
 - writes the auto-start service — the systemd user unit
   `~/.config/systemd/user/actana-core.service` on Linux, or the LaunchAgent
@@ -451,21 +504,34 @@ provisioning script.
 
 ### `actana` is not found in a new shell
 
-`setup` links the launcher into `~/.local/bin`, which some distributions leave
-off `PATH`. Add it:
+The install links the launcher into `~/.local/bin`, which some distributions
+leave off `PATH` — and which a shell that started before the install will not
+have picked up in any case. Add it:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-### `setup` said it left the launcher alone
+This is why the installer prints an absolute path rather than a bare `actana`
+when it can see that `~/.local/bin` is not on your `PATH`. Running the line it
+printed always works, `PATH` or no `PATH`.
+
+### The install finished and nothing is running
+
+That is the install working. `install.sh` places the bundle and stops;
+`actana setup` is the command that makes this machine a Core. Run the line the
+installer printed — `actana status` before that says there is no Core
+installed for this user, which is true until setup has run.
+
+### It said it left the launcher alone
 
 Something else already answers to `actana` — usually `npm i -g @actana/cli`,
 whose global shim lands in the same directory. Nothing is broken: it is the same
-program, so it runs this Core's `status`, `logs` and `update` as well. Setup
-prints where this install's own launcher is if you would rather run that one
-directly. To hand the path over, remove the other install
-(`npm rm -g @actana/cli`) and re-run `actana setup`.
+program, so it runs this Core's `status`, `logs` and `update` as well. The
+message names where this install's own launcher is if you would rather run that
+one directly, and the `actana setup` command it prints goes through that
+launcher rather than through the other program. To hand the path over, remove
+the other install (`npm rm -g @actana/cli`) and re-run the install.
 
 ### The service started but nothing is listening
 
@@ -522,11 +588,11 @@ actana setup --public-host <new-address>
 | `~/.local/share/actana/current` | Symlink to the version the unit runs. |
 | `~/.local/share/actana/data/missioncontrol.db` | SQLite: projects, tasks, sessions, event log. Never touched by setup. |
 | `~/.config/actana/material.json` | CA, server cert/key, client cert/key, bearer secret, coreId. `chmod 0600`. |
-| `~/.config/actana/actana.json` | What setup decided: version, port, host, public host, label. No secrets. |
+| `~/.config/actana/actana.json` | What setup decided: version, port, host, public host, label. No secrets. Absent until setup runs. |
 | `~/.config/systemd/user/actana-core.service` | Linux: the auto-start user unit. |
 | `~/Library/LaunchAgents/com.actana.core.plist` | macOS: the auto-start LaunchAgent. |
 | `~/Library/Logs/Actana/core.log` | macOS: the daemon's output — what `actana logs` tails. |
-| `~/.local/bin/actana` | Symlink to `current/bin/actana`. |
+| `~/.local/bin/actana` | Symlink to `current/bin/actana`, written by the install unless somebody else owns the name. |
 
 The two service paths are fixed — systemd and launchd each read exactly one
 directory. Everything else honours `XDG_DATA_HOME` and `XDG_CONFIG_HOME`

--- a/README.md
+++ b/README.md
@@ -91,10 +91,14 @@ against the one on screen. [deploy/README.md](deploy/README.md) walks through
 the file itself — the volumes, the loopback port, adding a second Core.
 
 **Installer** — turn a Linux or macOS (arm64) machine into a Core, as your own
-user, without sudo:
+user, without sudo. Two commands, because installing is not activating: the
+first puts the Core bundle and the `actana` CLI on the machine, the second
+turns the machine into a Core. The first prints the second — run the line it
+printed.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash
+actana setup
 ```
 
 **Which one?** Compose if you want the whole thing on one host to try it;

--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -1,18 +1,28 @@
-# Linux Core — the one-liner rehearsal
+# Linux Core — the install rehearsal
 
 CI installs a Core on Linux several times per pull request: `.github/workflows/ci.yml`'s
 `installer-e2e` job runs `scripts/e2e-actana-setup-linux.mjs` — the real
-one-liner, then the lifecycle verbs on the machine it produced — across Ubuntu
-and Debian at x64, and the `core-image` job pairs a Panel with the containerised
-Core. arm64 runs the same script on the release tag
-(`.github/workflows/release.yml`).
+one-liner, then `actana setup` as its own step, then the lifecycle verbs on the
+machine those two produced — across Ubuntu and Debian at x64, and the
+`core-image` job pairs a Panel with the containerised Core. arm64 runs the same
+script on the release tag (`.github/workflows/release.yml`).
 
 All of it runs with the prompts suppressed and nobody watching. That is the
 gap this fills: **once per release, a person pastes the real one-liner into a
-machine that has never seen it, answers the questions it asks, and takes a
-pairing code to a live Panel.** What it catches is the class of problem a green
-matrix cannot — a prompt that reads badly, a code that is awkward to read out
-loud, an instruction that is technically true and practically useless.
+machine that has never seen it, runs the second command it prints, answers the
+questions *that* asks, and takes a pairing code to a live Panel.** What it
+catches is the class of problem a green matrix cannot — a prompt that reads
+badly, a code that is awkward to read out loud, an instruction that is
+technically true and practically useless.
+
+**Two commands, because installing is not activating** (ADR 0036 C2, #316).
+`install.sh` places the Core bundle and the `actana` CLI and stops; `actana
+setup` is what turns the machine into a Core, and it is where every prompt this
+rehearsal exists to exercise now lives. The installer prints the exact `setup`
+line to run — an absolute path when `~/.local/bin` is not yet on `PATH` — and
+**that printed line is the one to paste**, not a retyped `actana setup`. A
+printed command that cannot be run is itself a release blocker, and this is the
+only place a person checks it.
 
 Fifteen minutes, and the only install rehearsal a release needs — Linux is the
 only platform a release publishes a Core for. [The macOS
@@ -57,10 +67,12 @@ pnpm core:rehearse
 ```
 
 That one command builds a systemd container with **no sudo on it**, starts a
-local release channel serving the tarball you just built, prints the one-liner
-to paste, and drops you into a shell inside the machine as `operator`.
+local release channel serving the tarball you just built, prints the two
+commands to paste, and drops you into a shell inside the machine as `operator`.
 
-- [ ] The banner prints a `curl -fsSL … | bash -s -- --base-url …` command.
+- [ ] The banner prints a `curl -fsSL … | bash -s -- --base-url …` command, and
+      an `actana setup` to follow it, and says that the first installs without
+      activating.
 - [ ] The prompt that follows is inside the machine (`whoami` says `operator`,
       `sudo` is not found).
 
@@ -78,8 +90,26 @@ re-enter it and how to destroy it.
 
 ## 2 — Install, the way an operator does
 
-Paste the printed one-liner. **Do not add `--yes`** — the prompts are the point.
+Paste the printed one-liner. `--base-url`, `--repo` and `--version` are the only
+options it still takes — `--yes` and the rest are `actana setup`'s now, and the
+script refuses them by name rather than ignoring them.
 
+- [ ] It downloads, says the checksum verified, and exits **without asking you
+      anything**. Nothing prompts, because nothing here decides anything.
+- [ ] It says plainly that nothing is running yet.
+- [ ] It prints one `actana setup` command, and only one.
+- [ ] `actana status` at this point says there is **no Core installed for this
+      user** — which is true, and is the machine being installed but not
+      activated. (If `actana` is not found yet, that is the case the printed
+      absolute path exists for; the next box checks it.)
+
+### Then the second command — this is the one with the prompts in it
+
+Paste **the line the installer printed**, exactly as printed. Do not retype it
+as a bare `actana setup`, and **do not add `--yes`** — the prompts are the point.
+
+- [ ] The printed line runs. If it was an absolute path, it worked as pasted;
+      a printed command that is not found is a release blocker on its own.
 - [ ] It asks about enabling lingering, and explains *why* before asking.
 - [ ] It offers to install the harness CLIs it found missing, one at a time.
       (Decline them all — this machine has no vendor logins on it, and CI
@@ -202,6 +232,7 @@ If 8443 is taken, `--port <n>` moves it — and then you pair against
 
 Note in the release PR: the distro you used, and which boxes did not tick.
 
-Unticked boxes in sections 2 and 3 are release blockers — "the one-liner ends
-with a Core a person can actually pair to a Panel" is the whole product promise
-this rehearsal exists to protect. Everything else is a bug report.
+Unticked boxes in sections 2 and 3 are release blockers — "the two commands end
+with a Core a person can actually pair to a Panel, and the first one prints a
+second one that runs" is the whole product promise this rehearsal exists to
+protect. Everything else is a bug report.

--- a/docs/core-macos-prerelease-checklist.md
+++ b/docs/core-macos-prerelease-checklist.md
@@ -44,9 +44,9 @@ Mac runs its Core from the container image, and both `install.sh` and
 `actana update` refuse it at detection and say so.
 
 The Linux path is covered by
-[the one-liner rehearsal](core-linux-rehearsal.md): `pnpm core:rehearse` for a
-throwaway machine to run the real one-liner on. Same standing as this page
-now has, for the other half of the release.
+[the install rehearsal](core-linux-rehearsal.md): `pnpm core:rehearse` for a
+throwaway machine to run the real one-liner and the `actana setup` it prints on.
+Same standing as this page now has, for the other half of the release.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,39 @@
 #!/bin/sh
-# actana — turn this machine into a Core.
+# actana — install the Core bundle and the CLI on this machine.
 #
 #   curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash
+#   actana setup
 #
-# This script is a bootstrapper and nothing more: detect the platform, resolve
-# the release, download the matching tarball, verify it against the release's
-# published SHA256SUMS, extract it, and hand over to `actana setup`. Every real
-# decision — where to install, the systemd unit, lingering, Harnesses, wiring
-# the Core into this machine's own registry — lives in that CLI, where it is
-# unit-tested. Anything this
-# script grows beyond "fetch, verify, exec" belongs there instead.
+# **Two commands, because installing is not activating** (ADR 0036 C2). This
+# script detects the platform, resolves the release, downloads the matching
+# tarball, verifies it against the release's published SHA256SUMS, extracts it,
+# places the bundle, links the launcher, prints the `actana setup` line to run
+# next, and exits. It does not turn this machine into a Core: the mTLS
+# material, the systemd unit or LaunchAgent, lingering, the Harness offers, the
+# daemon and this machine's own registration are all `actana setup`, which the
+# operator runs afterwards. There is no flag for this — it is what the script
+# does.
 #
-# Flags it does not own are forwarded verbatim to `actana setup`, so
-# `… | bash -s -- --yes --public-host 10.0.0.7` works and stays working as the
-# CLI gains flags.
+# **It does not know the install layout, and must not learn it.** Placement is
+# `"$extracted/bin/actana" place` — the CLI in the tree that was just verified,
+# running on the Node pinned inside it. ACTANA_HOME, ACTANA_CONFIG_DIR,
+# ACTANA_DATA_DIR, ACTANA_BIN_DIR, XDG_DATA_HOME and XDG_CONFIG_HOME resolve
+# there, in `packages/cli/src/actana-layout.ts`, where they are unit-tested
+# against a fake home. A second, subtly different copy of those rules in POSIX
+# sh is exactly the failure this repository refuses for release resolution.
+# So: "fetch, verify, place" — and anything this script grows beyond that
+# belongs in the CLI instead.
+#
+# Flags this script does not own are refused rather than forwarded. Every one
+# it used to forward belonged to `actana setup`, and `actana setup` is a
+# separate command now — passing `--yes` to an installer that prompts for
+# nothing would be a flag that quietly did nothing.
 #
 # POSIX sh: runs under bash, dash and ash. Tested by
 # `scripts/__tests__/install-sh.test.mjs` (the real script against a fixture
 # release server) and by `scripts/e2e-actana-setup-linux.mjs`, which enters at
-# the real one-liner on a real systemd machine and carries on into the
-# lifecycle verbs.
+# the real one-liner on a real systemd machine, runs `actana setup` as its own
+# next step, and carries on into the lifecycle verbs.
 
 set -eu
 
@@ -52,48 +66,61 @@ have() {
 
 usage() {
   cat <<'EOF'
-Install an Actana Control Core and turn this machine into a Core.
+Install the Actana Control Core bundle and the `actana` CLI on this machine.
+
+Installing is not activating. This script places the bundle and links the
+launcher; it starts nothing and configures nothing. It prints the
+`actana setup` command to run next, which is what turns this machine into a
+Core: the pairing material, the auto-start service, lingering, the Harness
+offers and the daemon.
 
 Usage:
   curl -fsSL <install-script-url> | bash
   curl -fsSL <install-script-url> | bash -s -- [options]
 
-Installer options:
+and then, as a separate command this script does not run for you:
+  actana setup [options]
+
+Options:
   --version <v>     Install this exact release (default: the latest release)
   --repo <slug>     GitHub repository to install from
   --base-url <url>  Fetch releases from here instead of GitHub (testing)
   --help            Show this help
 
-Every other option is passed through to `actana setup`, including:
-  --yes                 Take the recommended answer to every prompt, which
-                        includes installing every missing Harness
-  --with-<harness>        Install this Harness without asking (repeatable)
-  --no-harnesses           Do not install or offer any Harness
-  --port <n>            Port the daemon listens on
-  --public-host <addr>  Address your Panel dials
-  --label <name>        Alias shown in your Panel
-
-Piped into bash there is no terminal, so no Harness is installed unless one
-of the first two flags says to. Run `actana harnesses install <id>` later instead.
+These four are the whole of it. Options this script does not own are refused
+rather than ignored: `--yes`, `--port`, `--public-host`, `--label`,
+`--with-<harness>` and `--no-harnesses` are `actana setup`'s, and belong on the
+command this one prints. `actana setup --help` lists them.
 
 Environment: ACTANA_VERSION, ACTANA_REPO, ACTANA_BASE_URL set the same three
 installer options, for provisioning systems where flags are awkward.
+ACTANA_HOME, ACTANA_BIN_DIR, ACTANA_CONFIG_DIR, ACTANA_DATA_DIR and the XDG
+variables move where the bundle lands; they are read by the CLI, so this
+script and `actana setup` cannot disagree about where anything is.
 EOF
 }
 
 # ─── argument parsing ────────────────────────────────────────────────────────
 
-# Options this script owns are consumed; everything else is collected, shell-
-# quoted, and restored into "$@" for `actana setup`. Quoting through `eval` is
-# how a POSIX shell carries an argument list that may contain spaces without
-# arrays — `--label "my build box"` has to survive the round trip.
-quote() {
-  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+# This script owns four options and refuses everything else.
+#
+# It used to collect the rest, shell-quote them and restore them into "$@" for
+# `actana setup`. That machinery is gone with the call it fed: the flags it
+# carried are decisions about how this machine is configured as a Core, and
+# they belong on the command the operator runs next. Refusing is the honest
+# answer — an installer that accepted `--public-host core1.example.com` and
+# then did nothing with it would silently drop the one setting that decides
+# whether a Panel can ever reach this machine.
+setup_flag_refusal() {
+  die "$1 is an \`actana setup\` option, and this script no longer runs setup.
+  It installs the Core bundle and the CLI, then prints the \`actana setup\` line
+  to run next — pass $1 to that command instead. \`--help\` lists the four
+  options this script does own."
 }
 
 # A flag's value must be present and must not itself look like a flag:
-# `--version --yes` silently pinning a release called "--yes" and swallowing
-# the `--yes` is the kind of quiet wrong that only shows up as "why did it
+# `--version --repo` silently pinning a release called "--repo" and swallowing
+# the `--repo` is the kind of quiet wrong that only shows up as "why did it
 # install nothing" much later.
 need_value() {
   case ${2-} in
@@ -102,7 +129,6 @@ need_value() {
 }
 
 parse_args() {
-  FORWARD=""
   while [ $# -gt 0 ]; do
     case $1 in
       --version)
@@ -139,9 +165,16 @@ parse_args() {
         usage
         exit 0
         ;;
+      # Named one by one rather than swept up by the wildcard below, so an
+      # operator pasting a command line from before the split is told where
+      # their flag went instead of reading "unknown option".
+      --yes | -y | --port | --port=* | --public-host | --public-host=* | \
+        --label | --label=* | --host | --host=* | --no-harnesses | --with-*)
+        setup_flag_refusal "${1%%=*}"
+        ;;
       *)
-        FORWARD="$FORWARD $(quote "$1")"
-        shift
+        die "unknown option: $1. \`--help\` lists the four options this script owns;
+  everything else belongs on the \`actana setup\` line it prints when it is done."
         ;;
     esac
   done
@@ -289,8 +322,9 @@ main() {
   say "Installing the Actana Core $VERSION for $TARGET."
 
   work_dir=$(mktemp -d 2>/dev/null || mktemp -d -t actana-install)
-  # Whatever happens next — a bad checksum, a failed setup, Ctrl-C — the
-  # download does not outlive this script.
+  # Whatever happens next — a bad checksum, a refused placement, Ctrl-C — the
+  # download does not outlive this script. What does outlive it is whatever
+  # `place` copied out of here, which is the point of the call at the bottom.
   trap 'rm -rf "$work_dir"' EXIT
   trap 'rm -rf "$work_dir"; exit 130' INT
   trap 'rm -rf "$work_dir"; exit 143' TERM
@@ -333,28 +367,30 @@ main() {
   [ -x "$extracted/bin/actana" ] ||
     die "$asset does not contain bin/actana — the release asset looks wrong."
 
-  # Restore the flags meant for the CLI.
-  eval "set -- $FORWARD"
-
   say ""
-  # Run rather than `exec`: the EXIT trap above is what removes the download,
-  # and an exec'd process has no trap to run. Setup's exit code is propagated
-  # below, so a caller sees the same status either way.
-  # Piped runs (the one-liner) have the script itself on stdin; handing that to
-  # the CLI would let it eat the rest of the script. It has nothing to read
-  # there anyway — with no terminal, `setup` prompts for nothing and takes its
-  # answers from the flags above. A run from a real terminal keeps its stdin,
-  # so the prompts still work when a person is there to answer them.
-  set +e
-  if [ -t 0 ]; then
-    "$extracted/bin/actana" setup "$@"
-  else
-    "$extracted/bin/actana" setup "$@" </dev/null
-  fi
-  status=$?
-  set -e
-
-  exit $status
+  # **The line that makes any of this survive.** The tree above is inside
+  # `work_dir`, which the EXIT trap deletes; `place` copies it into
+  # `versions/<version>`, points `current` at it and links the launcher. Take
+  # this call away and a successful run leaves the machine exactly as it was
+  # found.
+  #
+  # Run rather than `exec`: the EXIT trap is what removes the download, and an
+  # exec'd process has no trap to run. `set -e` carries a failure out with its
+  # own status, so a caller still sees what went wrong — there is no longer a
+  # separate exit code to propagate, because there is no longer a `setup` run
+  # to propagate one from.
+  #
+  # stdin is /dev/null on every path, terminal or not. In the one-liner the
+  # rest of this script is still on stdin, and handing that to a child would
+  # let it eat the script; `place` has nothing to read there in any case. It is
+  # `actana setup` that talks to an operator, and that is their next command,
+  # run with their own terminal attached.
+  #
+  # What it prints — including the exact `actana setup` line to run next, as an
+  # absolute path when `<binDir>` is not on PATH — is printed by the CLI, which
+  # is the half that knows the layout. This script deliberately does not print
+  # a second copy of it.
+  "$extracted/bin/actana" place </dev/null
 }
 
 # Everything above is a definition, so the shell has read this whole script

--- a/packages/cli/src/__tests__/actana-install.test.ts
+++ b/packages/cli/src/__tests__/actana-install.test.ts
@@ -179,15 +179,38 @@ describe("actana install (#288 D8)", () => {
   });
 
   it("leaves `install.sh` as the door for a machine with no Node", () => {
-    // Not a behaviour test — a boundary one. The shell script does the same
-    // three steps this verb does, and it stays because a bare machine has no
+    // Not a behaviour test — a boundary one. The shell script does the fetch
+    // half of what this verb does, and it stays because a bare machine has no
     // Node to run this verb with. Two doors, one implementation of the real
-    // work: what would be wrong is `install.sh` growing a fourth step.
+    // work: what would be wrong is `install.sh` growing a step of its own.
+    //
+    // Since #316 the third step is `place`, not `exec`: the script hands the
+    // verified bundle to the CLI inside it and stops, because installing is
+    // not activating (ADR 0036 C2). The phrase is asserted because it is the
+    // script's own statement of how much it is allowed to know.
     const script = fs.readFileSync(
       path.resolve(import.meta.dirname, "../../../../install.sh"),
       "utf8",
     );
-    expect(script).toContain("fetch, verify, exec");
+    expect(script).toContain("fetch, verify, place");
+    expect(script).not.toContain("fetch, verify, exec");
+  });
+
+  // #316: the two front doors part company here, and it is deliberate.
+  // `install.sh` installs and stops; `actana install` fetches *and* sets up,
+  // because an operator who already has the CLI and types `actana install` has
+  // asked for a Core rather than for a bundle on disk. `actana place` is the
+  // stopping-short verb, and it is the one the script runs.
+  it("still activates, unlike the shell script that no longer does", async () => {
+    expect(await install()).toBe(0);
+    expect(fs.existsSync(layout().servicePath)).toBe(true);
+
+    const script = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../../../../install.sh"),
+      "utf8",
+    );
+    expect(script).toMatch(/bin\/actana" place/);
+    expect(script).not.toMatch(/bin\/actana" setup/);
   });
 });
 

--- a/packages/cli/src/__tests__/actana-machine-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-machine-cli.test.ts
@@ -266,6 +266,150 @@ describe("help and dispatch stay in sync", () => {
   });
 });
 
+// ─── `actana place` — install without activating (ADR 0036 C2, #316) ────────
+//
+// The verb `install.sh` hands the bundle to. The script used to end by running
+// `actana setup`, so one line both installed a Core and turned the machine
+// into one; this is the half that is left when activation is taken out of it.
+// What has to hold at this level is the whole of what an operator's next
+// command depends on: the bundle is on disk, the launcher is linked, nothing
+// is running, and the printed command is one they can actually run.
+
+describe("place", () => {
+  /** The layout paths a placement writes, for the scratch home under test. */
+  const placed = () => {
+    const layout = layoutForHome();
+    return { layout, installDir: installDirFor(layout, MANIFEST.version) };
+  };
+
+  it("places the bundle, points `current` at it, and links the launcher", async () => {
+    expect(await runActanaCli(deps(["place"], fakeSystem()))).toBe(0);
+
+    const { layout, installDir } = placed();
+    expect(fs.existsSync(path.join(installDir, "app", "core-entry.cjs"))).toBe(true);
+    expect(fs.realpathSync(layout.currentLink)).toBe(fs.realpathSync(installDir));
+    expect(fs.readlinkSync(layout.binLink)).toBe(path.join(layout.currentLink, "bin", "actana"));
+    expect(out.join("\n")).toContain(installDir);
+  });
+
+  // The sentence that stops an operator believing the machine is a Core.
+  it("says nothing is running, and prints the command that changes that", async () => {
+    await runActanaCli(deps(["place"], fakeSystem()));
+
+    const text = out.join("\n");
+    expect(text).toMatch(/not a Core until you set it up/i);
+    expect(text).toMatch(/^ {2}actana setup$/m);
+    // Once, so there is one command and not two free to disagree — the e2e
+    // reads this line back and runs it.
+    expect(text.match(/\bactana setup\b/g)).toHaveLength(1);
+  });
+
+  // Advice that does not work is worse than no advice: `actana setup --help`
+  // is a usage error, because `--help` is a global flag rather than one of
+  // setup's own. Whatever `place` points at has to be a command that runs.
+  it("names a help command that actually answers", async () => {
+    await runActanaCli(deps(["place"], fakeSystem()));
+    const advised = /`(actana[^`]*--help)`/.exec(out.join("\n"));
+    expect(advised, "place stopped naming a help command").not.toBeNull();
+
+    out.length = 0;
+    const argv = advised![1].split(" ").slice(1);
+    expect(await runActanaCli(deps(argv, fakeSystem()))).toBe(0);
+    expect(out.join("\n")).toMatch(/actana <command>/);
+  });
+
+  it("asks the init system for nothing at all", async () => {
+    const system = fakeSystem();
+    expect(await runActanaCli(deps(["place"], system))).toBe(0);
+
+    // No `systemctl`, no `loginctl`, no `launchctl`: placement is a copy and
+    // two symlinks, and a verb that touched the init system would be the
+    // removed tail growing back.
+    expect(system.calls).toEqual([]);
+    const { layout } = placed();
+    expect(fs.existsSync(layout.servicePath)).toBe(false);
+    expect(fs.existsSync(materialFilePath(layout.configDir))).toBe(false);
+    // Nothing was registered with this machine's own CLI either — that is
+    // setup's, and it needs a credential that does not exist yet.
+    expect(() => wiredCredential()).toThrow();
+  });
+
+  // #316's fourth criterion, and the case it exists for: on a fresh machine
+  // `~/.local/bin` does not exist at login, so the shell never put it on
+  // `PATH`, so a bare `actana setup` is a command that will not be found.
+  it("prints an absolute path when the launcher's directory is not on PATH", async () => {
+    await runActanaCli(deps(["place"], fakeSystem(), { env: { HOME: home, PATH: "/usr/bin" } }));
+
+    const { layout } = placed();
+    const absolute = `${path.join(layout.currentLink, "bin", "actana")} setup`;
+    expect(out.join("\n")).toContain(absolute);
+    expect(out.join("\n")).not.toMatch(/^ {2}actana setup$/m);
+  });
+
+  // The CLI-only install this milestone must not break (#288 / ADR 0032): an
+  // `npm i -g @actana/cli` shim sits at exactly `binLink` inside the Core
+  // image, because `NPM_CONFIG_PREFIX` makes that directory the npm prefix's
+  // bin. Placement reaches that path before setup does now.
+  it("does not clobber an `actana` somebody else installed at the same path", async () => {
+    const { layout } = placed();
+    const shim = path.join(home, ".local", "lib", "node_modules", "@actana", "cli", "bin", "actana.mjs");
+    fs.mkdirSync(path.dirname(shim), { recursive: true });
+    fs.writeFileSync(shim, "#!/usr/bin/env node\n");
+    fs.mkdirSync(layout.binDir, { recursive: true });
+    fs.symlinkSync(shim, layout.binLink);
+
+    expect(await runActanaCli(deps(["place"], fakeSystem()))).toBe(0);
+
+    expect(fs.readlinkSync(layout.binLink)).toBe(shim);
+    const text = out.join("\n");
+    expect(text).toContain(layout.binLink);
+    // And the printed command goes through this install's own launcher, not
+    // through the other program — which has no bundle around it and would
+    // download a release rather than activate the one just placed.
+    expect(text).toContain(`${path.join(layout.currentLink, "bin", "actana")} setup`);
+  });
+
+  it("takes no options, and says where the ones it refuses went", async () => {
+    expect(await runActanaCli(deps(["place", "--public-host", "10.0.0.7"], fakeSystem()))).toBe(
+      EXIT_USAGE,
+    );
+    expect(err.join("\n")).toContain("--public-host");
+    expect(err.join("\n")).toMatch(/actana setup/);
+    expect(fs.existsSync(placed().installDir)).toBe(false);
+  });
+
+  it("refuses when there is no bundle here, and names the verb that fetches one", async () => {
+    // The `npm i -g @actana/cli` shape: a CLI with no tarball around it.
+    const code = await runActanaCli(deps(["place"], fakeSystem(), { installRoot: "" }));
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/actana install/);
+  });
+
+  it("reports a build for another machine as an error, not a stack trace", async () => {
+    const code = await runActanaCli(deps(["place"], fakeSystem(), { arch: "arm64" }));
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/linux-x64/);
+    expect(err.join("\n")).not.toMatch(/at Object\.|node:internal/);
+    expect(fs.existsSync(placed().installDir)).toBe(false);
+  });
+
+  // The two-command install, end to end at this level: place, then set up
+  // over what was placed. `setup` finds its own tree as its source, so it
+  // copies nothing and the machine ends up exactly where the one-command
+  // install used to leave it.
+  it("leaves a machine `actana setup` can finish activating", async () => {
+    expect(await runActanaCli(deps(["place"], fakeSystem()))).toBe(0);
+    out.length = 0;
+
+    const { installDir } = placed();
+    expect(await runActanaCli(deps(["setup"], fakeSystem(), { installRoot: installDir }))).toBe(0);
+
+    expect(out.join("\n")).toContain("actana pair new");
+    expect(wiredCredential().endpoint).toBe("wss://10.0.0.5:8443");
+    expect(fs.existsSync(layoutForHome().servicePath)).toBe(true);
+  });
+});
+
 describe("setup", () => {
   it("installs, starts, and points the operator at `actana pair new`", async () => {
     expect(await setup(fakeSystem())).toBe(0);

--- a/packages/cli/src/__tests__/actana-machine-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-machine-cli.test.ts
@@ -369,6 +369,111 @@ describe("place", () => {
     expect(text).toContain(`${path.join(layout.currentLink, "bin", "actana")} setup`);
   });
 
+  // Review finding 7. `claimLauncher` writes nothing at `binLink` when another
+  // `actana` is earlier on `PATH` — often there is no such file at all — so a
+  // `Launcher <binLink>` row would name a path with nothing at it, three lines
+  // under a note saying the launcher was left alone.
+  it("does not claim a launcher it did not write", async () => {
+    const elsewhere = path.join(home, "usr", "bin");
+    fs.mkdirSync(elsewhere, { recursive: true });
+    fs.writeFileSync(path.join(elsewhere, "actana"), "#!/bin/sh\n");
+    const { layout } = placed();
+
+    expect(
+      await runActanaCli(
+        deps(["place"], fakeSystem(), {
+          env: { HOME: home, PATH: `${elsewhere}:${layout.binDir}` },
+        }),
+      ),
+    ).toBe(0);
+
+    expect(fs.existsSync(layout.binLink)).toBe(false);
+    const text = out.join("\n");
+    expect(text).not.toMatch(new RegExp(`Launcher\\s+${layout.binLink}$`, "m"));
+    expect(text).toContain(path.join(elsewhere, "actana"));
+    expect(text).toMatch(/Launcher\s+left alone/);
+  });
+
+  // Review finding 5. `installTree` renames a fresh tree over `installDir`, so
+  // a daemon executing out of *that* directory loses the files behind it —
+  // which is the documented "paste both again" upgrade whenever the version
+  // has not moved. `runActanaSetup` stops the service first for exactly this;
+  // `place` has to as well, or the guard has a hole the size of the new front
+  // door.
+  it("stops a running Core whose own tree it is about to replace", async () => {
+    await runActanaCli(deps(["place"], fakeSystem()));
+    out.length = 0;
+
+    const system = fakeSystem({
+      "systemctl --user is-active": { status: 0, stdout: "active\n", stderr: "" },
+    });
+    expect(await runActanaCli(deps(["place"], system))).toBe(0);
+
+    const commands = system.calls.map((call) => call.join(" "));
+    expect(commands).toContain("systemctl --user stop actana-core.service");
+    expect(out.join("\n")).toMatch(/Stopping the running Core/);
+    // And the bundle still landed.
+    expect(fs.existsSync(path.join(placed().installDir, "app", "core-entry.cjs"))).toBe(true);
+  });
+
+  it("asks the init system nothing when there is no tree at that path to destroy", async () => {
+    // The ordinary case — a fresh machine — and the reason the guard above is
+    // not simply "always consult the service": `install.sh` runs this on
+    // machines whose init system this CLI may not support at all.
+    const system = fakeSystem({
+      "systemctl --user is-active": { status: 0, stdout: "active\n", stderr: "" },
+    });
+    expect(await runActanaCli(deps(["place"], system))).toBe(0);
+    expect(system.calls).toEqual([]);
+  });
+
+  it("stops it through whatever this machine's init system is, not through systemd", async () => {
+    // The same guard on the other platform, because the hazard is the
+    // filesystem rename and not the init system: a LaunchAgent's job is
+    // executing out of the tree being replaced just as a systemd unit's is.
+    const mac = { platform: "darwin" as NodeJS.Platform, arch: "arm64" };
+    const macManifest = { ...MANIFEST, target: "mac-arm64", platform: "darwin", arch: "arm64" };
+    const macRoot = path.join(tmp, "extract-mac", "actana-core-0.1.0-mac-arm64");
+    makeTarballTree(macRoot, macManifest);
+    await runActanaCli(deps(["place"], fakeSystem(), { ...mac, installRoot: macRoot }));
+    out.length = 0;
+
+    const system = fakeSystem({
+      "launchctl print": { status: 0, stdout: "state = running\npid = 4211\n", stderr: "" },
+    });
+    expect(await runActanaCli(deps(["place"], system, { ...mac, installRoot: macRoot }))).toBe(0);
+
+    const commands = system.calls.map((call) => call.join(" "));
+    expect(commands.some((command) => command.startsWith("launchctl bootout"))).toBe(true);
+    expect(commands.some((command) => command.startsWith("systemctl"))).toBe(false);
+    expect(out.join("\n")).toMatch(/Stopping the running Core/);
+  });
+
+  // Review finding 6. The unit's `ExecStart` resolves through `current`, so a
+  // placement on a machine that is already a Core moves what a restart would
+  // start while `actana.json` and `actana status` still describe the old
+  // version. Saying so is the difference between an operator who finishes the
+  // upgrade and one who reboots into a Core nothing has set up.
+  it("says the running Core is still on the old version until setup finishes", async () => {
+    await setup(fakeSystem());
+    out.length = 0;
+
+    const newer = { ...MANIFEST, version: "0.2.0" };
+    const newRoot = path.join(tmp, "extract-2", "actana-core-0.2.0-linux-x64");
+    makeTarballTree(newRoot, newer);
+    expect(await runActanaCli(deps(["place"], fakeSystem(), { installRoot: newRoot }))).toBe(0);
+
+    const text = out.join("\n");
+    expect(text).toMatch(/already set up as a Core on 0\.1\.0/);
+    expect(text).toContain("0.2.0");
+    expect(text).toMatch(/still running 0\.1\.0/);
+    expect(text).toMatch(/finish the upgrade with/);
+    // Not the fresh-machine sentence — this machine is a Core, and telling it
+    // "nothing is running yet" would be false.
+    expect(text).not.toMatch(/Nothing is running yet/);
+    expect(text).toMatch(/^ {2}actana setup$/m);
+  });
+
   it("takes no options, and says where the ones it refuses went", async () => {
     expect(await runActanaCli(deps(["place", "--public-host", "10.0.0.7"], fakeSystem()))).toBe(
       EXIT_USAGE,

--- a/packages/cli/src/__tests__/actana-setup.test.ts
+++ b/packages/cli/src/__tests__/actana-setup.test.ts
@@ -272,18 +272,59 @@ describe("placeCoreBundle — what `install.sh` leaves behind", () => {
     },
   );
 
-  it("does not delete a version that was already installed when a re-place fails", () => {
+  // Skipped as root for the same reason as the test above. The failure has to
+  // happen *during the copy*: a source `planCorePlacement` refuses throws
+  // before `placeCoreBundle` is entered at all, and a test built that way would
+  // pass without ever entering the code it is about.
+  it.skipIf(process.getuid?.() === 0)(
+    "keeps the version that was already installed when a re-place fails mid-copy",
+    () => {
+      const first = place();
+      fs.writeFileSync(path.join(first.installDir, "app", "keep-me"), "installed\n");
+
+      // A second source, same version, well-formed enough to be planned and
+      // impossible to copy.
+      const second = path.join(tmp, "extract-2", "actana-core-0.1.0-linux-x64");
+      makeTarballTree(second);
+      fs.chmodSync(path.join(second, "app", "core-entry.cjs"), 0o000);
+
+      expect(() => place({ sourceRoot: second })).toThrow();
+
+      expect(fs.readFileSync(path.join(first.installDir, "app", "keep-me"), "utf8")).toBe(
+        "installed\n",
+      );
+      expect(fs.existsSync(`${first.installDir}.incoming`)).toBe(false);
+      expect(fs.existsSync(`${first.installDir}.previous`)).toBe(false);
+    },
+  );
+
+  // The swap moves the old tree aside rather than deleting it, so that the
+  // rename putting the new one in place has something to be undone with. Both
+  // scratch paths are this call's to clean up — a `versions/0.1.0.previous`
+  // left lying around is a full copy of a Core bundle nobody will ever look at.
+  it("leaves neither scratch directory behind when it replaces a tree", () => {
     const first = place();
-    fs.writeFileSync(path.join(first.installDir, "app", "keep-me"), "installed\n");
-    // A second source, same version, that cannot be copied.
+    fs.writeFileSync(path.join(first.installDir, "app", "old-marker"), "old\n");
+
     const second = path.join(tmp, "extract-2", "actana-core-0.1.0-linux-x64");
     makeTarballTree(second);
-    fs.rmSync(path.join(second, "node", "bin", "node"));
+    const again = place({ sourceRoot: second });
 
-    expect(() => place({ sourceRoot: second })).toThrow();
-    expect(fs.readFileSync(path.join(first.installDir, "app", "keep-me"), "utf8")).toBe(
-      "installed\n",
-    );
+    expect(again.installDir).toBe(first.installDir);
+    expect(fs.existsSync(path.join(again.installDir, "app", "old-marker"))).toBe(false);
+    expect(fs.existsSync(`${again.installDir}.incoming`)).toBe(false);
+    expect(fs.existsSync(`${again.installDir}.previous`)).toBe(false);
+  });
+
+  it("does not adopt a `.previous` a crashed run left behind", () => {
+    const installDir = path.join(layout.versionsDir, "0.1.0");
+    fs.mkdirSync(`${installDir}.previous`, { recursive: true });
+    fs.writeFileSync(path.join(`${installDir}.previous`, "from-a-crash"), "junk\n");
+
+    const result = place();
+
+    expect(fs.existsSync(`${result.installDir}.previous`)).toBe(false);
+    expect(fs.existsSync(path.join(result.installDir, "from-a-crash"))).toBe(false);
   });
 
   it("does not adopt a staging directory a crashed run left behind", () => {

--- a/packages/cli/src/__tests__/actana-setup.test.ts
+++ b/packages/cli/src/__tests__/actana-setup.test.ts
@@ -7,9 +7,17 @@ import { X509Certificate, createPublicKey } from "node:crypto";
 import { verifyBearer } from "@actana/shared/core-link-bearer";
 import { readActanaConfig } from "../actana-config";
 import { resolveActanaLayout, type ActanaLayout } from "../actana-layout";
-import { loadMaterial, persistMaterial } from "@actana/shared/core-material-store";
+import { loadMaterial, materialFilePath, persistMaterial } from "@actana/shared/core-material-store";
 import { createServiceManager } from "../actana-service";
-import { runActanaSetup, choosePublicHost, type SetupOptions } from "../actana-setup";
+import {
+  runActanaSetup,
+  choosePublicHost,
+  placeCoreBundle,
+  planCorePlacement,
+  setupCommandFor,
+  type PlacementOptions,
+  type SetupOptions,
+} from "../actana-setup";
 import type { ActanaSystem, CommandResult } from "../actana-system";
 
 const MANIFEST = {
@@ -138,6 +146,249 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// ─── placement, without activation (ADR 0036 C2, #316) ──────────────────────
+//
+// `install.sh` places a bundle and stops, so placement is a function with its
+// own contract rather than the first third of `runActanaSetup`. What is
+// asserted here is both halves of "install is not activation": that the tree,
+// the `current` symlink and the launcher are all there, **and** that nothing
+// which makes this machine a Core is — no config, no material, no unit. A
+// placement that quietly did one more thing than it says would be the removed
+// tail growing back under a different name.
+
+/** The placement half of the setup options the rest of this file builds. */
+function placing(over: Partial<PlacementOptions> = {}): PlacementOptions {
+  return {
+    layout,
+    env: { HOME: home, PATH: layout.binDir },
+    sourceRoot,
+    manifest: MANIFEST,
+    platform: "linux",
+    arch: "x64",
+    out: () => {},
+    ...over,
+  };
+}
+
+/** Plan and place in one call, the way both callers do. */
+function place(over: Partial<PlacementOptions> = {}) {
+  const opts = placing(over);
+  return placeCoreBundle(opts, planCorePlacement(opts));
+}
+
+describe("placeCoreBundle — what `install.sh` leaves behind", () => {
+  it("lands the tree under versions/<v>, points current at it, links the launcher", () => {
+    const result = place();
+
+    expect(result.installDir).toBe(path.join(layout.versionsDir, "0.1.0"));
+    expect(result.version).toBe("0.1.0");
+    expect(fs.existsSync(path.join(result.installDir, "app", "core-entry.cjs"))).toBe(true);
+    expect(fs.existsSync(path.join(result.installDir, "node", "bin", "node"))).toBe(true);
+    expect(fs.realpathSync(layout.currentLink)).toBe(fs.realpathSync(result.installDir));
+    expect(fs.readlinkSync(layout.binLink)).toBe(path.join(layout.currentLink, "bin", "actana"));
+    expect(result.launcher.outcome).toBe("linked");
+  });
+
+  // The other half of the contract, and the one the whole ticket is about.
+  it("activates nothing: no config, no material, no unit, no data dir", () => {
+    place();
+
+    expect(readActanaConfig(layout.configDir)).toBeNull();
+    expect(fs.existsSync(materialFilePath(layout.configDir))).toBe(false);
+    expect(fs.existsSync(layout.servicePath)).toBe(false);
+    // The data dir is the daemon's, and there is no daemon yet.
+    expect(fs.existsSync(layout.dataDir)).toBe(false);
+  });
+
+  it("needs no init system, so it works where `setup` could not run at all", () => {
+    // `PlacementOptions` has no `service` and no `system` to give it one.
+    // Stated as a test because it is the reason placement is separable at all:
+    // a bundle can be put on a machine whose init system nothing here supports.
+    expect(Object.keys(placing())).not.toContain("service");
+    expect(() => place()).not.toThrow();
+  });
+
+  it("runs twice over its own output without copying anything", () => {
+    const first = place();
+    const marker = path.join(first.installDir, "app", "marker");
+    fs.writeFileSync(marker, "still here\n");
+
+    // The shape of the two-command install: `setup` runs from the launcher of
+    // the tree `install.sh` just placed, so its source *is* its destination.
+    const again = place({ sourceRoot: first.installDir });
+
+    expect(again.installDir).toBe(first.installDir);
+    expect(fs.readFileSync(marker, "utf8")).toBe("still here\n");
+    expect(fs.realpathSync(layout.currentLink)).toBe(fs.realpathSync(first.installDir));
+  });
+
+  it("refuses a tree that is not a Core build, before writing anything", () => {
+    fs.rmSync(path.join(sourceRoot, "node", "bin", "node"));
+
+    expect(() => place()).toThrow(/not an extracted Core tarball/);
+    expect(fs.existsSync(layout.versionsDir)).toBe(false);
+    expect(fs.existsSync(layout.currentLink)).toBe(false);
+  });
+
+  it("refuses a build for another machine, before writing anything", () => {
+    expect(() => place({ arch: "arm64" })).toThrow(/but the machine is/);
+    expect(fs.existsSync(layout.versionsDir)).toBe(false);
+  });
+
+  // #316's fifth criterion: a failed run leaves the machine as it was found.
+  // Two shapes, because they fail at different points and clean up different
+  // things — one before the copy starts, one with the staging tree already on
+  // disk.
+  it("leaves nothing behind when the install root cannot be written", () => {
+    // Something else owns `versions` — the shape a hand-made file or a stray
+    // mount leaves. `mkdir` refuses and no tree is begun.
+    fs.mkdirSync(layout.root, { recursive: true });
+    fs.writeFileSync(layout.versionsDir, "not a directory\n");
+
+    expect(() => place()).toThrow();
+    expect(fs.statSync(layout.versionsDir).isFile()).toBe(true);
+    // Neither link was touched, so nothing points at a tree that is not there.
+    expect(fs.existsSync(layout.currentLink)).toBe(false);
+    expect(fs.existsSync(layout.binLink)).toBe(false);
+  });
+
+  // Skipped as root, where a mode of 000 stops nothing. Everywhere else this
+  // is the real thing: the copy gets part way, throws, and has to take its own
+  // staging tree and the version directory it was about to become with it.
+  it.skipIf(process.getuid?.() === 0)(
+    "leaves nothing behind when the copy fails part-way through",
+    () => {
+      fs.chmodSync(path.join(sourceRoot, "app", "core-entry.cjs"), 0o000);
+
+      expect(() => place()).toThrow();
+
+      const installDir = path.join(layout.versionsDir, "0.1.0");
+      expect(fs.existsSync(installDir), "a half-placed tree survived").toBe(false);
+      expect(fs.existsSync(`${installDir}.incoming`), "the staging tree survived").toBe(false);
+      expect(fs.existsSync(layout.currentLink)).toBe(false);
+      expect(fs.existsSync(layout.binLink)).toBe(false);
+    },
+  );
+
+  it("does not delete a version that was already installed when a re-place fails", () => {
+    const first = place();
+    fs.writeFileSync(path.join(first.installDir, "app", "keep-me"), "installed\n");
+    // A second source, same version, that cannot be copied.
+    const second = path.join(tmp, "extract-2", "actana-core-0.1.0-linux-x64");
+    makeTarballTree(second);
+    fs.rmSync(path.join(second, "node", "bin", "node"));
+
+    expect(() => place({ sourceRoot: second })).toThrow();
+    expect(fs.readFileSync(path.join(first.installDir, "app", "keep-me"), "utf8")).toBe(
+      "installed\n",
+    );
+  });
+
+  it("does not adopt a staging directory a crashed run left behind", () => {
+    const installDir = path.join(layout.versionsDir, "0.1.0");
+    fs.mkdirSync(`${installDir}.incoming`, { recursive: true });
+    fs.writeFileSync(path.join(`${installDir}.incoming`, "half-copied"), "junk\n");
+
+    const result = place();
+
+    expect(fs.existsSync(`${installDir}.incoming`)).toBe(false);
+    expect(fs.existsSync(path.join(result.installDir, "half-copied"))).toBe(false);
+  });
+});
+
+// **The collision is tested, not reasoned about** (#288 D10, #316 landmine).
+// `deploy/core.Dockerfile` sets `NPM_CONFIG_PREFIX=/home/core/.local`, so
+// `npm i -g @actana/cli` puts its shim at `$HOME/.local/bin/actana` — the very
+// path `resolveActanaLayout` calls `binLink`. `install.sh` reaches that path
+// before `setup` does now, so the refusal to clobber has to hold on the
+// placement path too, or the CLI-only install this milestone must not break
+// gets its launcher deleted by the first bundle install on the same machine.
+describe("placeCoreBundle — the launcher path still has one owner", () => {
+  /** What `npm i -g` leaves at `<prefix>/bin/actana`: a symlink into its own tree. */
+  function plantNpmShim(): string {
+    const target = path.join(
+      layout.home, ".local", "lib", "node_modules", "@actana", "cli", "bin", "actana.mjs",
+    );
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "#!/usr/bin/env node\n");
+    fs.mkdirSync(layout.binDir, { recursive: true });
+    fs.symlinkSync(target, layout.binLink);
+    return target;
+  }
+
+  it("does not clobber an `actana` npm put at the very same path", () => {
+    expect(layout.binLink).toBe(path.join(layout.home, ".local", "bin", "actana"));
+    const shim = plantNpmShim();
+
+    const result = place();
+
+    expect(result.launcher.outcome).toBe("foreign");
+    expect(fs.readlinkSync(layout.binLink)).toBe(shim);
+    // The bundle still landed: refusing the launcher is not refusing the install.
+    expect(fs.realpathSync(layout.currentLink)).toBe(fs.realpathSync(result.installDir));
+  });
+
+  it("says so, naming both programs", () => {
+    plantNpmShim();
+    const said: string[] = [];
+    place({ out: (line) => said.push(line) });
+
+    const text = said.join("\n");
+    expect(text).toContain(layout.binLink);
+    expect(text).toContain(path.join(layout.currentLink, "bin", "actana"));
+  });
+
+  it("leaves an `actana` that is only earlier on PATH alone too", () => {
+    const elsewhere = path.join(layout.home, "bin");
+    fs.mkdirSync(elsewhere, { recursive: true });
+    fs.writeFileSync(path.join(elsewhere, "actana"), "#!/bin/sh\n");
+
+    const result = place({ env: { HOME: home, PATH: `${elsewhere}:${layout.binDir}` } });
+
+    expect(result.launcher.outcome).toBe("foreign");
+    expect(fs.existsSync(layout.binLink)).toBe(false);
+  });
+});
+
+// #316's fourth criterion. The script reaches "is the launcher findable?"
+// *before* setup does now, so the answer has to be in the command it prints
+// rather than in a note setup makes afterwards.
+describe("setupCommandFor — the next command, runnable as printed", () => {
+  const linked = { outcome: "linked", binLink: "", foreignPath: null, note: null } as const;
+  const foreign = { outcome: "foreign", binLink: "", foreignPath: "/usr/bin/actana", note: null } as const;
+
+  it("is bare `actana setup` when this install's launcher is the one on PATH", () => {
+    expect(setupCommandFor(layout, linked, { PATH: layout.binDir })).toBe("actana setup");
+  });
+
+  it("is an absolute path when the launcher's directory is not on PATH", () => {
+    // The ordinary state of a fresh machine: `~/.local/bin` does not exist at
+    // login, so the shell never added it, so a bare `actana` is not found.
+    expect(setupCommandFor(layout, linked, { PATH: "/usr/bin:/bin" })).toBe(
+      `${path.join(layout.currentLink, "bin", "actana")} setup`,
+    );
+  });
+
+  it("is an absolute path when somebody else owns the name, even on PATH", () => {
+    // An `actana` from npm has no bundle around it, so `actana setup` there
+    // would resolve a release and download one — a different act from
+    // activating the bundle that was just placed.
+    expect(setupCommandFor(layout, foreign, { PATH: layout.binDir })).toBe(
+      `${path.join(layout.currentLink, "bin", "actana")} setup`,
+    );
+  });
+
+  it("goes through `current`, so it survives the next update", () => {
+    const command = setupCommandFor(layout, linked, { PATH: "/usr/bin" });
+    expect(command).toContain(layout.currentLink);
+    expect(command).not.toContain(layout.versionsDir);
+  });
+
+  it("names no PATH at all as not on PATH", () => {
+    expect(setupCommandFor(layout, linked, {})).toContain(layout.currentLink);
+  });
 });
 
 describe("runActanaSetup — the install layout", () => {

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -2,6 +2,7 @@
 //
 //   Machine-side verbs — what this machine's own Core is and does
 //     actana install   fetch a release, verify it, install and start a Core
+//     actana place     place an extracted bundle and stop — install, no setup
 //     actana setup     install from an extracted tarball, or fetch one first
 //     actana status    daemon state, versions, endpoint, Harness availability
 //     actana token regenerate   mint fresh credentials, invalidating the old ones
@@ -96,7 +97,13 @@ import {
   type ActanaServiceManager,
   type ServiceVerb,
 } from "./actana-service.ts";
-import { choosePublicHost, runActanaSetup } from "./actana-setup.ts";
+import {
+  choosePublicHost,
+  placeCoreBundle,
+  planCorePlacement,
+  runActanaSetup,
+  setupCommandFor,
+} from "./actana-setup.ts";
 import {
   harnessFlagNames,
   harnessFromFlagName,
@@ -170,6 +177,10 @@ Cores this machine can reach
 
 This machine's own Core
   install    Fetch a release, verify it, install the Core and start it
+  place      Put the extracted bundle here and link the launcher, and stop.
+             Installing is not activating: nothing is started, no identity is
+             minted, no service is written. This is what \`install.sh\` runs, and
+             \`actana setup\` is the command that follows it
   setup      Install from an extracted tarball — or fetch one when there is none
   status     Show daemon state, versions, endpoint, and Harness availability
   token regenerate
@@ -619,6 +630,85 @@ async function cmdSetup(
     );
     return 1;
   }
+  return 0;
+}
+
+/**
+ * `actana place` — the install half of the install, and nothing after it.
+ *
+ * The verb `install.sh` hands placement to (#316, ADR 0036 C2). The script has
+ * verified and unpacked a bundle into a temporary directory its own EXIT trap
+ * is about to delete; this is what makes any of it survive. It writes
+ * `versions/<v>`, points `current` at it, links `<binDir>/actana` unless
+ * somebody else owns that name — and then stops, because the mTLS material,
+ * the service unit, lingering and this machine's registration are `actana
+ * setup`'s to write and the operator's to ask for.
+ *
+ * **This is why the script does not learn the layout.** `ACTANA_HOME`,
+ * `ACTANA_CONFIG_DIR`, `ACTANA_DATA_DIR`, `ACTANA_BIN_DIR`, `XDG_DATA_HOME`
+ * and `XDG_CONFIG_HOME` resolve here, through `resolveActanaLayout`, against
+ * the same rules and the same unit tests every other verb resolves against. A
+ * second copy of them in POSIX sh would be a second front door.
+ *
+ * It takes no flags. Every flag the old tail forwarded belonged to `setup`,
+ * and `setup` is a separate command now.
+ */
+function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
+  const parsed = parseFlags(argv, {});
+  if ("error" in parsed) {
+    deps.err(parsed.error);
+    // The flags an operator is most likely to try here are setup's, and they
+    // have not been deleted — they moved to the command that uses them.
+    deps.err("`actana place` takes no options — `actana setup` is where the install's choices are made.");
+    return EXIT_USAGE;
+  }
+
+  // A CLI from `npm i -g @actana/cli` is not standing in a bundle, and there is
+  // nothing for it to place. That is not a broken install, it is the other
+  // door: `actana install` fetches a release and sets it up in one go.
+  const manifest = readCoreManifest(deps.installRoot);
+  if (!manifest) {
+    deps.err(
+      "there is no extracted Core bundle here to place. `actana place` runs from inside " +
+        "an unpacked release — `actana install` fetches one and sets it up instead.",
+    );
+    return 1;
+  }
+
+  const layout = resolveActanaLayout(deps.env, deps.home, deps.platform);
+  const placing = {
+    layout,
+    env: deps.env,
+    sourceRoot: deps.installRoot,
+    manifest,
+    platform: deps.platform,
+    arch: deps.arch,
+    out: deps.out,
+  };
+
+  let placed;
+  try {
+    placed = placeCoreBundle(placing, planCorePlacement(placing));
+  } catch (err) {
+    deps.err(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+
+  deps.out("");
+  deps.out(`Core ${placed.version} installed at ${placed.installDir}`);
+  deps.out(`  Launcher   ${placed.launcher.binLink}`);
+  deps.out(`  Current    ${layout.currentLink}`);
+  deps.out("");
+  // Installing is not activating, and an operator who is not told that has a
+  // machine they believe is a Core and a Panel that will never reach it.
+  deps.out("Nothing is running yet: this machine is not a Core until you set it up.");
+  deps.out("");
+  deps.out("  " + setupCommandFor(layout, placed.launcher, deps.env));
+  deps.out("");
+  deps.out(
+    "That writes this Core's identity, its auto-start service and its registration, and " +
+      "starts the daemon. `actana --help` lists its port, host, label and Harness options.",
+  );
   return 0;
 }
 
@@ -1330,6 +1420,8 @@ export async function runActanaCli(deps: ActanaCliDeps): Promise<number> {
   switch (head) {
     case "install":
       return cmdInstall(deps, rest);
+    case "place":
+      return cmdPlace(deps, rest);
     case "setup":
       return cmdSetup(deps, rest);
     case "status":

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -103,6 +103,7 @@ import {
   planCorePlacement,
   runActanaSetup,
   setupCommandFor,
+  type PlacementPlan,
 } from "./actana-setup.ts";
 import {
   harnessFlagNames,
@@ -652,6 +653,29 @@ async function cmdSetup(
  *
  * It takes no flags. Every flag the old tail forwarded belonged to `setup`,
  * and `setup` is a separate command now.
+ *
+ * **Two things it does touch that are not strictly placement**, both because
+ * the alternative is worse and neither is activation:
+ *
+ * - *It stops a daemon whose own tree it is about to delete.* Placement only
+ *   ever destroys a directory that is already at `installDir`, which means a
+ *   re-place of a version that is already installed — the documented "paste
+ *   both again" upgrade, when the version has not moved. `runActanaSetup`
+ *   stops the service first for exactly that case, and `installTree` would
+ *   otherwise rename a fresh tree over the one a live daemon is executing out
+ *   of, leaving every lazy `require` and asset read in the window until
+ *   `setup` restarts it pointing at nothing. So `place` stops it too, says so,
+ *   and the `setup` line it prints is what brings it back. The service is
+ *   consulted **only** when there is an existing tree at that path to
+ *   destroy — a fresh machine, which is the ordinary case, asks the init
+ *   system nothing at all — and a machine with no supported init system just
+ *   places, because refusing there would break the one job this verb has.
+ * - *It says when `current` has moved ahead of what is set up.* `current` is
+ *   what the unit's `ExecStart` resolves through, so on a machine that is
+ *   already a Core a placement that is never followed by `setup` leaves a
+ *   reboot starting a version `actana.json` does not describe. That is a
+ *   sentence in the output, not a refusal: the fix is the command already
+ *   printed below it.
  */
 function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
   const parsed = parseFlags(argv, {});
@@ -686,9 +710,17 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
     out: deps.out,
   };
 
+  // What was already here, read before anything moves: an activated install
+  // records itself in `actana.json`, and that is what makes the difference
+  // between "nothing is running yet" and "something is running, on the version
+  // this is about to move `current` off".
+  const existing = readActanaConfig(layout.configDir);
+
   let placed;
   try {
-    placed = placeCoreBundle(placing, planCorePlacement(placing));
+    const plan = planCorePlacement(placing);
+    stopDaemonBeingReplaced(deps, layout, plan);
+    placed = placeCoreBundle(placing, plan);
   } catch (err) {
     deps.err(err instanceof Error ? err.message : String(err));
     return 1;
@@ -696,20 +728,96 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
 
   deps.out("");
   deps.out(`Core ${placed.version} installed at ${placed.installDir}`);
-  deps.out(`  Launcher   ${placed.launcher.binLink}`);
+  // Only when one was actually written. `claimLauncher` leaves `binLink`
+  // untouched — often absent entirely — when somebody else answers to
+  // `actana`, and a `Launcher` row naming a path with nothing at it would
+  // contradict the note it printed three lines earlier.
+  deps.out(
+    placed.launcher.outcome === "linked"
+      ? `  Launcher   ${placed.launcher.binLink}`
+      : `  Launcher   left alone — ${placed.launcher.foreignPath} owns \`actana\` here`,
+  );
   deps.out(`  Current    ${layout.currentLink}`);
   deps.out("");
-  // Installing is not activating, and an operator who is not told that has a
-  // machine they believe is a Core and a Panel that will never reach it.
-  deps.out("Nothing is running yet: this machine is not a Core until you set it up.");
+  if (existing) {
+    // The unit's `ExecStart` runs through `current`, which now points at the
+    // tree just placed. Until `setup` runs, `actana status` and `actana.json`
+    // still describe the old version, and a restart or a reboot would start
+    // the new one with none of its work done.
+    deps.out(
+      `This machine is already set up as a Core on ${existing.version}, and \`current\` now ` +
+        `points at ${placed.version}. Nothing has restarted, so it is still running ` +
+        `${existing.version} — finish the upgrade with:`,
+    );
+  } else {
+    // Installing is not activating, and an operator who is not told that has a
+    // machine they believe is a Core and a Panel that will never reach it.
+    deps.out("Nothing is running yet: this machine is not a Core until you set it up.");
+  }
   deps.out("");
   deps.out("  " + setupCommandFor(layout, placed.launcher, deps.env));
   deps.out("");
   deps.out(
-    "That writes this Core's identity, its auto-start service and its registration, and " +
-      "starts the daemon. `actana --help` lists its port, host, label and Harness options.",
+    existing
+      ? "That restarts the daemon on the version just placed. This Core's identity, its " +
+          "service and every client paired with it are kept."
+      : "That writes this Core's identity, its auto-start service and its registration, and " +
+          "starts the daemon. `actana --help` lists its port, host, label and Harness options.",
   );
   return 0;
+}
+
+/**
+ * Stop a daemon whose own install directory is about to be replaced.
+ *
+ * The narrow case, and the only one placement can corrupt: `installTree`
+ * renames a fresh tree over `installDir`, so a daemon executing out of *that*
+ * directory loses the files behind it. Placing a different version writes a
+ * different directory and touches nothing running, which is why this asks the
+ * init system nothing on the ordinary path — a fresh machine has no tree there
+ * at all.
+ *
+ * Best effort in both directions. A platform with neither systemd nor launchd
+ * has no daemon to stop and must still be able to place a bundle, so a service
+ * manager that cannot be built is not an error here; and a `stop` that fails
+ * is reported rather than fatal, because the placement is still the better
+ * outcome than leaving the bundle in a temporary directory about to be
+ * deleted.
+ */
+function stopDaemonBeingReplaced(
+  deps: ActanaCliDeps,
+  layout: ActanaLayout,
+  plan: PlacementPlan,
+): void {
+  if (!plan.replacingTree) return;
+  if (!fs.existsSync(plan.installDir)) return;
+
+  let service: ActanaServiceManager;
+  try {
+    service = createServiceManager({
+      platform: deps.platform,
+      layout,
+      system: deps.system,
+      user: deps.user,
+      uid: deps.uid,
+    });
+  } catch {
+    return;
+  }
+
+  try {
+    if (!service.isActive()) return;
+    deps.out(
+      `Stopping the running Core: this install replaces ${plan.installDir}, which is the ` +
+        "tree it is executing from. The command printed below starts it again.",
+    );
+    service.stop();
+  } catch (err) {
+    deps.out(
+      `Could not stop the running Core (${err instanceof Error ? err.message : String(err)}). ` +
+        "Continuing — restart it with the command printed below.",
+    );
+  }
 }
 
 /** `actana install` — always the download path, even inside a tarball. */

--- a/packages/cli/src/actana-container.ts
+++ b/packages/cli/src/actana-container.ts
@@ -62,7 +62,7 @@ export {
 /**
  * The verbs the image owns, and what the operator runs on the host instead.
  *
- * `logs` is here for the same reason as the other seven: there is no journal
+ * `logs` is here for the same reason as the other eight: there is no journal
  * and no unit in the image, so `journalctl --user -u actana-core.service` has
  * nothing to read. `docker logs` reads the daemon's stdout, which is where the
  * container's Core writes.
@@ -84,6 +84,17 @@ const DOCKER_EQUIVALENT: Record<string, { why: string; run: string }> = {
   // module's header exists to refuse.
   install: {
     why: "this image is the install — there is no release to fetch and no tree to lay down",
+    run:
+      `set ${CONTAINER_PUBLIC_HOST_ENV} (and optionally ${CONTAINER_PORT_ENV}, ` +
+      `${CONTAINER_LABEL_ENV}) in your compose file, then:\n  docker compose up -d`,
+  },
+  // `place` is `setup`'s first half since #316, and it refuses for the first
+  // half of `setup`'s reason: the image *is* the versioned tree (ADR 0016 D13),
+  // so there is nowhere to place a bundle and no launcher to link. A `place`
+  // that ran here would lay a second Core down beside the image's own and
+  // repoint a `current` symlink nothing in the container reads.
+  place: {
+    why: "this image is the install — there is no tree to lay down and no launcher to link",
     run:
       `set ${CONTAINER_PUBLIC_HOST_ENV} (and optionally ${CONTAINER_PORT_ENV}, ` +
       `${CONTAINER_LABEL_ENV}) in your compose file, then:\n  docker compose up -d`,

--- a/packages/cli/src/actana-setup.ts
+++ b/packages/cli/src/actana-setup.ts
@@ -1,4 +1,20 @@
-// `actana setup` — turning the extracted tarball into a running, pairable Core.
+// `actana setup` — turning a placed Core bundle into a running, pairable Core.
+//
+// **Install is not activation, and this file is where the seam is** (ADR 0036
+// C2, #316). Two jobs used to be one function: *placing* a bundle — the
+// versioned `versions/<v>` tree, the `current` symlink, the `~/.local/bin`
+// launcher — and *activating* the machine as a Core — mTLS material, a unit or
+// a LaunchAgent, lingering, the daemon, registration. `install.sh` wanted the
+// first without the second and had no way to ask for it, so it ran `setup` and
+// got both.
+//
+// So placement is `planCorePlacement` + `placeCoreBundle` below, `actana place`
+// is the verb that stops there, and `runActanaSetup` calls the same two
+// functions before it activates anything. One implementation, entered at two
+// points — the arrangement `actana-install.ts` already uses for the download
+// half. **The layout is never resolved anywhere but `actana-layout.ts`**: a
+// second copy of those rules in POSIX sh is the failure this repository
+// already refuses for release resolution.
 //
 // Everything happens under the operator's home and nothing shells to sudo, on
 // Linux and on macOS alike. The one privilege-adjacent step is Linux's
@@ -41,8 +57,14 @@ import {
 } from "@actana/shared/core-material-store";
 import { offerHarnessInstalls, type HarnessInstallOutcome } from "./actana-harnesses.ts";
 import { endpointFor, readActanaConfig, writeActanaConfig } from "./actana-config.ts";
-import { installDirFor, type ActanaLayout } from "./actana-layout.ts";
-import { installTree, missingTreeFile, pointSymlink, realpathOrNull } from "./actana-tree.ts";
+import { binDirOnPath, installDirFor, type ActanaLayout } from "./actana-layout.ts";
+import {
+  installTree,
+  lstatOrNull,
+  missingTreeFile,
+  pointSymlink,
+  realpathOrNull,
+} from "./actana-tree.ts";
 import { claimLauncher, type LauncherClaim } from "./actana-launcher.ts";
 import { wireLocalCore, type LocalCoreWiring } from "./local-core-wiring.ts";
 import type { RegistryPaths } from "./blob-registry.ts";
@@ -58,8 +80,30 @@ const BEARER_DAYS = 365;
 /** How long setup waits for the daemon's port to answer before saying so. */
 const LISTEN_TIMEOUT_MS = 30_000;
 
-export type SetupOptions = {
+/**
+ * What placing a bundle needs — and deliberately nothing more.
+ *
+ * No registry, no service manager, no port, no public host: placement writes a
+ * tree, a symlink and possibly a launcher, and none of those is a decision
+ * about what this machine *is*. `SetupOptions` is this plus the activation
+ * half, so `actana place` and `actana setup` cannot drift apart on where
+ * things go.
+ */
+export type PlacementOptions = {
   layout: ActanaLayout;
+  /** The `PATH` this run was given, for deciding who owns the launcher. */
+  env: NodeJS.ProcessEnv;
+  /** The extracted tarball tree being placed. */
+  sourceRoot: string;
+  /** That tree's `core-manifest.json`. */
+  manifest: CoreManifest;
+  platform: NodeJS.Platform;
+  arch: string;
+  /** Progress and warnings for the operator. */
+  out: (line: string) => void;
+};
+
+export type SetupOptions = PlacementOptions & {
   /**
    * Where this machine's client half keeps its Cores (#288 D9).
    *
@@ -68,20 +112,12 @@ export type SetupOptions = {
    * hand-carried from one half of this command into the other.
    */
   registry: RegistryPaths;
-  /** The `PATH` this run was given, for deciding who owns the launcher. */
-  env: NodeJS.ProcessEnv;
-  /** The extracted tarball tree setup is running from. */
-  sourceRoot: string;
-  /** That tree's `core-manifest.json`. */
-  manifest: CoreManifest;
   port: number;
   /** The address the daemon binds. */
   host: string;
   /** The address a client dials — goes in the cert SAN and the endpoint. */
   publicHost: string;
   label: string;
-  platform: NodeJS.Platform;
-  arch: string;
   /** Skip prompts and take the recommended answer. */
   assumeYes: boolean;
   /** Whether there is a terminal to prompt on. */
@@ -95,8 +131,29 @@ export type SetupOptions = {
   system: ActanaSystem;
   /** This machine's init system — systemd on Linux, launchd on macOS. */
   service: ActanaServiceManager;
-  /** Progress and warnings for the operator. */
-  out: (line: string) => void;
+};
+
+/** Where a bundle is going, and whether the tree itself has to be written. */
+export type PlacementPlan = {
+  /** `versions/<version>` under this layout's root. */
+  installDir: string;
+  /** The extracted tree, with symlinks resolved. */
+  source: string;
+  /**
+   * False when the source *is* the install directory — a `setup` run by the
+   * launcher of an install that `install.sh` already placed, which is the
+   * ordinary shape of the two-command install (ADR 0036 C2).
+   */
+  replacingTree: boolean;
+};
+
+/** What a placement put on the machine. Nothing here is running. */
+export type PlacementResult = {
+  /** The version that is now on disk — the tree's, not this CLI's (#288 D10). */
+  version: string;
+  installDir: string;
+  /** Whether `<binDir>/actana` was linked, or left to whoever owns it (#288 D10). */
+  launcher: LauncherClaim;
 };
 
 /** What `actana setup` did to this machine's pairing material. */
@@ -201,9 +258,19 @@ async function resolveMaterial(
   };
 }
 
-/** Install, register, start, and pair this machine. */
-export async function runActanaSetup(opts: SetupOptions): Promise<SetupResult> {
-  const { layout, manifest, service } = opts;
+// ─── placement: what `actana place` does, and what `setup` does first ───────
+
+/**
+ * Where a bundle is going, decided before a single byte is written.
+ *
+ * Split from {@link placeCoreBundle} so the caller can act between deciding
+ * and writing: `runActanaSetup` takes out a pre-rename unit and stops a running
+ * daemon in that gap, and neither belongs to placement. Every refusal —
+ * wrong platform, incomplete tree, unusable version string — happens here, so
+ * a plan that came back is a plan that can be carried out.
+ */
+export function planCorePlacement(opts: PlacementOptions): PlacementPlan {
+  const { layout, manifest } = opts;
 
   if (manifest.platform !== opts.platform || manifest.arch !== opts.arch) {
     throw new Error(
@@ -218,7 +285,71 @@ export async function runActanaSetup(opts: SetupOptions): Promise<SetupResult> {
 
   const installDir = installDirFor(layout, manifest.version);
   const source = realpathOrNull(opts.sourceRoot) ?? opts.sourceRoot;
-  const replacingTree = source !== realpathOrNull(installDir);
+  return { installDir, source, replacingTree: source !== realpathOrNull(installDir) };
+}
+
+/**
+ * Put the bundle where it lives and link the launcher. Activates nothing.
+ *
+ * This is the whole of what survives `install.sh`: without it the extracted
+ * tree is deleted by the script's own EXIT trap and the machine is exactly as
+ * it was found. Nothing here writes config, mints material, or asks an init
+ * system for anything — see the file header.
+ *
+ * **A failed placement leaves the machine as it was found.** The copy lands in
+ * `<installDir>.incoming` and is renamed into place, so a tree is either whole
+ * or absent; if the rename never happens, the staging directory goes, and a
+ * version directory this call created goes with it. `current` and the launcher
+ * are only touched once the tree is complete.
+ */
+export function placeCoreBundle(opts: PlacementOptions, plan: PlacementPlan): PlacementResult {
+  const { layout, manifest } = opts;
+  const hadInstallDir = lstatOrNull(plan.installDir) !== null;
+
+  try {
+    if (plan.replacingTree) installTree(plan.source, plan.installDir);
+  } catch (err) {
+    // `installTree` takes its own staging directory with it. What is left to
+    // undo is a version directory this call brought into existence — an
+    // install that was already there is not this failure's to delete.
+    if (!hadInstallDir) fs.rmSync(plan.installDir, { recursive: true, force: true });
+    throw err;
+  }
+
+  pointSymlink(layout.currentLink, plan.installDir);
+  // Not an unconditional symlink any more: `<binDir>/actana` may already be
+  // somebody else's, and in the Core image it is the very directory
+  // `NPM_CONFIG_PREFIX` puts npm's global shims in (#288 D10).
+  const launcher = claimLauncher(layout, opts.env);
+  if (launcher.note) opts.out(launcher.note);
+
+  return { version: manifest.version, installDir: plan.installDir, launcher };
+}
+
+/**
+ * The `actana setup` line to print after placing a bundle, runnable as printed.
+ *
+ * A bare `actana` is only correct when this install's own launcher is the one
+ * that answers to that name *and* its directory is on `PATH`. Otherwise the
+ * operator gets a path: through `current`, so it keeps working after the next
+ * update repoints that link. Today `setup` reports the not-on-PATH condition
+ * after it has already run; `install.sh` now reaches it first, and a next
+ * command that is not found is a dead end rather than a note (#316).
+ */
+export function setupCommandFor(
+  layout: ActanaLayout,
+  launcher: LauncherClaim,
+  env: NodeJS.ProcessEnv,
+): string {
+  const usable = launcher.outcome === "linked" && binDirOnPath(layout.binDir, env.PATH);
+  return usable ? "actana setup" : `${path.join(layout.currentLink, "bin", "actana")} setup`;
+}
+
+/** Install, register, start, and pair this machine. */
+export async function runActanaSetup(opts: SetupOptions): Promise<SetupResult> {
+  const { layout, manifest, service } = opts;
+
+  const plan = planCorePlacement(opts);
 
   // A machine installed before the Harness → Core rename has a second service
   // under the old name, running out of this same tree and binding this same
@@ -231,18 +362,16 @@ export async function runActanaSetup(opts: SetupOptions): Promise<SetupResult> {
   // Swapping the tree under a running daemon works on both platforms (the open
   // inodes survive) but leaves it executing a version that no longer exists on
   // disk. Stop first so the restart below is the only thing that brings it back.
-  if (replacingTree && service.isActive()) {
+  if (plan.replacingTree && service.isActive()) {
     opts.out("Stopping the running Core before upgrading it…");
     service.stop();
   }
 
-  if (replacingTree) installTree(source, installDir);
-  pointSymlink(layout.currentLink, installDir);
-  // Not an unconditional symlink any more: `<binDir>/actana` may already be
-  // somebody else's, and in the Core image it is the very directory
-  // `NPM_CONFIG_PREFIX` puts npm's global shims in (#288 D10).
-  const launcher = claimLauncher(layout, opts.env);
-  if (launcher.note) opts.out(launcher.note);
+  // The same placement `actana place` performs, and the same one `install.sh`
+  // has already performed when setup is the operator's second command: it is
+  // idempotent, so running it again over its own output is a no-op plus two
+  // symlink writes.
+  const { installDir, launcher } = placeCoreBundle(opts, plan);
   fs.mkdirSync(layout.dataDir, { recursive: true });
 
   const { material, outcome } = await resolveMaterial(opts);

--- a/packages/cli/src/actana-setup.ts
+++ b/packages/cli/src/actana-setup.ts
@@ -296,11 +296,14 @@ export function planCorePlacement(opts: PlacementOptions): PlacementPlan {
  * it was found. Nothing here writes config, mints material, or asks an init
  * system for anything — see the file header.
  *
- * **A failed placement leaves the machine as it was found.** The copy lands in
- * `<installDir>.incoming` and is renamed into place, so a tree is either whole
- * or absent; if the rename never happens, the staging directory goes, and a
- * version directory this call created goes with it. `current` and the launcher
- * are only touched once the tree is complete.
+ * **A failed placement leaves the machine as it was found.** `installTree` owns
+ * that: the copy lands in `<installDir>.incoming`, the tree it replaces is
+ * moved aside rather than deleted, and either the new tree arrives or the old
+ * one is put back. What is left here is the one thing that module cannot know
+ * — whether the version directory existed before this call — so a directory
+ * this call brought into being does not survive a failure. `current` and the
+ * launcher are only touched once the tree is complete, so neither can end up
+ * pointing at something that is not there.
  */
 export function placeCoreBundle(opts: PlacementOptions, plan: PlacementPlan): PlacementResult {
   const { layout, manifest } = opts;
@@ -309,9 +312,10 @@ export function placeCoreBundle(opts: PlacementOptions, plan: PlacementPlan): Pl
   try {
     if (plan.replacingTree) installTree(plan.source, plan.installDir);
   } catch (err) {
-    // `installTree` takes its own staging directory with it. What is left to
-    // undo is a version directory this call brought into existence — an
-    // install that was already there is not this failure's to delete.
+    // `installTree` cleans up after itself and restores what it displaced, so
+    // this is the belt to its braces: a version directory that did not exist
+    // before this call does not exist after it failed. An install that was
+    // already there is never this failure's to delete.
     if (!hadInstallDir) fs.rmSync(plan.installDir, { recursive: true, force: true });
     throw err;
   }

--- a/packages/cli/src/actana-tree.ts
+++ b/packages/cli/src/actana-tree.ts
@@ -59,18 +59,31 @@ export function pointSymlink(linkPath: string, target: string): void {
   fs.renameSync(staging, linkPath);
 }
 
-/** Copy the extracted tree into its versioned home, replacing any existing one. */
+/**
+ * Copy the extracted tree into its versioned home, replacing any existing one.
+ *
+ * A copy that fails part-way takes its own staging directory with it, so the
+ * only states this leaves behind are "the old tree" and "the new tree" — never
+ * a `versions/<v>.incoming` for the next run to trip over. That matters more
+ * since #316: `install.sh` places before anything is activated, and a failed
+ * placement has to leave the machine as it was found.
+ */
 export function installTree(source: string, installDir: string): void {
   const staging = `${installDir}.incoming`;
   fs.rmSync(staging, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(installDir), { recursive: true });
-  // verbatimSymlinks so a symlink inside the tarball is copied as-is rather
-  // than resolved against this machine's paths.
-  fs.cpSync(source, staging, {
-    recursive: true,
-    preserveTimestamps: true,
-    verbatimSymlinks: true,
-  });
+  try {
+    // verbatimSymlinks so a symlink inside the tarball is copied as-is rather
+    // than resolved against this machine's paths.
+    fs.cpSync(source, staging, {
+      recursive: true,
+      preserveTimestamps: true,
+      verbatimSymlinks: true,
+    });
+  } catch (err) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw err;
+  }
   // Replace wholesale rather than copying over the top: a half-written tree
   // from a crashed install must not survive as a merge.
   fs.rmSync(installDir, { recursive: true, force: true });

--- a/packages/cli/src/actana-tree.ts
+++ b/packages/cli/src/actana-tree.ts
@@ -62,15 +62,27 @@ export function pointSymlink(linkPath: string, target: string): void {
 /**
  * Copy the extracted tree into its versioned home, replacing any existing one.
  *
- * A copy that fails part-way takes its own staging directory with it, so the
- * only states this leaves behind are "the old tree" and "the new tree" — never
- * a `versions/<v>.incoming` for the next run to trip over. That matters more
- * since #316: `install.sh` places before anything is activated, and a failed
- * placement has to leave the machine as it was found.
+ * **Either the old tree or the new one, at every instant, on every path.** The
+ * copy lands in `<installDir>.incoming` and a failure there takes that
+ * directory with it. The swap then moves the existing tree aside to
+ * `<installDir>.previous` rather than deleting it, so the rename that puts the
+ * new tree in place has something to be undone with: if it throws, the old
+ * tree goes straight back. `rmSync(installDir)` followed by a rename would
+ * have destroyed a working install to make room for one that then failed to
+ * arrive — rare, but it is the one failure with no recovery, and it is the
+ * failure the two callers' docstrings promise cannot happen.
+ *
+ * That promise matters more since #316: `install.sh` places before anything is
+ * activated, and a failed placement has to leave the machine as it was found.
+ *
+ * Both scratch paths are cleared on entry as well as on exit, so a process
+ * killed mid-swap leaves nothing for the next run to trip over or adopt.
  */
 export function installTree(source: string, installDir: string): void {
   const staging = `${installDir}.incoming`;
+  const previous = `${installDir}.previous`;
   fs.rmSync(staging, { recursive: true, force: true });
+  fs.rmSync(previous, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(installDir), { recursive: true });
   try {
     // verbatimSymlinks so a symlink inside the tarball is copied as-is rather
@@ -84,8 +96,20 @@ export function installTree(source: string, installDir: string): void {
     fs.rmSync(staging, { recursive: true, force: true });
     throw err;
   }
-  // Replace wholesale rather than copying over the top: a half-written tree
-  // from a crashed install must not survive as a merge.
-  fs.rmSync(installDir, { recursive: true, force: true });
-  fs.renameSync(staging, installDir);
+
+  // Aside, not away: `rename` cannot replace a non-empty directory, so the old
+  // tree has to leave `installDir` before the new one can arrive — but it does
+  // not have to stop existing until the new one has.
+  const displaced = lstatOrNull(installDir) !== null;
+  if (displaced) fs.renameSync(installDir, previous);
+  try {
+    fs.renameSync(staging, installDir);
+  } catch (err) {
+    if (displaced) fs.renameSync(previous, installDir);
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw err;
+  }
+  // Replace wholesale rather than merging: a half-written tree from a crashed
+  // install must not survive inside the new one.
+  fs.rmSync(previous, { recursive: true, force: true });
 }

--- a/packages/panel/src/components/views/CoreNeedsUpdate.tsx
+++ b/packages/panel/src/components/views/CoreNeedsUpdate.tsx
@@ -11,6 +11,11 @@ import { CORE_UPDATE_COMMAND, coreDriftDirection, type CoreDialStatus } from "~/
 // on a different machine — usually from a phone or a second laptop, which is
 // the whole point of the Panel being a web service.
 //
+// **The command has to leave the daemon running the new version**, or the
+// button is decoration: the Core would keep announcing the old protocol and
+// this notice would keep saying the same thing. `CORE_UPDATE_COMMAND`'s
+// docstring says which command does that and which two do not.
+//
 // Everything else about the Core — its projects, sessions, terminals — is
 // suppressed at the panel-link router, so this notice stands where that data
 // would have been rather than beside it.
@@ -73,7 +78,7 @@ export function CoreNeedsUpdateNotice({
       <div style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.45 }}>
         {panelBehind
           ? "This Core is ahead of this Panel. Its sessions stay hidden until the Panel itself is upgraded — pull a newer Panel and restart it."
-          : "Its sessions stay hidden until the Core on that machine is updated. Run this there — it upgrades in place and keeps the pairing:"}
+          : "Its sessions stay hidden until the Core on that machine is updated. Run this there — it lands the new version, restarts the daemon, and keeps the pairing:"}
       </div>
       {!panelBehind && (
       <div

--- a/packages/panel/src/components/views/__tests__/CoreNeedsUpdate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/CoreNeedsUpdate.test.tsx
@@ -7,6 +7,13 @@ import { CORE_UPDATE_COMMAND, type CoreDialStatus } from "~/shared/cores";
 // What the operator is owed when a Core drifts: the fact, the two versions, and
 // the one command that fixes it — copyable, because it is going to be pasted
 // into a terminal on another machine.
+//
+// Every assertion below reads `CORE_UPDATE_COMMAND` rather than a literal, so
+// none of them can tell whether the constant still names a command that works.
+// `the command it offers actually updates a running Core` is the one that can,
+// and it is here because #316 broke the old value: `install.sh` installs and no
+// longer activates, so the installer one-liner now lands a tree and leaves the
+// daemon on the version it started with — a notice that would never clear.
 
 function needsUpdate(overrides: Partial<CoreDialStatus> = {}): CoreDialStatus {
   return {
@@ -55,6 +62,20 @@ describe("CoreNeedsUpdateNotice", () => {
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/ahead of this Panel/i);
     expect(screen.queryByText(CORE_UPDATE_COMMAND)).toBeNull();
+  });
+
+  // Bound to the value, not to the rendering: the rest of this file would pass
+  // just as happily with a command that does nothing.
+  it("the command it offers actually updates a running Core", () => {
+    // `actana update` is the only one of the three candidates that lands the
+    // new tree *and* restarts the daemon onto it (see the constant's
+    // docstring). The installer one-liner stopped doing the second half in
+    // #316, and `install.sh … && actana setup` is the gesture for activating a
+    // machine, not for upgrading one that is already a Core.
+    expect(CORE_UPDATE_COMMAND).toBe("actana update");
+    expect(CORE_UPDATE_COMMAND).not.toMatch(/install\.sh/);
+    expect(CORE_UPDATE_COMMAND).not.toMatch(/\bcurl\b/);
+    expect(CORE_UPDATE_COMMAND).not.toMatch(/\bsetup\b/);
   });
 
   it("stays useful when the Core advertised no version at all", () => {

--- a/packages/panel/src/shared/cores.ts
+++ b/packages/panel/src/shared/cores.ts
@@ -80,17 +80,30 @@ export type CoreDialStatus = {
 };
 
 /**
- * The command that brings a Core up to date — the same one-liner that installed
- * it. Re-running it on that machine upgrades the Core in place, keeping the
- * pairing (INSTALL.md, "Re-running the one-liner … upgrades it in place"), so
+ * The command that brings a Core up to date: `actana update`, run on that
+ * machine. It resolves the latest release, verifies it against the release's
+ * own `SHA256SUMS`, swaps `current` onto the new tree and **restarts the
+ * daemon**, leaving the pairing material and the data dir untouched — so
  * "needs update" is one paste on the Core rather than a re-pair in the Panel.
  *
- * The `actana` bundle will eventually own this as an `update` verb (CONTEXT.md);
- * until that verb exists, the installer *is* the update path and this is the
- * only command that actually works.
+ * **This was the installer one-liner, and it stopped working as one** (#316).
+ * `install.sh` installs and no longer activates (ADR 0036 C2): pasting it
+ * downloads the bundle, writes a new `versions/<v>`, repoints `current` and
+ * exits. The daemon keeps executing the version it started on, so the Core
+ * still announces the old protocol, the Panel still says "needs update", and
+ * the button never fixes anything. The one-liner plus `actana setup` would
+ * close the gap, but it is the wrong gesture for a machine that already has a
+ * Core: setup is what *activates* a machine, and this one is already active.
+ *
+ * The verb this docstring used to say did not exist yet does now
+ * (`packages/cli/src/actana-update.ts`), and it is the only one of the three
+ * that both lands the new tree and leaves the daemon running on it.
+ *
+ * A Core running as a container refuses `actana update` and names
+ * `docker compose pull && docker compose up -d` instead, which is the right
+ * answer there and is more than the one-liner ever gave that operator.
  */
-export const CORE_UPDATE_COMMAND =
-  "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash";
+export const CORE_UPDATE_COMMAND = "actana update";
 
 /**
  * The command that brings a Panel up to date.

--- a/scripts/__tests__/install-sh.test.mjs
+++ b/scripts/__tests__/install-sh.test.mjs
@@ -8,8 +8,19 @@
 // container e2e (`scripts/e2e-actana-setup-linux.mjs`) runs the same script
 // against a real tarball on a real init system; this file covers the decisions
 // the bootstrapper itself makes — platform mapping, version resolution,
-// checksum verification, flag passthrough, exit codes — in under a second, on
-// every platform CI runs.
+// checksum verification, which verb it hands the bundle to, exit codes — in
+// under a second, on every platform CI runs.
+//
+// **Install is not activation** (ADR 0036 C2, #316). The script places the
+// bundle and stops: it runs `actana place`, never `actana setup`, and the
+// flags it used to forward to setup are refused rather than ignored. Two
+// things follow for this file, and they are what the placement block below is
+// for. First, "did not run setup" is only half a contract — the other half is
+// that something *was* placed, outside the temp directory the EXIT trap
+// deletes, or a successful run would leave the machine as it was found.
+// Second, the next command is printed by the CLI (which knows the layout) and
+// never by the script, so what is asserted here is that the script adds no
+// second copy of it.
 //
 // Platform mapping is tested by putting a `uname` shim first on PATH. It looks
 // like a trick and is the opposite: `uname` is precisely the input the script
@@ -48,8 +59,16 @@ const BROKEN_VERSION = "0.0.9";
 
 /**
  * Stands in for the tarball's `bin/actana`: prints what it was called with and
- * whether it got a terminal, so the tests can assert both the flags that
- * reached `actana setup` and that a piped run has no TTY to prompt on.
+ * whether it got a terminal, so the tests can assert both the verb the
+ * bootstrapper handed the bundle to and that no run has a TTY to prompt on.
+ *
+ * It also does the smallest honest version of what `actana place` does — write
+ * one file *outside* the script's temp directory. That is the property the
+ * whole ticket turns on: before #316 the extracted tree survived only because
+ * `actana setup` copied it into the install layout, so a script that stopped
+ * calling setup and placed nothing would install nothing at all and still
+ * exit 0. The real placement is unit-tested in `packages/cli` and exercised
+ * for real by the container e2e; here it only has to be observable.
  */
 const stubActana = (version, target) => `#!/bin/sh
 printf 'stub-actana version=%s target=%s\\n' '${version}' '${target}'
@@ -59,6 +78,13 @@ if [ -t 0 ]; then printf 'tty=yes\\n'; else printf 'tty=no\\n'; fi
 # /dev/null, which is what stops a piped install being eaten by its own child.
 printf 'stdin=%s\\n' "$(cat)"
 if [ -n "\${ACTANA_STUB_LOG:-}" ]; then printf '%s\\n' "$*" >> "\${ACTANA_STUB_LOG}"; fi
+if [ -n "\${ACTANA_STUB_PLACED:-}" ] && [ "\${ACTANA_STUB_EXIT:-0}" = "0" ]; then
+  mkdir -p "$(dirname "\${ACTANA_STUB_PLACED}")"
+  printf 'placed by: %s\\n' "$*" > "\${ACTANA_STUB_PLACED}"
+fi
+# The CLI is the half that knows the layout, so the CLI is the half that
+# prints the next command. \`NEXT\` stands in for that line.
+printf 'NEXT %s/bin/actana setup\\n' "\${ACTANA_STUB_CURRENT:-/home/op/.local/share/actana/current}"
 exit \${ACTANA_STUB_EXIT:-0}
 `;
 
@@ -175,12 +201,17 @@ describeOnPosix("install.sh", () => {
     const tmpDir = path.join(caseDir, "tmp");
     fs.mkdirSync(tmpDir, { recursive: true });
     const stubLog = path.join(caseDir, "actana-args.log");
+    // Outside `tmpDir` on purpose: this is the stand-in for the install layout,
+    // and the whole question is whether what the CLI wrote outlives the temp
+    // directory the script's EXIT trap removes.
+    const placed = path.join(caseDir, "placed", "marker");
 
     const env = {
       ...process.env,
       PATH: `${unameShim(caseDir, uname[0], uname[1], rosetta)}:${process.env.PATH}`,
       TMPDIR: tmpDir,
       ACTANA_STUB_LOG: stubLog,
+      ACTANA_STUB_PLACED: placed,
       ...extraEnv,
     };
     let stdin = "ignore";
@@ -203,6 +234,9 @@ describeOnPosix("install.sh", () => {
       /** The argv `actana` was execed with, or null when it never ran. */
       actanaArgs: fs.existsSync(stubLog) ? fs.readFileSync(stubLog, "utf8").trim() : null,
       tmpDir,
+      /** Whether anything survived the script — see `stubActana`. */
+      placed: fs.existsSync(placed),
+      placedPath: placed,
     };
   }
 
@@ -224,11 +258,11 @@ describeOnPosix("install.sh", () => {
   const withServer = (args = []) => ["--base-url", server.url, ...args];
 
   describe("resolving a release", () => {
-    it("installs the latest release and hands off to `actana setup`", async () => {
-      const run = await runInstaller({ args: withServer(["--yes"]) });
+    it("installs the latest release and places it with `actana place`", async () => {
+      const run = await runInstaller({ args: withServer([]) });
       expect(run.status, run.output).toBe(0);
       expect(run.stdout).toContain(`version=${NEW_VERSION}`);
-      expect(run.actanaArgs).toBe("setup --yes");
+      expect(run.actanaArgs).toBe("place");
 
       const fetched = traffic();
       expect(fetched).toContain(`/repos/${DEFAULT_REPO}/releases/latest`);
@@ -379,16 +413,64 @@ describeOnPosix("install.sh", () => {
     });
   });
 
-  describe("handing off to `actana setup`", () => {
-    it("forwards every flag it does not own, in order", async () => {
-      const run = await runInstaller({
-        args: withServer(["--yes", "--public-host", "10.0.0.7", "--label", "build-box", "--no-harnesses"]),
-      });
+  // ─── install is not activation (ADR 0036 C2, #316) ─────────────────────────
+  //
+  // This block replaces the `handing off to \`actana setup\`` one it is the same
+  // size as. The old contract was "the flags reach setup, the exit code comes
+  // back, and stdin is not eaten"; the new one is "the bundle is placed, setup
+  // is not run, setup's flags are refused, the failure still comes back, and
+  // stdin is still not eaten". Deleting the old cases without replacing them
+  // would have left the negative space around the tail thinner than the tail
+  // it removed.
+  describe("placing the bundle, and stopping there", () => {
+    it.each([[[]], [["--version", OLD_VERSION]]])(
+      "runs `actana place`, and never `actana setup`, with %j",
+      async (args) => {
+        const run = await runInstaller({ args: withServer(args) });
+        expect(run.status, run.output).toBe(0);
+        expect(run.actanaArgs).toBe("place");
+        expect(run.actanaArgs).not.toMatch(/setup/);
+      },
+    );
+
+    it("runs `actana place` with no terminal, the same as when piped", async () => {
+      // The one shape that used to take the other branch: run as a file, so
+      // the old tail's `[ -t 0 ]` test would have handed stdin straight
+      // through. There is no branch left — nothing the script runs prompts.
+      const run = await runInstaller({ args: withServer([]), piped: false });
       expect(run.status, run.output).toBe(0);
-      expect(run.actanaArgs).toBe("setup --yes --public-host 10.0.0.7 --label build-box --no-harnesses");
+      expect(run.actanaArgs).toBe("place");
+      expect(run.stdout).toContain("tty=no");
     });
 
-    it("hands setup an empty stdin when there is no terminal", async () => {
+    // The property the whole ticket turns on. Before #316 the extracted tree
+    // survived only because `actana setup` copied it out of the temp
+    // directory, so a script that stopped calling setup and placed nothing
+    // would install nothing and still exit 0 — the most expensive way to pass
+    // a test suite.
+    it("leaves something behind: the placement outlives the temp dir", async () => {
+      const run = await runInstaller({ args: withServer([]) });
+      expect(run.status, run.output).toBe(0);
+      expect(run.placed, `nothing was placed at ${run.placedPath}`).toBe(true);
+      expect(fs.readFileSync(run.placedPath, "utf8")).toContain("place");
+      // And the download itself did not survive with it.
+      expect(fs.readdirSync(run.tmpDir)).toEqual([]);
+    });
+
+    it("prints the next command once — the CLI's copy, not a second one", async () => {
+      const run = await runInstaller({ args: withServer([]) });
+      expect(run.status, run.output).toBe(0);
+      // The stub stands in for the CLI, which is the half that knows the
+      // layout and therefore the half that prints the runnable command. A
+      // script that printed its own `actana setup` line would be a second
+      // copy free to disagree with it — about the launcher's path, most of
+      // all, which is exactly what an operator whose bin dir is not on PATH
+      // needs to be right.
+      expect(run.stdout).toMatch(/^NEXT \S+\/bin\/actana setup$/m);
+      expect(run.stdout.match(/\bsetup\b/g)).toHaveLength(1);
+    });
+
+    it("hands the CLI an empty stdin, so a piped install is not eaten by its child", async () => {
       // The installer is run as a file with real data waiting on its stdin —
       // the shape a `curl | bash` run has, where that data is the rest of the
       // script. If it passed stdin through, the stub would read LEFTOVER and
@@ -403,19 +485,63 @@ describeOnPosix("install.sh", () => {
       expect(run.stdout).not.toContain("LEFTOVER");
     });
 
-    it("gives setup no terminal to prompt on when piped", async () => {
-      const run = await runInstaller({ args: withServer([]), piped: true });
-      expect(run.stdout).toContain("tty=no");
+    // Every flag `usage()` used to advertise as passthrough, one case each: an
+    // operator pasting last month's command line has to be told where their
+    // flag went, and a loop inside one `it` would stop at the first one that
+    // regressed.
+    const SETUP_FLAGS = [
+      ["--yes"],
+      ["--public-host", "10.0.0.7"],
+      ["--public-host=10.0.0.7"],
+      ["--label", "build-box"],
+      ["--port", "9443"],
+      ["--host", "0.0.0.0"],
+      ["--no-harnesses"],
+      ["--with-codex"],
+    ];
+
+    it.each(SETUP_FLAGS)("refuses %s, and says it belongs to `actana setup`", async (...flag) => {
+      const run = await runInstaller({ args: withServer(flag) });
+      expect(run.status, `${flag.join(" ")}: ${run.output}`).not.toBe(0);
+      expect(run.output).toContain(flag[0].split("=")[0]);
+      expect(run.output).toMatch(/actana setup/);
+      // Refused while parsing, so nothing was fetched and nothing was run.
+      expect(run.actanaArgs).toBeNull();
+      expect(run.placed).toBe(false);
+      expect(traffic()).toEqual([]);
     });
 
-    it("propagates setup's exit code", async () => {
+    it("refuses a flag nobody owns rather than passing it on", async () => {
+      // The old script swallowed every unrecognised token and handed it to
+      // setup, so `--pubic-host 10.0.0.7` reached the CLI and was rejected
+      // there. There is nothing downstream to reject it now, and silently
+      // dropping the one flag that decides whether a Panel can reach this
+      // machine is the failure this refusal exists for.
+      const run = await runInstaller({ args: withServer(["--pubic-host", "10.0.0.7"]) });
+      expect(run.status).not.toBe(0);
+      expect(run.output).toContain("--pubic-host");
+      expect(run.actanaArgs).toBeNull();
+      expect(traffic()).toEqual([]);
+    });
+
+    it("comes back with the placement's own failure status", async () => {
+      // There is no `setup` exit code to propagate any more, and `set -e` is
+      // what carries this one out. A placement that failed and an install that
+      // reported success would be the worst of the two.
       const run = await runInstaller({ args: withServer([]), env: { ACTANA_STUB_EXIT: "7" } });
       expect(run.status).toBe(7);
+      expect(run.placed).toBe(false);
     });
 
     it("leaves no temporary files behind", async () => {
       const run = await runInstaller({ args: withServer([]) });
       expect(run.status, run.output).toBe(0);
+      expect(fs.readdirSync(run.tmpDir)).toEqual([]);
+    });
+
+    it("leaves no temporary files behind when the placement fails either", async () => {
+      const run = await runInstaller({ args: withServer([]), env: { ACTANA_STUB_EXIT: "7" } });
+      expect(run.status).toBe(7);
       expect(fs.readdirSync(run.tmpDir)).toEqual([]);
     });
   });
@@ -428,6 +554,32 @@ describeOnPosix("install.sh", () => {
       expect(traffic()).toEqual([]);
     });
 
+    it("describes what it does now: two commands, and no passthrough", async () => {
+      const run = await runInstaller({ args: ["--help"] });
+      const text = run.stdout;
+      // The help is the only place an operator learns there is a second
+      // command, so it has to name it and it has to stop advertising the
+      // flags the script no longer carries.
+      expect(text).toMatch(/actana setup/);
+      expect(text).toMatch(/Installing is not activating/i);
+      expect(text).not.toMatch(/passed through|passthrough/i);
+      for (const gone of ["--with-", "--no-harnesses"]) {
+        // Named only as somebody else's, never as this script's own option.
+        const owned = new RegExp(`^\\s{2}${gone.replace("-", "\\-")}\\S*\\s{2,}\\S`, "m");
+        expect(text, `${gone} is still documented as an installer option`).not.toMatch(owned);
+      }
+    });
+
+    it("does not claim to hand over to `actana setup` in its own header", () => {
+      // The header is the first thing anyone reading the script sees, and it
+      // said the job was "fetch, verify, exec" for as long as that was true.
+      const source = fs.readFileSync(INSTALL_SH, "utf8");
+      const header = source.slice(0, source.indexOf("set -eu"));
+      expect(header).not.toMatch(/hand over to/i);
+      expect(header).not.toMatch(/fetch, verify, exec/);
+      expect(header).toMatch(/fetch, verify, place/);
+    });
+
     it("rejects a flag of its own that was given no value", async () => {
       const run = await runInstaller({ args: withServer(["--version"]) });
       expect(run.status).not.toBe(0);
@@ -436,9 +588,9 @@ describeOnPosix("install.sh", () => {
     });
 
     it("rejects a flag whose value is the next flag, rather than eating it", async () => {
-      // `--version --yes` pinning a release called "--yes" and swallowing the
-      // flag that was meant for setup is the quiet kind of wrong.
-      for (const args of [["--version", "--yes"], ["--repo", "--yes"], ["--version="]]) {
+      // `--version --repo` pinning a release called "--repo" and swallowing
+      // the flag behind it is the quiet kind of wrong.
+      for (const args of [["--version", "--repo"], ["--repo", "--base-url"], ["--version="]]) {
         const run = await runInstaller({ args: withServer(args) });
         expect(run.status, `${args.join(" ")}: ${run.output}`).not.toBe(0);
         expect(run.output).toMatch(/needs a value/);
@@ -463,11 +615,11 @@ describeOnPosix("install.sh", () => {
       const stubLog = path.join(caseDir, "actana-args.log");
       const result = await runToCompletion(
         "/bin/sh",
-        ["-c", `curl -fsSL "$0/install.sh" | sh -s -- --base-url "$0" --yes`, server.url],
+        ["-c", `curl -fsSL "$0/install.sh" | sh -s -- --base-url "$0"`, server.url],
         { ...process.env, TMPDIR: caseDir, ACTANA_STUB_LOG: stubLog },
       );
       expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-      expect(fs.readFileSync(stubLog, "utf8").trim()).toBe("setup --yes");
+      expect(fs.readFileSync(stubLog, "utf8").trim()).toBe("place");
     });
   });
 });

--- a/scripts/__tests__/rehearsal.test.mjs
+++ b/scripts/__tests__/rehearsal.test.mjs
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { hostTarget, pickTarball, rehearsalOneLiner } from "../lib/rehearsal.mjs";
+import {
+  hostTarget,
+  pickTarball,
+  rehearsalOneLiner,
+  rehearsalSetupCommand,
+} from "../lib/rehearsal.mjs";
 
 import { captureFailure } from "./capture-failure.mjs";
 
@@ -62,5 +67,30 @@ describe("rehearsalOneLiner", () => {
   it("passes nothing that suppresses a prompt — the prompts are the rehearsal", () => {
     const command = rehearsalOneLiner(url);
     expect(command).not.toMatch(/--yes|--no-harnesses|--with-/);
+  });
+
+  // Since #316 those flags are not merely unwanted here: `install.sh` refuses
+  // them, so a one-liner carrying one would end the rehearsal at the first
+  // paste. This is the same claim as the test above, bound to the script's
+  // own option list rather than to a preference.
+  it("carries only options `install.sh` still owns", () => {
+    const flags = rehearsalOneLiner(url).match(/--[a-z-]+/g) ?? [];
+    for (const flag of flags) {
+      expect(["--base-url"], `${flag} is not an installer option`).toContain(flag);
+    }
+  });
+});
+
+describe("rehearsalSetupCommand", () => {
+  // The rehearsal is two commands now — install is not activation (ADR 0036
+  // C2). A rehearsal that printed only the first would stall at an installed
+  // machine with nothing running on it, which is exactly what the operator
+  // is there to avoid discovering in production.
+  it("is the second command, and it is the one with the prompts in it", () => {
+    expect(rehearsalSetupCommand()).toBe("actana setup");
+  });
+
+  it("suppresses no prompt either", () => {
+    expect(rehearsalSetupCommand()).not.toMatch(/--yes|--no-harnesses|--with-/);
   });
 });

--- a/scripts/__tests__/setup-e2e.test.mjs
+++ b/scripts/__tests__/setup-e2e.test.mjs
@@ -1,0 +1,80 @@
+// The one decision `scripts/lib/setup-e2e.mjs` makes without a machine in
+// front of it: reading the `actana setup` command out of what the installer
+// printed.
+//
+// It is tested here rather than only inside the container e2e because the
+// container e2e cannot fail *usefully* on it — a bad extraction there shows up
+// as "`ctana setup --public-host 127.0.0.1`: command not found" twenty minutes
+// into a run, or worse, as a run that silently never activates the machine and
+// then fails on an assertion three screens later.
+
+import { describe, expect, it } from "vitest";
+
+import { nextSetupCommand } from "../lib/setup-e2e.mjs";
+
+import { captureFailure } from "./capture-failure.mjs";
+
+/** What `actana place` prints, in the shape it prints it. */
+const placed = (command) =>
+  [
+    "Installing the Actana Core 0.4.1 for linux-x64.",
+    "Checksum verified against the release's SHA256SUMS.",
+    "",
+    "Core 0.4.1 installed at /home/op/.local/share/actana/versions/0.4.1",
+    "  Launcher   /home/op/.local/bin/actana",
+    "  Current    /home/op/.local/share/actana/current",
+    "",
+    "Nothing is running yet: this machine is not a Core until you set it up.",
+    "",
+    `  ${command}`,
+    "",
+    "That writes this Core's identity, its auto-start service and its registration.",
+  ].join("\n");
+
+describe("nextSetupCommand", () => {
+  it("reads back the bare command when the launcher answers to `actana`", () => {
+    expect(nextSetupCommand(placed("actana setup"), () => {})).toBe("actana setup");
+  });
+
+  // The case a hard-coded `actana setup` in the e2e would hide, and the reason
+  // the command is extracted rather than retyped: a fresh machine has no
+  // `~/.local/bin` at login, so it is not on `PATH`, so the runnable form is a
+  // path.
+  it("reads back the absolute path when the launcher's directory is not on PATH", () => {
+    const absolute = "/home/op/.local/share/actana/current/bin/actana setup";
+    expect(nextSetupCommand(placed(absolute), () => {})).toBe(absolute);
+  });
+
+  // `machinectl shell` pipes the container session through a PTY, so what the
+  // Linux e2e reads back is CRLF. This is the whole reason the pattern is not
+  // anchored on `[ \t]*$`.
+  it("reads it back out of PTY output, where every line ends CRLF", () => {
+    const pty = placed("actana setup").replace(/\n/g, "\r\n");
+    expect(nextSetupCommand(pty, () => {})).toBe("actana setup");
+  });
+
+  it("ignores prose that merely mentions the command", () => {
+    const noisy = [
+      "Run `actana setup` when you are ready — actana setup does the rest.",
+      "  /home/op/.local/bin/actana setup",
+    ].join("\n");
+    expect(nextSetupCommand(noisy, () => {})).toBe("/home/op/.local/bin/actana setup");
+  });
+
+  it("fails when the installer stopped saying what to run next", () => {
+    const message = captureFailure((fail) =>
+      nextSetupCommand("Core 0.4.1 installed at /home/op/.local/share/actana/versions/0.4.1", fail),
+    );
+    expect(message).toMatch(/exactly one/);
+    expect(message).toMatch(/found 0/);
+  });
+
+  // Two copies are two things free to disagree — about the launcher's path
+  // most of all. The CLI owns the line precisely so there is one.
+  it("fails when two commands were printed", () => {
+    const twice = ["  actana setup", "  /home/op/.local/bin/actana setup"].join("\n");
+    const message = captureFailure((fail) => nextSetupCommand(twice, fail));
+    expect(message).toMatch(/exactly one/);
+    expect(message).toMatch(/found 2/);
+  });
+});

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -7,14 +7,19 @@
 // machine the one-liner produced instead of on a second machine that a
 // duplicated install phase set up:
 //
-//   • the one-liner ends with a running Core, registered in this machine's own
-//     `actana`, whose credential a test client can dial the core-link with —
-//     with no `--yes` passed, because a piped (non-TTY) run must prompt for
-//     nothing, and **printing no credential of its own** (#287);
+//   • the one-liner ends with a machine that is **installed and not
+//     activated** (ADR 0036 C2, #316): the versioned tree, the `current`
+//     symlink and the launcher are there, no unit is running, and the exact
+//     `actana setup` command to run next has been printed;
+//   • that printed command, run as printed, ends with a running Core,
+//     registered in this machine's own `actana`, whose credential a test
+//     client can dial the core-link with — with no `--yes` passed, because a
+//     non-TTY run must prompt for nothing, and **printing no credential of its
+//     own** (#287);
 //   • `--version` installs that exact release; with no flag, the latest;
 //   • `status` / `start` / `stop` / `restart` / `logs` control and report the
 //     daemon, and `pair new` mints a code on it;
-//   • re-running the one-liner upgrades in place — one unit, same pairing
+//   • re-running the two commands upgrades in place — one unit, same pairing
 //     credentials, and a pre-rename `actana-harness.service` is taken out on
 //     the way;
 //   • lingering is on, and the daemon comes back after the machine reboots;
@@ -29,8 +34,8 @@
 //     dir; `--purge-data` removes that too.
 //
 // install-sh's negative cases — a bad checksum, an unknown platform,
-// `--version` pinning, non-TTY behaviour, flag passthrough, exit codes — are
-// covered hermetically and in under a second by
+// `--version` pinning, non-TTY behaviour, the refusal of `actana setup`'s
+// flags, exit codes — are covered hermetically and in under a second by
 // `scripts/__tests__/install-sh.test.mjs`, and are deliberately not repeated
 // here: each one costs a whole extra one-liner run on a real container. What
 // only a real machine can prove is that the script works against a real init
@@ -77,6 +82,7 @@ import {
 } from "./lib/fixture-release.mjs";
 import { dialAndListProjects, makeDie } from "./lib/core-smoke.mjs";
 import { tarballName as releaseAssetName } from "./lib/core-tarball.mjs";
+import { nextSetupCommand } from "./lib/setup-e2e.mjs";
 import {
   OPERATOR,
   pickHostPort,
@@ -193,18 +199,76 @@ async function main() {
     return parsed;
   };
 
-  /** The one-liner, exactly as the docs print it. */
-  const oneLiner = (url, flags) =>
-    `curl -fsSL ${url}/install.sh | bash -s -- --base-url ${url} ${flags}`;
+  /**
+   * The one-liner, exactly as the docs print it.
+   *
+   * It carries only the flags the script still owns. Since #316 it installs
+   * and does not activate, so `--public-host`, `--yes` and the rest are not
+   * merely unnecessary here — the script refuses them, and
+   * `scripts/__tests__/install-sh.test.mjs` holds that refusal.
+   */
+  const oneLiner = (url, flags = "") =>
+    `curl -fsSL ${url}/install.sh | bash -s -- --base-url ${url} ${flags}`.trimEnd();
 
-  // ─── the real thing, pinned, with no flag that suppresses prompts ───
+  /**
+   * Run the one-liner, assert it installed without activating, and hand back
+   * the `actana setup` command it printed.
+   *
+   * The two halves of #316's contract, checked together because either alone
+   * is passable by a broken script: a run that activated nothing but also
+   * placed nothing would satisfy the first, and a run that placed a bundle and
+   * started a daemon would satisfy the second.
+   */
+  const installOnly = (url, flags) => {
+    const run = mustAsOperator(oneLiner(url, flags));
+
+    // Placed: the tree, the `current` symlink and the launcher all survived
+    // the script's own EXIT trap, which is the whole of what `install.sh` now
+    // leaves behind.
+    for (const check of [
+      "test -d ~/.local/share/actana/versions",
+      "test -L ~/.local/share/actana/current",
+      "test -x ~/.local/share/actana/current/bin/actana",
+      "test -e ~/.local/bin/actana",
+    ]) {
+      if (asOperator(check).status !== 0) {
+        die(`the one-liner installed nothing: \`${check}\` failed`, run.stdout.split("\n"));
+      }
+    }
+    return { run, setupCommand: nextSetupCommand(run.stdout, die) };
+  };
+
+  // ─── the real thing, pinned: install, and only install ───
   log(`running the one-liner pinned to v${pinnedVersion}`);
-  const install = mustAsOperator(
-    oneLiner(installChannel.url, `--version ${pinnedVersion} --public-host 127.0.0.1`),
-  );
-  // #287: the install emits no credential. A PEM header or a base64 blob on
-  // stdout would be the hand-carry back, and the one-liner is where an operator
-  // would find it.
+  const placed = installOnly(installChannel.url, `--version ${pinnedVersion}`);
+
+  // **Install is not activation** (ADR 0036 C2). Nothing is running, no
+  // identity has been minted, and no unit has been written — an installer that
+  // did any of those would be the tail this ticket removed, back under another
+  // name.
+  const beforeSetup = asOperator("systemctl --user is-active actana-core.service");
+  if (beforeSetup.stdout.trim() === "active") {
+    die("the one-liner started a Core — install.sh must not activate", placed.run.stdout.split("\n"));
+  }
+  for (const trace of [
+    "~/.config/systemd/user/actana-core.service",
+    "~/.config/actana/actana.json",
+    "~/.config/actana/material.json",
+  ]) {
+    if (asOperator(`test -e ${trace}`).status === 0) {
+      die(`the one-liner wrote ${trace} — that is \`actana setup\`'s to write`);
+    }
+  }
+  log(`the one-liner installed without activating, and printed \`${placed.setupCommand}\``);
+
+  // ─── the second command, run exactly as the installer printed it ───
+  //
+  // Not a retyped `actana setup`: #316's criterion is that the printed command
+  // is runnable *as printed*, and the launcher's directory being absent from
+  // `PATH` is precisely the case a hard-coded bare `actana` would hide.
+  const install = mustAsOperator(`${placed.setupCommand} --public-host 127.0.0.1`);
+  // #287: setup emits no credential. A PEM header or a base64 blob on stdout
+  // would be the hand-carry back, and this is where an operator would find it.
   if (/BEGIN (CERTIFICATE|PRIVATE KEY|RSA PRIVATE KEY)/.test(install.stdout)) {
     die("the install printed certificate material", install.stdout.split("\n"));
   }
@@ -217,7 +281,7 @@ async function main() {
   if (/\[Y\/n\]|\(y\/n\)/i.test(install.stdout)) {
     die("a piped install prompted for input", install.stdout.split("\n"));
   }
-  log("the one-liner installed unattended, printed no credential, and named `pair new`");
+  log("`actana setup` activated the machine unattended, printed no credential, and named `pair new`");
 
   const active = mustAsOperator("systemctl --user is-active actana-core.service");
   if (active.stdout.trim() !== "active") {
@@ -339,8 +403,9 @@ async function main() {
     die(`the planted pre-rename unit is ${plantedState.stdout.trim()}, expected active`);
   }
 
-  log("re-running the one-liner with no version pinned");
-  mustAsOperator(oneLiner(installChannel.url, "--public-host 127.0.0.1"));
+  log("re-running the install with no version pinned, then setup over it");
+  const upgraded = installOnly(installChannel.url, "");
+  mustAsOperator(`${upgraded.setupCommand} --public-host 127.0.0.1`);
   // Not byte equality: the bearer inside carries a fresh expiry every time it
   // is signed. What must not change is the material the Panel pinned — a new
   // CA or client cert means the paired Panel is locked out.
@@ -530,9 +595,12 @@ async function main() {
   // The launcher is gone, so getting a CLI back means running the one-liner
   // again — which is also what an operator who uninstalled and changed their
   // mind does, and the only route left once nothing is extracted on the disk.
-  mustAsOperator(oneLiner(updateChannel.url, "--public-host 127.0.0.1"));
+  // Both commands, because uninstall removed the install and not just the
+  // service: the first puts the bundle back, the second makes it a Core again.
+  const reinstalled = installOnly(updateChannel.url, "");
+  mustAsOperator(`${reinstalled.setupCommand} --public-host 127.0.0.1`);
   await waitForPort(hostPort, die);
-  log("the one-liner reinstalled onto a machine that had been uninstalled");
+  log("the one-liner and `actana setup` reinstalled a machine that had been uninstalled");
 
   mustAsOperator("actana uninstall --purge-data --yes");
   const dataTraces = asOperator("ls -d ~/.local/share/actana ~/.config/actana 2>/dev/null; true");
@@ -544,7 +612,8 @@ async function main() {
   updateChannel.stop();
   tamperedServer.stop();
   log(
-    `OK — on ${distro.label} the one-liner installs, pins, upgrades in place, and the lifecycle verbs work`,
+    `OK — on ${distro.label} the one-liner installs without activating, \`actana setup\` activates, ` +
+      "pinning and in-place upgrades work, and so do the lifecycle verbs",
   );
   process.exit(0);
 }

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -238,6 +238,28 @@ async function main() {
     return { run, setupCommand: nextSetupCommand(run.stdout, die) };
   };
 
+  /**
+   * Run the `actana setup` the installer printed, on the machine it printed it
+   * on.
+   *
+   * **`</dev/null` is load-bearing, and it is what `install.sh` used to do.**
+   * The old tail handed setup an empty stdin on every path, so setup saw no
+   * terminal, prompted for nothing, and took the recommended answer to
+   * everything — which is the unattended install this file has always
+   * asserted, right down to `Linger=yes` with no `--yes` passed. Now that setup
+   * is its own step it runs through `machinectl shell`, which pipes the session
+   * through a **PTY** — so without this redirect setup is interactive, asks
+   * about lingering and offers the Harness CLIs one at a time, and waits
+   * forever for an answer nobody is there to give. That is a 30-minute job
+   * timeout, not a failed assertion.
+   *
+   * The interactive path is not untested; it is tested by a person, once per
+   * release, in `docs/core-linux-rehearsal.md` §2. What belongs here is the
+   * unattended one.
+   */
+  const activate = (setupCommand, flags = "") =>
+    mustAsOperator(`${setupCommand} ${flags} </dev/null`.replace(/\s+/g, " ").trim());
+
   // ─── the real thing, pinned: install, and only install ───
   log(`running the one-liner pinned to v${pinnedVersion}`);
   const placed = installOnly(installChannel.url, `--version ${pinnedVersion}`);
@@ -266,7 +288,7 @@ async function main() {
   // Not a retyped `actana setup`: #316's criterion is that the printed command
   // is runnable *as printed*, and the launcher's directory being absent from
   // `PATH` is precisely the case a hard-coded bare `actana` would hide.
-  const install = mustAsOperator(`${placed.setupCommand} --public-host 127.0.0.1`);
+  const install = activate(placed.setupCommand, "--public-host 127.0.0.1");
   // #287: setup emits no credential. A PEM header or a base64 blob on stdout
   // would be the hand-carry back, and this is where an operator would find it.
   if (/BEGIN (CERTIFICATE|PRIVATE KEY|RSA PRIVATE KEY)/.test(install.stdout)) {
@@ -405,7 +427,7 @@ async function main() {
 
   log("re-running the install with no version pinned, then setup over it");
   const upgraded = installOnly(installChannel.url, "");
-  mustAsOperator(`${upgraded.setupCommand} --public-host 127.0.0.1`);
+  activate(upgraded.setupCommand, "--public-host 127.0.0.1");
   // Not byte equality: the bearer inside carries a fresh expiry every time it
   // is signed. What must not change is the material the Panel pinned — a new
   // CA or client cert means the paired Panel is locked out.
@@ -598,7 +620,7 @@ async function main() {
   // Both commands, because uninstall removed the install and not just the
   // service: the first puts the bundle back, the second makes it a Core again.
   const reinstalled = installOnly(updateChannel.url, "");
-  mustAsOperator(`${reinstalled.setupCommand} --public-host 127.0.0.1`);
+  activate(reinstalled.setupCommand, "--public-host 127.0.0.1");
   await waitForPort(hostPort, die);
   log("the one-liner and `actana setup` reinstalled a machine that had been uninstalled");
 

--- a/scripts/fixture-release-server.mjs
+++ b/scripts/fixture-release-server.mjs
@@ -28,6 +28,7 @@ import * as path from "node:path";
 
 import { makeFail, parseArgs, stringFlag } from "./lib/cli.mjs";
 import { DEFAULT_REPO, indexReleases, startFixtureReleaseServer } from "./lib/fixture-release.mjs";
+import { rehearsalSetupCommand } from "./lib/rehearsal.mjs";
 
 const fail = makeFail("fixture-release");
 const log = (message) => console.log(`[fixture-release] ${message}`);
@@ -72,7 +73,12 @@ async function main() {
     log(`serving ${asset} corrupted — its checksum will not verify`);
   }
   log(`listening on ${server.url} (${server.repo})`);
-  log(`one-liner: curl -fsSL ${server.url}/install.sh | bash -s -- --base-url ${server.url}`);
+  // Two lines, because the one-liner installs and does not activate since #316
+  // (ADR 0036 C2). A hint that named only the first would leave a developer at
+  // an installed, inactive machine with nothing to run next — which is exactly
+  // the state the second command exists for.
+  log(`install:   curl -fsSL ${server.url}/install.sh | bash -s -- --base-url ${server.url}`);
+  log(`then:      ${rehearsalSetupCommand()}   (or the exact line the install printed)`);
 }
 
 void main().catch((err) => {

--- a/scripts/lib/panel-image.mjs
+++ b/scripts/lib/panel-image.mjs
@@ -96,6 +96,10 @@ export const CORE_HOME = "/home/core";
  */
 export const CORE_REFUSED_VERBS = Object.freeze([
   "install",
+  // `place` is `setup`'s install half since #316 (ADR 0036 C2), and it refuses
+  // here for the first half of `setup`'s reason: the image *is* the versioned
+  // tree, so there is nothing to place and no launcher to link.
+  "place",
   "setup",
   "start",
   "stop",

--- a/scripts/lib/rehearsal.mjs
+++ b/scripts/lib/rehearsal.mjs
@@ -46,10 +46,26 @@ export function pickTarball(fileNames, target, fail) {
 /**
  * The one-liner to paste inside the rehearsal machine.
  *
- * Deliberately carries no `--yes`, no `--with-<harness>` and no `--no-harnesses`:
- * the prompts are the whole point of doing this by hand, and a rehearsal that
- * skips them rehearses the unattended path CI already covers.
+ * It carries only `--base-url`, and since #316 that is the only kind of flag
+ * it *could* carry: install is not activation (ADR 0036 C2), so the script
+ * owns four options and refuses the rest. `--yes`, `--with-<harness>` and
+ * `--no-harnesses` were never wanted here anyway — the prompts are the whole
+ * point of doing this by hand, and they belong to the second command.
  */
 export function rehearsalOneLiner(baseUrl) {
   return `curl -fsSL ${baseUrl}/install.sh | bash -s -- --base-url ${baseUrl}`;
+}
+
+/**
+ * The second command of the rehearsal — the one that turns the machine into a
+ * Core, and the one with all the prompts in it.
+ *
+ * Printed as a hint rather than as gospel: `actana place` prints the runnable
+ * form itself, with an absolute path when `~/.local/bin` is not yet on the
+ * rehearser's `PATH`, and that printed line is the one to trust. Saying so
+ * here is the difference between a rehearsal that stalls at "it installed and
+ * nothing happened" and one that carries on.
+ */
+export function rehearsalSetupCommand() {
+  return "actana setup";
 }

--- a/scripts/lib/setup-e2e.mjs
+++ b/scripts/lib/setup-e2e.mjs
@@ -12,12 +12,56 @@
 // entry setup wrote — `credentialFromMaterial` in `core-smoke.mjs` builds the
 // dialling half of it.
 //
+// There is a fourth again since #316, and it is a different kind of thing:
+// picking the `actana setup` command out of the *installer's* output. Install
+// is not activation (ADR 0036 C2), so an e2e that enters at the one-liner now
+// has two steps, and the second one is a command the first one printed.
+//
 // `scripts/lib/core-smoke.mjs` stays the home for the tarball smoke's own
 // helpers — spawning the Core and dialling it. This module never spawns a
 // Core; it drives an installed one.
 
 import { spawnSync } from "node:child_process";
 import * as net from "node:net";
+
+/**
+ * A line that is nothing but an `actana setup` invocation — bare, or through
+ * an absolute path when the launcher's directory is not on `PATH`.
+ *
+ * `[^\S\n]` rather than `[ \t]` because the Linux e2e reads this back through
+ * `machinectl shell`, which pipes the session through a PTY and therefore
+ * ends every line `\r\n`. A pattern anchored on `[ \t]*$` matches nothing at
+ * all there, and it fails as "the installer printed no next command" — a
+ * diagnosis that sends the reader to the wrong file.
+ */
+const SETUP_COMMAND_LINE = /^[^\S\n]*((?:\S*\/)?actana setup)[^\S\n]*$/gm;
+
+/**
+ * The `actana setup` command the installer printed, to be run exactly as
+ * printed.
+ *
+ * **Extracted rather than retyped, and that is the point.** #316's criterion
+ * is that the printed command is runnable as printed — bare `actana setup`
+ * only when this install's own launcher answers to that name and its directory
+ * is on `PATH`, and an absolute path otherwise. An e2e that hard-coded
+ * `actana setup` would pass on a machine where the printed line was wrong, and
+ * fail on one where it was right and the launcher was somebody else's.
+ *
+ * Exactly one match is required. Zero means the installer stopped saying what
+ * to do next; more than one means two copies of a command that are free to
+ * disagree, which is the failure the CLI owning the line exists to prevent.
+ */
+export function nextSetupCommand(stdout, fail) {
+  const found = [...String(stdout).matchAll(SETUP_COMMAND_LINE)].map((match) => match[1]);
+  if (found.length !== 1) {
+    return fail(
+      `expected the installer to print exactly one \`actana setup\` command, found ` +
+        `${found.length}: ${JSON.stringify(found)}`,
+      String(stdout).split("\n"),
+    );
+  }
+  return found[0];
+}
 
 /** How long the daemon gets to answer on its port before a test gives up. */
 export const LISTEN_TIMEOUT_MS = 60_000;

--- a/scripts/rehearse-install.mjs
+++ b/scripts/rehearse-install.mjs
@@ -4,9 +4,18 @@
 // Everything CI does to the installer, it does with the prompts suppressed and
 // nobody watching. This is the other half: a throwaway systemd machine, a
 // fixture release channel serving the tarball you just built, and an
-// interactive root-less shell inside the machine with the real one-liner
-// printed above the prompt. Paste it, answer the questions, take the pairing
-// token to a live Panel, and work the Core the way an operator would.
+// interactive root-less shell inside the machine with the real commands
+// printed above the prompt. Paste them, answer the questions, pair a live
+// Panel with the code `actana pair new` prints, and work the Core the way an
+// operator would.
+//
+// **Two commands, because install is not activation** (ADR 0036 C2, #316).
+// The one-liner places the Core bundle and the CLI and stops; `actana setup`
+// is what turns the machine into a Core, and it is where every prompt this
+// rehearsal exists to exercise now lives. The installer prints the exact
+// `actana setup` line to run — including an absolute path when the launcher's
+// directory is not yet on `PATH` — so the line to paste second is the line it
+// printed, not the one below.
 //
 // Usage:
 //   pnpm core:rehearse
@@ -34,7 +43,12 @@ import { parseArgs, stringFlag } from "./lib/cli.mjs";
 import { distroDockerfile, distroFlag, imageTag } from "./lib/container-matrix.mjs";
 import { startFixtureServerProcess } from "./lib/fixture-release.mjs";
 import { makeDie } from "./lib/core-smoke.mjs";
-import { hostTarget, pickTarball, rehearsalOneLiner } from "./lib/rehearsal.mjs";
+import {
+  hostTarget,
+  pickTarball,
+  rehearsalOneLiner,
+  rehearsalSetupCommand,
+} from "./lib/rehearsal.mjs";
 import { OPERATOR, pickHostPort, run, startSystemdContainer } from "./lib/systemd-container.mjs";
 
 const die = makeDie("rehearse");
@@ -143,6 +157,15 @@ async function main() {
     "  release channel serving the build you just made:",
     "",
     `    ${oneLiner}`,
+    "",
+    "  It installs the Core bundle and the CLI and stops. Nothing is running",
+    "  yet: installing is not activating. It prints the command that turns",
+    "  this machine into a Core — run that one next, exactly as printed:",
+    "",
+    `    ${rehearsalSetupCommand()}`,
+    "",
+    "  That is the command with the prompts in it — lingering, the Harness",
+    "  offers — which is what you are here to work through by hand.",
     "",
     `  Serving: ${path.basename(tarball)}`,
     `  The Core will be reachable from this machine on port ${hostPort}.`,


### PR DESCRIPTION
Closes #316. **Base is `feat/release-pipeline`** — the feature branch for #314 — not `main`
and not `beta/0.4.1`.

## What changed

`install.sh` ended by running `actana setup`, so one line both **installed** a Core bundle
and **activated** the machine as a Core: mTLS material, a unit or LaunchAgent, lingering, the
daemon, registration in this machine's own registry. ADR 0036 **C2** records
install-is-not-activation as a fixed operator constraint. This is that tail coming out.

The script now resolves, downloads, verifies against `SHA256SUMS`, extracts, **places the
bundle and links the launcher**, prints the `actana setup` line to run next, and exits 0.
There is no flag for it — it is what the script does.

## The part that is more than deleting eleven lines

The extracted tree is ephemeral: `install.sh` unpacks into `mktemp -d` and deletes it on
EXIT. It survived only because `runActanaSetup` copied it into place. Remove the `setup` call
and nothing is installed at all.

So placement moved ahead of activation, and it did **not** move into POSIX sh.
`runActanaSetup` is split into `planCorePlacement` + `placeCoreBundle`, `actana place` is the
verb that stops there, and setup calls the same two functions before it activates anything.
One implementation entered at two points — the arrangement `actana-install.ts` already uses
for the download half. `resolveActanaLayout` stays the one place `ACTANA_HOME`,
`ACTANA_CONFIG_DIR`, `ACTANA_DATA_DIR`, `ACTANA_BIN_DIR` and the two XDG variables are
resolved.

The plan and the write are separate calls because setup does two things in the gap: it
removes a pre-rename unit and stops a running daemon, and neither belongs to placement.

## Forwarded flags: refused, not echoed

The ticket left this open. **The script stops accepting them.** Every flag it forwarded
belonged to `actana setup`, and setup is a separate command now — accepting `--public-host`
and doing nothing with it would silently drop the one setting that decides whether a Panel
can reach the machine. The six that `usage()` documented as passthrough are named one by one
so an operator pasting an old command line is told where their flag went, and anything else
gets an "unknown option" that points at the same place.

The e2e passes `--public-host` to its own `setup` step, which is what the ticket describes.

## The next command, and who prints it

`setupCommandFor` picks it: bare `actana setup` only when this install's own launcher answers
to that name **and** its directory is on `PATH`; a path through `current` otherwise. Both
failing cases are real — a fresh machine has no `~/.local/bin` at login, and an `actana` from
npm has no bundle around it, so `setup` there would download a release rather than activate
the one just placed.

The CLI prints it, because the CLI is the half that knows the layout. The script deliberately
prints no second copy, and a test asserts the word appears exactly once in a run's output.

## Landmine three: tested, not reasoned about

`deploy/core.Dockerfile` sets `NPM_CONFIG_PREFIX=/home/core/.local`, so an
`npm i -g @actana/cli` shim lands at exactly the path `resolveActanaLayout` calls `binLink`.
Placement reaches that path before setup does now. `claimLauncher` is on the placement path,
and **the committed coverage is two suites**, both against real files rather than a stubbed
`exists`: `actana-setup.test.ts` → *placeCoreBundle — the launcher path still has one owner*,
and `actana-machine-cli.test.ts` → *place* → *does not clobber an `actana` somebody else
installed at the same path*. Container-side, `place` joins `CORE_REFUSED_VERBS`, which
`panel-image.test.mjs` binds to `DOCKER_EQUIVALENT` and `smoke-core-image.mjs` runs against
the real image in CI. **The CLI-only path is not broken.**

The same collision was also walked through by hand against the real script and a real built
CLI — see *Verification* — but that was out-of-band checking, not a level of coverage. The
two suites above are what CI enforces.

## Not in this PR

- **No stamping.** ADR 0036 D1/D2 is #317. Nothing here makes it harder: the header, `usage()`
  and the resolution block are all still where #317 needs them, and `resolve_version` is
  untouched.
- Nothing under `.github/workflows` (#325), nothing in `packages/shared/src/semver.ts`,
  `packages/cli/src/actana-update.ts` or `packages/core/src/core-update-notice.ts` (#322), no
  `packages/shared/src/actana-release-channel.ts` (ADR 0036 D6 → #322), no tarball scripts
  under `scripts/lib`.
- The wider docs sweep is #323. `INSTALL.md` is corrected so it is not actively wrong, and
  README's front-page one-liner with it.

## Review round 2

Four blocking findings, all fixed; findings 5–10 fixed too, 11 fixed.

- **B1** `INSTALL.md`'s macOS section said the installer *"hands over to `actana setup`"* and
  loads a LaunchAgent, over a bare one-liner code block. Rewritten to two commands, with the
  absolute-path case named — a Mac that has never had `~/.local/bin` on `PATH` is the ordinary
  case there.
- **B2** `CORE_UPDATE_COMMAND` → **`actana update`**, not the two-step form. It is the only
  candidate that lands the new tree *and* restarts the daemon onto it, which is what "needs
  update" has to clear; `install.sh` + `actana setup` would work but is the wrong gesture —
  `setup` activates a machine, and this one is already active — and it drags a full install
  through a machine that already has the bundle. The constant's docstring said the verb did
  not exist yet; it does now. Every existing test read the constant rather than a literal, so
  none of them could tell its value had stopped working — one now binds the value.
- **B3** `docs/core-linux-rehearsal.md` §2 split into install and activate, with every prompt
  box moved to the second step and a new box for "the printed line runs". The page was
  unpassable as written, and its own unticked boxes are release blockers.
- **B4** Below.
- **N5** `place` now stops a daemon whose own `installDir` it is about to replace, and says so.
  Only when there is a tree at that path to destroy — a fresh machine asks the init system
  nothing — and best-effort, because placement must not fail for a reason that belongs to
  activation. Tested on both systemd and launchd.
- **N6** When an activated install is already present, the summary names both versions, says
  the daemon is still on the old one, and calls the printed command finishing the upgrade.
- **N7** The `Launcher` row is gated on `outcome === "linked"`; otherwise it names the program
  that owns the name.
- **N8** `installTree` moves the old tree aside to `<installDir>.previous` and puts it back if
  the rename fails, instead of deleting it first. Both docstrings are true now rather than
  aspirational.
- **N9** The guard test fails during the copy (`chmod 000`) instead of at `missingTreeFile`, so
  it enters the branch it is named for.
- **N10** `fixture-release-server.mjs` prints both commands.
- **N11** `INSTALL.md:5` rewrapped.

Nothing deferred. Boundaries unchanged: no `.github/workflows`, no `semver.ts`,
`actana-update.ts`, `actana-release.ts` or `core-update-notice.ts`, no
`packages/shared/src/actana-release-channel.ts`.

## Verification

- `packages/cli`: 1029 passed, 3 skipped. Root script suite: 567 passed. `tsc --noEmit` clean
  for cli/core/shared/sdk; `eslint` clean.
- **The real script against the real CLI**, out of band: a bundle built from
  `dist-tarball/actana-cli.cjs`, served by the fixture release server, installed by the real
  one-liner. Verified end to end — exit 0; `versions/<v>`, `current` and the launcher all
  present; nothing under `~/.config`; no temp files left; every `ACTANA_*` and XDG override
  honoured (including "a relative `ACTANA_*` resolves against `$HOME`, a relative XDG value is
  ignored"); the npm-shim collision refused without clobbering; the printed command absolute
  when the bin dir is off `PATH`, bare when it is on, and runnable in both cases.
- `scripts/e2e-actana-setup-linux.mjs` **was not run**: this machine has no Docker and no
  systemd. Its one new piece of logic — reading the printed command back out — is unit-tested
  in `scripts/__tests__/setup-e2e.test.mjs`, CRLF included, because `machinectl shell` pipes
  through a PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01811GQ3GsC6v7mCTkag9a7m

