### PR TITLE
feat(core-tarball): the version stays on all three surfaces, and a beta says beta

### DIFF
--- a/packages/cli/src/__tests__/actana-layout.test.ts
+++ b/packages/cli/src/__tests__/actana-layout.test.ts
@@ -107,6 +107,17 @@ describe("installDirFor", () => {
     expect(installDirFor(l, "0.2.0")).toBe("/home/op/.local/share/actana/versions/0.2.0");
   });
 
+  // ADR 0036 D20: a beta and its line are different strings, so they are
+  // different directories — an install from a beta tarball cannot land where
+  // the release's would, or be reported as it.
+  it("gives a beta a directory of its own, beside its line's release", () => {
+    const l = resolveActanaLayout({}, HOME, "linux");
+    expect(installDirFor(l, "0.4.1-beta")).toBe(
+      "/home/op/.local/share/actana/versions/0.4.1-beta",
+    );
+    expect(installDirFor(l, "0.4.1-beta")).not.toBe(installDirFor(l, "0.4.1"));
+  });
+
   it("refuses a version that would escape the versions dir", () => {
     const l = resolveActanaLayout({}, HOME, "linux");
     expect(() => installDirFor(l, "../../etc")).toThrow(/version/i);

--- a/packages/cli/src/__tests__/actana-setup.test.ts
+++ b/packages/cli/src/__tests__/actana-setup.test.ts
@@ -192,6 +192,18 @@ describe("placeCoreBundle — what `install.sh` leaves behind", () => {
   });
 
   // The other half of the contract, and the one the whole ticket is about.
+  // The consumer half of ADR 0036 D18: the tarball keeps stating its version in
+  // its manifest, so a beta bundle installs under the beta string and the
+  // machine reports that. Nothing here special-cases a beta, and that is the
+  // claim — the version is a string this side reads, not a channel it decides.
+  it("installs a beta under its own version, and reports it", () => {
+    const result = place({ manifest: { ...MANIFEST, version: "0.4.1-beta" } });
+
+    expect(result.installDir).toBe(path.join(layout.versionsDir, "0.4.1-beta"));
+    expect(result.version).toBe("0.4.1-beta");
+    expect(fs.existsSync(path.join(layout.versionsDir, "0.4.1"))).toBe(false);
+  });
+
   it("activates nothing: no config, no material, no unit, no data dir", () => {
     place();
 

--- a/packages/cli/src/actana-layout.ts
+++ b/packages/cli/src/actana-layout.ts
@@ -125,6 +125,15 @@ export function resolveActanaLayout(
  * The version string comes from a downloaded tarball's manifest, so it is
  * treated as untrusted input: anything that is not a plain path segment is
  * rejected rather than allowed to escape `versionsDir`.
+ *
+ * A beta's version is `x.y.z-beta` (ADR 0036 C1) and gets a directory of its
+ * own, beside the release of the same line rather than on top of it. That is
+ * the whole of what this side of the tarball contract has to do about a beta,
+ * and it is why it needs no change: the tarball keeps carrying its version in
+ * the manifest (0036 D18), a beta's string differs from its line's, and two
+ * different strings are two different directories. A machine installed from
+ * `actana-core-0.4.1-beta-linux-x64.tar.gz` therefore lands in
+ * `versions/0.4.1-beta` and reports that — never `0.4.1` (0036 D20).
  */
 export function installDirFor(layout: ActanaLayout, version: string): string {
   if (!version || version !== path.basename(version) || version === "." || version === "..") {

--- a/scripts/__tests__/core-tarball.test.mjs
+++ b/scripts/__tests__/core-tarball.test.mjs
@@ -3,24 +3,31 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  BETA_PRERELEASE,
   BUNDLED_NODE_VERSION,
   CORE_RUNTIME_DEPENDENCIES,
   CORE_TARGETS,
   UNBUNDLED_EXTERNALS,
+  assertCoreVersion,
+  assertShasumsSet,
+  assertTarballSurfaces,
   buildManifest,
   findTarget,
   formatShasums,
   hostTarget,
+  isBetaVersion,
   nodeDistDirName,
   nodeDistShasumsUrl,
   nodeDistTarballUrl,
   parseCoreLinkProtocolVersion,
   parseShasums,
+  parseTarballName,
   planDependencyLayout,
   prebuildDirName,
   tarballName,
   tarballRootDirName,
 } from "../lib/core-tarball.mjs";
+import { parseAssetName } from "../lib/fixture-release.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 
@@ -183,6 +190,61 @@ describe("formatShasums", () => {
   });
 });
 
+// ─── the version a tarball may carry ───────────────────────────────────────
+//
+// A Core tarball self-identifies, and ADR 0036 D18 keeps it that way: the
+// version is in the asset name, in the archive root and in the manifest, which
+// is precisely why a beta's bytes cannot be renamed into a release's. The
+// string those three carry is therefore worth being strict about, and C1 fixes
+// it — a beta is `x.y.z-beta` with nothing after the word, on every surface.
+
+describe("assertCoreVersion", () => {
+  it("takes a release version", () => {
+    expect(assertCoreVersion("0.4.1")).toEqual({
+      version: "0.4.1",
+      line: "0.4.1",
+      prerelease: null,
+    });
+  });
+
+  it("takes a beta, which is the line plus one fixed word", () => {
+    expect(assertCoreVersion("0.4.1-beta")).toEqual({
+      version: "0.4.1-beta",
+      line: "0.4.1",
+      prerelease: BETA_PRERELEASE,
+    });
+    expect(isBetaVersion("0.4.1-beta")).toBe(true);
+    expect(isBetaVersion("0.4.1")).toBe(false);
+  });
+
+  // ADR 0036 C1 bans a counted beta outright, on every surface — and an asset
+  // filename is a surface. A run number or a short sha appended by a workflow
+  // is the shape that would arrive by accident, so it dies here rather than in
+  // a published asset name nobody can rename afterwards.
+  it("refuses a counted beta, whatever counts it", () => {
+    for (const version of ["0.4.1-beta.1", "0.4.1-beta1", "0.4.1-beta.20260824", "0.4.1-beta-2"]) {
+      expect(() => assertCoreVersion(version), version).toThrow(/counted beta/);
+    }
+  });
+
+  it("refuses a beta that is spelled differently rather than treating it as one", () => {
+    expect(() => assertCoreVersion("0.4.1-BETA")).toThrow(/counted beta/);
+  });
+
+  // The backport candidate ADR 0023 D30 publishes carries an identifier by
+  // design, and C1 binds the beta channel only. Banning every prerelease would
+  // be a wider rule than the record made.
+  it("leaves a backport release candidate alone", () => {
+    expect(assertCoreVersion("1.2.4-rc.1").prerelease).toBe("rc.1");
+  });
+
+  it("refuses anything that is not a version at all", () => {
+    for (const version of ["v0.4.1", "0.4", "0.4.1.2", "", "latest", "0.4.1 ", undefined]) {
+      expect(() => assertCoreVersion(version), JSON.stringify(version)).toThrow(/unusable/);
+    }
+  });
+});
+
 describe("tarball naming", () => {
   it("names the archive after version and target", () => {
     expect(tarballName("0.1.0", "linux-arm64")).toBe("actana-core-0.1.0-linux-arm64.tar.gz");
@@ -190,6 +252,174 @@ describe("tarball naming", () => {
 
   it("puts everything under one directory so extraction never litters the CWD", () => {
     expect(tarballRootDirName("0.1.0", "linux-arm64")).toBe("actana-core-0.1.0-linux-arm64");
+  });
+
+  // The beta's asset name is the release's with the version it actually has —
+  // no separate naming scheme, no channel segment. That is what makes a beta
+  // installable the same way a release is, and what makes the two impossible
+  // to confuse (ADR 0036 D20).
+  it("names a beta's archive with the beta version, unchanged", () => {
+    expect(tarballName("0.4.1-beta", "linux-x64")).toBe("actana-core-0.4.1-beta-linux-x64.tar.gz");
+    expect(tarballRootDirName("0.4.1-beta", "linux-x64")).toBe("actana-core-0.4.1-beta-linux-x64");
+  });
+
+  it("refuses a version the build may not publish, at every surface", () => {
+    // One gate, three doors: a counted beta cannot reach one of the three by a
+    // path that skips the other two.
+    expect(() => tarballName("0.4.1-beta.1", "linux-x64")).toThrow(/counted beta/);
+    expect(() => tarballRootDirName("0.4.1-beta.1", "linux-x64")).toThrow(/counted beta/);
+    expect(() =>
+      buildManifest({
+        version: "0.4.1-beta.1",
+        protocolVersion: "0.8.0",
+        target: "linux-x64",
+        nodeVersion: BUNDLED_NODE_VERSION,
+      }),
+    ).toThrow(/counted beta/);
+  });
+});
+
+describe("parseTarballName", () => {
+  it("is the inverse of tarballName for every shape the build emits", () => {
+    for (const [version, target] of [
+      ["0.1.0", "linux-x64"],
+      ["0.4.1-beta", "linux-arm64"],
+      ["1.2.4-rc.1", "mac-arm64"],
+    ]) {
+      expect(parseTarballName(tarballName(version, target))).toEqual({ version, target });
+    }
+  });
+
+  it("is null for a name this build could not have produced", () => {
+    for (const name of [
+      "SHA256SUMS",
+      "actana-core-0.1.0-linux-x64.tar.gz.bak",
+      "actana-core-0.1.0-solaris-sparc.tar.gz",
+      "actana-core-0.4.1-beta.1-linux-x64.tar.gz",
+      "notes.txt",
+    ]) {
+      expect(parseTarballName(name), name).toBeNull();
+    }
+  });
+
+  // The fixture release server reads asset names off a directory to answer as
+  // GitHub would, so its parser and this one are two readings of one contract
+  // — `install.sh`'s (ADR 0016 D29). They may differ in what they tolerate;
+  // they may not differ on what a name the build emits *means*.
+  it("agrees with the fixture server's reading of the same names", () => {
+    for (const [version, target] of [
+      ["0.1.0", "linux-x64"],
+      ["0.4.1-beta", "mac-arm64"],
+    ]) {
+      const name = tarballName(version, target);
+      expect(parseAssetName(name)).toEqual(parseTarballName(name));
+    }
+  });
+});
+
+describe("assertShasumsSet", () => {
+  it("reports the one version covered and the targets it covers", () => {
+    expect(
+      assertShasumsSet(CORE_TARGETS.map((t) => tarballName("0.4.1-beta", t.target))),
+    ).toEqual({
+      version: "0.4.1-beta",
+      targets: ["linux-x64", "linux-arm64", "mac-arm64"],
+    });
+  });
+
+  // The case this exists for. `SHA256SUMS` is one Release's asset, and a file
+  // covering a beta and a release at once is the confusion ADR 0036 D20 rules
+  // out — published under a single name, with no way for a downloader to tell
+  // which half they verified against.
+  it("refuses a set holding two versions", () => {
+    expect(() =>
+      assertShasumsSet([
+        tarballName("0.4.1-beta", "linux-x64"),
+        tarballName("0.4.1", "linux-arm64"),
+      ]),
+    ).toThrow(/two versions/);
+  });
+
+  it("refuses two tarballs claiming one target", () => {
+    expect(() =>
+      assertShasumsSet([tarballName("0.4.1", "linux-x64"), "actana-core-0.4.1-linux-x64.tar.gz"]),
+    ).toThrow(/two linux-x64 tarballs/);
+  });
+
+  it("refuses a file that is not one of ours, rather than checksumming it", () => {
+    expect(() => assertShasumsSet(["actana-core-0.4.1-linux-x64.tar.gz", "notes.tar.gz"])).toThrow(
+      /not a Core tarball asset name/,
+    );
+  });
+
+  it("refuses an empty set", () => {
+    expect(() => assertShasumsSet([])).toThrow(/no Core tarballs/);
+  });
+});
+
+describe("assertTarballSurfaces", () => {
+  const surfaces = (over = {}) => ({
+    assetName: "actana-core-0.4.1-beta-linux-x64.tar.gz",
+    rootDirName: "actana-core-0.4.1-beta-linux-x64",
+    manifest: buildManifest({
+      version: "0.4.1-beta",
+      protocolVersion: "0.8.0",
+      target: "linux-x64",
+      nodeVersion: BUNDLED_NODE_VERSION,
+    }),
+    ...over,
+  });
+
+  it("returns the version and target all three agree on", () => {
+    expect(assertTarballSurfaces(surfaces())).toEqual({
+      version: "0.4.1-beta",
+      target: "linux-x64",
+    });
+  });
+
+  // Each of these is a real published artifact that would install as something
+  // other than what its name says. The first is the rename ADR 0036 D18 refuses
+  // — beta bytes under a release name — and it is refused here on the bytes.
+  it("refuses an archive root that disagrees with the asset name", () => {
+    expect(() =>
+      assertTarballSurfaces(surfaces({ assetName: "actana-core-0.4.1-linux-x64.tar.gz" })),
+    ).toThrow(/asset name and the archive root disagree/);
+  });
+
+  it("refuses a manifest that disagrees about the version", () => {
+    expect(() =>
+      assertTarballSurfaces(
+        surfaces({
+          manifest: buildManifest({
+            version: "0.4.1",
+            protocolVersion: "0.8.0",
+            target: "linux-x64",
+            nodeVersion: BUNDLED_NODE_VERSION,
+          }),
+        }),
+      ),
+    ).toThrow(/disagree about the version/);
+  });
+
+  it("refuses a manifest that disagrees about the target", () => {
+    expect(() =>
+      assertTarballSurfaces(
+        surfaces({
+          manifest: buildManifest({
+            version: "0.4.1-beta",
+            protocolVersion: "0.8.0",
+            target: "linux-arm64",
+            nodeVersion: BUNDLED_NODE_VERSION,
+          }),
+        }),
+      ),
+    ).toThrow(/disagree about the target/);
+  });
+
+  it("refuses a name that is not a Core tarball's", () => {
+    expect(() => assertTarballSurfaces(surfaces({ assetName: "core.tar.gz" }))).toThrow(
+      /not a Core tarball asset name/,
+    );
   });
 });
 
@@ -235,6 +465,21 @@ describe("buildManifest", () => {
       arch: "arm64",
       nodeVersion: BUNDLED_NODE_VERSION,
     });
+  });
+
+  it("writes a beta version through unchanged — the manifest is the third surface", () => {
+    // `runActanaSetup` installs into `versions/<manifest.version>` and
+    // `actana status` reports it, so this field is what a machine says it is
+    // running. A beta that wrote its line here would be a machine reporting a
+    // release it is not (ADR 0036 D20).
+    expect(
+      buildManifest({
+        version: "0.4.1-beta",
+        protocolVersion: "0.8.0",
+        target: "linux-x64",
+        nodeVersion: BUNDLED_NODE_VERSION,
+      }).version,
+    ).toBe("0.4.1-beta");
   });
 
   it("rejects an unknown target", () => {

--- a/scripts/build-core-tarball.mjs
+++ b/scripts/build-core-tarball.mjs
@@ -27,7 +27,10 @@
 //                                          [--cache-dir <dir>]
 //
 // --out-dir      Where the tarball lands (default: artifacts/core).
-// --version      Release version, bare semver (default: root package.json).
+// --version      Version to build, bare semver — `x.y.z` for a release,
+//                `x.y.z-beta` for a beta, with nothing after the word
+//                (ADR 0036 C1). A leading `v` is stripped; anything else
+//                is refused. Default: the root package.json's version.
 // --target       Sanity check — must match the host's own target.
 // --node-version Node runtime to bundle (default: BUNDLED_NODE_VERSION).
 // --cache-dir    Where downloaded Node tarballs are kept (default: .cache/node-dist).
@@ -47,6 +50,7 @@ import {
   DEPENDENCY_PRUNE_PATHS,
   CORE_RUNTIME_DEPENDENCIES,
   LAUNCHER_SCRIPT,
+  assertCoreVersion,
   buildManifest,
   findTarget,
   hostTarget,
@@ -220,7 +224,23 @@ async function main() {
   const rootPackageJson = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
   );
-  const version = (stringFlag(args, "version", fail) ?? rootPackageJson.version).replace(/^v/, "");
+  // The `v` a git tag carries is not part of a version on any of the three
+  // surfaces below, so it comes off here — and what is left has to be a
+  // version this repository will publish. A beta is `x.y.z-beta` and nothing
+  // longer (ADR 0036 C1), so the counted string a run number would produce is
+  // refused here, before it can reach an asset name, an archive root or a
+  // manifest.
+  const requestedVersion = (stringFlag(args, "version", fail) ?? rootPackageJson.version).replace(
+    /^v/,
+    "",
+  );
+  let parsedVersion;
+  try {
+    parsedVersion = assertCoreVersion(requestedVersion);
+  } catch (err) {
+    fail(err.message);
+  }
+  const version = parsedVersion.version;
   const nodeVersion = stringFlag(args, "node-version", fail, BUNDLED_NODE_VERSION);
   const outDir = path.resolve(
     stringFlag(args, "out-dir", fail, path.join(repoRoot, "artifacts", "core")),
@@ -258,7 +278,14 @@ async function main() {
     fs.readFileSync(path.join(repoRoot, "packages", "sdk", "src", "core-link-frames.ts"), "utf8"),
   );
 
-  log(`target=${descriptor.target} version=${version} node=${nodeVersion} protocol=${protocolVersion}`);
+  // The channel is named in the log because the three surfaces below are the
+  // only place it is ever written down: there is no channel field, and there
+  // is not going to be one — a beta is a beta because its version says so.
+  log(
+    `target=${descriptor.target} version=${version} channel=` +
+      `${parsedVersion.prerelease === null ? "release" : parsedVersion.prerelease} ` +
+      `node=${nodeVersion} protocol=${protocolVersion}`,
+  );
 
   const nodeDir = await downloadNodeRuntime(nodeVersion, descriptor, cacheDir);
 

--- a/scripts/compose-core-shasums.mjs
+++ b/scripts/compose-core-shasums.mjs
@@ -7,8 +7,15 @@
 // the tool already on their machine — and `install.sh` / `actana update` can
 // verify it with the same file.
 //
+// Every tarball in the directory has to belong to the same release: one
+// version, one tarball per target. `SHA256SUMS` is an asset of a single
+// Release, and a beta's assets and a release's are never confusable
+// (ADR 0036 D20) — a checksum file listing `0.4.1-beta` beside `0.4.1` would
+// be exactly that confusion, published under one name.
+//
 // Usage:
 //   node scripts/compose-core-shasums.mjs --dir <dir> [--expect <n>]
+//                                         [--version <v>]
 //
 // --dir     Directory holding the tarballs (searched one level deep, so
 //           GitHub's per-artifact subdirectories work unflattened).
@@ -16,13 +23,18 @@
 //           full target count (`CORE_TARGETS.length`, spelled out in
 //           release.yml) so a silently missing platform is a red build, not a
 //           checksum file that quietly covers two of three.
+// --version Fail unless the tarballs are that version. Optional: the set is
+//           already required to agree with itself, and this is for a caller
+//           that knows which version it asked for — a beta cut naming
+//           `x.y.z-beta` proves the assets it is about to publish are the
+//           beta's rather than a stale release build left in the directory.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { makeFail, parseArgs, stringFlag } from "./lib/cli.mjs";
 import { digestFile } from "./lib/hash.mjs";
-import { formatShasums } from "./lib/core-tarball.mjs";
+import { assertShasumsSet, formatShasums } from "./lib/core-tarball.mjs";
 
 const fail = makeFail("core-shasums");
 const log = (message) => console.log(`[core-shasums] ${message}`);
@@ -69,11 +81,24 @@ async function main() {
     }
   }
 
+  // One release's worth of tarballs, or nothing. This rejects a stray archive,
+  // a second copy of a target, and — the case this file exists to refuse — a
+  // directory holding two versions at once.
+  let covered;
+  try {
+    covered = assertShasumsSet(tarballs.map((t) => path.basename(t)));
+  } catch (err) {
+    fail(`${err.message} (under ${dir})`);
+  }
+
+  const versionFlag = stringFlag(args, "version", fail);
+  if (versionFlag !== undefined && versionFlag !== covered.version) {
+    fail(`--version ${versionFlag} but the tarballs are ${covered.version}`);
+  }
+
   const entries = new Map();
   for (const tarball of tarballs) {
-    const name = path.basename(tarball);
-    if (entries.has(name)) fail(`two tarballs named ${name} under ${dir}`);
-    entries.set(name, await digestFile(tarball, "sha256"));
+    entries.set(path.basename(tarball), await digestFile(tarball, "sha256"));
   }
 
   // The checksum file sits next to the assets it covers, with bare basenames,
@@ -81,7 +106,7 @@ async function main() {
   const outPath = path.join(dir, "SHA256SUMS");
   fs.writeFileSync(outPath, formatShasums(entries));
 
-  log(`wrote ${outPath}`);
+  log(`wrote ${outPath} — ${covered.version}, covering ${covered.targets.join(", ")}`);
   for (const [name, digest] of [...entries].sort(([a], [b]) => (a < b ? -1 : 1))) {
     log(`  ${digest}  ${name}`);
   }

--- a/scripts/lib/core-tarball.mjs
+++ b/scripts/lib/core-tarball.mjs
@@ -222,16 +222,134 @@ export function formatShasums(entries) {
 }
 
 /**
+ * The version string a Core tarball is allowed to carry.
+ *
+ * `x.y.z` is a release. `x.y.z-beta` is a beta, and it is exactly that on
+ * every surface — the git tag, the Release, the image tags, the asset filename
+ * — with no counter, no run number and no short sha after the word (ADR 0036
+ * C1). A backport's release candidate keeps its identifier (`1.2.4-rc.1`, ADR
+ * 0023 D30), so the rule is not "no prerelease": it is that a prerelease which
+ * calls itself a beta is the one fixed string and nothing longer.
+ *
+ * The `v` prefix belongs to tags. It is not part of a version here — the asset
+ * name, the archive root and the manifest all carry the bare string — so a
+ * caller reading a tag strips it before this.
+ */
+const CORE_VERSION_PATTERN = /^(\d+\.\d+\.\d+)(?:-([0-9A-Za-z.-]+))?$/;
+
+/** The beta channel's whole prerelease identifier (ADR 0036 C1). */
+export const BETA_PRERELEASE = "beta";
+
+/**
+ * Split a Core version into `{ version, line, prerelease }`, or throw naming
+ * the rule it broke.
+ *
+ * Every surface goes through this: `tarballName`, `tarballRootDirName` and
+ * `buildManifest` all call it. The version appears in three places at once and
+ * that is the property ADR 0036 D18 keeps rather than removes — so the one
+ * thing that must not exist is a path by which a string reaches one of the
+ * three without passing the same gate as the other two.
+ */
+export function assertCoreVersion(version) {
+  const match = typeof version === "string" ? CORE_VERSION_PATTERN.exec(version) : null;
+  if (!match) {
+    throw new Error(
+      `unusable Core version: ${JSON.stringify(version)} — expected x.y.z, x.y.z-beta or ` +
+        `x.y.z-<prerelease>, with no leading v`,
+    );
+  }
+  const [, line, prerelease] = match;
+  if (
+    prerelease !== undefined &&
+    prerelease.toLowerCase().startsWith(BETA_PRERELEASE) &&
+    prerelease !== BETA_PRERELEASE
+  ) {
+    throw new Error(
+      `counted beta version: ${version} — a beta is exactly ${line}-${BETA_PRERELEASE}, with ` +
+        `nothing after the word, on every surface (ADR 0036 C1)`,
+    );
+  }
+  return { version, line, prerelease: prerelease ?? null };
+}
+
+/** Whether a version names this line's beta rather than its release. */
+export function isBetaVersion(version) {
+  return assertCoreVersion(version).prerelease === BETA_PRERELEASE;
+}
+
+/**
  * Tarball basename for a release. `version` is the bare semver (no `v` prefix)
- * so the name matches what `actana --version` reports.
+ * so the name matches what `actana --version` reports — and, for a beta, the
+ * `x.y.z-beta` the tag and the manifest carry unchanged.
  */
 export function tarballName(version, target) {
+  assertCoreVersion(version);
   return `actana-core-${version}-${target}.tar.gz`;
 }
 
 /** Top-level directory inside a tarball — extraction never litters the CWD. */
 export function tarballRootDirName(version, target) {
+  assertCoreVersion(version);
   return `actana-core-${version}-${target}`;
+}
+
+/**
+ * A target name as it appears in an asset name: two lowercase words. Kept
+ * loose, because `findTarget` below is what decides which of them exist.
+ */
+const TARBALL_NAME_PATTERN = /^actana-core-(.+)-([a-z]+-[a-z0-9]+)\.tar\.gz$/;
+
+/**
+ * Split a tarball basename back into `{ version, target }`, or null when the
+ * name is not one this build could have produced — an unknown target, a
+ * version this repository refuses to build, or a file that is simply not ours.
+ *
+ * The inverse of `tarballName`, which the unit test pins by round-tripping the
+ * pair. `install.sh` derives the same two fields from the same name in POSIX
+ * sh (ADR 0016 D29), which is why this is a parser rather than a `split`.
+ */
+export function parseTarballName(name) {
+  const match = TARBALL_NAME_PATTERN.exec(name);
+  if (!match) return null;
+  const [, version, target] = match;
+  if (!findTarget(target)) return null;
+  try {
+    assertCoreVersion(version);
+  } catch {
+    return null;
+  }
+  return { version, target };
+}
+
+/**
+ * The one version a `SHA256SUMS` covers, and the targets it covers it for.
+ *
+ * A release's checksum file and a beta's are the same shape over different
+ * bytes, and the one thing neither may be is a mixture: `SHA256SUMS` is an
+ * asset of a single Release, and a file listing `0.4.1` and `0.4.1-beta` side
+ * by side is exactly the confusion ADR 0036 D20 rules out. Two tarballs
+ * claiming one target are refused for a duller reason — one of them is a
+ * leftover, and there is no way to tell which.
+ */
+export function assertShasumsSet(names) {
+  const byTarget = new Map();
+  let version;
+  for (const name of names) {
+    const parsed = parseTarballName(name);
+    if (!parsed) throw new Error(`not a Core tarball asset name: ${name}`);
+    if (version === undefined) {
+      version = parsed.version;
+    } else if (parsed.version !== version) {
+      throw new Error(
+        `two versions in one checksum set: ${version} and ${parsed.version} (${name})`,
+      );
+    }
+    const seen = byTarget.get(parsed.target);
+    if (seen) throw new Error(`two ${parsed.target} tarballs: ${seen} and ${name}`);
+    byTarget.set(parsed.target, name);
+  }
+  if (version === undefined) throw new Error("no Core tarballs to cover");
+  return { version, targets: [...byTarget.keys()] };
 }
 
 /**
@@ -262,6 +380,7 @@ export function parseCoreLinkProtocolVersion(source) {
 export function buildManifest({ version, protocolVersion, target, nodeVersion }) {
   const descriptor = findTarget(target);
   if (!descriptor) throw new Error(`unknown target: ${target}`);
+  assertCoreVersion(version);
   return {
     name: "actana-core",
     version,
@@ -271,6 +390,51 @@ export function buildManifest({ version, protocolVersion, target, nodeVersion })
     arch: descriptor.arch,
     nodeVersion,
   };
+}
+
+/**
+ * Assert that a built tarball says one thing about itself in all three of the
+ * places it says anything: the asset name, the directory the archive extracts
+ * to, and the `core-manifest.json` at that directory's root.
+ *
+ * This is the invariant ADR 0036 D18 leaves standing. A Core tarball
+ * self-identifies — that is why a beta's bytes cannot be promoted to a release
+ * by renaming them — and the value of a self-identifying artifact is exactly
+ * zero if the three statements can disagree. Both consumers rely on them
+ * agreeing: `install.sh` extracts and then looks for `bin/actana` under
+ * `actana-core-$VERSION-$TARGET`, refusing the download if it is not there
+ * (ADR 0016 D29), and `runActanaSetup` installs into `versions/<version>` off
+ * the manifest and refuses a tree whose platform disagrees with the machine.
+ * Split those two apart and an operator who downloaded a beta could end up
+ * with a machine reporting a release version, which is the one outcome
+ * ADR 0036 D20 rules out.
+ *
+ * Returns the `{ version, target }` all three agree on.
+ */
+export function assertTarballSurfaces({ assetName, rootDirName, manifest }) {
+  const parsed = parseTarballName(assetName);
+  if (!parsed) throw new Error(`not a Core tarball asset name: ${assetName}`);
+
+  const expectedRoot = tarballRootDirName(parsed.version, parsed.target);
+  if (rootDirName !== expectedRoot) {
+    throw new Error(
+      `${assetName} extracts to ${rootDirName}, not ${expectedRoot} — the asset name and the ` +
+        `archive root disagree`,
+    );
+  }
+  if (manifest.version !== parsed.version) {
+    throw new Error(
+      `${assetName} carries a manifest for ${manifest.version} — the asset name and the ` +
+        `manifest disagree about the version`,
+    );
+  }
+  if (manifest.target !== parsed.target) {
+    throw new Error(
+      `${assetName} carries a manifest for ${manifest.target} — the asset name and the ` +
+        `manifest disagree about the target`,
+    );
+  }
+  return parsed;
 }
 
 /**

--- a/scripts/smoke-core-tarball.mjs
+++ b/scripts/smoke-core-tarball.mjs
@@ -6,6 +6,14 @@
 // Node scrubbed from PATH, then makes the shared boot-and-dial assertion
 // (see scripts/lib/core-smoke.mjs).
 //
+// It also checks the thing a Core tarball is that a container image is not:
+// self-identifying. The asset name, the directory the archive extracts to and
+// the `core-manifest.json` at its root each state the version and the target,
+// the two consumers read different ones, and this is where they are proven to
+// be the same string on real bytes rather than in the builder's own variables
+// (ADR 0036 D18, D20). A beta is where it matters most — `0.4.1-beta` on all
+// three surfaces is what stops a beta install reporting `0.4.1`.
+//
 // This is the acceptance criterion of the per-platform tarball work stated as
 // a test: "extracting a tarball on its target platform and running the
 // launcher boots a dialable Core with no system Node." If a future change
@@ -34,6 +42,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { parseArgs, stringFlag } from "./lib/cli.mjs";
+import { assertTarballSurfaces } from "./lib/core-tarball.mjs";
 import {
   assertBootsAndDials,
   coreSmokeEnv,
@@ -128,6 +137,21 @@ async function main() {
   const installRoot = extractTarball(tarball, extractDir);
   const manifest = readManifest(installRoot);
 
+  // `install.sh` finds the extracted tree by rebuilding its name from the
+  // version and target it downloaded, and `actana setup` installs into
+  // `versions/<manifest.version>`. The two consumers therefore agree only for
+  // as long as the three surfaces do.
+  let surfaces;
+  try {
+    surfaces = assertTarballSurfaces({
+      assetName: path.basename(tarball),
+      rootDirName: path.basename(installRoot),
+      manifest,
+    });
+  } catch (err) {
+    die(err.message);
+  }
+
   const launcher = path.join(installRoot, "bin", "actana");
   if (!fs.existsSync(launcher)) die("tarball has no bin/actana launcher");
   if (!(fs.statSync(launcher).mode & 0o111)) {
@@ -137,6 +161,7 @@ async function main() {
   const scrubbedPath = pathWithoutNode(process.env.PATH);
 
   log(`tarball=${tarball}`);
+  log(`asset name, archive root and manifest agree: ${surfaces.version} ${surfaces.target}`);
   log(
     `manifest version=${manifest.version} protocol=${manifest.protocolVersion} ` +
       `target=${manifest.target} node=${manifest.nodeVersion}`,


### PR DESCRIPTION
Implements #321 under the decision [ADR 0036](https://github.com/actana/control/blob/feat/release-pipeline/docs/adr/0036-the-beta-release-channel.md) §E already reached. Base is `feat/release-pipeline`.

## Read this first: the branch name is wrong on purpose, and the work is not

The branch is called `fix/core-tarball-version-neutral`, and **a version-neutral Core tarball is exactly what this PR does not build**. ADR 0036 **D19** refuses that route once, with its price attached: taking the version out of the asset name, the archive root and the manifest is a change to the installer contract 0016 D29 names, *"a breaking change requiring a major bump plus a documented migration"* — the wrong trade at 0.4.1. **D18** drops the tarball half of promotion instead: a digest is version-neutral, a Core tarball is not, and that is a property to keep rather than a defect to remove. `release.yml` is unchanged, and so is the shape of `core-manifest.json`.

So what is implementable here is the other half of the record: if a tarball self-identifies, make it say one true thing, make a beta's string exactly `x.y.z-beta` (**C1**), and make beta assets and release assets unconfusable in the artifact rather than in a promise (**D20**).

## What changed

**One gate, three doors** (`scripts/lib/core-tarball.mjs`). `assertCoreVersion` is the version contract in one place, and `tarballName`, `tarballRootDirName` and `buildManifest` all call it — no string can reach one surface by a path that skips the other two. The rule is C1's: a beta is `x.y.z-beta`, with nothing after the word, on every surface including the asset filename. A counted beta (`0.4.1-beta.1`, `0.4.1-beta1`, a run number, a date, a short sha) is refused outright. The backport candidate 0023 D30 publishes keeps its identifier, so the ban is on a counted *beta*, not on every prerelease.

New pure helpers, all unit-tested: `parseTarballName` (reads a name back the way `install.sh` does), `assertShasumsSet` (what one checksum file may cover), `assertTarballSurfaces` (the asset name, the archive root and the manifest must be one string).

**The builder** (`scripts/build-core-tarball.mjs`) gates `--version` before anything is staged, so a bad string fails with a `[core-tarball]` line instead of deep inside a tar, and the log names the channel. There is no channel field in the manifest and this PR does not add one — a beta is a beta because its version says so.

**The composer** (`scripts/compose-core-shasums.mjs`) now reads every basename through that contract before hashing: an unrecognisable file, a second tarball for one target, and two versions in one directory are each refused by name. A `SHA256SUMS` listing `0.4.1-beta` beside `0.4.1` is precisely the confusion D20 rules out, published under a single name. `--expect` is untouched; the new `--version` is optional and nothing passes it today.

**The smoke** (`scripts/smoke-core-tarball.mjs`) checks the three surfaces against each other on the extracted bytes before it boots anything. The builder derives all three from one variable, so only the artifact can prove it.

**The consumer** (`packages/cli/src/actana-layout.ts` + tests) needed no code, and that is the claim: the manifest shape is unchanged, `installDirFor` already treats the version as an untrusted path segment, and two different strings are two different directories. A beta lands in `versions/0.4.1-beta`, beside its line's release rather than on top of it, and `placeCoreBundle` reports `0.4.1-beta`. Asserted rather than assumed.

## Proved by building, not by reading

The tarball job's earlier failure was the CLI bundle (`packages/cli/dist-tarball`), so nothing here is claimed off the source:

- Built `actana-core-0.4.1-beta-linux-x64.tar.gz`: asset name, archive root **and** `core-manifest.json` all `0.4.1-beta`, `protocolVersion 0.17.0`.
- Smoked it: `OK — extracted tarball boots a dialable Core with no system Node`.
- Built and smoked `0.4.1` as well — the release path is unchanged.
- **Renamed the beta file to the release's name and re-smoked it**: refused with *"extracts to `actana-core-0.4.1-beta-linux-x64`, not `actana-core-0.4.1-linux-x64` — the asset name and the archive root disagree"*. That is D18's central claim, checked against bytes.
- Composer over a directory holding both: refused, *"two versions in one checksum set"*. Over the beta alone: `SHA256SUMS` written and verified with `sha256sum -c`.
- `node scripts/build-core-tarball.mjs --version 0.4.1-beta.1` → `[core-tarball] counted beta version … (ADR 0036 C1)`.

Unit tests: `scripts/__tests__/core-tarball.test.mjs` 58 passing; `install-sh.test.mjs` 43 passing (the naming contract's other reader); `packages/cli` layout + setup suites passing; ESLint and `tsc --noEmit` clean on every file touched.

## Notes for the tickets that own the files I did not touch

I own none of these and edited none of them.

**#327 (`.github/workflows/*`)** — nothing is *required*. Two optional pickups, both additive:
1. `release.yml`'s `compose-core-shasums.mjs --dir core-tarballs --expect 3` may gain `--version "$RELEASE_VERSION"`, which asserts the composed set is the version being released rather than something left in the directory.
2. Same for the `github-release` job if it ever wants the assertion earlier than the asset-count check.

Everything already in `release.yml` keeps working unchanged, including `--expect 3` and both tarball legs. Under D18 it stays a build, not a promotion.

**#318 (`beta-release.yml`)** — the builder takes the beta version directly:
```
node scripts/build-core-tarball.mjs --target "$TARGET" --version "$LINE-beta" --out-dir artifacts/core
node scripts/compose-core-shasums.mjs --dir core-tarballs --expect 3 --version "$LINE-beta"
```
`pnpm build:core-tarball-bundles` must run first — both bundles, not just the Core's; that is what broke the tarball legs before, and `core-tarball.test.mjs` asserts every workflow calling the builder runs it. A leading `v` is stripped, so a tag ref works; a counted string (`-beta.${{ github.run_number }}`) is refused by the builder, by design.

**#320 (npm)** — unaffected. `assertCoreVersion` governs the Core tarball's surfaces only; nothing here touches `packages/cli/build.mjs`, its manifest or `assertPackedManifest`.

**#322 / #317 (version comparison, out of scope here)** — worth knowing: `isNewerSemver` in `packages/shared/src/semver.ts` compares the numeric core only, so a machine on `0.4.1-beta` is never told `0.4.1` is available (`actana-update-check.ts:148`). That is the "compared numerically" question ADR 0036 assigns to #322's second criterion, not this ticket's file set — flagging it rather than editing it.

**Not touched, as instructed:** any workflow, `install.sh`, `packages/cli/build.mjs`, `packages/cli/package.json`, `docs/`. Nothing merged, nothing dispatched, `main` untouched.

## One environment note

Running the tarball smoke *inside* an Actana Core container makes the spawned daemon read the container contract it inherits (`ACTANA_CONTAINER=1`, `ACTANA_PORT`) and ignore the port `coreSmokeEnv` picked, so it collides with the host Core on 443. Scrubbing those variables makes it pass. CI never runs the smoke inside a Core, so nothing is broken here; `scripts/lib/core-smoke.mjs` is not in this ticket's file set, and this is a note rather than a change.
