### PR TITLE
feat(ci): the beta image tags, retagged from the train's digest — and #337's npm asset step

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -209,18 +209,24 @@ name: Beta release
 #      the same string the tag, the Release and every asset filename carry. A
 #      counter cannot reach the image tag without failing the cut outright.
 #   2. The digest's own `org.opencontainers.image.version` label, held to that
-#      string by `scripts/lib/version-agreement.mjs`. That module and
-#      `container-image.yml`'s `version:` input arrive with #327 (ADR 0037 D3,
-#      D4), which is open and not in this branch's base. Image mode is exactly
-#      where that ban had a hole — it short-circuits before `checkAgreement`,
-#      and `lineOf("0.4.1-beta.1")` is `0.4.1`, which agrees with a correctly
-#      labelled digest — so #327 moved the ban into `imageVersionProblem`
-#      itself *"which is what lets #319's beta retag inherit it"*.
+#      string by `scripts/lib/version-agreement.mjs` — #327's module, reached
+#      here by passing `version: <beta_version>` to `container-image.yml` (ADR
+#      0037 D3, D4). Image mode is exactly where that ban had a hole: it
+#      short-circuits before `checkAgreement`, which was the only caller of
+#      `versionProblem`, and `lineOf("0.4.1-beta.1")` is `0.4.1` — which agrees
+#      with a correctly labelled digest, so the counted string published green.
+#      #327 moved the ban into `imageVersionProblem` itself *"which is what lets
+#      #319's beta retag inherit it"*, and this is the caller that inherits it.
 #
-# Passing an input a reusable workflow does not declare is a hard failure, so
-# these jobs cannot pass `version:` before #327 lands. `workflows.test.mjs`
-# binds the two instead: the moment `container-image.yml` declares that input,
-# the retag jobs must pass `beta_version` or the suite goes red.
+# **The beta string is passed, not the line.** `--expected 0.4.1 --image-label
+# 0.4.1` exits zero for a digest tagged `0.4.1-beta.1`; `--expected 0.4.1-beta.1`
+# exits one and names the counted beta. Handing this the line would restore the
+# hole while looking like a version check, so `workflows.test.mjs` pins the
+# value rather than the presence — and it pins it conditionally, on whether
+# `container-image.yml` declares the input at all, because passing one a
+# reusable workflow does not declare is a hard failure. That binding is what
+# turned red the moment #327 merged under this branch, which is how the wiring
+# above came to be written rather than remembered.
 #
 # ── The CLI is a Release asset, never an npm version (#320, D15, D16) ────────
 #
@@ -1313,6 +1319,16 @@ jobs:
       # scaffolding tags to discriminate (ADR 0023 D12) — but the input is
       # required, and the honest value is the version this cut publishes.
       stage: ${{ needs.resolve.outputs.beta_version }}
+      # ADR 0037 D4, and the half of C1's ban this file does not own. The
+      # **beta string**, not the line: `container-image.yml` holds the
+      # digest's `org.opencontainers.image.version` label to `lineOf` this,
+      # and refuses a counted beta by name before the comparison — which is
+      # the check that reaches image mode at all, because image mode
+      # short-circuits before `checkAgreement` and `lineOf("0.4.1-beta.1")`
+      # is `0.4.1`, agreeing with a correctly labelled digest. Passing the
+      # line here would hand it the string that already agrees and lose the
+      # ban (ADR 0037 D7, D8).
+      version: ${{ needs.resolve.outputs.beta_version }}
       mode: promote
       # `beta-0.4.1`, the moving handle `ci.yml`'s train jobs publish on every
       # merge. It moves on a different clock from the tag below: this one per
@@ -1338,6 +1354,16 @@ jobs:
       image: panel
       ref: ${{ needs.resolve.outputs.sha }}
       stage: ${{ needs.resolve.outputs.beta_version }}
+      # ADR 0037 D4, and the half of C1's ban this file does not own. The
+      # **beta string**, not the line: `container-image.yml` holds the
+      # digest's `org.opencontainers.image.version` label to `lineOf` this,
+      # and refuses a counted beta by name before the comparison — which is
+      # the check that reaches image mode at all, because image mode
+      # short-circuits before `checkAgreement` and `lineOf("0.4.1-beta.1")`
+      # is `0.4.1`, agreeing with a correctly labelled digest. Passing the
+      # line here would hand it the string that already agrees and lose the
+      # ban (ADR 0037 D7, D8).
+      version: ${{ needs.resolve.outputs.beta_version }}
       mode: promote
       source_tag: beta-${{ needs.resolve.outputs.version }}
       tags: ${{ needs.resolve.outputs.beta_version }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -201,6 +201,39 @@ name: Beta release
 # this file is idempotent: the tag is force-moved, the assets are clobbered,
 # and a retag re-points a name that is already a name.
 #
+# **The two retags are not atomic with each other, and that state is named
+# rather than implied.** `core-image` and `panel-image` are independent
+# `promote` calls with no mutual gate, so one can fail where the other
+# succeeded — most plausibly on D16's or ADR 0037 D4's assertion, whose own
+# *Consequences* predict the trigger: *"the first promotion of a train whose
+# images predate this refuses."* The outcome is `core:x.y.z-beta` created and
+# `panel:x.y.z-beta` absent, beside a Release that is already published, with
+# the Core tag unwithdrawable under ADR 0023 D45. The *"they run last"*
+# argument above is about publish-versus-retag ordering and says nothing about
+# this split. Re-dispatching converges — the retag is idempotent — but only
+# while the train tip has not moved, which is the same caveat the paragraph
+# above carries. Making the pair atomic would need a barrier that does not
+# exist in `container-image.yml` and is not #319's to build.
+#
+# ── What #319 asks for and this file does not do (deferred to #315) ──────────
+#
+# #319's last criterion is *"a second cut re-points the tag, and says in the
+# log which digest it was moved off."* The first half is met: the tag moves,
+# and `container-image.yml` prints the source digest and inspects the result.
+# **The second half is not, and it is deferred rather than met.** Nothing on
+# this path reads `$IMAGE:x.y.z-beta`'s *existing* digest before `docker buildx
+# imagetools create` overwrites it: the tag-move step prints a git commit and
+# not an image digest, `build` prints the digest being moved **onto**, and the
+# `imagetools inspect` runs **after** the create. So on a second cut — the case
+# the criterion is about — the log does not say what was displaced.
+#
+# Meeting it properly needs a read in `container-image.yml`'s promote path,
+# before the create, and #319 puts that file out of scope in as many words
+# (*"that is a finding for #315, not a patch here"*). This file cannot do it
+# from the calling side: it never touches the registry itself. So the gap is
+# recorded here, in the pull request, and on #315, rather than left for a
+# reader to assume met.
+#
 # **The counted-beta ban reaches this path, and it is not this file's ban to
 # write** (ADR 0036 C1, ADR 0037 D7, D8). Two halves:
 #

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,17 +1,17 @@
 name: Beta release
 
 # A requested beta cut: the moving `vx.y.z-beta` tag, a prerelease GitHub
-# Release, three Core tarballs, their `SHA256SUMS`, `install.sh` beside them,
-# and the two `x.y.z-beta` image tags retagged from the train's own digests
-# (ADR 0036 D10).
+# Release, three Core tarballs, their `SHA256SUMS`, the packed CLI asset with
+# its checksum, `install.sh` beside them, and the two `x.y.z-beta` image tags
+# retagged from the train's own digests (ADR 0036 D10).
 #
 #   resolve ─┬─ tarball (linux-x64, linux-arm64) ─┬─ installer-e2e ─┬─ publish ─┬─ core-image
 #            │                                    │   (ubuntu x64)  │            │
 #            └─ tarball-macos (mac-arm64) ────────┴─────────────────┘            └─ panel-image
 #
 # Two stages write, and they are ordered by what cannot be taken back.
-# `publish` verifies every asset, moves the tag, creates or updates the
-# Release, and then reads the Release back to prove the prerelease flag
+# `publish` packs and verifies every asset, moves the tag, creates or updates
+# the Release, and then reads the Release back to prove the prerelease flag
 # survived. `core-image` and `panel-image` run after it and re-point
 # `x.y.z-beta` at the digest the train already published — the one act in this
 # file that nothing can undo (ADR 0023 D45: Docker Hub has no tag garbage
@@ -221,6 +221,48 @@ name: Beta release
 # these jobs cannot pass `version:` before #327 lands. `workflows.test.mjs`
 # binds the two instead: the moment `container-image.yml` declares that input,
 # the retag jobs must pass `beta_version` or the suite goes red.
+#
+# ── The CLI is a Release asset, never an npm version (#320, D15, D16) ────────
+#
+# `publish` packs `@actana/cli` with `scripts/rehearse-npm-publish.mjs --beta`
+# and attaches `actana-cli-x.y.z-beta.tgz` to this Release with its checksum
+# beside it. **Nothing is published to registry.npmjs.org, under any dist-tag**
+# (D15): a beta string carries no counter (C1) and npm burns a version on its
+# first publish, so a fixed string could go out once per train and the second
+# cut of the same beta would 403 after the tag had already moved.
+#
+# `--beta` takes the **line** (`0.4.1`), not the beta string: the `-beta` is
+# appended by the script, so there is no parameter a counter could arrive
+# through. The script also holds that line against the one
+# `packages/cli/package.json` carries, so a cut from the wrong branch fails
+# there rather than attaching the right filename to the wrong program. The
+# manifest edits it makes — the version, and the dropped `@actana/sdk`, which
+# is inlined into the bundle — are restored from the original bytes in a
+# `finally` before the step returns. Nothing is committed: the train's six
+# manifests carry `x.y.z` and `ci.yml`'s `Train rules` asserts them on every
+# pull request into the train (ADR 0023 D3).
+#
+# `--install-check` runs a real `npm i -g` into a fresh prefix under an empty
+# HOME and asks the installed `actana` its version. It is #320's acceptance
+# criterion, and it is run here as well as in `pnpm test` so the assertion is
+# made against the bytes that are actually attached. The staging step refuses
+# to continue unless the script reported `install=ok`, which it emits only when
+# the flag was really passed — a flag dropped from the invocation would
+# otherwise leave the check unmade and the run green.
+#
+# **The checksum is its own file, not a fourth `SHA256SUMS` row.** ADR 0036 D10
+# puts `SHA256SUMS` over *exactly* the three Core tarballs, and this file's
+# `--expect` is derived from `CORE_TARGETS` in `workflows.test.mjs` rather than
+# written as a literal — so a fourth row would contradict the record and break
+# the derivation at once. #320 asks for *"a row in `SHA256SUMS` or its own
+# file"*; this is its own file, `actana-cli-x.y.z-beta.tgz.sha256`, in
+# `sha256sum`'s two-space format, verified here the way an operator verifies
+# it, and named in `EXPECTED` so the prune step does not delete it on the next
+# cut.
+#
+# There is no provenance attestation on this path and the printed instructions
+# say so in as many words (D17). An attestation is a registry artifact and an
+# asset has none; the integrity story for a beta is the published checksums.
 #
 # ── The prerelease flag is read back, not trusted (ADR 0023 D9, ADR 0036 D11)
 #
@@ -767,6 +809,19 @@ jobs:
           node-version: 24.15.0
           package-manager-cache: false
 
+      # The CLI asset is packed in this job (#320, D16), and `pnpm pack` runs
+      # `packages/cli`'s `prepack` — `node build.mjs` — so the workspace has to
+      # be installed. This is the same pair `release.yml`'s `npm` job carries
+      # for the same script, and it is the only reason this job needs pnpm at
+      # all: nothing else here builds anything.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.1.2
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: core-tarball-*
@@ -829,6 +884,82 @@ jobs:
           done < <(find core-tarballs -maxdepth 1 -type f -name '*.tar.gz')
           echo "✅ three tarballs, all at $BETA_VERSION, no counter on any of them"
 
+      # ── The CLI asset (#320, ADR 0036 D16) ─────────────────────────────────
+      #
+      # The step #337 wrote out as YAML in its own pull request comment,
+      # because #318 owned this file at the time and that ticket owned none of
+      # it. Landed here, adjusted to the file as it now exists: `resolve`'s
+      # output is `version` rather than `line`, the Release ref is this job's
+      # `$TAG` rather than one re-derived from the pack's output, and the
+      # upload folds into `EXPECTED` — the single list the create, the clobber
+      # and the prune all read — instead of being a second `gh release upload`.
+      # That last one is not a preference: an asset attached outside `EXPECTED`
+      # is an asset the prune step deletes on the next cut.
+      #
+      # It runs **before the tag moves**, which is this job's own ordering
+      # principle rather than a change of mind about #337's: the assets are
+      # assembled and verified first, so a failed pack, a failed
+      # `--install-check` or a mis-named artifact leaves `vx.y.z-beta` naming
+      # the commit it named before the run started.
+      #
+      # `--out-dir artifacts/beta`, not `core-tarballs`: the two steps above
+      # sweep `*.tar.gz` there and are deliberately strict. A `.tgz` slips past
+      # both harmlessly, but staging the CLI asset into that directory before
+      # them is the debugging round this file's `EXPECTED` comment warned #320
+      # about, and there is no reason to walk up to the line.
+      #
+      # No `contents: write` is added for it — this job already has it for the
+      # Release — and no `id-token` at all: there is no provenance attestation
+      # on this path (D17).
+      - id: beta-cli
+        name: Pack the CLI as a beta Release asset
+        env:
+          # The LINE (`0.4.1`), not the beta string. The script appends
+          # `-beta`, which is why there is no parameter a counter could arrive
+          # through, and it holds this value against the line
+          # `packages/cli/package.json` carries before it packs anything.
+          BETA_LINE: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/rehearse-npm-publish.mjs \
+            --beta "$BETA_LINE" \
+            --out-dir artifacts/beta \
+            --install-check | tee -a "$GITHUB_OUTPUT"
+
+      # C1 and #320's acceptance criterion, both asserted against what the pack
+      # actually produced rather than against the variable that asked for it.
+      #
+      # `install=ok` is emitted only when `--install-check` really ran, so this
+      # is the guard on the flag itself: dropped from the invocation above, the
+      # pack still succeeds, the asset is still attached, and the one assertion
+      # #320 calls the whole ticket would simply not have been made.
+      #
+      # The checksum is written here as its own file rather than as a fourth
+      # `SHA256SUMS` row (ADR 0036 D10 — that file is over exactly the three
+      # Core tarballs), in `sha256sum`'s two-space format, and verified the way
+      # an operator verifies it.
+      - name: Stage the CLI asset and its checksum beside the Core assets
+        env:
+          BETA_VERSION: ${{ needs.resolve.outputs.beta_version }}
+          ASSET: ${{ steps.beta-cli.outputs.asset }}
+          TARBALL: ${{ steps.beta-cli.outputs.tarballs }}
+          SHA256: ${{ steps.beta-cli.outputs.sha256 }}
+          INSTALL: ${{ steps.beta-cli.outputs.install }}
+        run: |
+          set -euo pipefail
+          if [[ "$INSTALL" != "ok" ]]; then
+            echo "::error title=The CLI asset was packed but never installed::scripts/rehearse-npm-publish.mjs reported install='$INSTALL'. It emits \`install=ok\` only when \`--install-check\` actually ran the \`npm i -g\` into a fresh prefix and asked the installed \`actana\` its version — #320's acceptance criterion, made here against the bytes that are attached rather than against a copy of them. Restore \`--install-check\` on the pack step."
+            exit 1
+          fi
+          if [[ "$ASSET" != "actana-cli-$BETA_VERSION.tgz" ]]; then
+            echo "::error title=The CLI asset is misnamed::the pack produced '$ASSET', not \`actana-cli-$BETA_VERSION.tgz\`. The asset filename is the URL an operator pastes into \`npm i -g\`, and it carries the bare beta version with no counter (ADR 0036 C1)."
+            exit 1
+          fi
+          cp "$TARBALL" "core-tarballs/$ASSET"
+          printf '%s  %s\n' "$SHA256" "$ASSET" > "core-tarballs/$ASSET.sha256"
+          ( cd core-tarballs && sha256sum -c "$ASSET.sha256" )
+          echo "✅ $ASSET staged at $BETA_VERSION, installed for real, checksum verified"
+
       # ── The tag move (ADR 0036 D7) ─────────────────────────────────────────
       #
       # Deliberately force-updated, and the previous sha is named in the log
@@ -888,18 +1019,20 @@ jobs:
       # beta is a supported operation, not a repair, and must leave nothing of
       # the previous one behind (ADR 0036 D7).
       #
-      # **`EXPECTED` is the asset contract of this file, and it is the line #320
-      # extends.** That ticket attaches the packed CLI tarball to this same
-      # Release (D16); adding the upload without adding the name here would have
-      # the prune step delete it on the next cut.
+      # **`EXPECTED` is the asset contract of this file**, read by the create,
+      # by the clobbering upload and by the prune, so a name that is not here
+      # is a name the next cut deletes. It is seven now: the three Core
+      # tarballs, `SHA256SUMS`, `install.sh`, and #320's packed CLI tarball
+      # with its own `.sha256` beside it (D16, and D10 for why the CLI's
+      # checksum is a file rather than a fourth `SHA256SUMS` row).
       #
-      # One ordering caveat for that ticket, so it is not found by debugging:
-      # `compose-core-shasums.mjs --expect 3` and the filename guard above both
-      # sweep `*.tar.gz` in `core-tarballs/`, and both are deliberately strict.
-      # `pnpm pack` produces a `.tgz`, which slips past both harmlessly — but a
-      # CLI asset staged into that directory under a `*.tar.gz` name before
-      # those steps would break `--expect 3` and trip the foreign-asset guard.
-      # Stage it after them, or give it a name that is not `*.tar.gz`.
+      # The ordering caveat this comment used to leave for #320 has been taken
+      # rather than left: `compose-core-shasums.mjs --expect 3` and the
+      # filename guard above both sweep `*.tar.gz` in `core-tarballs/` and both
+      # are deliberately strict, so the CLI asset is packed into
+      # `artifacts/beta` and staged in after them. A `.tgz` would have slipped
+      # past both harmlessly; staging it in before them under a `*.tar.gz` name
+      # would break `--expect 3` and trip the foreign-asset guard.
       #
       # `install.sh` is attached as a **copy, not a door** (D5). The canonical
       # installer stays on `raw.githubusercontent.com/actana/control/main/install.sh`
@@ -941,11 +1074,13 @@ jobs:
                     "actana-core-$BETA_VERSION-linux-arm64.tar.gz"
                     "actana-core-$BETA_VERSION-mac-arm64.tar.gz"
                     "SHA256SUMS"
+                    "actana-cli-$BETA_VERSION.tgz"
+                    "actana-cli-$BETA_VERSION.tgz.sha256"
                     "install.sh")
           files=()
           for name in "${EXPECTED[@]}"; do
             if [[ ! -f "core-tarballs/$name" ]]; then
-              echo "::error title=An expected asset is missing::core-tarballs/$name was not produced by this run. The beta asset set is three Core tarballs, SHA256SUMS and install.sh (ADR 0036 D10)."
+              echo "::error title=An expected asset is missing::core-tarballs/$name was not produced by this run. The beta asset set is three Core tarballs, SHA256SUMS, the packed CLI tarball with its .sha256, and install.sh (ADR 0036 D10, D16)."
               exit 1
             fi
             files+=("core-tarballs/$name")
@@ -1096,6 +1231,37 @@ jobs:
             echo "- assets: $assets"
             echo ""
             echo "Nothing was published to npm — a beta is invisible to registry.npmjs.org (ADR 0036 D15)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # #320's last criterion: the instructions in the summary are the exact
+      # command an operator runs, built from the pack's own outputs and this
+      # job's `$TAG` rather than re-derived — so the string a reader copies and
+      # the string on the Release cannot drift.
+      #
+      # `npm i -g <asset URL>`, and nothing about an attestation, because there
+      # is not one on this path (D17). Integrity is the checksum row, which is
+      # named here and shipped beside the asset.
+      - name: Print the CLI install command
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          ASSET: ${{ steps.beta-cli.outputs.asset }}
+          SHA256: ${{ steps.beta-cli.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/$REPO/releases/download/$TAG/$ASSET"
+          {
+            echo "### Install the CLI half of this beta"
+            echo ""
+            echo "For a machine that drives Cores it does not host — no daemon, no Core on the box."
+            echo ""
+            echo '```'
+            echo "npm i -g $url"
+            echo '```'
+            echo ""
+            echo "Verify first, if you want to: \`$SHA256  $ASSET\` — the same row is in \`$ASSET.sha256\`, attached beside it."
+            echo ""
+            echo "_No npm registry version is published for a beta, and an asset carries no provenance attestation (ADR 0036 D15, D17)._"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── The two beta image tags (#319) ──────────────────────────────────────────

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,17 +1,26 @@
 name: Beta release
 
 # A requested beta cut: the moving `vx.y.z-beta` tag, a prerelease GitHub
-# Release, three Core tarballs, their `SHA256SUMS`, and `install.sh` beside
-# them (ADR 0036 D10).
+# Release, three Core tarballs, their `SHA256SUMS`, `install.sh` beside them,
+# and the two `x.y.z-beta` image tags retagged from the train's own digests
+# (ADR 0036 D10).
 #
-#   resolve ─┬─ tarball (linux-x64, linux-arm64) ─┬─ installer-e2e ─┬─ publish
-#            │                                    │   (ubuntu x64)  │
-#            └─ tarball-macos (mac-arm64) ────────┴─────────────────┘
+#   resolve ─┬─ tarball (linux-x64, linux-arm64) ─┬─ installer-e2e ─┬─ publish ─┬─ core-image
+#            │                                    │   (ubuntu x64)  │            │
+#            └─ tarball-macos (mac-arm64) ────────┴─────────────────┘            └─ panel-image
 #
-# `publish` is the only job that writes anything: it moves the tag, creates or
-# updates the Release, replaces every asset, and then reads the Release back to
-# prove the prerelease flag survived. Everything above it is a gate, so a red
-# leg leaves `vx.y.z-beta` exactly where it was.
+# Two stages write, and they are ordered by what cannot be taken back.
+# `publish` verifies every asset, moves the tag, creates or updates the
+# Release, and then reads the Release back to prove the prerelease flag
+# survived. `core-image` and `panel-image` run after it and re-point
+# `x.y.z-beta` at the digest the train already published — the one act in this
+# file that nothing can undo (ADR 0023 D45: Docker Hub has no tag garbage
+# collection and no undelete; ADR 0036 D23: nothing sweeps a beta image tag,
+# and the delete-capable credential is not widened to reach one).
+#
+# Everything above `publish` is a gate, so a red leg leaves `vx.y.z-beta`
+# exactly where it was — and because the retag is downstream of `publish`, a
+# red publish leaves the image tags where they were too.
 #
 # ── Why this is a file of its own (ADR 0036 D9) ──────────────────────────────
 #
@@ -131,6 +140,87 @@ name: Beta release
 # A second cut of the same beta is therefore a supported operation and not a
 # repair: the tag moves, every asset is replaced, and any asset the previous cut
 # left that this one does not produce is deleted before the new ones go up.
+#
+# ── The images are retagged, never rebuilt (#319, ADR 0036 D12, ADR 0023 D17)
+#
+# `core-image` and `panel-image` call `container-image.yml` in `promote` mode,
+# which is the machinery ADR 0023 D16 and D17 already built and which this file
+# calls rather than re-implements. **Nothing is built**: no `docker build`, no
+# Dockerfile, no Trivy leg, no per-arch scaffolding. Every build step in that
+# workflow is gated on `inputs.mode == 'build'`, and `resolve` there refuses a
+# `promote` without a `source_tag` and a `promote` with `push: false` before
+# anything is pulled.
+#
+# The bytes already exist. `ci.yml`'s `train-tags` → `*-image-train` jobs
+# published them as `beta-x.y.z` on the merge that made this tip, and the
+# greenness gate above refused to cut unless that **push** run was green —
+# which is precisely the run that publishes them. A `pull_request` run has the
+# same head sha and skips those jobs, and a draft resolves both image checks to
+# `pass` without building (ADR 0023 D33); that is why the gate filters the
+# event at the API *and* asserts it again in the `jq`, and it is why these jobs
+# hang off `resolve`. Retagging from a digest a `pull_request` run never
+# published is the hole that filter exists to close.
+#
+# What the two jobs do is give that digest a second name, `x.y.z-beta`, with
+# `docker buildx imagetools create` — one source, no rewritten config blob.
+# Standing between that and publishing bytes nobody cut is D16's assertion,
+# which `container-image.yml` makes on **every architecture the manifest
+# lists**, in the `build` job that `publish` there needs:
+#
+#     if [[ "$revision" != "$EXPECTED" ]]; then
+#       echo "::error title=Refusing to promote a digest built from another
+#       commit::…"
+#
+# It is the point, not a formality. `beta-x.y.z` moves on every train merge, so
+# between `resolve` reading the tip and these jobs retagging it somebody may
+# have merged, and D16 refuses that digest by name rather than publishing bytes
+# nobody cut.
+#
+# **`latest` is never in the tag list**, on either repository, and no `-dev`
+# handle is either — `promote` mode refuses `dev_tags` outright (ADR 0023 D36).
+# The tag list is exactly `x.y.z-beta`, one entry.
+#
+# **The two pinned check names are not reused.** `Panel image` / `Core image`
+# are required checks in the "Protect main" ruleset and are used by `ci.yml` on
+# pull requests and by `release.yml` on the release. These jobs are `Core image
+# (beta)` and `Panel image (beta)`, following the `Core image (train)`
+# convention `ci.yml` adopted for the same reason.
+#
+# **They run last, and that ordering is the irreversibility argument.** An
+# image tag cannot be taken back: ADR 0023 D45 records that Docker Hub has no
+# tag garbage collection and no undelete, D36 and D38 keep the delete-capable
+# credential permanently out of the repositories that hold `latest` — which is
+# exactly where these tags go — and ADR 0036 D23 settles the consequence: the
+# `x.y.z-beta` tags persist once the line promotes, nothing sweeps them, and
+# *"do not revisit by widening the list."* So this file puts the un-absorbable
+# act last, the way `release.yml` argues for its own final job. A retag that
+# ran before `publish` and then met a red `publish` would leave `x.y.z-beta` on
+# Docker Hub beside a Release that does not exist, permanently and with no
+# credential able to remove it. The reverse — a Release whose images are not
+# yet retagged — is repaired by re-dispatching the cut, because every step in
+# this file is idempotent: the tag is force-moved, the assets are clobbered,
+# and a retag re-points a name that is already a name.
+#
+# **The counted-beta ban reaches this path, and it is not this file's ban to
+# write** (ADR 0036 C1, ADR 0037 D7, D8). Two halves:
+#
+#   1. `resolve` refuses anything but `x.y.z-beta` before a single job starts,
+#      and these jobs publish `needs.resolve.outputs.beta_version` verbatim —
+#      the same string the tag, the Release and every asset filename carry. A
+#      counter cannot reach the image tag without failing the cut outright.
+#   2. The digest's own `org.opencontainers.image.version` label, held to that
+#      string by `scripts/lib/version-agreement.mjs`. That module and
+#      `container-image.yml`'s `version:` input arrive with #327 (ADR 0037 D3,
+#      D4), which is open and not in this branch's base. Image mode is exactly
+#      where that ban had a hole — it short-circuits before `checkAgreement`,
+#      and `lineOf("0.4.1-beta.1")` is `0.4.1`, which agrees with a correctly
+#      labelled digest — so #327 moved the ban into `imageVersionProblem`
+#      itself *"which is what lets #319's beta retag inherit it"*.
+#
+# Passing an input a reusable workflow does not declare is a hard failure, so
+# these jobs cannot pass `version:` before #327 lands. `workflows.test.mjs`
+# binds the two instead: the moment `container-image.yml` declares that input,
+# the retag jobs must pass `beta_version` or the suite goes red.
 #
 # ── The prerelease flag is read back, not trusted (ADR 0023 D9, ADR 0036 D11)
 #
@@ -1007,3 +1097,82 @@ jobs:
             echo ""
             echo "Nothing was published to npm — a beta is invisible to registry.npmjs.org (ADR 0036 D15)."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── The two beta image tags (#319) ──────────────────────────────────────────
+  #
+  # The argument for these two jobs — retag never rebuild, D16's assertion on
+  # every architecture, why `latest` cannot appear, why the check names carry
+  # `(beta)`, why they run after `publish`, and how the counted-beta ban
+  # reaches them — is at the head of this file under *"The images are
+  # retagged, never rebuilt"*. What is left here is the wiring.
+  #
+  # Both are `uses:` calls into the same reusable workflow `ci.yml` and
+  # `release.yml` call, in the mode that exists for exactly this
+  # (`container-image.yml`'s `promote`, ADR 0023 D16, D17). Nothing is
+  # re-implemented, and nothing about D16's refusal is weakened: this file
+  # cannot weaken it, because it does not contain it.
+  #
+  # `needs:` names every gate rather than only `publish`, which subsumes them.
+  # That is deliberate: #319's last acceptance criterion is about the tarball
+  # and installer-e2e legs specifically, and a later edit that took `publish`
+  # off this list must not silently take those with it.
+  #
+  # No `matrix:` override. The default is `amd64` + `arm64`, which is what the
+  # train publishes and therefore what the manifest lists — and the revision
+  # assertion runs once per row, so narrowing the matrix here would narrow the
+  # assertion rather than the work (there is no work: nothing is built).
+  #
+  # No `dev_tags:`. A promotion publishes to the release repository only, and
+  # `promote` mode refuses one outright (ADR 0023 D36).
+  #
+  # `push_required` is left at its default `true`. A registry outage must fail
+  # a cut: the alternative is a green run whose Release advertises an image tag
+  # that does not exist.
+  core-image:
+    name: Core image (beta)
+    needs: [resolve, tarball, tarball-macos, installer-e2e, publish]
+    uses: ./.github/workflows/container-image.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      image: core
+      # The commit, not the tag. This is the value D16 compares the digest's
+      # `org.opencontainers.image.revision` label against, and it is the same
+      # sha `publish` just moved `vx.y.z-beta` onto — so the image the beta
+      # advertises and the bytes the beta names are one commit by assertion
+      # rather than by coincidence.
+      ref: ${{ needs.resolve.outputs.sha }}
+      # Unused in this mode — nothing is built, so there are no per-arch
+      # scaffolding tags to discriminate (ADR 0023 D12) — but the input is
+      # required, and the honest value is the version this cut publishes.
+      stage: ${{ needs.resolve.outputs.beta_version }}
+      mode: promote
+      # `beta-0.4.1`, the moving handle `ci.yml`'s train jobs publish on every
+      # merge. It moves on a different clock from the tag below: this one per
+      # train merge, `0.4.1-beta` per cut (ADR 0036 D7). Lagging between cuts
+      # is what makes a cut a cut, and D16 is what stops the lag becoming a
+      # publish of bytes this run never gated.
+      source_tag: beta-${{ needs.resolve.outputs.version }}
+      # Exactly one tag, and `latest` is not in it — on either repository, ever
+      # (ADR 0036 D10). `beta_version` is the string `resolve` already refused
+      # to let carry a counter, and it is the same string the git tag, the
+      # Release and every asset filename carry (C1).
+      tags: ${{ needs.resolve.outputs.beta_version }}
+      push: true
+
+  panel-image:
+    name: Panel image (beta)
+    needs: [resolve, tarball, tarball-macos, installer-e2e, publish]
+    uses: ./.github/workflows/container-image.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      image: panel
+      ref: ${{ needs.resolve.outputs.sha }}
+      stage: ${{ needs.resolve.outputs.beta_version }}
+      mode: promote
+      source_tag: beta-${{ needs.resolve.outputs.version }}
+      tags: ${{ needs.resolve.outputs.beta_version }}
+      push: true

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -534,6 +534,42 @@ jobs:
           echo "::error title=No App identity::APP_ID and APP_PRIVATE_KEY must both be set. The beta tag is created under \`refs/tags/v*\`, whose ruleset restricts creation to bypass actors, and the App is the bypass actor (ADR 0023 D39, docs/REPO_SETUP.md §3). Checked here so a missing secret costs one dispatch rather than three tarball builds and a macOS runner."
           exit 1
 
+      # The same argument as the step above, applied to the other half of what
+      # this cut writes. `core-image` and `panel-image` push to Docker Hub, and
+      # `container-image.yml`'s own `resolve` refuses a missing credential —
+      # *"decided here, before anything is built"* — but that job does not
+      # start until `publish` has force-moved `vx.y.z-beta`, created the
+      # prerelease and uploaded all seven assets. Its refusal would arrive
+      # after the irreversible half of this cut, leaving a published beta
+      # Release advertising `x.y.z-beta` image tags that do not exist.
+      #
+      # That is the half-state the retag's placement after `publish` is meant
+      # to prevent, arriving from the other side — and the repair the header
+      # names, re-dispatching because every write here is idempotent, only
+      # converges while the train tip has not moved.
+      #
+      # `promote.yml:626-641` (*The credentials release.yml refuses without*)
+      # is the in-repo precedent and gives the reason in the same words: the
+      # downstream refusal is real, it is just too late. This is a copy rather
+      # than a shared script for the same reason it is there — the point is to
+      # fail in `resolve`, fifteen seconds in, instead of after the Release
+      # exists. `container-image.yml` still checks them itself; a beta cut is
+      # not the only way in.
+      - name: The Docker Hub credentials the retag refuses without
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -n "$DOCKERHUB_USERNAME" ]] || missing+=(DOCKERHUB_USERNAME)
+          [[ -n "$DOCKERHUB_TOKEN" ]] || missing+=(DOCKERHUB_TOKEN)
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            echo "::error title=A Docker Hub credential is missing::${missing[*]} not set. \`core-image\` and \`panel-image\` retag \`beta-x.y.z\` as \`x.y.z-beta\` on Docker Hub, which is the only registry images are published to (ADR 0018), and \`container-image.yml\` refuses on exactly these in its own \`resolve\` — but that job does not start until this cut has moved \`vx.y.z-beta\`, published the prerelease and uploaded every asset, so its refusal would arrive after the irreversible half. Nothing has been published. One personal access token (Read & Write) serves the push; see docs/REPO_SETUP.md section 2."
+            exit 1
+          fi
+          echo "✅ Docker Hub credentials are present. container-image.yml checks them again in its own resolve."
+
   # The two Linux legs, split from the mac leg for the reason `release.yml`
   # splits them: the mac runner bills at 10×, and keeping it out of this matrix
   # is what lets these two and the installer e2e run without waiting on it.

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -878,6 +878,30 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
   };
 
   /**
+   * A named step's `run:` script, as the shell receives it — comment lines
+   * dropped, blank lines dropped, every line trimmed.
+   *
+   * Step-scoped on purpose. `resolve` runs four `exit 1`s across three steps,
+   * so a `toContain("exit 1")` over the whole job is satisfied by the
+   * greenness gate's refusal while the credential preflight has none — the
+   * same class of assertion this file has now been reviewed for twice.
+   */
+  const stepRun = (text, job, stepName) => {
+    const lines = code(jobBlock(text, job)).split("\n");
+    const start = lines.findIndex((line) => line === `      - name: ${stepName}`);
+    expect(start, `no \`${stepName}\` step in ${job}`).toBeGreaterThan(-1);
+    const runAt = lines.findIndex((line, i) => i > start && line === "        run: |");
+    expect(runAt, `\`${stepName}\` has no run: block`).toBeGreaterThan(start);
+    const script = [];
+    for (const line of lines.slice(runAt + 1)) {
+      if (line.trim() === "") continue;
+      if (!/^ {10}/.test(line)) break;
+      script.push(line.trim());
+    }
+    return script;
+  };
+
+  /**
    * Every job in the file whose `uses:` is `container-image.yml`, in file
    * order — the jobs that can put a tag on Docker Hub.
    *
@@ -1400,14 +1424,58 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
         `missing+=(${secret})`,
       );
     }
-    expect(job).toContain("::error title=A Docker Hub credential is missing::");
     // The App identity, checked in the same job for the same reason — the beta
     // tag is created under a ruleset only the App can bypass. Pinned here
     // beside the registry credential because the argument is one argument.
     for (const secret of ["APP_ID", "APP_PRIVATE_KEY"]) {
       expect(job, `resolve does not preflight ${secret}`).toContain(`secrets.${secret}`);
     }
-    expect(job).toContain("::error title=No App identity::");
+
+    // Both preflights, held to the **refusal** and not to the annotation.
+    //
+    // A `::error` annotation does not fail a step — it decorates one. So a
+    // step that emits the message and then falls through to its success line
+    // exits 0, the cut proceeds, and every assertion above it still passes:
+    // the secrets are wired, the arms append, the title is present, the job is
+    // `resolve`. Review r2 mutated exactly that — the annotation kept, `exit 1`
+    // dropped — and the suite stayed at 95 passed. It is r1's finding 3 in the
+    // test written to answer r1's finding 1, so it is held to the same bar.
+    //
+    // Pinned structurally, in three links, per step: the guard that routes to
+    // the refusal, the annotation, and the `exit 1` on the line after it.
+    for (const [step, title, guard] of [
+      [
+        "The Docker Hub credentials the retag refuses without",
+        "A Docker Hub credential is missing",
+        'if [[ "${#missing[@]}" -gt 0 ]]; then',
+      ],
+      [
+        "Require the App credentials",
+        "No App identity",
+        'if [[ -n "$APP_ID" && -n "$APP_PRIVATE_KEY" ]]; then',
+      ],
+    ]) {
+      const script = stepRun(source, "resolve", step);
+      // The condition that decides whether the refusal is reached. Without
+      // this, a guard mutated to one that can never hold leaves an `exit 1`
+      // that is present and unreachable.
+      expect(script, `${step}: the guard that reaches the refusal is gone`).toContain(guard);
+      let annotations = 0;
+      script.forEach((line, i) => {
+        if (!line.includes("::error title=")) return;
+        annotations += 1;
+        // Asserted inside the step rather than over the job: the title is what
+        // an operator reads, and it has to belong to the refusal that fires.
+        expect(line, `${step}: wrong ::error title`).toContain(`::error title=${title}::`);
+        expect(
+          script[i + 1],
+          `${step}: the ::error annotation is not followed by \`exit 1\` — an annotation decorates a step, it does not fail one, so this preflight would print its complaint and let the cut proceed`,
+        ).toBe("exit 1");
+      });
+      expect(annotations, `${step} emits no ::error annotation`).toBe(1);
+      expect(script, `${step} cannot fail`).toContain("exit 1");
+      expect(script[0], `${step} does not set -e`).toBe("set -euo pipefail");
+    }
     // Both refusals are in `resolve`, which is upstream of every job that
     // builds, publishes or retags — so a missing secret costs one dispatch
     // rather than three tarball builds, a macOS runner and a published

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -877,6 +877,20 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
     return match === null ? undefined : match[1].trim();
   };
 
+  /**
+   * Every job in the file whose `uses:` is `container-image.yml`, in file
+   * order — the jobs that can put a tag on Docker Hub.
+   *
+   * Derived rather than listed, because the invariants below are stated about
+   * the file and not about two names: a third promoting job added later must
+   * fall under them automatically, or the assertion is narrower than the claim
+   * it is written to defend.
+   */
+  const imageCallers = (text) =>
+    [...code(text).matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)]
+      .map((match) => match[1])
+      .filter((job) => jobKey(text, job, "uses") === "./.github/workflows/container-image.yml");
+
   // C3. A beta cut is *requested*, the way a promotion is (ADR 0023 D14),
   // because "published by accident" is the failure worth designing out. A
   // `push:` on `beta/**` here would be one line and would turn every merge into
@@ -1274,18 +1288,27 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
   // criterion is about those legs, and an edit that drops `publish` must not
   // silently drop them with it.
   it("retags only after every gate and after the Release exists (#319)", () => {
-    for (const job of ["core-image", "panel-image"]) {
+    const gates = ["resolve", "tarball", "tarball-macos", "installer-e2e", "publish"];
+    // Derived, not listed — the ordering is a property of every promoting job
+    // in this file, so a third one added later inherits it (see `imageCallers`).
+    const promoters = imageCallers(source);
+    expect(promoters).toEqual(["core-image", "panel-image"]);
+    for (const job of promoters) {
       const needs = jobKey(source, job, "needs");
-      for (const gate of ["resolve", "tarball", "tarball-macos", "installer-e2e", "publish"]) {
+      for (const gate of gates) {
         expect(needs, `${job} does not wait for ${gate}`).toContain(gate);
       }
     }
     // The other direction: nothing upstream of `publish` may reach the
-    // registry, or the ordering above is decoration.
-    for (const job of ["resolve", "tarball", "tarball-macos", "installer-e2e"]) {
-      const block = code(jobBlock(source, job));
-      expect(block, `${job} touches an image ahead of the gates`).not.toContain(
-        "container-image.yml",
+    // registry, or the ordering above is decoration. Asserted as *is not a
+    // caller* rather than *does not contain the string*, because `resolve`
+    // legitimately **names** `container-image.yml` — its credential preflight
+    // exists to refuse early on behalf of exactly that call, and quotes the
+    // file to say so. A string ban would forbid the reference rather than the
+    // reach; what makes a job reach the registry is its `uses:`.
+    for (const gate of gates) {
+      expect(promoters, `${gate} calls container-image.yml ahead of the gates`).not.toContain(
+        gate,
       );
     }
   });
@@ -1312,6 +1335,56 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
       expect(jobKey(source, job, "needs"), `${job} does not depend on the gate`).toContain(
         "resolve",
       );
+    }
+  });
+
+  // The credential preflight, which exists because of the two jobs above.
+  //
+  // `container-image.yml`'s own `resolve` refuses a missing `DOCKERHUB_*` —
+  // and it refuses **after** `publish` has force-moved `vx.y.z-beta`, created
+  // the prerelease and uploaded every asset, because that is where these jobs
+  // sit in the graph. A cut with an unset, rotated or expired token would
+  // therefore end green through the macOS leg and the installer e2e, publish a
+  // beta Release, and only then fail — leaving the Release advertising image
+  // tags that do not exist. That is the half-state the retag's placement after
+  // `publish` exists to prevent, arriving from the other side, and the repair
+  // the header names (re-dispatch; every write is idempotent) converges only
+  // while the train tip has not moved.
+  //
+  // `promote.yml`'s *The credentials release.yml refuses without* is the
+  // in-repo precedent for moving exactly this refusal earlier, for exactly
+  // this reason, and it is asserted in this file already.
+  //
+  // Asserted on the **secret names and the refusal**, in `resolve`, and paired
+  // with the App check beside it: what matters is that both irreversible
+  // halves of a cut are decided before either one starts.
+  it("refuses a cut whose Docker Hub credentials are missing, before anything is published", () => {
+    const job = code(jobBlock(source, "resolve"));
+    for (const secret of ["DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"]) {
+      expect(job, `resolve does not preflight ${secret}`).toContain(`secrets.${secret}`);
+      // The check itself, not just the wiring: an `env:` line with nothing
+      // reading it is a secret that is passed and never asked about.
+      expect(job, `resolve does not refuse on a missing ${secret}`).toContain(
+        `missing+=(${secret})`,
+      );
+    }
+    expect(job).toContain("::error title=A Docker Hub credential is missing::");
+    // The App identity, checked in the same job for the same reason — the beta
+    // tag is created under a ruleset only the App can bypass. Pinned here
+    // beside the registry credential because the argument is one argument.
+    for (const secret of ["APP_ID", "APP_PRIVATE_KEY"]) {
+      expect(job, `resolve does not preflight ${secret}`).toContain(`secrets.${secret}`);
+    }
+    expect(job).toContain("::error title=No App identity::");
+    // Both refusals are in `resolve`, which is upstream of every job that
+    // builds, publishes or retags — so a missing secret costs one dispatch
+    // rather than three tarball builds, a macOS runner and a published
+    // Release.
+    for (const later of ["tarball", "tarball-macos", "installer-e2e", "publish"]) {
+      expect(
+        jobKey(source, later, "needs"),
+        `${later} does not hang off the preflight`,
+      ).toContain("resolve");
     }
   });
 

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -136,8 +136,13 @@ describe("the workflow inventory (ADR 0016 D34)", () => {
     expect(source).not.toMatch(/^ {2}(?:push|pull_request|schedule|workflow_dispatch):/m);
   });
 
+  // `beta-release.yml` joined the list with #319. It calls the same reusable
+  // workflow in the one mode that builds nothing (`promote`, ADR 0023 D17), so
+  // "every path that touches an image" is the honest reading of this test now:
+  // three callers, one implementation, and no second place for D16's refusal
+  // to be weakened.
   it("calls the reusable build from every path that builds an image", () => {
-    for (const file of ["ci.yml", "release.yml"]) {
+    for (const file of ["ci.yml", "release.yml", "beta-release.yml"]) {
       expect(read(file)).toContain("uses: ./.github/workflows/container-image.yml");
     }
   });
@@ -839,6 +844,39 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
     return call.join("\n");
   };
 
+  /**
+   * The `with:` mapping a reusable-workflow job hands `container-image.yml`,
+   * as `key -> value`, read off the comment-stripped job the way the runner
+   * reads it.
+   *
+   * Same reason as `invocation` above: the inputs decide what is published,
+   * and a `toContain` over the job's text is satisfied by a comment or an
+   * error message naming the same string. This returns the mapping, so an
+   * assertion can say `tags` **is** one thing rather than that the word
+   * appears somewhere in the job.
+   */
+  const withInputs = (text, job) => {
+    const block = code(jobBlock(text, job));
+    const lines = block.split("\n");
+    const start = lines.findIndex((line) => line === "    with:");
+    expect(start, `no with: block in ${job}`).toBeGreaterThan(-1);
+    const inputs = {};
+    for (const line of lines.slice(start + 1)) {
+      if (line.trim() === "") continue;
+      if (!/^ {6}\S/.test(line)) break;
+      const pair = /^ {6}([a-z_]+): (.+)$/.exec(line);
+      expect(pair, `unparsed input line in ${job}: ${line}`).not.toBeNull();
+      inputs[pair[1]] = pair[2].trim();
+    }
+    return inputs;
+  };
+
+  /** A job's own scalar key (`name`, `uses`, `secrets`) at the job's indent. */
+  const jobKey = (text, job, key) => {
+    const match = new RegExp(`^ {4}${key}: (.+)$`, "m").exec(code(jobBlock(text, job)));
+    return match === null ? undefined : match[1].trim();
+  };
+
   // C3. A beta cut is *requested*, the way a promotion is (ADR 0023 D14),
   // because "published by accident" is the failure worth designing out. A
   // `push:` on `beta/**` here would be one line and would turn every merge into
@@ -894,12 +932,24 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
     const job = jobBlock(source, "resolve");
     expect(job).toContain("RUN_REF: ${{ github.ref_name }}");
     expect(code(job)).toContain('if [[ "$RUN_REF" != "$train" ]]; then');
-    // Dispatching nothing is what makes that refusal sufficient: this file runs
-    // the workflow it was dispatched as and calls no other, so there is no
-    // second copy for a caller's SHA to resolve.
-    expect(body, "a local uses: resolves from the caller's SHA (#326)").not.toMatch(
-      /uses: \.\/\.github\/workflows\//,
-    );
+    // Dispatching nothing is what makes that refusal sufficient, and #319's two
+    // retag jobs do not weaken it. This assertion used to read "no local
+    // `uses:` at all", which was true of a file that called nothing and is the
+    // wrong rule now: a reusable workflow named by **path** resolves from the
+    // *same commit* as its caller, so once the refusal above has held
+    // `github.ref_name` to the train, `core-image` and `panel-image` run the
+    // train's own copy of `container-image.yml`. That is the inverse of #326's
+    // trap rather than an instance of it.
+    //
+    // What resolves from somewhere else is a `owner/repo/....yml@ref` call —
+    // pinned to a ref this run did not choose — and a *dispatch*. The first is
+    // banned here; the second is covered by the loop below, which holds every
+    // `gh workflow run` in the file to its `--ref`.
+    for (const [, target] of body.matchAll(/uses: (\S*\.github\/workflows\/\S+)/g)) {
+      expect(target, "a reusable call that is not a local path (#326)").toMatch(
+        /^\.\/\.github\/workflows\/[a-z-]+\.yml$/,
+      );
+    }
     // The re-dispatch this file prints when it refuses is the one an operator
     // will paste, so it carries the `--ref` for the same reason #326 requires it
     // on every `gh workflow run release.yml` in the repository: a dispatch
@@ -1115,6 +1165,185 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
   // the sentence is pinned here, in the file whose existence depends on it.
   it("leaves release.yml's refusal of a tag on a train in place (D9)", () => {
     expect(code(read("release.yml"))).toContain("Tag is on neither main nor a release line");
+  });
+
+  // ── #319: the beta image tags ───────────────────────────────────────────────
+  //
+  // Every assertion below reads the `with:` mapping or a job's own keys rather
+  // than searching the file for a string. That is the shape the review of #318
+  // asked for after a flag count over a whole job was satisfied by two error
+  // messages quoting the flag: this file's header names `promote`, `latest`,
+  // `beta-x.y.z` and `x.y.z-beta` dozens of times in prose, so a `toContain`
+  // here would pass against a file that publishes nothing at all.
+
+  // #319's first and second criteria. The mode that retags is
+  // `container-image.yml`'s and this file calls it — the machinery is not
+  // re-implemented, so there is no second place for D16's refusal to be
+  // weakened. `mode: promote` refuses `push: false` and a missing `source_tag`
+  // in its own `resolve`, so a malformed call here fails before a pull.
+  it("retags both images from the train's digest, and builds nothing (#319, D12)", () => {
+    for (const [job, image] of [
+      ["core-image", "core"],
+      ["panel-image", "panel"],
+    ]) {
+      expect(jobKey(source, job, "uses")).toBe("./.github/workflows/container-image.yml");
+      // `version` is #327's input and is governed exclusively by the binding
+      // test below, which is the one that knows whether it exists yet. It is
+      // held out here so that wiring it correctly the day #327 lands does not
+      // make this test red for the right change.
+      const { version: _version, ...inputs } = withInputs(source, job);
+      expect(inputs).toEqual({
+        image,
+        ref: "${{ needs.resolve.outputs.sha }}",
+        stage: "${{ needs.resolve.outputs.beta_version }}",
+        mode: "promote",
+        // `beta-0.4.1` — the train's moving handle, from the line, not from
+        // the beta string. `beta-${{ … beta_version }}` would be
+        // `beta-0.4.1-beta`, a tag nothing publishes.
+        source_tag: "beta-${{ needs.resolve.outputs.version }}",
+        tags: "${{ needs.resolve.outputs.beta_version }}",
+        push: "true",
+      });
+      // The exhaustive `toEqual` above is what pins the absences, and each one
+      // is a real failure rather than tidiness: `dev_tags` is refused outright
+      // by promote mode (ADR 0023 D36), and a narrowed `matrix` would narrow
+      // D16's per-architecture assertion rather than any work — a promotion
+      // builds nothing, so there is nothing to save.
+      expect(inputs.dev_tags).toBeUndefined();
+      expect(inputs.matrix).toBeUndefined();
+      // `push_required` left at its default `true`: a registry outage must
+      // fail a cut rather than leave a Release advertising a tag that is not
+      // there.
+      expect(inputs.push_required).toBeUndefined();
+    }
+    // Nothing in this file builds an image or scans one. The retag is a
+    // second name for bytes the train already gated (#319's second criterion).
+    expect(body).not.toContain("docker build");
+    expect(body).not.toContain("Dockerfile");
+    expect(body).not.toMatch(/trivy/i);
+  });
+
+  // #319's fourth criterion, on the surface it is about. Asserted as the whole
+  // value of `tags` rather than as the absence of the word: this file says
+  // `--latest=false` and `/releases/latest` in the Release steps, so "latest
+  // does not appear" is both false and beside the point. One tag, no space, no
+  // second entry.
+  it("puts exactly one tag on each repository, and latest is never it (D10)", () => {
+    for (const job of ["core-image", "panel-image"]) {
+      const tags = withInputs(source, job).tags;
+      expect(tags).toBe("${{ needs.resolve.outputs.beta_version }}");
+      // `tags` is space-separated, so one whole expression and nothing beside
+      // it is what "exactly one tag" means at this level. A second entry —
+      // `latest`, or a literal — would sit outside the braces.
+      expect(tags, "a second tag would ride along on the same retag").toMatch(
+        /^\$\{\{[^{}]*\}\}$/,
+      );
+    }
+    // And the string that expands there cannot be `latest` or anything else:
+    // `resolve` builds it by one concatenation and refuses any other shape.
+    expect(code(jobBlock(source, "resolve"))).toContain('beta_version="$version-beta"');
+    expect(code(jobBlock(source, "resolve"))).toContain(
+      '^[0-9]+\\.[0-9]+\\.[0-9]+-beta$',
+    );
+  });
+
+  // #319's fifth criterion. `Panel image` / `Core image` are required checks in
+  // the "Protect main" ruleset; reusing either name here would make a beta cut
+  // report under a check the ruleset gates pull requests on. `ci.yml`'s train
+  // jobs solved this with `(train)` and this file follows with `(beta)`.
+  it("does not reuse the pinned Panel image / Core image check names", () => {
+    expect(jobKey(source, "core-image", "name")).toBe("Core image (beta)");
+    expect(jobKey(source, "panel-image", "name")).toBe("Panel image (beta)");
+    // The pinned names, unqualified, must not appear as a job name anywhere in
+    // this file — the check the ruleset knows is the bare one.
+    expect(source).not.toMatch(/^ {4}name: (?:Panel|Core) image$/m);
+    // And they are still where the ruleset expects them, so this test fails if
+    // the convention it is following is the thing that moved.
+    expect(read("release.yml")).toMatch(/^ {4}name: Core image$/m);
+    expect(read("ci.yml")).toMatch(/^ {4}name: Core image \(train\)$/m);
+  });
+
+  // #319's sixth criterion, and the irreversibility argument behind it. An
+  // image tag cannot be taken back: Docker Hub has no tag garbage collection
+  // and no undelete (ADR 0023 D45), the delete-capable credential is kept out
+  // of the repositories holding `latest` (D36, D38), and ADR 0036 D23 refuses
+  // to widen it — so `x.y.z-beta` persists, and a retag that ran beside a
+  // failed publish would persist beside a Release that does not exist.
+  //
+  // `publish` subsumes the three gate jobs, and they are named anyway: the
+  // criterion is about those legs, and an edit that drops `publish` must not
+  // silently drop them with it.
+  it("retags only after every gate and after the Release exists (#319)", () => {
+    for (const job of ["core-image", "panel-image"]) {
+      const needs = jobKey(source, job, "needs");
+      for (const gate of ["resolve", "tarball", "tarball-macos", "installer-e2e", "publish"]) {
+        expect(needs, `${job} does not wait for ${gate}`).toContain(gate);
+      }
+    }
+    // The other direction: nothing upstream of `publish` may reach the
+    // registry, or the ordering above is decoration.
+    for (const job of ["resolve", "tarball", "tarball-macos", "installer-e2e"]) {
+      const block = code(jobBlock(source, job));
+      expect(block, `${job} touches an image ahead of the gates`).not.toContain(
+        "container-image.yml",
+      );
+    }
+  });
+
+  // #318's review named this as the hole that opens the moment #319 lands: a
+  // promotion pull request run has the same head sha as the train tip and
+  // skips `Resolve train tags` / `Core image (train)` / `Panel image (train)`,
+  // and under ADR 0023 D33 a draft resolves both image checks to `pass`
+  // without building. The digest this retag re-points is exactly the one such
+  // a run never publishes.
+  //
+  // So the filter and the dependency are asserted together. Either alone is
+  // satisfiable while the hole is open: a filter nothing depends on gates
+  // nothing, and a dependency on an unfiltered gate is a dependency on a
+  // pull_request run.
+  it("retags only behind the greenness gate that filters the push event (D21, D41)", () => {
+    const gate = code(jobBlock(source, "resolve"));
+    expect(gate, "the gate no longer filters the event at the API").toContain("--event push");
+    expect(gate, "the gate no longer asserts the event it selected").toContain(
+      'select(.headSha == $sha and .event == "push")',
+    );
+    expect(gate).toContain("Not a push run");
+    for (const job of ["core-image", "panel-image"]) {
+      expect(jobKey(source, job, "needs"), `${job} does not depend on the gate`).toContain(
+        "resolve",
+      );
+    }
+  });
+
+  // ADR 0037 D7 and D8: a counted beta is refused wherever a version string is
+  // validated, and #319 *inherits* that check rather than writing one. #327
+  // moved the ban into `imageVersionProblem` precisely because image mode
+  // short-circuits before `checkAgreement` and `lineOf("0.4.1-beta.1")` is
+  // `0.4.1`, which agrees with a correctly labelled digest.
+  //
+  // That module and `container-image.yml`'s `version:` input are #327's and
+  // are not in this branch's base. Passing an input a reusable workflow does
+  // not declare is a hard failure, so this test binds the two rather than
+  // asserting one of them: while the input does not exist the retag must not
+  // pass it, and the moment it does exist the retag must pass the beta string
+  // — `beta_version`, not the line, because the line is what a correctly
+  // labelled digest already says and the counter is what has to be caught.
+  it("passes the version the counted-beta ban is applied to, once #327 declares it", () => {
+    const declared = /^ {6}version:$/m.test(read("container-image.yml"));
+    for (const job of ["core-image", "panel-image"]) {
+      const { version } = withInputs(source, job);
+      if (declared) {
+        expect(
+          version,
+          `${job} does not hand container-image.yml the string ADR 0037 D7 bans a counter in`,
+        ).toBe("${{ needs.resolve.outputs.beta_version }}");
+      } else {
+        expect(
+          version,
+          `${job} passes a version input container-image.yml does not declare — the call would fail to start`,
+        ).toBeUndefined();
+      }
+    }
   });
 });
 

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -1345,6 +1345,106 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
       }
     }
   });
+
+  // ── #320: the CLI asset, landed from #337's pull request comment ────────────
+
+  // D15 and D16. The line, never the beta string — the script appends `-beta`,
+  // which is what leaves no parameter a counter could arrive through — and the
+  // real `npm i -g`, run against the bytes that are attached rather than
+  // against a copy of them.
+  it("packs the CLI as an asset from the line, and installs it for real (D16)", () => {
+    const job = code(jobBlock(source, "publish"));
+    const call = invocation(job, "rehearse-npm-publish.mjs");
+    expect(call).toContain('--beta "$BETA_LINE"');
+    expect(call, "the pack must not reach the release path's publish flags").not.toContain(
+      "--version",
+    );
+    expect(call, "the asset must not be staged where the Core guards sweep").toContain(
+      "--out-dir artifacts/beta",
+    );
+    expect(call, "#320's acceptance criterion is the install, not the pack").toContain(
+      "--install-check",
+    );
+    // `BETA_LINE` is the line (`0.4.1`), not `beta_version` (`0.4.1-beta`).
+    // `betaVersion("0.4.1-beta")` throws, so the wrong one is caught at
+    // runtime — but only after a macOS leg and three tarballs have been paid
+    // for, and the point of C1 is that no surface derives a second time.
+    expect(job).toContain("BETA_LINE: ${{ needs.resolve.outputs.version }}");
+    expect(job).not.toContain("BETA_LINE: ${{ needs.resolve.outputs.beta_version }}");
+  });
+
+  // The guard on the flag rather than on the artifact. `install=ok` is emitted
+  // by the script only when `--install-check` actually ran, so dropping the
+  // flag leaves a green run with an attached asset and the one assertion #320
+  // calls the whole ticket never made.
+  it("refuses an asset that was packed but never installed (D16)", () => {
+    const job = code(jobBlock(source, "publish"));
+    expect(job).toContain("INSTALL: ${{ steps.beta-cli.outputs.install }}");
+    expect(job).toContain('if [[ "$INSTALL" != "ok" ]]; then');
+    // And the filename, which is what an operator pastes into a terminal (C1).
+    expect(job).toContain('if [[ "$ASSET" != "actana-cli-$BETA_VERSION.tgz" ]]; then');
+  });
+
+  // ADR 0036 D10 puts `SHA256SUMS` over exactly the three Core tarballs and
+  // this file's `--expect` is derived from `CORE_TARGETS`, so #320's checksum
+  // is its own file rather than a fourth row — the option that ticket names
+  // beside the row and leaves both the record and the derivation intact.
+  //
+  // Ordering is asserted, not assumed: `compose-core-shasums.mjs` and the
+  // foreign-asset guard both sweep `core-tarballs/`, so the CLI asset is
+  // staged in after them.
+  it("gives the CLI asset its own checksum file, staged after the Core guards (D10)", () => {
+    const job = code(jobBlock(source, "publish"));
+    expect(job).toContain(
+      `compose-core-shasums.mjs --dir core-tarballs --expect ${CORE_TARGETS.length}`,
+    );
+    expect(job).toContain(`printf '%s  %s\\n' "$SHA256" "$ASSET" > "core-tarballs/$ASSET.sha256"`);
+    expect(job, "the sidecar is verified the way an operator verifies it").toContain(
+      'sha256sum -c "$ASSET.sha256"',
+    );
+    const compose = job.indexOf("compose-core-shasums.mjs");
+    const guard = job.indexOf("A foreign asset is in the tarball directory");
+    const stage = job.indexOf('cp "$TARBALL" "core-tarballs/$ASSET"');
+    expect(compose).toBeGreaterThan(-1);
+    expect(guard).toBeGreaterThan(-1);
+    expect(stage, "the CLI asset is staged before the Core guards sweep the directory")
+      .toBeGreaterThan(Math.max(compose, guard));
+    // And before the tag moves, which is this job's own ordering principle: a
+    // failed pack must leave `vx.y.z-beta` where it was.
+    expect(stage, "the asset is assembled after the tag has already moved").toBeLessThan(
+      job.indexOf('git push --force origin "refs/tags/$TAG"'),
+    );
+  });
+
+  // `EXPECTED` is the one list the create, the clobbering upload and the prune
+  // all read. An asset uploaded outside it is an asset the next cut deletes,
+  // which is the trap this file's own comment warned #320 about.
+  it("names the CLI asset and its checksum in the asset contract (D7, D16)", () => {
+    const job = code(jobBlock(source, "publish"));
+    const expected = /EXPECTED=\(([\s\S]*?)\)\n/.exec(job);
+    expect(expected, "no EXPECTED list").not.toBeNull();
+    const names = [...expected[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    expect(names).toEqual([
+      ...CORE_TARGETS.map(({ target }) => `actana-core-$BETA_VERSION-${target}.tar.gz`),
+      "SHA256SUMS",
+      "actana-cli-$BETA_VERSION.tgz",
+      "actana-cli-$BETA_VERSION.tgz.sha256",
+      "install.sh",
+    ]);
+  });
+
+  // #320's last criterion: the printed command is the one an operator runs,
+  // built from the pack's own outputs and this job's tag rather than
+  // re-derived — and it says there is no attestation, because ADR 0036 D17
+  // says #323's instructions must not imply one.
+  it("prints the exact install command, and claims no attestation (D17)", () => {
+    const job = code(jobBlock(source, "publish"));
+    expect(job).toContain('url="https://github.com/$REPO/releases/download/$TAG/$ASSET"');
+    expect(job).toContain('echo "npm i -g $url"');
+    expect(job).toContain("ASSET: ${{ steps.beta-cli.outputs.asset }}");
+    expect(job).toContain("SHA256: ${{ steps.beta-cli.outputs.sha256 }}");
+    expect(job).toMatch(/no provenance attestation/);
+  });
 });
 
 describe("the manifest version assertion (ADR 0023 D3, amended by #152 and #157)", () => {

--- a/scripts/__tests__/workflows.test.mjs
+++ b/scripts/__tests__/workflows.test.mjs
@@ -1201,6 +1201,15 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
       ["panel-image", "panel"],
     ]) {
       expect(jobKey(source, job, "uses")).toBe("./.github/workflows/container-image.yml");
+      // Without this the reusable workflow sees no `DOCKERHUB_*` and the retag
+      // fails at its credential check — after `publish` has already moved the
+      // tag and published the Release. It fails closed, but it fails late,
+      // which is the whole of finding 1 below; assert it here so the two
+      // halves of "the credential is present and reaches the call" are both
+      // pinned rather than only the first.
+      expect(jobKey(source, job, "secrets"), `${job} does not pass its secrets on`).toBe(
+        "inherit",
+      );
       // `version` is #327's input and is governed exclusively by the binding
       // test below, which is the one that knows whether it exists yet. It is
       // held out here so that wiring it correctly the day #327 lands does not
@@ -1243,7 +1252,18 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
   // does not appear" is both false and beside the point. One tag, no space, no
   // second entry.
   it("puts exactly one tag on each repository, and latest is never it (D10)", () => {
-    for (const job of ["core-image", "panel-image"]) {
+    // Every job that calls `container-image.yml`, not the two named ones. The
+    // claim this pins is file-wide — *`latest` is never in the tag list, on
+    // either repository* — and a loop over a hard-coded pair is not that
+    // claim: a third `uses: ./.github/workflows/container-image.yml` job with
+    // `tags: latest` would satisfy it while breaking the invariant. So the
+    // list is derived from the file.
+    const promoters = imageCallers(source);
+    expect(promoters, "no job calls container-image.yml").toEqual([
+      "core-image",
+      "panel-image",
+    ]);
+    for (const job of promoters) {
       const tags = withInputs(source, job).tags;
       expect(tags).toBe("${{ needs.resolve.outputs.beta_version }}");
       // `tags` is space-separated, so one whole expression and nothing beside
@@ -1330,7 +1350,19 @@ describe("the beta cut (ADR 0036 C1, C3, D7, D9-D11, D13, D14)", () => {
     expect(gate, "the gate no longer asserts the event it selected").toContain(
       'select(.headSha == $sha and .event == "push")',
     );
-    expect(gate).toContain("Not a push run");
+    // The refusal itself, by its **condition** and not by its error title.
+    // "Not a push run" is the `::error title=` of the very block this means to
+    // pin, so a `toContain` on the message is satisfied by the message —
+    // rewriting the test to `if [[ "$event" == "neverever" ]]` leaves the
+    // string in place, the block unreachable and the suite green. That is #339
+    // review r1's finding 3 in this same file, and the reason every #319
+    // assertion beside it reads structure through `withInputs` / `jobKey`.
+    expect(gate, "the non-push refusal can no longer fire").toContain(
+      'if [[ "$event" != "push" ]]; then',
+    );
+    // And the message stays too, because it is what an operator reads when it
+    // does fire — asserted after the condition, not instead of it.
+    expect(gate).toContain("::error title=Not a push run::");
     for (const job of ["core-image", "panel-image"]) {
       expect(jobKey(source, job, "needs"), `${job} does not depend on the gate`).toContain(
         "resolve",


### PR DESCRIPTION
## This pull request carries two things, and both edit `beta-release.yml`

**1. #319 — the beta image tags.** `x.y.z-beta` is retagged from the digest the
train already published as `beta-x.y.z`, never rebuilt, with `docker buildx
imagetools create` and ADR 0023 D16's revision assertion in front of it.

**2. #320's workflow step, which #320 deliberately did not land.** [#337
(4d6107a)](https://github.com/actana/control/pull/337) finished the script half —
`scripts/rehearse-npm-publish.mjs --beta`, packed, asserted and install-checked —
and could not land the workflow half, because **#318 owned `beta-release.yml` at
the time and #337 owned no file under `.github/workflows`**. It wrote the step
out as YAML in [a pull request
comment](https://github.com/actana/control/pull/337#issuecomment-5400143000) for a
later turn instead, and left that one acceptance box unchecked.

**Why they are one pull request:** they edit the same file, in the same job in
two places. `EXPECTED` in `publish` is the single asset contract the create, the
clobbering upload and the prune all read; #320 extends it and #319 does not, but
both changes land inside the same `publish` job and the same header. Two pull
requests would conflict on every hunk, and the second would be rebasing prose
about the first. Split into **two commits**, one per ticket, so each is
reviewable on its own.

---

## #319 — retag, never rebuild

Two `uses:` calls into `container-image.yml`'s `promote` mode — the machinery
issue #319 says to call rather than re-implement:

```yaml
  core-image:
    name: Core image (beta)
    needs: [resolve, tarball, tarball-macos, installer-e2e, publish]
    uses: ./.github/workflows/container-image.yml
    with:
      image: core
      ref: ${{ needs.resolve.outputs.sha }}
      stage: ${{ needs.resolve.outputs.beta_version }}
      mode: promote
      source_tag: beta-${{ needs.resolve.outputs.version }}
      tags: ${{ needs.resolve.outputs.beta_version }}
      push: true
```

- **Nothing is built.** Every build step in `container-image.yml` is gated on
  `inputs.mode == 'build'`, Trivy included, and `Push the per-arch tags` on
  `inputs.push && inputs.mode == 'build'`. No `docker build`, no Dockerfile, no
  Trivy leg, no per-arch scaffolding, and no such string anywhere in this file
  (asserted).
- **D16 is inherited, not restated.** `container-image.yml` refuses the digest,
  **on every architecture the manifest lists**, when its
  `org.opencontainers.image.revision` label is not the commit being cut. This
  pull request cannot weaken it, because it does not contain it. That is the
  point rather than a formality: `beta-x.y.z` moves per train merge, so a merge
  landing between `resolve` and the retag would otherwise publish bytes nobody
  cut.
- **`latest` is never in the tag list**, on either repository, and no `-dev`
  handle is either — promote mode refuses `dev_tags` outright (ADR 0023 D36).
  Exactly one tag, and it is `beta_version`.
- **Check names do not collide.** `Core image (beta)` / `Panel image (beta)`,
  following `ci.yml`'s `(train)` convention. `Panel image` / `Core image` stay
  the "Protect main" ruleset's pinned names and are not reused.
- **No `matrix:` override.** The default is `amd64` + `arm64`, which is what the
  train publishes. Narrowing it would narrow D16's per-architecture assertion
  rather than any work — a promotion builds nothing.

### The landmines, each answered

**Landmine 1 — the counted-beta ban (ADR 0037 D7, D8).** Both halves are wired,
and the second one arrived mid-flight.

The first is local: `resolve` refuses anything that is not
`^[0-9]+\.[0-9]+\.[0-9]+-beta$` before a single job starts, and the retag jobs
publish `needs.resolve.outputs.beta_version` **verbatim** — the same string the
git tag, the Release and every asset filename carry. Both jobs `needs: resolve`,
so the path goes through it.

The second is #327's. When this branch was cut, [#338](https://github.com/actana/control/pull/338)
was open and `container-image.yml` declared no `version:` input — and passing an
input a reusable workflow does not declare is a hard workflow error, so the retag
could not pass one. Rather than leave the gap to be remembered, the test **bound**
the two:

```js
const declared = /^ {6}version:$/m.test(read("container-image.yml"));
// declared → both retag jobs must pass ${{ needs.resolve.outputs.beta_version }}
// not declared → neither may pass it
```

**#338 merged into `feat/release-pipeline` while this pull request was open, and
that test went red on the rebase** rather than being remembered. Both jobs now
pass `version: ${{ needs.resolve.outputs.beta_version }}` (third commit), and the
binding still holds from both sides — removing the input from
`container-image.yml` is red too.

`container-image.yml` makes the assertion under `(mode == 'verify' || mode ==
'promote') && inputs.version != ''`, in the matrix `build` job that its `publish`
needs, so it runs **once per architecture before any tag is re-pointed**:

```
node scripts/assert-version-agreement.mjs --expected "$VERSION" \
  --image-label "$label" --source "$ref at linux/$ARCH"
```

**The beta string is passed, not the line**, and that is the whole of what #327
closed. Run directly against its checker:

```
$ node scripts/assert-version-agreement.mjs --expected 0.4.1-beta --image-label 0.4.1
✅ … self-reports 0.4.1, the line being published as 0.4.1-beta.          exit 0

$ node scripts/assert-version-agreement.mjs --expected 0.4.1-beta.1 --image-label 0.4.1
❌ `0.4.1-beta.1` cannot be published: it is a counted beta …             exit 1

$ node scripts/assert-version-agreement.mjs --expected 0.4.1 --image-label 0.4.1
✅ … self-reports 0.4.1, the line being published as 0.4.1.               exit 0   ← the hole
```

`lineOf("0.4.1-beta.1")` is `0.4.1`, which agrees with a correctly labelled
digest, and image mode short-circuits before `checkAgreement` — so handing this
the **line** would restore the hole while still looking like a version check.
`imageVersionProblem` is where #327 put the ban *"which is what lets #319's beta
retag inherit it"*, and it only ever sees the string this file hands it. Three
mutations pin it: dropping the input, passing the line, and removing the input
from `container-image.yml` are each red on that one test.

**Landmine 2 — `x.y.z-beta`, exactly, on every registry surface.** One
concatenation in `resolve`, one anchored regex, and the retag publishes that
string with nothing appended. The `tags:` input is asserted to be exactly one
`${{ }}` expression with nothing beside it, so a second entry cannot ride along.

**Landmine 3 — the tags persist; nothing sweeps them.** Docker Hub only (ADR
0018). ADR 0023 D45: no tag garbage collection, no undelete, and the weekly
sweep covers `pr-*` / `sha-*` in the `-dev` repositories. D36 and D38 keep the
delete-capable credential permanently out of the repositories holding `latest`,
which is where these tags go. **ADR 0036 D23 settles it and this pull request
follows it**: the `x.y.z-beta` tags persist once the line promotes, nothing
removes them, the credential is not widened — *"do not revisit by widening the
list"* — and the accumulation is bounded at **one per line, not one per cut**,
because the tag moves. Nothing here sweeps, deletes, or asks for a credential.

That irreversibility is also the ordering argument: both retag jobs run **after
`publish`**. A retag beside a failed `publish` would leave `x.y.z-beta` on
Docker Hub next to a Release that does not exist, permanently and with no
credential able to remove it. The reverse — a Release whose images are not yet
retagged — is repaired by re-dispatching, because every write in this file is
idempotent.

**Landmine 4 — the greenness gate's event filter.** Confirmed present as #318
landed it, and now depended on. `resolve` queries `gh run list … --event push`
**and** re-asserts `select(.headSha == $sha and .event == "push")` **and** fails
explicitly on a non-push run. Both retag jobs `needs: resolve`, so the digest
this retags from is one a `push` run published. The test asserts the filter and
the dependency **together**, because either alone is satisfiable while the hole
is open: a filter nothing depends on gates nothing, and a dependency on an
unfiltered gate is a dependency on a `pull_request` run.

**Landmine 5 — assertions that fail under mutation.** See below.

### One #319 criterion is **not met**, and is deferred to #315

Stated here rather than left to be inferred, which is the whole of review r1's
finding 2. #319's last criterion is:

> a second cut re-points the tag, **and says in the log which digest it was
> moved off**.

**The first half is met. The second is not.** Nothing on this path reads
`$IMAGE:x.y.z-beta`'s *existing* digest before `docker buildx imagetools
create` overwrites it. Tracing every log line the cut emits:

| log line | what it prints |
| --- | --- |
| `resolve`'s *Cutting …* | the train, the version, the sha |
| the tag move's `moves from <previous>` | a **git commit**, not an image digest |
| `container-image.yml` `resolve`'s *Promoting …* | the source tag and the target |
| `build`'s `…:beta-0.4.1 is …@sha256:…` | the **source** digest — the one being moved **onto** |
| `imagetools inspect "$primary"` | the result, **after** the create |

So on a **second** cut — the case the criterion is about — the operator cannot
tell from the log what was displaced.

**Why it is deferred rather than implemented.** Meeting it properly needs a read
of the destination tag's digest in `container-image.yml`'s promote path, before
the create. #319 puts that file out of scope in as many words — *"that is a
finding for #315, not a patch here"* — and this branch keeps
`container-image.yml` byte-identical to its base, which is also what let #338
merge underneath it without a conflict. `beta-release.yml` cannot do it from the
calling side: it never touches the registry itself.

**Recorded in three places** so it cannot be ticked by the next reader: this
section, the file's header comment (*"What #319 asks for and this file does not
do"*), and a comment on #315.

### Two states the header now names rather than implies

- **The two retags are not atomic with each other** (finding 5). `core-image`
  and `panel-image` are independent `promote` calls with no mutual gate, so one
  can fail where the other succeeded — most plausibly on ADR 0037 D4's
  assertion, whose own *Consequences* predict the trigger: *"the first promotion
  of a train whose images predate this refuses."* That leaves
  `core:x.y.z-beta` created and `panel:x.y.z-beta` absent, beside a Release
  already published, with the Core tag unwithdrawable under ADR 0023 D45. The
  *"they run last"* argument covers publish-versus-retag ordering and says
  nothing about this split.
- **A missing Docker Hub credential is now refused in `resolve`** (finding 1),
  beside the App-identity check and for the same reason. Previously the refusal
  came from `container-image.yml` *after* the Release was published — the same
  half-state the ordering prevents, arriving from the other side.

---

## #320 — the packed CLI asset, landed from #337's comment

`publish` packs `@actana/cli` and attaches `actana-cli-x.y.z-beta.tgz` with its
checksum. **Nothing reaches registry.npmjs.org, under any dist-tag** (D15).

Four adjustments to the YAML in #337's comment, each because the file now exists:

| #337 wrote | landed as | why |
| --- | --- | --- |
| `needs.resolve.outputs.line` | `needs.resolve.outputs.version` | that is the output's name; it is the line `0.4.1` |
| a second `gh release upload` | two names added to `EXPECTED` | that list is what the create, the clobber **and the prune** read — an asset outside it is deleted on the next cut, as this file's own comment warned |
| `v${{ steps.beta-cli.outputs.version }}` | `$TAG` | the job already has it, and one source cannot drift |
| step placed beside the attach | placed **before the tag moves** | this job's stated principle: assets are assembled and verified first, so a failed pack leaves `vx.y.z-beta` where it was |

Two guards the comment's YAML did not have:

- **`install=ok` is asserted.** The script emits it only when `--install-check`
  really ran. Dropped from the invocation, the pack still succeeds, the asset is
  still attached, and #320's central assertion is simply never made.
- **The packed filename is held to `actana-cli-<beta>.tgz`**, because that name
  is the URL an operator pastes into a terminal (C1).

**The checksum question #337 left to #318, answered.** #337 proposed a fourth
`SHA256SUMS` row *"#318 chooses and I follow"*; #318 chose *"this file owns the
three Core rows"* and deferred the CLI's to #315. **ADR 0036 D10 is the record
and it says `SHA256SUMS` is over exactly those three** — and #318 derived
`--expect` from `CORE_TARGETS.length` rather than writing a literal, so a fourth
row would contradict the record and break the derivation at once. So it is
#320's other option: **its own file**, `actana-cli-x.y.z-beta.tgz.sha256`, in
`sha256sum`'s two-space format, verified in CI the way an operator verifies it,
and named in `EXPECTED`.

`pnpm/action-setup` + `pnpm install --frozen-lockfile` join `publish` for the
same reason `release.yml`'s `npm` job carries them: `pnpm pack` runs
`packages/cli`'s `prepack`. The asset is packed into `artifacts/beta` and staged
in **after** the two steps that sweep `core-tarballs/`, taking the ordering
caveat this file left for #320 rather than leaving it.

---

## How the tests were proven to fail under mutation

#318's review found assertions in `workflows.test.mjs` satisfiable by the error
messages rather than the invocations — a `>= 2` count of `--prerelease=true` over
the whole `publish` job that four `::error` remediation hints already met, so
deleting the flag from both `gh release` calls left the suite green.

This file's header names `promote`, `latest`, `beta-x.y.z` and `x.y.z-beta`
dozens of times in prose. A `toContain` here would pass against a file that
publishes nothing. So every new assertion reads **structure**, through two
helpers beside #318's `invocation`:

- `withInputs(source, job)` — the `with:` mapping of a reusable-workflow job as
  `key → value`, off the comment-stripped job. Lets a test say `tags` **is** one
  thing, and pin the absent inputs with an exhaustive `toEqual`.
- `jobKey(source, job, key)` — a job's own `name` / `uses` / `needs`.

**21 mutations applied, suite re-run on each, 21 red, 0 survivors.** Each row
names the test that caught it:

| mutation | caught by |
| --- | --- |
| `mode: promote` → `build` | retags both images… |
| a second tag `latest` rides along | retags both images… **+** puts exactly one tag… |
| reuse the pinned name `Core image` | does not reuse the pinned check names |
| drop `publish` from `core-image` `needs:` | retags only after every gate… |
| drop `installer-e2e` from `panel-image` `needs:` | retags only after every gate… |
| drop `--event push` from the greenness gate | cuts nothing from a tip… **+** retags only behind the greenness gate… |
| promote carries `dev_tags` | retags both images… |
| `source_tag` built from the beta string, not the line | retags both images… |
| drop `version:` from `core-image` | passes the version the ban is applied to… |
| pass the **line** as `version` | passes the version the ban is applied to… |
| remove `version:` from `container-image.yml` | passes the version the ban is applied to… |
| drop `resolve` from both `needs:` | retags only after every gate… **+** retags only behind the greenness gate… |
| `push: false` on the retag | retags both images… |
| a remote `owner/repo@main` reusable call | refuses another ref's copy (#326) **+** retags both images… |
| the retag replaced by a hand `docker build` | retags both images… |
| drop `--install-check` from the pack | packs the CLI as an asset… |
| pass the beta string to `--beta` instead of the line | packs the CLI as an asset… |
| pack straight into the guarded directory | packs the CLI as an asset… |
| drop the `install=ok` guard | refuses an asset packed but never installed |
| drop the CLI checksum from `EXPECTED` | names the CLI asset and its checksum… |
| make the CLI checksum a fourth `SHA256SUMS` row | gives the CLI asset its own checksum file… |

And the control: with `version:` declared **and** wired to `beta_version`, the
suite is **green** — so the binding test asks for the right thing rather than
merely for change. It was also proven in anger: it is what caught the missing
wiring when #338 landed under this branch.

Baseline: `scripts/__tests__/workflows.test.mjs` **94 passed**. All 26 multi-line
`run:` blocks are `bash -n` clean; the file parses as YAML and its job graph is
`resolve → {tarball, tarball-macos} → installer-e2e → publish → {core-image,
panel-image}`.

### One existing assertion is restated, deliberately

`refuses to cut a train with another ref's copy of itself (#326)` contained:

```js
expect(body, "a local uses: resolves from the caller's SHA (#326)")
  .not.toMatch(/uses: \.\/\.github\/workflows\//);
```

That was true of a file that called nothing, and it is the **wrong rule** now: a
reusable workflow named by **path** resolves from the *same commit* as its
caller, so once `resolve`'s refusal has held `github.ref_name` to the train, the
retag jobs run the train's own copy of `container-image.yml`. That is the
*inverse* of #326's trap. What is an instance of it — an `owner/repo/….yml@ref`
call, pinned to a ref this run did not choose — is banned in its place, and the
loop below it still holds every `gh workflow run` in the file to its `--ref`.

---

## What #323's documentation must state

I own no docs page and edited none. `docs/ci-cd.md`, `docs/beta-*`, and the tag
ladder need these facts:

1. **The tag ladder gains `0.4.1-beta` on `actana/core` and `actana/panel`**, and
   it must state the difference from `beta-0.4.1` explicitly — issue #319 asks
   for this by name. They are two moving names for one digest on **different
   clocks**: `beta-0.4.1` moves per **train merge**, `0.4.1-beta` moves per
   **beta cut**, and between cuts the second lags. That lag is what makes a cut
   a cut.
2. **These tags are never garbage collected and never deleted.** One per line,
   not one per cut. Say this beside the `-dev` sweep so a reader does not assume
   the sweep reaches them (ADR 0023 D45, D36, D38; ADR 0036 D23).
3. **A beta image is the train's bytes, byte for byte** — retagged, never
   rebuilt, and refused if the digest's revision label is not the commit cut
   (ADR 0023 D16, D17; ADR 0036 D12).
4. **`latest` is never moved by a beta cut**, on either repository.
5. **The CLI beta install is an asset URL**, not a registry version:
   `npm i -g https://github.com/actana/control/releases/download/v<x.y.z>-beta/actana-cli-<x.y.z>-beta.tgz`.
   No npm version exists for a beta, under any dist-tag.
6. **The CLI asset's checksum is `actana-cli-<x.y.z>-beta.tgz.sha256`, a
   separate file** — `SHA256SUMS` stays the three Core tarballs. An operator runs
   two `sha256sum -c` commands, not one.
7. **There is no provenance attestation on the beta path** (ADR 0036 D17). The
   pages must not imply one; the integrity story is the published checksums.
8. **The beta asset set is now seven**: three Core tarballs, `SHA256SUMS`, the
   CLI tarball, its `.sha256`, and `install.sh`.

`#315` may also want a dated note under ADR 0036 D10 recording that the CLI
row's checksum is a sidecar file rather than a `SHA256SUMS` row — the record
lists the artifact but not where its checksum lives.

---

## Boundary

- **Two files**: `.github/workflows/beta-release.yml`,
  `scripts/__tests__/workflows.test.mjs`.
- **`container-image.yml` is byte-identical to the base.** It is in my scope and
  needed no change: the mode this ticket calls already exists and carries D16,
  and #338 added the `version:` input this now passes. Leaving it alone is also
  what let #338 merge under this branch without a conflict.
- No documentation touched (#323's). No `scripts/**` source touched (#337's
  `rehearse-npm-publish.mjs` is called, not edited). No `packages/**`.
- **Nothing merged, nothing on `main`, no workflow dispatched, no image tag
  pushed by hand.** This pull request is a **draft** and its base is
  `feat/release-pipeline`.

## What is not proven here, said plainly

- The retag has not been executed. It cannot be: dispatching `beta-release.yml`
  is a publish, and this branch is not the train. What is proven is the call
  shape, the ordering, the gates it hangs off, and the refusals it inherits.
- The `https:` half of #320's install criterion is still unexercised — an asset
  URL cannot resolve before the Release exists. #337 said so honestly and it is
  still true; `--install-check` covers the bytes, and what a URL adds is *"was
  the asset attached"*, which `EXPECTED` and the prune now cover.
- The label check is wired and asserted by test, but has never executed against
  a real digest — that needs a dispatch, which is a publish. What is proven is
  that the call is made, on every architecture, with the string the ban reads,
  and that #327's checker refuses a counted beta given exactly that string.


---

## Rebased mid-flight

Cut from `feat/release-pipeline@66ef4df`. **#338 (issue #327) merged into that
branch at 07:12 UTC while this was being written**, so the branch is rebased onto
`141e5ce` and carries a third commit wiring the `version:` input that merge
introduced. Clean rebase — #338 touched `ci.yml`, `container-image.yml`,
`promote.yml`, `release.yml`, `scripts/lib/`, `scripts/__tests__/version-agreement.test.mjs`
and `docs/`, none of which this pull request edits.

`scripts/__tests__/` is green on the new base: **21 files, 724 tests**, the 485
lines #338 added included.

