### PR TITLE
feat(install.sh): the stamped line is the channel, resolved per line (#317)

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -980,12 +980,22 @@ re-cut it when the guess was wrong — which it was on the first promotion after
 the clause was written.
 
 The cut creates `beta/x.y.z` from `main` and writes that version into every
-manifest in one commit (D3, amended by #152 and #157). A required check on the
-train asserts every one of them equals the branch's version, so drift afterwards
-is impossible rather than merely discouraged. That commit **is** the stamp: a
-branch created without it is a train that looks right and carries the previous
-train's versions, and it stays quiet until the first pull request into it goes
-red with six errors at once, on whoever happened to open it.
+manifest in one commit (D3, amended by #152 and #157), **and into `install.sh`'s
+line stamp beside them** ([ADR 0036](adr/0036-the-beta-release-channel.md) D1). A
+required check on the train asserts every manifest equals the branch's version,
+so drift afterwards is impossible rather than merely discouraged. That commit
+**is** the stamp: a branch created without it is a train that looks right and
+carries the previous train's versions, and it stays quiet until the first pull
+request into it goes red with six errors at once, on whoever happened to open it.
+
+The stamp in `install.sh` is a seventh file and **not** a seventh manifest. It is
+what makes the copy of the installer on this train install this train's beta and
+the copy on `main` install the release, out of bytes that become identical at the
+promotion fast-forward (0036 D1 and D2) — so a train cut without it serves the
+previous line's beta from its own door, silently. It is edited on its own line
+below rather than added to `files=()` because `install.sh` is not a workspace
+package, and `Train rules`' manifest set deliberately refuses to grow past the
+packages (0036 D4).
 
 ```bash
 git fetch origin --prune
@@ -1014,6 +1024,12 @@ VERSION=x.y.z node -e '
 
 for file in "${files[@]}"; do jq -r --arg f "$file" '"\($f): \(.version)"' "$file"; done
 
+# The line stamp (ADR 0036 D1) — one assignment on one line, so this is a `sed`
+# and the diff stays one line like the six above. `-i.bak` because BSD `sed` on
+# macOS requires an argument to `-i` and GNU `sed` accepts one.
+sed -i.bak 's/^LINE=".*"$/LINE="x.y.z"/' install.sh && rm -f install.sh.bak
+grep -n '^LINE=' install.sh                    # must print LINE="x.y.z"
+
 git commit -a -F cut-message.txt               # Conventional Commits, see below
 git push --no-verify origin beta/x.y.z         # --no-verify: see below
 ```
@@ -1036,14 +1052,19 @@ too late:
   and ran `git config core.hooksPath .husky`, which you should have. Tracked
   as #269; when the hook learns the class, drop the `--no-verify`.
 - **The diff is only the cut.** `git diff origin/main beta/x.y.z` is exactly
-  those six manifests and six lines.
-- **The line stamp, once it exists.** [ADR 0036](adr/0036-the-beta-release-channel.md)
-  D1 gives `install.sh` a stamped line version and says it is *"written by the
-  cut exactly as the six manifests are"*. That is this procedure — the cut is
-  the hand that writes it, and [#317](https://github.com/actana/control/issues/317)
-  is what puts the stamp in the file and adds `Train rules`' separate assertion
-  for it (0036 D4). Until #317 lands there is no stamp in `install.sh` and this
-  is six files; when it does, this list and that assertion move together.
+  those six manifests, `install.sh`'s stamp, and seven lines.
+- **The line stamp.** [ADR 0036](adr/0036-the-beta-release-channel.md) D1 gives
+  `install.sh` a stamped line version and says it is *"written by the cut exactly
+  as the six manifests are"*. That is this procedure — the cut is the hand that
+  writes it. [#317](https://github.com/actana/control/issues/317) put the stamp
+  in the file and the resolution that reads it, and
+  `scripts/__tests__/install-sh.test.mjs` asserts that the stamp is a plain
+  `x.y.z` equal to the workspace version and that nothing in the file names a
+  channel. **The separate `Train rules` assertion 0036 D4 asks for is not there
+  yet**: #317 landed without touching `.github/workflows`, which another ticket
+  held open across the same wave. Until it lands, nothing goes red on the train
+  when a cut forgets the stamp — the check is this step and the test above it,
+  so measure the `grep` output before you commit.
 - **Every body line of the message is at most 132 characters.** `commitlint`
   lints every commit in a pull request, not just its title — but no pull
   request puts a cut commit in front of it until the promotion gate, when the

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,9 @@ SHASUMS_ASSET="SHA256SUMS"
 
 REPO="${ACTANA_REPO:-$DEFAULT_REPO}"
 VERSION="${ACTANA_VERSION:-}"
+# Where $VERSION came from, in words, for the one message that has to say so:
+# a failed download can no longer assume a flag was passed (see `main`).
+VERSION_ORIGIN=""
 # One base URL replaces both of GitHub's hosts. That is what lets CI run the
 # real one-liner against locally built artifacts, with no published release and
 # no network.
@@ -68,9 +71,12 @@ BASE_URL="${ACTANA_BASE_URL:-}"
 # fast-forward has made those bytes main's own.
 #
 # One assignment on one line, so the cut can rewrite it in place and a reviewer
-# can see the whole of the change:
+# can see the whole of the change. Copied verbatim from docs/ci-cd.md, down to
+# the `-i.bak`, because this comment sits one line above the value being edited
+# and is the copy-paste source a person cutting a train reaches for first —
+# BSD `sed` on macOS requires an argument to `-i` and GNU `sed` accepts one:
 #
-#   sed -i 's/^LINE=".*"$/LINE="x.y.z"/' install.sh
+#   sed -i.bak 's/^LINE=".*"$/LINE="x.y.z"/' install.sh && rm -f install.sh.bak
 LINE="0.4.1"
 
 say() {
@@ -304,12 +310,106 @@ sha256_of() {
 
 # ─── release resolution ──────────────────────────────────────────────────────
 
-# Does $REPO publish a Release on this tag? Existence is the whole question —
-# the tag itself is fully determined by the stamp — so the body is discarded
-# and a 404 is the answer rather than an error. Both curl and wget already
-# report one as a failure, which is why this needs no parsing.
+# The HTTP status of one GET, as three digits, or the empty string when the
+# request never reached an answer at all — DNS, TLS, or a refused connection.
+#
+# **This exists because absence and failure are different answers, and an exit
+# code cannot tell them apart.** curl and wget fail a 404, a 403 rate limit, a
+# 502 and a dead resolver identically, so a probe that read the exit code would
+# call all of them "no such release" — and under D2 that turns one transient
+# failure on the step-2 probe into a beta served from the public door, which is
+# the outcome D1 exists to prevent, and turns C4's pinned second row into a
+# floating install. Nothing here parses a body; the status is the whole answer.
+#
+# No `--retry` on the curl call, deliberately: `--retry` cannot rewind
+# `-o /dev/null`, so a retried 5xx ends as a write error with **no code
+# printed** — the one input this function exists to return. Retrying is
+# `http_status`'s job, one line down, where a status can be looked at first.
+http_status_once() {
+  if have curl; then
+    # No `-f`: the body is discarded either way, and `-f` would hide the very
+    # status this is here to read. `%{http_code}` is the last response's, so a
+    # redirect is followed to the answer that matters, and a transport failure
+    # prints `000` — which this reports as no answer rather than as one.
+    status=$(curl -sSL -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || true)
+    case $status in
+      000 | "" | *[!0-9]*) status="" ;;
+    esac
+    printf '%s' "$status"
+    return 0
+  fi
+
+  # wget has no `-w`, so the status is read out of what it says. GNU wget
+  # prints the response headers under `-S`; busybox's rejects `-S` outright but
+  # names the code in its own line. So the header form is tried first, the bare
+  # run is the fallback, and both shapes are matched — and when neither yields
+  # a code, this returns nothing and the caller stops rather than guessing.
+  for wget_opt in -S ""; do
+    status=$(
+      LC_ALL=C wget $wget_opt -O /dev/null "$1" 2>&1 |
+        LC_ALL=C sed -n \
+          -e 's|.*HTTP/[0-9.]*[[:space:]]\{1,\}\([0-9][0-9][0-9]\).*|\1|p' \
+          -e 's|.*response\.\.\.[[:space:]]*\([0-9][0-9][0-9]\).*|\1|p' |
+        tail -n 1
+    )
+    if [ -n "$status" ]; then
+      break
+    fi
+  done
+  printf '%s' "$status"
+}
+
+# The same, retried while the answer looks transient.
+#
+# `fetch_url` gets its retries from curl; this one cannot (see above), so the
+# loop is here and it is the better place for it anyway: a 404 is an answer and
+# is returned at once, while a 429, a 5xx or no answer at all is worth asking
+# again before an install is refused over a blip.
+http_status() {
+  attempt=1
+  while :; do
+    status=$(http_status_once "$1")
+    case $status in
+      "" | 429 | 5[0-9][0-9]) ;;
+      *) break ;;
+    esac
+    if [ "$attempt" -ge 3 ]; then
+      break
+    fi
+    sleep "$attempt"
+    attempt=$((attempt + 1))
+  done
+  printf '%s' "$status"
+}
+
+# Does $REPO publish a Release on this tag?
+#
+# Three answers, not two: yes, no, and "the question could not be asked". Only
+# a clean 404 is absence. Anything else stops the install here, because every
+# other status is a statement about the connection or about GitHub rather than
+# about this release — and falling through on one would pick a *different*
+# version to install, silently. `--version` needs none of this and is what the
+# messages point at.
 release_exists() {
-  fetch_url "$API_BASE/repos/$REPO/releases/tags/$1" >/dev/null 2>&1
+  tag_url="$API_BASE/repos/$REPO/releases/tags/$1"
+  tag_status=$(http_status "$tag_url")
+  case $tag_status in
+    200) return 0 ;;
+    404) return 1 ;;
+    "")
+      die "could not reach $tag_url while resolving the $LINE line.
+  That is not the same as \"there is no such release\", so nothing is installed
+  rather than something else being chosen — check the network, or name the
+  version you want with --version, which asks nothing."
+      ;;
+    *)
+      die "$tag_url answered HTTP $tag_status while resolving the $LINE line.
+  403 is usually GitHub's unauthenticated rate limit, 60 requests an hour per
+  IP; 5xx is GitHub. Neither means the release is missing, so nothing is
+  installed rather than a different version being chosen — retry later, or name
+  the version you want with --version, which asks nothing."
+      ;;
+  esac
 }
 
 # **The mechanism is ADR 0036 D1's stamped line, and this is the whole of D2.**
@@ -340,16 +440,23 @@ release_exists() {
 resolve_version() {
   if [ -n "$VERSION" ]; then
     VERSION=${VERSION#v}
+    VERSION_ORIGIN="That version came from --version or ACTANA_VERSION — check it, or drop it to
+  take the version this copy of the script installs by default."
     return 0
   fi
 
   if [ -n "$LINE" ]; then
     if release_exists "v$LINE"; then
       VERSION=$LINE
+      VERSION_ORIGIN="Nothing chose that version: it is the $LINE line this copy of the script is
+  stamped with, and there is no flag to drop. Name another with --version."
       return 0
     fi
     if release_exists "v$LINE-beta"; then
       VERSION="$LINE-beta"
+      VERSION_ORIGIN="Nothing chose that version: it is the current beta of the $LINE line this copy
+  of the script is stamped with, and there is no flag to drop. Name another
+  with --version."
       return 0
     fi
   fi
@@ -370,6 +477,8 @@ resolve_version() {
       head -n 1
   )
   [ -n "$VERSION" ] || die "no release tag in the answer from $latest_url — is $REPO the right repository?"
+  VERSION_ORIGIN="Nothing chose that version: it is the newest release $REPO publishes, and there
+  is no flag to drop. Name another with --version."
 }
 
 # ─── main ────────────────────────────────────────────────────────────────────
@@ -387,6 +496,12 @@ main() {
   fi
 
   have tar || die "tar is not installed — it is needed to unpack the Core."
+  # Asked once, here, rather than left to the first fetch. `http_status`
+  # redirects wget's own stderr into a pipe it parses, so a `die` raised from
+  # inside a probe would be swallowed on its way out; asking up front means the
+  # machine that has neither tool is told so instead of exiting silently.
+  have curl || have wget ||
+    die "neither curl nor wget is installed — one of them is needed to download the Core."
 
   detect_target
   resolve_version
@@ -411,8 +526,9 @@ main() {
   sums_file="$work_dir/$SHASUMS_ASSET"
   fetch_url "$release_url/$SHASUMS_ASSET" "$sums_file" ||
     die "could not fetch $release_url/$SHASUMS_ASSET. Either there is no release $tag,
-  or this machine cannot reach $DOWNLOAD_BASE — check the version, or drop
-  --version to install the latest."
+  or it publishes no checksums, or this machine cannot reach $DOWNLOAD_BASE.
+  Nothing was installed.
+  $VERSION_ORIGIN"
 
   expected=$(awk -v name="$asset" '$2 == name || $2 == "*" name { print $1 }' "$sums_file" | head -n 1)
   [ -n "$expected" ] || die "release $tag has no build for $TARGET.

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,15 @@
 # operator runs afterwards. There is no flag for this — it is what the script
 # does.
 #
+# **The copy you fetched decides what it installs** (ADR 0036 D1). A script
+# read from a pipe cannot know its own URL — there is no `$0`, no BASH_SOURCE,
+# no argv naming one — so "the ref is the channel" can only mean that the copy
+# of this file on that ref differs. Each copy therefore carries the *line* it
+# was cut from, written by the cut; `resolve_version` turns that line into a
+# release tag or into that line's beta tag. There is no `--channel` flag and no
+# environment variable for it: promotion is a fast-forward, so a channel
+# constant committed on a train would become `main`'s own bytes.
+#
 # **It does not know the install layout, and must not learn it.** Placement is
 # `"$extracted/bin/actana" place` — the CLI in the tree that was just verified,
 # running on the Node pinned inside it. ACTANA_HOME, ACTANA_CONFIG_DIR,
@@ -49,6 +58,21 @@ VERSION="${ACTANA_VERSION:-}"
 # no network.
 BASE_URL="${ACTANA_BASE_URL:-}"
 
+# ─── the line this copy installs (ADR 0036 D1) ───────────────────────────────
+#
+# The one value a cut writes into this file, alongside the six manifests
+# (docs/ci-cd.md § "Cutting a train"). It is a **line** — `x.y.z` — and not a
+# channel: `resolve_version` below turns it into either that line's release or
+# that line's beta, which is what makes the same bytes correct on a train,
+# where only the beta tag exists, and on `main` after the promotion
+# fast-forward has made those bytes main's own.
+#
+# One assignment on one line, so the cut can rewrite it in place and a reviewer
+# can see the whole of the change:
+#
+#   sed -i 's/^LINE=".*"$/LINE="x.y.z"/' install.sh
+LINE="0.4.1"
+
 say() {
   printf '%s\n' "$*"
 }
@@ -82,7 +106,8 @@ and then, as a separate command this script does not run for you:
   actana setup [options]
 
 Options:
-  --version <v>     Install this exact release (default: the latest release)
+  --version <v>     Install this exact version, release or beta. Overrides
+                    everything below; the default is this copy's own line
   --repo <slug>     GitHub repository to install from
   --base-url <url>  Fetch releases from here instead of GitHub (testing)
   --help            Show this help
@@ -98,6 +123,15 @@ ACTANA_HOME, ACTANA_BIN_DIR, ACTANA_CONFIG_DIR, ACTANA_DATA_DIR and the XDG
 variables move where the bundle lands; they are read by the CLI, so this
 script and `actana setup` cannot disagree about where anything is.
 EOF
+  # The channel this copy installs from — printed rather than written into the
+  # heredoc above, because it is the one line of this help that differs between
+  # copies of the script (ADR 0036 D1, D2).
+  printf '\n'
+  printf 'This copy is stamped with the %s line, and that stamp is its channel:\n' "$LINE"
+  printf 'it installs v%s if that release exists, otherwise v%s-beta, and\n' "$LINE" "$LINE"
+  printf 'otherwise the newest release. Which copy you fetched is the whole of\n'
+  printf 'the choice: there is no --channel option and no environment variable\n'
+  printf 'that selects one.\n'
 }
 
 # ─── argument parsing ────────────────────────────────────────────────────────
@@ -270,19 +304,61 @@ sha256_of() {
 
 # ─── release resolution ──────────────────────────────────────────────────────
 
-# `latest` is one API call; a pinned version is none. A pinned install that
-# still asked what the latest release was would be one API change away from
-# quietly installing something else.
+# Does $REPO publish a Release on this tag? Existence is the whole question —
+# the tag itself is fully determined by the stamp — so the body is discarded
+# and a 404 is the answer rather than an error. Both curl and wget already
+# report one as a failure, which is why this needs no parsing.
+release_exists() {
+  fetch_url "$API_BASE/repos/$REPO/releases/tags/$1" >/dev/null 2>&1
+}
+
+# **The mechanism is ADR 0036 D1's stamped line, and this is the whole of D2.**
+# In order:
+#
+#   1. an explicit --version / ACTANA_VERSION wins, and asks nothing;
+#   2. the release `v<line>`, if that Release exists;
+#   3. otherwise `v<line>-beta`, if that Release exists;
+#   4. otherwise `/releases/latest` — exactly what this script read before the
+#      stamp existed, kept as the terminal fallback.
+#
+# On a train only the beta tag exists, so step 3 answers. On `main` after a
+# promotion the release exists, so the same bytes answer at step 2. At a
+# release tag the stamp is that tag's own version and step 2 pins it, and at a
+# beta tag the file carries the line like every other copy — which is why that
+# ref is an alias for the train's door and not a pin. The pinned beta form is
+# `--version x.y.z-beta`, and step 1 is where it is served.
+#
+# **No step lists releases.** `GET /repos/<repo>/releases` answers every line
+# newest-first, so "the newest prerelease" would hand a machine installing the
+# beta of one line the beta of another. Resolution is per line by construction
+# instead: the stamp names the tag, and the steady-state path is the single
+# call at step 2 — the same number the stable path made before this.
+#
+# **Step 4 is not decoration.** A line with neither a release nor a beta cut
+# from it yet is a real state, not a hypothetical, and today's answer is the
+# right one for a line that has published nothing.
 resolve_version() {
   if [ -n "$VERSION" ]; then
     VERSION=${VERSION#v}
     return 0
   fi
 
+  if [ -n "$LINE" ]; then
+    if release_exists "v$LINE"; then
+      VERSION=$LINE
+      return 0
+    fi
+    if release_exists "v$LINE-beta"; then
+      VERSION="$LINE-beta"
+      return 0
+    fi
+  fi
+
   latest_url="$API_BASE/repos/$REPO/releases/latest"
   latest_json=$(fetch_url "$latest_url") ||
-    die "could not fetch $latest_url. Either $REPO has no releases, or this machine
-  cannot reach it — check the network, or pin a version with --version."
+    die "the $LINE line has neither a release nor a beta, and $latest_url could not
+  be fetched either. Either $REPO has no releases, or this machine cannot reach
+  it — check the network, or pin a version with --version."
 
   # Splitting on the JSON punctuation first keeps this honest whether the API
   # answers pretty-printed or on one line. LC_ALL=C because the release body is

--- a/scripts/__tests__/fixture-release.test.mjs
+++ b/scripts/__tests__/fixture-release.test.mjs
@@ -18,6 +18,8 @@ import {
   SHASUMS_ASSET,
   compareVersions,
   indexReleases,
+  isPrerelease,
+  latestRelease,
   parseAssetName,
   releaseJson,
   routeFixtureRequest,
@@ -54,6 +56,39 @@ describe("compareVersions", () => {
   it("sorts a prerelease before the release it leads to", () => {
     expect(compareVersions("1.0.0-rc.1", "1.0.0")).toBe(-1);
     expect(compareVersions("1.0.0-rc.1", "1.0.0-rc.2")).toBe(-1);
+  });
+});
+
+// `/releases/latest` excludes prereleases, and that exclusion is the whole
+// reason ADR 0036 D2 stopped making it the installer's default: a beta could
+// never be found through it. The fixture has to exclude them for the same
+// reason a `uname` shim has to answer like `uname` — a fixture more generous
+// than the real endpoint would let a beta install pass here and fail on
+// github.com.
+describe("latestRelease", () => {
+  const index = (versions) =>
+    indexReleases(versions.map((version) => tarballName(version, "linux-x64")));
+
+  it("skips prereleases, however new they are", () => {
+    expect(latestRelease(index(["0.1.0", "0.2.0", "0.3.0-beta"])).version).toBe("0.2.0");
+    expect(latestRelease(index(["0.1.0", "9.9.0-beta"])).version).toBe("0.1.0");
+  });
+
+  it("answers the newest release when there is no prerelease to skip", () => {
+    expect(latestRelease(index(["0.1.0", "0.2.0"])).version).toBe("0.2.0");
+  });
+
+  it("has no answer at all for a repository that has published only betas", () => {
+    // A young line, before its first release: GitHub's endpoint 404s here, and
+    // so does the fixture, which is what sends `install.sh` into the failure
+    // path rather than into a prerelease it never asked for.
+    expect(latestRelease(index(["0.9.0-beta", "1.0.0-beta"]))).toBeUndefined();
+  });
+
+  it("calls exactly the `-suffix` versions prereleases", () => {
+    expect(isPrerelease("0.4.1-beta")).toBe(true);
+    expect(isPrerelease("1.2.3-rc.1")).toBe(true);
+    expect(isPrerelease("0.4.1")).toBe(false);
   });
 });
 
@@ -141,6 +176,28 @@ describe("the fixture server", () => {
     const { status, body } = await get(`/repos/${DEFAULT_REPO}/releases/latest`);
     expect(status).toBe(200);
     expect(JSON.parse(body.toString()).tag_name).toBe("v0.2.0");
+  });
+
+  it("answers a beta on its own tag, and never on `latest`", async () => {
+    // The two halves of ADR 0036 D2 over a socket: step 3 reaches a beta by
+    // naming its tag, and step 4 cannot reach one at all. Both matter — the
+    // first is how a train installs, the second is why the public one-liner
+    // does not become a beta installer the day a beta is published.
+    writeStubRelease({
+      dir,
+      version: "0.3.0-beta",
+      target: "linux-x64",
+      script: "#!/bin/sh\nexit 0\n",
+    });
+
+    const tagged = await get(`/repos/${DEFAULT_REPO}/releases/tags/v0.3.0-beta`);
+    expect(tagged.status).toBe(200);
+    const json = JSON.parse(tagged.body.toString());
+    expect(json.tag_name).toBe("v0.3.0-beta");
+    expect(json.prerelease).toBe(true);
+
+    const latest = await get(`/repos/${DEFAULT_REPO}/releases/latest`);
+    expect(JSON.parse(latest.body.toString()).tag_name).toBe("v0.2.0");
   });
 
   it("answers a pinned tag with that exact release", async () => {

--- a/scripts/__tests__/install-sh.test.mjs
+++ b/scripts/__tests__/install-sh.test.mjs
@@ -35,7 +35,7 @@
 // else either; `restamp` below is the cut's `sed`, and every case that claims
 // to be a different door runs a genuinely different copy of the script.
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -44,7 +44,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_REPO,
   SHASUMS_ASSET,
+  installerStamp,
   startFixtureReleaseServer,
+  writeRestampedInstaller,
   writeStubRelease,
 } from "../lib/fixture-release.mjs";
 import { tarballName } from "../lib/core-tarball.mjs";
@@ -52,19 +54,9 @@ import { tarballName } from "../lib/core-tarball.mjs";
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 const INSTALL_SH = path.join(repoRoot, "install.sh");
 
-/**
- * The stamp the cut writes, matched exactly as the cut's `sed` matches it —
- * `^LINE="..."$`, one assignment on one line (docs/ci-cd.md § "Cutting a
- * train"). Written here as the same anchored shape rather than a loose search,
- * so a stamp that stopped being rewritable by that command fails here.
- */
-const STAMP_PATTERN = /^LINE="([^"]*)"$/m;
-
 /** The line a copy of the installer is stamped with. */
 function stampOf(scriptPath) {
-  const found = STAMP_PATTERN.exec(fs.readFileSync(scriptPath, "utf8"));
-  if (!found) throw new Error(`no LINE stamp in ${scriptPath}`);
-  return found[1];
+  return installerStamp(fs.readFileSync(scriptPath, "utf8"));
 }
 
 /**
@@ -76,16 +68,14 @@ function stampOf(scriptPath) {
  * that wanted to run "the copy on `beta/0.9.0`" has to produce that copy.
  * Everything else about the script is the shipped article, which is what makes
  * these cases evidence about it rather than about a fake.
+ *
+ * The edit itself is `writeRestampedInstaller`, shared with the container e2e
+ * (`scripts/e2e-actana-setup-linux.mjs`), whose install channel serves a copy
+ * stamped with the line its own newest release is on. Two harnesses restamping
+ * the same file by two different rules is drift waiting to happen.
  */
 function restamp(dir, line) {
-  fs.mkdirSync(dir, { recursive: true });
-  const source = fs.readFileSync(INSTALL_SH, "utf8");
-  const stamped = source.replace(STAMP_PATTERN, `LINE="${line}"`);
-  if (stamped === source) throw new Error(`restamping to ${line} changed nothing`);
-  const out = path.join(dir, "install.sh");
-  fs.writeFileSync(out, stamped);
-  fs.chmodSync(out, 0o755);
-  return out;
+  return writeRestampedInstaller({ source: INSTALL_SH, outPath: path.join(dir, "install.sh"), line });
 }
 
 /** The version every manifest in this workspace carries — the line, per ADR 0023 D3. */
@@ -1049,6 +1039,192 @@ describeOnPosix("install.sh", () => {
         expect(run.stdout).toContain("v0.9.0-beta");
         expect(run.stdout).not.toContain(`v${WORKSPACE_VERSION}-beta`);
       });
+    });
+
+    // ─── a failed probe is not an absent release ──────────────────────────
+    //
+    // The resolution asks "does this Release exist" over the network, and the
+    // question can fail as well as be answered. An exit code cannot tell the
+    // two apart — curl and wget fail a 404, a 403 rate limit, a 502 and a dead
+    // resolver identically — so a probe that read one would call every failure
+    // "no such release" and *pick a different version to install*. On the
+    // public door that is a beta served from `main` (the outcome D1 exists to
+    // prevent, by a route the record does not carry); at a release ref it is
+    // C4's second row quietly ceasing to be a pin.
+    //
+    // Unauthenticated GitHub allows 60 requests an hour per IP, so 403 is not
+    // hypothetical: it is what a shared NAT gets on a busy afternoon.
+    describe("a probe that fails is not a release that is missing", () => {
+      /** A door whose tag probes answer with forced statuses. */
+      async function flakyChannel({ line, versions, tagStatus }) {
+        const id = ++channelCases;
+        const dir = path.join(root, `flaky-${id}`);
+        fs.mkdirSync(dir, { recursive: true });
+        for (const version of versions) {
+          const built = pool.get(version);
+          if (!built) throw new Error(`${version} is not in POOL_VERSIONS`);
+          fs.linkSync(built, path.join(dir, path.basename(built)));
+        }
+        const script = line === null ? INSTALL_SH : restamp(path.join(root, `flaky-copy-${id}`), line);
+        const srv = await startFixtureReleaseServer({ dir, scriptPath: script, tagStatus });
+        channelServers.push(srv);
+        return {
+          run: (args = []) => runInstaller({ script, args: ["--base-url", srv.url, ...args] }),
+          paths: () => srv.requests.slice(),
+        };
+      }
+
+      it.each([[403], [500]])(
+        "refuses to serve a beta from the public door when the release probe answers %i",
+        async (status) => {
+          const line = WORKSPACE_VERSION;
+          const door = await flakyChannel({
+            line: null,
+            versions: [line, `${line}-beta`],
+            tagStatus: { [`v${line}`]: status },
+          });
+          const run = await door.run();
+          expect(run.status, run.output).not.toBe(0);
+          expect(run.output).toContain(String(status));
+          expect(run.output, "it fell through to the beta").not.toContain("-beta for");
+          expect(run.actanaArgs, "something was installed anyway").toBeNull();
+          expect(run.placed).toBe(false);
+          // It stopped at the failure rather than asking the next question.
+          expect(door.paths()).not.toContain(`/repos/${DEFAULT_REPO}/releases/tags/v${line}-beta`);
+          expect(door.paths()).not.toContain(`/repos/${DEFAULT_REPO}/releases/latest`);
+        },
+      );
+
+      it("keeps a release ref a pin when its probe fails and the beta is genuinely absent", async () => {
+        // The exact shape the deleted comment warned about: one transient
+        // failure on the release probe, a real 404 on the beta, and step 4
+        // installs whatever is newest — from a ref whose whole purpose is to
+        // pin. It must refuse instead.
+        const door = await flakyChannel({
+          line: OLD_VERSION,
+          versions: [OLD_VERSION, NEW_VERSION, WORKSPACE_VERSION],
+          tagStatus: { [`v${OLD_VERSION}`]: 403 },
+        });
+        const run = await door.run();
+        expect(run.status, run.output).not.toBe(0);
+        expect(run.stdout).not.toContain(`version=${WORKSPACE_VERSION}`);
+        expect(run.actanaArgs).toBeNull();
+        expect(door.paths()).not.toContain(`/repos/${DEFAULT_REPO}/releases/latest`);
+      });
+
+      it("says which line and which status, and points at the flag that asks nothing", async () => {
+        const line = WORKSPACE_VERSION;
+        const door = await flakyChannel({
+          line: null,
+          versions: [line],
+          tagStatus: { [`v${line}`]: 403 },
+        });
+        const run = await door.run();
+        expect(run.output).toContain(`HTTP 403`);
+        expect(run.output).toContain(`the ${line} line`);
+        expect(run.output).toMatch(/--version/);
+        // The step-4 message would have claimed the line has neither a release
+        // nor a beta, which under a uniform rate limit is simply false.
+        expect(run.output).not.toMatch(/neither a release nor a beta/);
+      });
+
+      it("still treats a clean 404 as absence, which is the whole point of reading the status", async () => {
+        // The other half: a forced 404 must behave exactly like a missing
+        // release, or the fix above would have turned every young line into a
+        // failed install.
+        const line = WORKSPACE_VERSION;
+        const door = await flakyChannel({
+          line: null,
+          versions: [line, `${line}-beta`],
+          tagStatus: { [`v${line}`]: 404 },
+        });
+        const run = await door.run();
+        expect(run.status, run.output).toBe(0);
+        expect(run.stdout).toContain(`version=${line}-beta`);
+      });
+    });
+
+    // ─── the download failure says where the version came from ────────────
+    //
+    // The message under `SHA256SUMS` is unchanged in shape but newly reachable
+    // by two paths that never had a flag in play: steps 2 and 3 can now say a
+    // Release exists while its checksums are missing or unreachable. Telling
+    // that operator to "drop --version to install the latest" names a flag they
+    // never passed, and on a beta door names a behaviour that door does not
+    // have.
+    describe("a failed download names the version's origin, not a flag", () => {
+      async function brokenRelease({ line, tag, versions }) {
+        const id = ++channelCases;
+        const dir = path.join(root, `broken-${id}`);
+        fs.mkdirSync(dir, { recursive: true });
+        for (const version of versions) {
+          fs.linkSync(pool.get(version), path.join(dir, path.basename(pool.get(version))));
+        }
+        // The tag resolves, and then there is nothing behind it: a release
+        // whose assets never finished uploading looks exactly like this.
+        const script = line === null ? INSTALL_SH : restamp(path.join(root, `broken-copy-${id}`), line);
+        const srv = await startFixtureReleaseServer({
+          dir,
+          scriptPath: script,
+          tagStatus: { [tag]: 200 },
+        });
+        channelServers.push(srv);
+        return { run: () => runInstaller({ script, args: ["--base-url", srv.url] }) };
+      }
+
+      it("tells a beta door there is no flag to drop", async () => {
+        const line = "0.9.0";
+        const door = await brokenRelease({
+          line,
+          tag: `v${line}-beta`,
+          versions: [WORKSPACE_VERSION],
+        });
+        const run = await door.run();
+        expect(run.status, run.output).not.toBe(0);
+        expect(run.output).toContain(`current beta of the ${line} line`);
+        expect(run.output).toContain("there is no flag to drop");
+        expect(run.output, "it advised dropping a flag nobody passed").not.toMatch(
+          /drop\s+--version to install the latest/,
+        );
+      });
+
+      it("tells a release door the same, naming the line it is stamped with", async () => {
+        const line = WORKSPACE_VERSION;
+        const door = await brokenRelease({ line: null, tag: `v${line}`, versions: [] });
+        const run = await door.run();
+        expect(run.status, run.output).not.toBe(0);
+        expect(run.output).toContain(`the ${line} line this copy of the script is`);
+        expect(run.output).toContain("there is no flag to drop");
+      });
+
+      it("does tell a pinned install to drop the flag, because there is one", async () => {
+        const run = await runInstaller({ args: withServer(["--version", "9.9.9"]) });
+        expect(run.status).not.toBe(0);
+        expect(run.output).toMatch(/came from --version or ACTANA_VERSION/);
+      });
+    });
+
+    it("says so when the machine has neither curl nor wget", async () => {
+      // The diagnostic used to reach the operator because the first fetch was
+      // unredirected. The probe's own redirection would swallow it, so the
+      // question is asked up front instead — a machine that exits 1 with no
+      // output at all is the least debuggable failure an installer has.
+      const caseDir = path.join(root, `no-fetcher-${++channelCases}`);
+      const binDir = path.join(caseDir, "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      for (const tool of ["uname", "tar"]) {
+        const found = spawnSync("sh", ["-c", `command -v ${tool}`], { encoding: "utf8" });
+        fs.symlinkSync(found.stdout.trim(), path.join(binDir, tool));
+      }
+      // Run as a file, not piped: the piped form looks `sh` and `cat` up on
+      // this PATH too, and the shell is not what is under test here.
+      const run = await runInstaller({
+        args: ["--base-url", "http://127.0.0.1:1"],
+        piped: false,
+        env: { PATH: binDir },
+      });
+      expect(run.status).not.toBe(0);
+      expect(run.output).toMatch(/neither curl nor wget/);
     });
 
     it("still replaces both GitHub hosts with one `--base-url`", async () => {

--- a/scripts/__tests__/install-sh.test.mjs
+++ b/scripts/__tests__/install-sh.test.mjs
@@ -26,6 +26,14 @@
 // like a trick and is the opposite: `uname` is precisely the input the script
 // reads, so faking it exercises the real branch instead of a parallel copy of
 // the mapping table.
+//
+// **The channel is tested the same way, and it has to be** (ADR 0036 D1, #317).
+// The script's channel is a line stamped into its own bytes, so the only honest
+// way to run "the copy on the train" is to restamp a copy — which is precisely
+// what a cut does to this file. There is no flag and no environment variable
+// that would let a test ask for a channel, because there is none for anyone
+// else either; `restamp` below is the cut's `sed`, and every case that claims
+// to be a different door runs a genuinely different copy of the script.
 
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
@@ -43,6 +51,47 @@ import { tarballName } from "../lib/core-tarball.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 const INSTALL_SH = path.join(repoRoot, "install.sh");
+
+/**
+ * The stamp the cut writes, matched exactly as the cut's `sed` matches it —
+ * `^LINE="..."$`, one assignment on one line (docs/ci-cd.md § "Cutting a
+ * train"). Written here as the same anchored shape rather than a loose search,
+ * so a stamp that stopped being rewritable by that command fails here.
+ */
+const STAMP_PATTERN = /^LINE="([^"]*)"$/m;
+
+/** The line a copy of the installer is stamped with. */
+function stampOf(scriptPath) {
+  const found = STAMP_PATTERN.exec(fs.readFileSync(scriptPath, "utf8"));
+  if (!found) throw new Error(`no LINE stamp in ${scriptPath}`);
+  return found[1];
+}
+
+/**
+ * A copy of the shipped installer, restamped onto another line — the cut's
+ * one-line edit, performed by a test.
+ *
+ * This is how a channel is selected, because it is the only way one *can* be
+ * selected: the channel lives in the file's own bytes (ADR 0036 D1), so a case
+ * that wanted to run "the copy on `beta/0.9.0`" has to produce that copy.
+ * Everything else about the script is the shipped article, which is what makes
+ * these cases evidence about it rather than about a fake.
+ */
+function restamp(dir, line) {
+  fs.mkdirSync(dir, { recursive: true });
+  const source = fs.readFileSync(INSTALL_SH, "utf8");
+  const stamped = source.replace(STAMP_PATTERN, `LINE="${line}"`);
+  if (stamped === source) throw new Error(`restamping to ${line} changed nothing`);
+  const out = path.join(dir, "install.sh");
+  fs.writeFileSync(out, stamped);
+  fs.chmodSync(out, 0o755);
+  return out;
+}
+
+/** The version every manifest in this workspace carries — the line, per ADR 0023 D3. */
+const WORKSPACE_VERSION = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+).version;
 
 /** The two good releases the fixture serves. `--version` pins the older one. */
 const OLD_VERSION = "0.1.0";
@@ -189,6 +238,13 @@ describeOnPosix("install.sh", () => {
    */
   async function runInstaller({
     args = [],
+    /**
+     * The copy of the installer to run. Defaults to the one in the repository
+     * — the bytes that are actually shipped — and the channel tests pass a
+     * restamped copy instead, because the stamp is the only thing that
+     * distinguishes one door from another.
+     */
+    script = INSTALL_SH,
     uname = ["Linux", "x86_64"],
     /** Pretend the shell is running translated by Rosetta. */
     rosetta = false,
@@ -223,8 +279,8 @@ describeOnPosix("install.sh", () => {
 
     const quoted = args.map((a) => `'${a.replace(/'/g, `'\\''`)}'`).join(" ");
     const result = piped
-      ? await runToCompletion("/bin/sh", ["-c", `cat "$0" | sh -s -- ${quoted}`, INSTALL_SH], env, stdin)
-      : await runToCompletion("/bin/sh", [INSTALL_SH, ...args], env, stdin);
+      ? await runToCompletion("/bin/sh", ["-c", `cat "$0" | sh -s -- ${quoted}`, script], env, stdin)
+      : await runToCompletion("/bin/sh", [script, ...args], env, stdin);
 
     return {
       status: result.status,
@@ -258,6 +314,11 @@ describeOnPosix("install.sh", () => {
   const withServer = (args = []) => ["--base-url", server.url, ...args];
 
   describe("resolving a release", () => {
+    // The shared fixture publishes nothing on this copy's own line, so this is
+    // ADR 0036 D2's step 4 — the `/releases/latest` read the script made before
+    // the stamp existed, kept as the terminal fallback for a line that has
+    // published neither a release nor a beta. The line's own two steps get
+    // their own block at the bottom of this file.
     it("installs the latest release and places it with `actana place`", async () => {
       const run = await runInstaller({ args: withServer([]) });
       expect(run.status, run.output).toBe(0);
@@ -620,6 +681,397 @@ describeOnPosix("install.sh", () => {
       );
       expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
       expect(fs.readFileSync(stubLog, "utf8").trim()).toBe("place");
+    });
+  });
+
+  // ─── the line stamp is the channel (ADR 0036 D1 and D2, #317) ─────────────
+  //
+  // Three doors, one file. `raw.githubusercontent.com/actana/control/main/…`
+  // installs the newest release, `…/beta/0.4.1/…` installs that line's beta,
+  // and `…/v0.4.0/…` pins that release — and the only thing that differs
+  // between those three copies of the script is the line stamped into them
+  // (ADR 0036 C4's table, which is the specification these cases build).
+  //
+  // Each case therefore runs a copy restamped by `restamp`, exactly as a cut
+  // stamps one, against a fixture holding exactly the releases that door would
+  // see. What is asserted is both halves: the version installed, and *which
+  // endpoints were asked* — because "resolves per line, and enumerates
+  // nothing" is a claim about the calls, and a script that got the right answer
+  // by listing every release in the repository would be the wrong script with a
+  // passing test.
+  describe("the line it is stamped with, and what that resolves to", () => {
+    const channelServers = [];
+    let channelCases = 0;
+    /** version → the stub tarball built for it, built once and linked per case. */
+    const pool = new Map();
+
+    /**
+     * Every version any door below needs to see. Built once, in one place,
+     * because `writeStubRelease` runs `tar` and a case that built its own would
+     * pay for it again for every door that shares a release with it — sixteen
+     * doors' worth of `tar` for ten distinct tarballs.
+     */
+    const POOL_VERSIONS = [
+      OLD_VERSION,
+      NEW_VERSION,
+      "0.3.0",
+      WORKSPACE_VERSION,
+      `${WORKSPACE_VERSION}-beta`,
+      "0.9.0",
+      "0.9.0-beta",
+      "1.5.0-beta",
+      "2.0.0-beta",
+      "9.9.0-beta",
+    ];
+
+    beforeAll(() => {
+      const poolDir = path.join(root, "tarball-pool");
+      for (const version of POOL_VERSIONS) {
+        pool.set(
+          version,
+          writeStubRelease({
+            dir: poolDir,
+            version,
+            target: "linux-x64",
+            script: stubActana(version, "linux-x64"),
+          }),
+        );
+      }
+    });
+
+    afterAll(async () => {
+      for (const srv of channelServers) await srv.close();
+    });
+
+    /**
+     * One door: a release directory holding exactly the versions that door can
+     * see, a server in front of it, and the copy of the installer that door
+     * serves.
+     *
+     * `line: null` runs the script as it is in the repository — the bytes that
+     * actually ship on `main`, stamp included — which is the only way the
+     * public one-liner's own behaviour gets asserted rather than a rehearsal of
+     * it. Any other `line` restamps a copy.
+     *
+     * The releases are hard links into the pool: what makes two doors different
+     * is which versions they can see, never what is inside a tarball, so
+     * linking is the honest saving rather than a shortcut.
+     */
+    async function channel({ line, versions, script: reuse }) {
+      const id = ++channelCases;
+      const dir = path.join(root, `channel-${id}`);
+      fs.mkdirSync(dir, { recursive: true });
+      for (const version of versions) {
+        const built = pool.get(version);
+        if (!built) throw new Error(`${version} is not in POOL_VERSIONS`);
+        fs.linkSync(built, path.join(dir, path.basename(built)));
+      }
+      const script = reuse ?? (line === null ? INSTALL_SH : restamp(path.join(root, `copy-${id}`), line));
+      const srv = await startFixtureReleaseServer({ dir, scriptPath: script });
+      channelServers.push(srv);
+      return {
+        script,
+        url: srv.url,
+        run: (args = [], extra = {}) =>
+          runInstaller({ script, args: ["--base-url", srv.url, ...args], ...extra }),
+        /** Every path this door was asked for. */
+        paths: () => srv.requests.slice(),
+      };
+    }
+
+    const tags = `/repos/${DEFAULT_REPO}/releases/tags`;
+    const latest = `/repos/${DEFAULT_REPO}/releases/latest`;
+    /** The listing endpoint ADR 0036 D2 forbids: it answers every line at once. */
+    const listing = `/repos/${DEFAULT_REPO}/releases`;
+
+    /** No step enumerates releases — the tag came from the stamp or from a flag. */
+    function assertNoListing(paths) {
+      expect(paths, "the resolution listed releases").not.toContain(listing);
+      expect(
+        paths.filter((asked) => asked.startsWith(`${listing}?`)),
+        "the resolution listed releases with query parameters",
+      ).toEqual([]);
+    }
+
+    it("carries a line, not a channel, and that line is the workspace version", () => {
+      // The stamp cannot say `beta`, and this is where that is enforced. ADR
+      // 0036 D1's whole argument is that promotion is a fast-forward, so a
+      // channel constant committed on a train *becomes* `main`'s bytes and
+      // turns the public one-liner into a beta installer. What survives the
+      // fast-forward is a value true on both sides of it, and a line is one:
+      // `beta/0.4.1` is the 0.4.1 line, and so is `main` once it has been
+      // promoted. So the stamp is `x.y.z`, it equals what the cut wrote into
+      // every manifest (ADR 0023 D3), and no assignment in the file names a
+      // channel at all.
+      const stamp = stampOf(INSTALL_SH);
+      expect(stamp, "the stamp is not a plain x.y.z line").toMatch(/^\d+\.\d+\.\d+$/);
+      expect(stamp, "the stamp and the manifests disagree").toBe(WORKSPACE_VERSION);
+
+      const source = fs.readFileSync(INSTALL_SH, "utf8");
+      expect(source, "something in the file assigns a channel").not.toMatch(
+        /^[A-Za-z_]*CHANNEL[A-Za-z_]*=/m,
+      );
+      expect(source, "the stamp itself names a channel").not.toMatch(/^LINE=".*beta.*"$/m);
+    });
+
+    it("installs its own line's release — the public `main` door, unchanged", async () => {
+      // The shipped script, against a repository whose newest release is this
+      // line's and which also carries this line's beta and a much newer one on
+      // another line. It must take the release: that is today's behaviour, and
+      // it is what the one-liner in README.md, INSTALL.md and the landing page
+      // promises.
+      const line = WORKSPACE_VERSION;
+      const door = await channel({
+        line: null,
+        versions: ["0.3.0", line, `${line}-beta`, "9.9.0-beta"],
+      });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toContain(`version=${line}`);
+      expect(run.stdout, "it took a prerelease from the public door").not.toContain("-beta");
+
+      // Step 2 answered, so nothing below it ran: one call, the same number the
+      // stable path made when it read `/releases/latest`.
+      expect(door.paths()).toContain(`${tags}/v${line}`);
+      expect(door.paths(), "it asked for its own line's beta as well").not.toContain(
+        `${tags}/v${line}-beta`,
+      );
+      expect(door.paths(), "it still consulted /releases/latest").not.toContain(latest);
+      assertNoListing(door.paths());
+    });
+
+    it("installs the current beta from a train's copy of the script", async () => {
+      // A train: only the beta tag of this line exists, so step 2 misses and
+      // step 3 answers. The two later betas belong to other lines and are the
+      // whole reason "the newest prerelease" is not the rule.
+      const door = await channel({
+        line: "0.9.0",
+        versions: ["0.3.0", WORKSPACE_VERSION, "0.9.0-beta", "1.5.0-beta"],
+      });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toContain("version=0.9.0-beta");
+
+      expect(door.paths()).toContain(`${tags}/v0.9.0`);
+      expect(door.paths()).toContain(`${tags}/v0.9.0-beta`);
+      expect(door.paths()).toContain(
+        `/${DEFAULT_REPO}/releases/download/v0.9.0-beta/${tarballName("0.9.0-beta", "linux-x64")}`,
+      );
+      expect(door.paths(), "a beta install fell through to /releases/latest").not.toContain(latest);
+      assertNoListing(door.paths());
+    });
+
+    it("takes its own line's beta and never a newer line's, however much newer", async () => {
+      // The wrong-line case, with nothing else to distract it: every release in
+      // the repository is a prerelease, and two of them are newer than this
+      // line's. `GET /releases` answers all of them newest-first, which is
+      // exactly why no step asks it.
+      const door = await channel({
+        line: "0.9.0",
+        versions: ["0.9.0-beta", "1.5.0-beta", "2.0.0-beta"],
+      });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toContain("version=0.9.0-beta");
+      expect(run.stdout).not.toContain("1.5.0");
+      expect(run.stdout).not.toContain("2.0.0");
+
+      // Only this line's two tags were ever asked about.
+      expect(door.paths().filter((asked) => asked.startsWith(`${tags}/`))).toEqual([
+        `${tags}/v0.9.0`,
+        `${tags}/v0.9.0-beta`,
+      ]);
+      assertNoListing(door.paths());
+    });
+
+    it("names the beta `x.y.z-beta` exactly, with nothing after the word", async () => {
+      // ADR 0036 C1: no counter, no run number, no short sha, on any surface.
+      // The tag, the asset name and what the bundle reports are all the same
+      // string, so a counted form could not appear in one of them alone.
+      const door = await channel({ line: "0.9.0", versions: ["0.9.0-beta"] });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toMatch(/^stub-actana version=\d+\.\d+\.\d+-beta /m);
+      // A counter is a digit hung off the word, in any of the shapes one gets
+      // written in: `-beta.1`, `-beta-1`, `-beta1`. The target suffix that
+      // follows an asset's version — `-beta-linux-x64` — is not one, so the
+      // pattern asks for the digit rather than for the separator.
+      for (const asked of door.paths()) {
+        expect(asked, `${asked} carries a counted beta`).not.toMatch(/-beta[.-]?\d/);
+      }
+    });
+
+    it("resolves the same bytes to the release once that line has one", async () => {
+      // Promotion is a fast-forward, so the train tip's bytes *become* `main`'s
+      // (ADR 0023 D5). The same restamped copy is therefore run twice, against
+      // the two states of the same line — beta only, then release and beta —
+      // and it must answer differently without differing at all.
+      const beforeRelease = await channel({ line: "0.9.0", versions: ["0.9.0-beta"] });
+      const afterRelease = await channel({
+        script: beforeRelease.script,
+        versions: ["0.9.0", "0.9.0-beta"],
+      });
+      expect(afterRelease.script).toBe(beforeRelease.script);
+
+      const train = await beforeRelease.run();
+      expect(train.status, train.output).toBe(0);
+      expect(train.stdout).toContain("version=0.9.0-beta");
+
+      const promoted = await afterRelease.run();
+      expect(promoted.status, promoted.output).toBe(0);
+      expect(promoted.stdout).toContain("version=0.9.0");
+      expect(promoted.stdout).not.toContain("-beta");
+      expect(afterRelease.paths(), "the release did not answer at step 2").not.toContain(
+        `${tags}/v0.9.0-beta`,
+      );
+    });
+
+    it("pins at a release tag, because the stamp there is that tag's own version", async () => {
+      // ADR 0036 C4's second row. A release tag is immutable, so the copy at
+      // `…/v0.1.0/install.sh` carries `0.1.0` for ever and step 2 pins it —
+      // with no machinery of its own, and with two newer releases published.
+      const door = await channel({
+        line: OLD_VERSION,
+        versions: [OLD_VERSION, NEW_VERSION, WORKSPACE_VERSION],
+      });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toContain(`version=${OLD_VERSION}`);
+      expect(door.paths(), "a pinned ref still asked what was latest").not.toContain(latest);
+      assertNoListing(door.paths());
+    });
+
+    it("falls back to the newest release when its own line has published nothing", async () => {
+      // Step 4, and it is not decoration: a young train from which no beta has
+      // been cut is the normal state of one (ADR 0036 C3). Today's answer is
+      // the right answer for a line that has published nothing — and the
+      // fixture's `latest`, like GitHub's, skips the prerelease above it.
+      const door = await channel({
+        line: "7.7.7",
+        versions: ["0.3.0", WORKSPACE_VERSION, "9.9.0-beta"],
+      });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(run.stdout).toContain(`version=${WORKSPACE_VERSION}`);
+      expect(door.paths()).toEqual(
+        expect.arrayContaining([`${tags}/v7.7.7`, `${tags}/v7.7.7-beta`, latest]),
+      );
+      assertNoListing(door.paths());
+    });
+
+    describe("`--version` still overrides everything, on every door", () => {
+      const VERSIONS = ["0.3.0", WORKSPACE_VERSION, "0.9.0-beta"];
+
+      it.each([
+        ["the `main` copy", null],
+        ["a train's copy", "0.9.0"],
+      ])("pins a release from %s without asking about the line", async (_name, line) => {
+        const door = await channel({ line, versions: VERSIONS });
+        const run = await door.run(["--version", "0.3.0"]);
+        expect(run.status, run.output).toBe(0);
+        expect(run.stdout).toContain("version=0.3.0");
+        // A pin asks nothing: neither the line's tags nor what is latest.
+        expect(door.paths().filter((asked) => asked.startsWith(`${tags}/`))).toEqual([]);
+        expect(door.paths()).not.toContain(latest);
+        assertNoListing(door.paths());
+      });
+
+      it.each([["0.9.0-beta"], ["v0.9.0-beta"]])(
+        "installs a beta pinned as `--version %s` from the `main` copy",
+        async (pinned) => {
+          // The one thing in this design that pins a beta at all (ADR 0036 C4).
+          // No ref does it — the beta tag moves per cut and the file at it
+          // carries the line — so this form has to keep working, `v`-prefixed
+          // or bare, from the public door.
+          const door = await channel({ line: null, versions: VERSIONS });
+          const run = await door.run(["--version", pinned]);
+          expect(run.status, run.output).toBe(0);
+          expect(run.stdout).toContain("version=0.9.0-beta");
+          expect(door.paths()).not.toContain(latest);
+          assertNoListing(door.paths());
+        },
+      );
+
+      it("takes the same override from ACTANA_VERSION, on a train's copy", async () => {
+        const door = await channel({ line: "0.9.0", versions: VERSIONS });
+        const run = await door.run([], { env: { ACTANA_VERSION: "0.3.0" } });
+        expect(run.status, run.output).toBe(0);
+        expect(run.stdout).toContain("version=0.3.0");
+        expect(door.paths().filter((asked) => asked.startsWith(`${tags}/`))).toEqual([]);
+      });
+    });
+
+    describe("no flag, and no environment variable, selects a channel", () => {
+      it("refuses `--channel`, the flag this ticket did not add", async () => {
+        const run = await runInstaller({ args: withServer(["--channel", "beta"]) });
+        expect(run.status).not.toBe(0);
+        expect(run.output).toContain("--channel");
+        expect(run.actanaArgs).toBeNull();
+        expect(traffic()).toEqual([]);
+      });
+
+      it("ignores environment variables named for one", async () => {
+        // Nothing reads these, and the case exists so that nothing starts to:
+        // the copy you fetched is the whole of the choice, and an installer
+        // whose channel could be moved by the environment would put a beta on a
+        // machine whose operator asked for the public one-liner.
+        const door = await channel({
+          line: null,
+          versions: [WORKSPACE_VERSION, `${WORKSPACE_VERSION}-beta`, "0.9.0-beta"],
+        });
+        const run = await door.run([], {
+          env: { ACTANA_CHANNEL: "beta", ACTANA_LINE: "0.9.0", CHANNEL: "beta" },
+        });
+        expect(run.status, run.output).toBe(0);
+        expect(run.stdout).toContain(`version=${WORKSPACE_VERSION}`);
+        expect(run.stdout).not.toContain("-beta");
+      });
+    });
+
+    describe("`--help` says which channel this copy installs from", () => {
+      it("names the shipped copy's line and the rule it resolves by", async () => {
+        const run = await runInstaller({ args: ["--help"] });
+        expect(run.status).toBe(0);
+        expect(run.stdout).toContain(`stamped with the ${WORKSPACE_VERSION} line`);
+        expect(run.stdout).toContain(`v${WORKSPACE_VERSION}-beta`);
+        expect(run.stdout).toMatch(/no --channel option/);
+        expect(traffic()).toEqual([]);
+      });
+
+      it("names a train copy's own line instead — the help travels with the stamp", async () => {
+        // The help is where an operator finds out which door they are standing
+        // at, so it has to answer for *this* copy rather than for the one in
+        // the repository.
+        const script = restamp(path.join(root, "help-copy"), "0.9.0");
+        const run = await runInstaller({ script, args: ["--help"] });
+        expect(run.status).toBe(0);
+        expect(run.stdout).toContain("stamped with the 0.9.0 line");
+        expect(run.stdout).toContain("v0.9.0-beta");
+        expect(run.stdout).not.toContain(`v${WORKSPACE_VERSION}-beta`);
+      });
+    });
+
+    it("still replaces both GitHub hosts with one `--base-url`", async () => {
+      // The tags endpoint is new to this script, and it is on the API host — so
+      // the one flag that makes the fixture work with no network has to cover
+      // it too, or every case above would be reaching github.com.
+      const door = await channel({ line: "0.9.0", versions: ["0.9.0-beta"] });
+      const run = await door.run();
+      expect(run.status, run.output).toBe(0);
+      expect(door.paths()).toContain(`${tags}/v0.9.0-beta`);
+      expect(door.paths()).toContain(
+        `/${DEFAULT_REPO}/releases/download/v0.9.0-beta/${SHASUMS_ASSET}`,
+      );
+    });
+
+    it("asks the repository `--repo` names, on the line's tags too", async () => {
+      const door = await channel({ line: "0.9.0", versions: ["0.9.0-beta"] });
+      const run = await door.run(["--repo", "someone/fork"]);
+      // The fixture only answers for its own repo, so a fork install fails —
+      // and the paths it asked for are the observable behaviour.
+      expect(run.status).not.toBe(0);
+      expect(door.paths().some((asked) => asked.includes("someone/fork"))).toBe(true);
+      expect(door.paths().some((asked) => asked.startsWith(tags))).toBe(false);
     });
   });
 });

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -79,6 +79,7 @@ import {
   parseAssetName,
   repackWithVersion,
   startFixtureServerProcess,
+  writeRestampedInstaller,
 } from "./lib/fixture-release.mjs";
 import { dialAndListProjects, makeDie } from "./lib/core-smoke.mjs";
 import { tarballName as releaseAssetName } from "./lib/core-tarball.mjs";
@@ -123,6 +124,18 @@ async function main() {
   // while the one-liner is being re-run and v${latestVersion} once `update` is
   // the thing under test, and a channel cannot serve two answers to the same
   // question.
+  //
+  // **Each channel also serves a copy of `install.sh` stamped with its own
+  // line** (ADR 0036 D1, #317). Since #317 the script's channel is the line
+  // stamped into its own bytes and nothing at runtime can move it, so the
+  // unpinned one-liner installs *the stamp's* release rather than whatever
+  // `/releases/latest` answers. The tarball is built from this workspace, so
+  // the repository copy is stamped `pinnedVersion` on every run — serving it
+  // here would ask the machine to install `pinnedVersion` unpinned and then
+  // assert it got `firstLatest`, which is a fixture asking for the impossible
+  // rather than a script misbehaving. Stamping the served copy with
+  // `firstLatest` is what makes this channel `main` *after* v${firstLatest} was
+  // promoted, which is the door the assertion is about.
   const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-installer-e2e-"));
   process.on("exit", () => fs.rmSync(workDir, { recursive: true, force: true }));
 
@@ -144,13 +157,40 @@ async function main() {
   repackWithVersion(updateSeed, latestVersion, workDir, die);
   fs.rmSync(updateSeed);
 
-  const startChannel = async (dir) => {
-    const server = await startFixtureServerProcess({ dir, port: await pickHostPort(), die });
+  /**
+   * The copy of `install.sh` each channel serves: the shipped script, restamped
+   * onto the line that channel's newest release is on.
+   *
+   * `writeRestampedInstaller` is the cut's one-line `sed`, shared with
+   * `scripts/__tests__/install-sh.test.mjs` so the hermetic suite and this one
+   * cannot disagree about what a cut writes. Everything else in the copy is the
+   * shipped article, which is what keeps this a test of the real script.
+   */
+  const servedInstaller = (name, line) =>
+    writeRestampedInstaller({
+      source: installSh,
+      outPath: path.join(workDir, `${name}-install.sh`),
+      line,
+    });
+
+  const startChannel = async (dir, script) => {
+    const server = await startFixtureServerProcess({
+      dir,
+      script,
+      port: await pickHostPort(),
+      die,
+    });
     return { url: `http://${HOST_ALIAS}:${server.port}`, stop: server.stop };
   };
 
-  const installChannel = await startChannel(installDir);
-  log(`install channel serving v${pinnedVersion} (pinned) and v${firstLatest} (latest)`);
+  const installChannel = await startChannel(
+    installDir,
+    servedInstaller("install-channel", firstLatest),
+  );
+  log(
+    `install channel serving v${pinnedVersion} (pinned) and v${firstLatest} (latest), ` +
+      `with an install.sh stamped ${firstLatest}`,
+  );
 
   // ─── the machine ───
   log(`installing on ${distro.label}`);
@@ -484,7 +524,14 @@ async function main() {
   installChannel.stop();
 
   // ─── update ───
-  const updateChannel = await startChannel(updateDir);
+  // Nothing fetches `install.sh` from this channel — `actana update` is the CLI
+  // resolving on its own — but it is stamped with its own newest line all the
+  // same, so that a channel is never serving an installer that disagrees with
+  // the releases beside it.
+  const updateChannel = await startChannel(
+    updateDir,
+    servedInstaller("update-channel", latestVersion),
+  );
   log(`update channel serving v${nextVersion} and v${latestVersion} (latest)`);
 
   // The same releases, served by a second process that flips one byte of every

--- a/scripts/fixture-release-server.mjs
+++ b/scripts/fixture-release-server.mjs
@@ -13,7 +13,7 @@
 // Usage:
 //   node scripts/fixture-release-server.mjs --dir <dir> [--port <n>]
 //                                           [--host <addr>] [--repo <slug>]
-//                                           [--corrupt <asset>]
+//                                           [--corrupt <asset>] [--script <file>]
 //
 // --dir      Directory of `actana-core-<version>-<target>.tar.gz` files.
 //            Versions come from the file names; the newest non-prerelease is
@@ -24,6 +24,10 @@
 // --repo     Repository slug the paths are shaped for.
 // --corrupt  Serve these assets (comma-separated) with a flipped byte, so
 //            their checksums fail — for rehearsing a tampered download.
+// --script   The copy of `install.sh` to serve (default: this repository's).
+//            The script's channel is the line stamped into its own bytes
+//            (ADR 0036 D1), so serving a restamped copy is how a channel other
+//            than this checkout's is put in front of a real machine.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -66,7 +70,7 @@ async function main() {
     port,
     host: stringFlag(args, "host", fail, "127.0.0.1"),
     repo: stringFlag(args, "repo", fail, DEFAULT_REPO),
-    scriptPath: path.join(repoRoot, "install.sh"),
+    scriptPath: path.resolve(stringFlag(args, "script", fail, path.join(repoRoot, "install.sh"))),
     corruptAssets,
   });
 
@@ -88,6 +92,7 @@ async function main() {
     log(`serving ${asset} corrupted — its checksum will not verify`);
   }
   log(`listening on ${server.url} (${server.repo})`);
+  log(`install.sh: ${server.scriptPath}, stamped with the ${server.scriptStamp} line`);
   // Two lines, because the one-liner installs and does not activate since #316
   // (ADR 0036 C2). A hint that named only the first would leave a developer at
   // an installed, inactive machine with nothing to run next — which is exactly

--- a/scripts/fixture-release-server.mjs
+++ b/scripts/fixture-release-server.mjs
@@ -16,7 +16,9 @@
 //                                           [--corrupt <asset>]
 //
 // --dir      Directory of `actana-core-<version>-<target>.tar.gz` files.
-//            Versions come from the file names; the newest is `latest`.
+//            Versions come from the file names; the newest non-prerelease is
+//            `latest`, and a `x.y.z-beta` name is served on its own tag —
+//            which is what a beta line's installer asks for (ADR 0036 D2).
 // --port     Port to listen on (default 8788; 0 picks a free one).
 // --host     Address to bind (default 127.0.0.1; use 0.0.0.0 to serve a VM).
 // --repo     Repository slug the paths are shaped for.
@@ -27,7 +29,13 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { makeFail, parseArgs, stringFlag } from "./lib/cli.mjs";
-import { DEFAULT_REPO, indexReleases, startFixtureReleaseServer } from "./lib/fixture-release.mjs";
+import {
+  DEFAULT_REPO,
+  indexReleases,
+  isPrerelease,
+  latestRelease,
+  startFixtureReleaseServer,
+} from "./lib/fixture-release.mjs";
 import { rehearsalSetupCommand } from "./lib/rehearsal.mjs";
 
 const fail = makeFail("fixture-release");
@@ -67,8 +75,15 @@ async function main() {
     log(`warning: no Core tarballs in ${dir} — every release request will 404`);
   }
   for (const release of releases) {
-    log(`release v${release.version}: ${[...release.assets.keys()].sort().join(", ")}`);
+    // Prereleases are called out because `/releases/latest` skips them, the way
+    // GitHub's does — so a directory whose newest tarball is a beta still
+    // answers `latest` with the release under it, and the line that says so is
+    // cheaper than working out why the installer chose the other one.
+    const kind = isPrerelease(release.version) ? "prerelease" : "release";
+    log(`${kind} v${release.version}: ${[...release.assets.keys()].sort().join(", ")}`);
   }
+  const latest = latestRelease(releases);
+  log(latest ? `latest: v${latest.version}` : "latest: nothing — every version here is a prerelease");
   for (const asset of corruptAssets) {
     log(`serving ${asset} corrupted — its checksum will not verify`);
   }

--- a/scripts/lib/fixture-release.mjs
+++ b/scripts/lib/fixture-release.mjs
@@ -12,6 +12,12 @@
 //   GET /<owner>/<repo>/releases/download/<tag>/<asset>
 //   GET /install.sh                                → the bootstrapper itself
 //
+// `latest` excludes prereleases, because GitHub's does — that exclusion is the
+// reason ADR 0036 D2 stopped making it the installer's default, and a fixture
+// that answered a beta there would make the two rules look interchangeable.
+// The tags route is what D2's steps 2 and 3 ask, and it answers a beta tag the
+// same way it answers a release one.
+//
 // The releases it serves are whatever tarballs are in a directory: the file
 // names carry version and target, so a directory holding two versions is a
 // two-release fixture with no manifest to keep in sync. `SHA256SUMS` is
@@ -74,10 +80,14 @@ export function compareVersions(a, b) {
 /**
  * Group release tarball names by version.
  *
- * Returns `[{ version, assets: Map<target, name> }]` ordered oldest first, so
- * the last entry is what `releases/latest` answers with. Names that are not
- * release tarballs (a stray `SHA256SUMS`, an editor's backup file) are ignored
- * rather than rejected — the directory is a build output dir, not a manifest.
+ * Returns `[{ version, assets: Map<target, name> }]` ordered oldest first.
+ * Names that are not release tarballs (a stray `SHA256SUMS`, an editor's
+ * backup file) are ignored rather than rejected — the directory is a build
+ * output dir, not a manifest.
+ *
+ * The last entry is the newest release *including* prereleases; `latestRelease`
+ * is what `releases/latest` answers with, and the two differ exactly when a
+ * beta is the newest thing present.
  */
 export function indexReleases(fileNames) {
   const byVersion = new Map();
@@ -90,6 +100,25 @@ export function indexReleases(fileNames) {
   return [...byVersion.entries()]
     .sort(([a], [b]) => compareVersions(a, b))
     .map(([version, assets]) => ({ version, assets }));
+}
+
+/** Is this a prerelease version — anything carrying a `-suffix`? */
+export function isPrerelease(version) {
+  return version.includes("-");
+}
+
+/**
+ * What `GET /releases/latest` answers with: the newest **release**, prereleases
+ * skipped.
+ *
+ * GitHub's endpoint excludes them by definition, which is the whole reason
+ * `install.sh` could not use it to find a beta (ADR 0036 D2) — so the fixture
+ * excludes them too, and a test that installs from a beta line cannot pass by
+ * accident on a fixture that was more generous than the real thing.
+ */
+export function latestRelease(releases) {
+  const stable = releases.filter((release) => !isPrerelease(release.version));
+  return stable[stable.length - 1];
 }
 
 /**
@@ -136,7 +165,7 @@ export function releaseJson({ repo, version, assets, baseUrl }) {
     tag_name: tag,
     name: tag,
     draft: false,
-    prerelease: version.includes("-"),
+    prerelease: isPrerelease(version),
     assets: names.map((name) => ({
       name,
       browser_download_url: `${baseUrl}/${repo}/releases/download/${tag}/${name}`,
@@ -193,7 +222,7 @@ export async function startFixtureReleaseServer({
 
     if (route.kind === "latest" || route.kind === "tag") {
       const all = releases();
-      const release = route.kind === "latest" ? all[all.length - 1] : findRelease(route.tag);
+      const release = route.kind === "latest" ? latestRelease(all) : findRelease(route.tag);
       if (!release) return notFound("release");
       const body = JSON.stringify(
         releaseJson({ repo, version: release.version, assets: release.assets, baseUrl }),

--- a/scripts/lib/fixture-release.mjs
+++ b/scripts/lib/fixture-release.mjs
@@ -102,6 +102,51 @@ export function indexReleases(fileNames) {
     .map(([version, assets]) => ({ version, assets }));
 }
 
+// ─── the installer's line stamp (ADR 0036 D1) ────────────────────────────────
+//
+// `install.sh` carries the line it was cut from, and that stamp is its channel:
+// the copy on a train installs that train's beta, the copy on `main` installs
+// the release. Nothing at runtime can select one — there is no flag and no
+// environment variable — so a harness that wants to stand at a different door
+// has to serve a differently stamped copy, which is exactly what a cut writes.
+//
+// This lives here, once, because two harnesses need it and they must not drift:
+// the hermetic suite (`scripts/__tests__/install-sh.test.mjs`) and the container
+// e2e (`scripts/e2e-actana-setup-linux.mjs`), whose install channel serves a
+// copy stamped with the line its own "latest" release is on.
+
+/**
+ * The stamp, anchored exactly as the cut's `sed` anchors it — one assignment on
+ * one line (docs/ci-cd.md § "Cutting a train"). Written as the same shape
+ * rather than a loose search, so a stamp that stopped being rewritable by that
+ * command fails here rather than in a train's first pull request.
+ */
+export const INSTALLER_STAMP_PATTERN = /^LINE="([^"]*)"$/m;
+
+/** The line a copy of `install.sh` is stamped with, given its text. */
+export function installerStamp(text) {
+  const found = INSTALLER_STAMP_PATTERN.exec(text);
+  if (!found) throw new Error("no LINE stamp in the installer");
+  return found[1];
+}
+
+/**
+ * Write a copy of `install.sh` restamped onto another line — the cut's one-line
+ * edit, performed by a harness.
+ *
+ * Everything else about the copy is the shipped article, which is what makes a
+ * case that runs it evidence about the real script rather than about a fake.
+ */
+export function writeRestampedInstaller({ source, outPath, line }) {
+  const before = fs.readFileSync(source, "utf8");
+  const after = before.replace(INSTALLER_STAMP_PATTERN, `LINE="${line}"`);
+  if (after === before) throw new Error(`restamping ${source} to ${line} changed nothing`);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, after);
+  fs.chmodSync(outPath, 0o755);
+  return outPath;
+}
+
 /** Is this a prerelease version — anything carrying a `-suffix`? */
 export function isPrerelease(version) {
   return version.includes("-");
@@ -190,9 +235,17 @@ export async function startFixtureReleaseServer({
   port = 0,
   scriptPath,
   corruptAssets = [],
+  /**
+   * `{ "v0.4.1": 403 }` — answer this tag with that status instead of looking
+   * it up. The installer's resolution has to tell "no such release" apart from
+   * "the question could not be asked", and a fixture that could only 404 or 200
+   * could not put the second case in front of it.
+   */
+  tagStatus = {},
 } = {}) {
   const releaseDir = path.resolve(dir);
   if (!fs.existsSync(releaseDir)) throw new Error(`no such release directory: ${releaseDir}`);
+  if (scriptPath && !fs.existsSync(scriptPath)) throw new Error(`no such install.sh: ${scriptPath}`);
   const corrupt = new Set(corruptAssets);
   const requests = [];
 
@@ -218,6 +271,11 @@ export async function startFixtureReleaseServer({
     if (route.kind === "script") {
       if (!scriptPath) return notFound("install.sh");
       return send(200, fs.readFileSync(scriptPath), "text/x-shellscript");
+    }
+
+    if (route.kind === "tag" && Object.hasOwn(tagStatus, route.tag)) {
+      const status = tagStatus[route.tag];
+      return send(status, `${route.tag}: forced ${status}\n`, "text/plain");
     }
 
     if (route.kind === "latest" || route.kind === "tag") {
@@ -260,6 +318,9 @@ export async function startFixtureReleaseServer({
     port: actualPort,
     repo,
     requests,
+    scriptPath,
+    /** The line the served copy of `install.sh` is stamped with — its channel. */
+    scriptStamp: scriptPath ? installerStamp(fs.readFileSync(scriptPath, "utf8")) : undefined,
     close: () =>
       new Promise((resolve) => {
         server.closeAllConnections();
@@ -329,7 +390,19 @@ export function bumpPatch(version) {
  * in-process server could not answer a download while one of those is blocking
  * the event loop. The machine would hang on the fetch, not fail.
  */
-export async function startFixtureServerProcess({ dir, port, host = "0.0.0.0", corrupt = [], die }) {
+export async function startFixtureServerProcess({
+  dir,
+  port,
+  host = "0.0.0.0",
+  corrupt = [],
+  /**
+   * The copy of `install.sh` this channel serves. Defaults to the repository's
+   * own, and a caller passes a restamped one when the door it is standing at is
+   * not `main`'s (ADR 0036 D1).
+   */
+  script,
+  die,
+}) {
   const argv = [
     path.join(import.meta.dirname, "..", "fixture-release-server.mjs"),
     "--dir",
@@ -339,6 +412,7 @@ export async function startFixtureServerProcess({ dir, port, host = "0.0.0.0", c
     "--host",
     host,
   ];
+  if (script) argv.push("--script", script);
   if (corrupt.length > 0) argv.push("--corrupt", corrupt.join(","));
 
   const child = spawn(process.execPath, argv, { stdio: ["ignore", "inherit", "inherit"] });


### PR DESCRIPTION
Implements #317 under [ADR 0036](https://github.com/actana/control/blob/feat/release-pipeline/docs/adr/0036-the-beta-release-channel.md) **D1** and **D2**, against C4's URL table. The mechanism was already decided by the record; this is the implementation of it, not a redesign.

Base is `feat/release-pipeline` — the feature branch for #314. Not `main`, not `beta/0.4.1`.

## What lands

**`install.sh` carries a line, and the line is the channel (D1).** A script fetched by `curl … | bash` cannot know its own URL — no `$0`, no `BASH_SOURCE`, no argv naming one — so "the ref is the channel" can only mean *the copy of the file on that ref differs*. Promotion is a fast-forward (0023 D5), so the train tip's bytes **become** `main`'s bytes: any design storing a channel constant in the file is wrong by construction. What survives a fast-forward is a value true on both sides of it, and the train's own version is one. So the file carries `LINE="0.4.1"`, written by the cut alongside the six manifests, and nothing in it names a channel.

**`resolve_version` is D2, in order:**

1. explicit `--version` / `ACTANA_VERSION` wins, and asks nothing;
2. the release `v<line>`, if that Release exists;
3. otherwise `v<line>-beta`, if that Release exists;
4. otherwise `/releases/latest` — what the script read before the stamp existed, kept as the terminal fallback.

**No step enumerates releases.** `GET /repos/<repo>/releases` answers every line newest-first, so "the newest prerelease" would hand a machine installing one line's beta the beta of another. The stamp determines the tag instead; the steady-state path is the single call at step 2 — the same number the stable path made before.

**A probe has three answers, not two.** Steps 2 and 3 read the HTTP *status*, never the fetch's exit code: 200 is yes, a clean 404 is no, and anything else — a 403 rate limit, a 5xx, a TLS or DNS failure — stops the install with the status named. Falling through on a failed question would pick a different version to install, which on the public door means a beta served from `main` and at a release ref means a pin that floats.

## ⚠️ This changes the stable public one-liner's default, deliberately

The script read `/releases/latest` on **every** unpinned install (`install.sh:248` before this change). It now reads that endpoint only at step 4. That is a behaviour change to the door printed in `README.md`, `INSTALL.md` and on the landing page, and the record already priced it — so, stated plainly rather than left to review:

- **A backport produces no divergence.** 0036 D2 says so in as many words: 0023 D28 keeps `latest` on the current line after a backport publishes from a release branch, and the stamp reaches the same answer *without depending on that assertion continuing to hold*. D2 calls that a small strengthening rather than a change.
- **The promotion window is real, bounded and accepted (D3).** `advance` fast-forwards `main` and pushes the tag before `release` runs, so for the duration of one release run `main` carries a line whose Release does not exist yet. If a beta of that line was cut, step 3 answers and the public door serves a prerelease for that run; if none was, step 4 answers with today's newest release and there is no window at all. D3 also names the unbounded case — a red or cancelled `release` job — and its recovery: re-dispatch the release (0023 D40).
- **The one state where D2 is genuinely worse is a rollback, and that is D24.** 0023 D44's rollback re-points `latest` and flips the Release flag, and by its own design does not rewrite `main`. D2 resolves from the stamp and not from that flag, so a fresh `curl …/main/install.sh | bash` keeps installing the rolled-back release while every Docker pull has already moved off it. The recovery is the hotfix train, which re-stamps `main` in the same fast-forward. Recorded in the ADR, repeated here because it is a regression against today's script.

## Proof — all three channels, no network

The channel lives in the script's own bytes, so the only honest way to run "the copy on the train" is to restamp a copy — which is exactly what a cut does. `restamp` in the test file is the cut's `sed`; every case that claims to be a different door runs a genuinely different copy of the shipped script. Both halves are asserted: the version installed, **and which endpoints were asked** — "resolves per line and enumerates nothing" is a claim about the calls.

| Door | Copy | Fixture sees | Installs |
| --- | --- | --- | --- |
| `…/control/main/install.sh` | the shipped script, stamp and all | `0.3.0`, `0.4.1`, `0.4.1-beta`, `9.9.0-beta` | `0.4.1` — the release, at step 2, and `/releases/latest` is never consulted |
| `…/control/beta/0.9.0/install.sh` | restamped `0.9.0` | `0.9.0-beta`, `1.5.0-beta`, `2.0.0-beta` | `0.9.0-beta` — never the two newer betas on other lines |
| `…/control/v0.1.0/install.sh` | restamped `0.1.0` | `0.1.0`, `0.2.0`, `0.4.1` | `0.1.0` — a pin, C4's second row, with no machinery of its own |

Plus: the **same restamped copy** run against the promoted state of its line answers with the release without differing by a byte (the fast-forward, made observable); step 4 still answers for a line that has published nothing; a beta string is `x.y.z-beta` **exactly**, with no counter in the tag, the asset name or the reported version (C1); `--version` overrides on both doors, `v`-prefixed or bare, including the pinned `x.y.z-beta` form; `ACTANA_VERSION` does the same; `--channel` is refused and no environment variable moves the channel; `--help` names *this copy's* line; and `--base-url` covers the tags endpoint the resolution now reads.

Negative cases, because each of these used to install the wrong thing quietly rather than fail: a forced 403 or 500 on the step-2 probe stops the install with the status named, on the public door and at a release ref alike, and never reaches the beta or `/releases/latest`; a forced 404 still behaves exactly like a missing release; a machine with neither curl nor wget says so instead of exiting 1 in silence; and the download failure names where the version came from rather than a flag nobody passed.

`scripts/fixture-release-server.mjs` grows the half it was missing: `/releases/latest` now **excludes prereleases**, because GitHub's does. That exclusion is the whole reason the old default could never find a beta, and a fixture more generous than the real endpoint would let a beta install pass here and fail on github.com. The tags route it already served is what steps 2 and 3 ask.

`scripts/e2e-actana-setup-linux.mjs`'s install channel now serves a copy of the shipped script restamped onto the line its own newest release is on — the same one-line edit the unit suite and a real cut perform, shared as `writeRestampedInstaller`. It served the repository copy before, whose stamp is the *pinned* version on every run, so under D2 the unpinned re-run took that version and the harness's own assertion could not be satisfied by any correct script. See "What changed after review" below.

`docs/ci-cd.md` § "Cutting a train" gains the stamp as a seventh file and **not** a seventh manifest: its own `sed`, never added to `files=()`, because `install.sh` is not a workspace package and `Train rules`' manifest set refuses to grow past the packages by design (D4). The `files=()` ↔ `MANIFESTS` binding is untouched.

## Scope kept

- `packages/shared/src/actana-release-channel.ts` **not created and not edited** — D6 assigns it to #322, which landed on another feature branch. `ReleaseChannel` there means *which repository and which hosts*, and this ticket does not overload it. The new noun is a **line**.
- Nothing under `.github/workflows` — held open by #326 across this wave. **The consequence is a real gap, named below.**
- `scripts/build-core-tarball.mjs` and `scripts/lib/core-tarball.mjs` untouched.
- **`actana update` after a beta install is #322's, and it is worth knowing about.** This PR is the first thing that can put a beta bundle on a machine, and `packages/cli/src/actana-update.ts` still resolves an unpinned update to the newest *release* — so a machine installed from `…/beta/0.9.0/install.sh` is moved back to stable on its next update and told it succeeded. #317 puts that out of scope in as many words and ADR 0036 D6 assigns the prerelease-aware comparison to [#322](https://github.com/actana/control/issues/322); noted here so the next reader does not have to rediscover the loop.
- No merge, no change to `main`, and this PR stays a draft.

## What changed after review

- **`E2E — installer (ubuntu, x64)` and `E2E — installer (debian, x64)` were red on `a28c898`, and this diff caused it.** Both are required checks on `main` and both were green on the base. The install channel served the *repository* copy of the script, stamped with the pinned version, and then asserted the unpinned re-run resolved the next patch — a state no correct script can satisfy under D2, and one that is unreachable in production (`main`'s stamp is behind the newest release only during D3's window, where the release does not exist yet, and during D24's rollback). The channel now serves a copy restamped onto its own newest line, which makes it `main` *after* that release was promoted — the door the assertion has always been about. The pinned phase is unaffected: `--version` is step 1.
- **`release_exists` conflated absence with failure.** Fixed as described above; the failure modes it opened — a beta served from the public door after one transient failure, and C4's second row ceasing to be a pin — are the reason it was worth a status-reading probe rather than an exit code.
- **The probe's redirection swallowed `fetch_url`'s own `die`.** A machine with neither curl nor wget exited 1 with no output; the question is now asked up front, beside `have tar`.
- **The `SHA256SUMS` failure told operators to drop a flag they never passed.** Steps 2 and 3 can reach it with no `--version` in play, and on a beta door "drop `--version` to install the latest" is wrong twice over. The version's origin is recorded where it is decided and read back in the message.
- **The in-file cut `sed` was GNU-only.** It is now the portable form `docs/ci-cd.md` prints, which matters because it sits one line above the value a person cutting a train edits.

## Known gap, deliberately left

**D4's separate `Train rules` assertion is not in this PR, and it is now tracked as [#335](https://github.com/actana/control/issues/335).** `.github/workflows/ci.yml` was held open by #326 across this wave, so nothing goes red on a train when a cut forgets the stamp. What stands in the meantime: `scripts/__tests__/install-sh.test.mjs` asserts the stamp is a plain `x.y.z` **equal to the workspace version** and that nothing in the file assigns a channel, and the runbook step prints the stamp back for the person cutting. `docs/ci-cd.md` says this plainly rather than implying the check exists.

Refs #317, #314. Under ADR 0036 D1, D2, D4, D6 and C1–C4.
