### PR TITLE
fix(installer): drop the multi-byte ellipsis, and guard the shape it belongs to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,11 +584,32 @@ jobs:
           fi
           echo "No mc-*/actana-* directories were left behind."
 
+  # `install.sh` is linted here too, and by a shell script rather than by
+  # eslint (#346). The installer is the one file in this repository that runs
+  # on a shell no CI job has: macOS ships bash 3.2.57 under a UTF-8 locale, and
+  # that pair mis-parses `"$asset…"` into a reference to a variable named
+  # `asset?` — which `set -eu` turns into an aborted install on the very first
+  # command an operator ever runs. Linux CI cannot see it: every runner here is
+  # bash 5, where the same bytes are correct.
+  #
+  # The guard rides in `Lint` instead of taking a job of its own on purpose. A
+  # new job is a new check *context*, and a context no ruleset names does not
+  # gate anything — it would report green or red beside a mergeable pull
+  # request until an admin edited three rulesets. `Lint` is already required by
+  # `docs/rulesets/{main,beta,release}.json`, so the guard gates from its first
+  # run. `scripts/__tests__/install-sh-ascii-guard.test.mjs` pins that
+  # arrangement: the guard's step lives in a job whose name every gating
+  # ruleset requires.
+  #
+  # It runs before `setup-node`, so the answer costs seconds and arrives ahead
+  # of the install rather than behind it.
   lint:
     name: Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Guard — no expansion in install.sh precedes a non-ASCII byte
+        run: scripts/install-sh-ascii-guard.sh install.sh
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0

--- a/install.sh
+++ b/install.sh
@@ -534,7 +534,7 @@ main() {
   [ -n "$expected" ] || die "release $tag has no build for $TARGET.
   Its $SHASUMS_ASSET does not list $asset."
 
-  say "Downloading $asset…"
+  say "Downloading $asset..."
   tarball="$work_dir/$asset"
   fetch_url "$release_url/$asset" "$tarball" ||
     die "could not download $release_url/$asset"

--- a/scripts/__tests__/install-sh-ascii-guard.test.mjs
+++ b/scripts/__tests__/install-sh-ascii-guard.test.mjs
@@ -1,0 +1,299 @@
+// The #346 regression guard, exercised rather than eyeballed.
+//
+// #346 was one character: `say "Downloading $asset…"` in `install.sh`. On
+// macOS — bash 3.2.57 under a UTF-8 locale, which is every Mac — the
+// identifier scan runs past `asset` into the bytes of the `…`, the name it
+// ends up looking for is unbound, and `set -eu` aborts the installer on the
+// first command the product asks anyone to run. The fix was three ASCII bytes.
+//
+// The fix is not the deliverable, because the same three bytes can be typed
+// back tomorrow by anyone composing a nicer-looking message, and nothing on a
+// Linux runner under bash 5 would notice. `scripts/install-sh-ascii-guard.sh`
+// is the deliverable, and this file is what keeps *it* honest. Four properties,
+// each failing here on its own:
+//
+//   1. **It refuses the reported shape, and the neighbouring ones.** `$name…`,
+//      `${name}…`, `$1…`, and a bare `$…` are all refused, with the line
+//      number of the offence — a guard that says only "something is wrong in
+//      install.sh" sends the reader back to a 591-line file.
+//   2. **It passes what is correct.** The shipped installer, and the many
+//      lines where an em-dash follows a variable with a space between them.
+//      A guard with false positives is a guard people route around.
+//   3. **It cannot pass silently.** Its own detector is self-tested before the
+//      scan, and a missing file is a failure rather than a green no-op. The
+//      byte-range match under `LC_ALL=C` is this script's one environmental
+//      assumption, and "the assumption broke, so nothing matched, so the check
+//      is green" is precisely the shape of failure that would let #346 back in.
+//   4. **It gates.** The step lives in a job whose name every ruleset that
+//      requires checks at all requires — read out of `ci.yml` rather than
+//      asserted as a literal in two places, so a coordinated rename stays
+//      green and a one-sided one does not.
+//
+// And one property of the file under it: `install.sh` line 80 carries
+// `LINE="x.y.z"`, the release-train stamp that decides which line a fetched
+// copy installs (ADR 0036 D1, D2) and that `Train rules` asserts against the
+// train. The guard reads and never writes, and the stamp passes it — asserted
+// below, because a guard that "fixed" what it found would be a second thing
+// editing that line and there must be exactly one.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const GUARD = path.join(repoRoot, "scripts/install-sh-ascii-guard.sh");
+const INSTALL_SH = path.join(repoRoot, "install.sh");
+const ci = fs.readFileSync(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+
+const ELLIPSIS = "…";
+const EM_DASH = "—";
+
+let workDir;
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-ascii-guard-"));
+});
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+/** The real guard, run the way `ci.yml` runs it. */
+const run = (target) => {
+  const result = spawnSync("bash", [GUARD, target], { encoding: "utf8", cwd: repoRoot });
+  expect(result.error, `${GUARD} did not run`).toBeUndefined();
+  return { status: result.status, out: `${result.stdout}${result.stderr}` };
+};
+
+/** A throwaway shell file with the given body. */
+const fixture = (name, body) => {
+  const file = path.join(workDir, name);
+  fs.writeFileSync(file, body);
+  return file;
+};
+
+/** One job block from `ci.yml`, from its key up to the next job at that indent. */
+const jobBlock = (source, name) => {
+  const start = source.indexOf(`\n  ${name}:`);
+  expect(start, `no ${name} job`).toBeGreaterThan(-1);
+  const rest = source.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
+};
+
+describe("the guard refuses an expansion against a non-ASCII byte (#346)", () => {
+  it("refuses the exact line #346 was reported as, and names its line number", () => {
+    const file = fixture(
+      "reported.sh",
+      ["#!/bin/sh", "set -eu", 'asset=core.tgz', `say "Downloading $asset${ELLIPSIS}"`, ""].join(
+        "\n",
+      ),
+    );
+    const { status, out } = run(file);
+    expect(status, "the reported shape passed the guard").toBe(1);
+    // The line number, in the annotation and in the human-readable line. Both,
+    // because the Checks tab renders one and the log carries the other.
+    expect(out).toContain("line=4");
+    expect(out).toContain(":4:");
+    expect(out).toMatch(/::error file=/);
+  });
+
+  it("refuses the braced form as well", () => {
+    const file = fixture("braced.sh", `say "Downloading \${asset}${ELLIPSIS}"\n`);
+    const { status, out } = run(file);
+    expect(status).toBe(1);
+    expect(out).toContain("line=1");
+  });
+
+  it("refuses a positional parameter and a bare dollar sign", () => {
+    for (const [name, body] of [
+      ["positional.sh", `say "installing $1${ELLIPSIS}"\n`],
+      ["special.sh", `say "exit $?${ELLIPSIS}"\n`],
+      ["bare.sh", `say "$${ELLIPSIS}"\n`],
+    ]) {
+      const { status } = run(fixture(name, body));
+      expect(status, `${name} passed the guard`).toBe(1);
+    }
+  });
+
+  it("reports every offending line, not just the first", () => {
+    const file = fixture(
+      "several.sh",
+      [`say "one $a${ELLIPSIS}"`, "say 'fine'", `say "two $b${ELLIPSIS}"`, ""].join("\n"),
+    );
+    const { status, out } = run(file);
+    expect(status).toBe(1);
+    expect(out).toContain("line=1");
+    expect(out).toContain("line=3");
+  });
+
+  it("says what the fix is, so the reader does not have to find this issue", () => {
+    const { out } = run(fixture("advice.sh", `say "$a${ELLIPSIS}"\n`));
+    expect(out).toContain("#346");
+    expect(out).toMatch(/bash 3\.2/);
+    expect(out).toMatch(/UTF-8/);
+    expect(out).toMatch(/\.\.\./);
+  });
+});
+
+describe("the guard passes what is correct", () => {
+  it("passes the shipped installer", () => {
+    const { status, out } = run(INSTALL_SH);
+    expect(status, `install.sh fails its own guard:\n${out}`).toBe(0);
+  });
+
+  it("passes a non-ASCII character separated from the expansion by a space", () => {
+    // The shape `install.sh` uses on lines like `$latest_url — is $REPO …`.
+    // Refusing it would refuse most of the file's prose.
+    const file = fixture("spaced.sh", `die "no build for $TARGET ${EM_DASH} pin a version."\n`);
+    expect(run(file).status).toBe(0);
+  });
+
+  it("passes a command substitution, which closes on an ASCII byte of its own", () => {
+    const file = fixture("subst.sh", `say "$(date)${EM_DASH}"\n`);
+    expect(run(file).status).toBe(0);
+  });
+
+  it("passes the release-train stamp, and leaves it exactly as it found it", () => {
+    // ADR 0036 D1, D2: `LINE="x.y.z"` decides which line a fetched copy of the
+    // installer installs, `Train rules` asserts it against the train, and the
+    // cut's `sed` is the only thing that may rewrite it.
+    const stamp = 'LINE="0.4.2"\n';
+    const file = fixture("stamp.sh", stamp);
+    expect(run(file).status).toBe(0);
+    expect(fs.readFileSync(file, "utf8")).toBe(stamp);
+
+    const before = fs.readFileSync(INSTALL_SH);
+    run(INSTALL_SH);
+    expect(fs.readFileSync(INSTALL_SH).equals(before), "the guard wrote to install.sh").toBe(true);
+  });
+
+  it("finds the stamp in the shipped installer, unchanged and on one line", () => {
+    const lines = fs.readFileSync(INSTALL_SH, "utf8").split("\n");
+    const stamps = lines.filter((line) => /^LINE="[^"]*"$/.test(line));
+    expect(stamps, "install.sh carries no LINE stamp").toHaveLength(1);
+  });
+});
+
+describe("the guard cannot report green by accident", () => {
+  it("fails on a file that does not exist rather than passing over it", () => {
+    const { status, out } = run(path.join(workDir, "nothing-here.sh"));
+    expect(status, "a missing file reported green").toBe(1);
+    expect(out).toMatch(/::error/);
+  });
+
+  it("self-tests its own detector before it trusts a scan", () => {
+    // The one environmental assumption is that `grep -E` matches the
+    // 0x80-0xFF byte range under `LC_ALL=C`. If that ever stops holding, the
+    // scan matches nothing and the check goes green over a broken installer.
+    const source = fs.readFileSync(GUARD, "utf8");
+    expect(source).toMatch(/BAD_SAMPLE/);
+    expect(source).toMatch(/GOOD_SAMPLE/);
+    expect(source).toMatch(/self-test failed/);
+  });
+
+  it("scans under LC_ALL=C, so 'non-ASCII' means bytes and not the caller's locale", () => {
+    const source = fs.readFileSync(GUARD, "utf8");
+    expect(source).toMatch(/export LC_ALL=C/);
+    // Same answer whatever the caller's locale is.
+    const file = fixture("locale.sh", `say "$a${ELLIPSIS}"\n`);
+    for (const locale of ["C", "en_US.UTF-8"]) {
+      const result = spawnSync("bash", [GUARD, file], {
+        encoding: "utf8",
+        env: { ...process.env, LC_ALL: locale, LANG: locale },
+      });
+      expect(result.status, `guard passed under LC_ALL=${locale}`).toBe(1);
+    }
+  });
+});
+
+describe("the guard runs on bash 3.2, which is the shell the bug lives on", () => {
+  it("uses nothing newer than bash 3.2 in the guard or in the installer", () => {
+    // An operator reproducing #346 on their Mac runs both of these files under
+    // bash 3.2.57. A guard that needs bash 4 could only ever run where the bug
+    // cannot: on the Linux runner.
+    const BASH_4_ONLY = [
+      [/\bmapfile\b/, "mapfile"],
+      [/\breadarray\b/, "readarray"],
+      [/declare\s+-A/, "declare -A"],
+      [/local\s+-A/, "local -A"],
+      [/local\s+-n/, "local -n (nameref)"],
+      [/declare\s+-n/, "declare -n (nameref)"],
+      [/\$\{[A-Za-z_][A-Za-z0-9_]*\^\^?/, "${var^^} case conversion"],
+      [/\$\{[A-Za-z_][A-Za-z0-9_]*,,?/, "${var,,} case conversion"],
+      [/&>>/, "&>> redirection"],
+      [/\bcoproc\b/, "coproc"],
+    ];
+    for (const file of [GUARD, INSTALL_SH]) {
+      // Whole-line comments are dropped first. Both files explain themselves at
+      // length, and the guard's own portability note names `mapfile` in order
+      // to say it is not used — a scan that could not tell prose from code
+      // would make writing that sentence down impossible.
+      const source = fs
+        .readFileSync(file, "utf8")
+        .split("\n")
+        .filter((line) => !/^\s*#/.test(line))
+        .join("\n");
+      for (const [pattern, what] of BASH_4_ONLY) {
+        expect(pattern.test(source), `${path.basename(file)} uses ${what}, which is bash 4+`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it("parses under every shell the installer claims to run on", () => {
+    const shells = ["bash", "dash", "sh"].filter(
+      (shell) => spawnSync("sh", ["-c", `command -v ${shell}`]).status === 0,
+    );
+    expect(shells.length, "no shell available to parse install.sh").toBeGreaterThan(0);
+    for (const shell of shells) {
+      const result = spawnSync(shell, ["-n", INSTALL_SH], { encoding: "utf8" });
+      expect(result.status, `${shell} -n install.sh: ${result.stderr}`).toBe(0);
+    }
+  });
+});
+
+describe("the guard gates every pull request", () => {
+  const job = jobBlock(ci, "lint");
+
+  it("is a step in that job, run against the shipped installer", () => {
+    expect(job).toContain("scripts/install-sh-ascii-guard.sh install.sh");
+    expect(fs.existsSync(GUARD), "the guard the workflow runs does not exist").toBe(true);
+  });
+
+  it("runs before anything is installed, so it answers in seconds", () => {
+    expect(job.indexOf("install-sh-ascii-guard.sh")).toBeLessThan(job.indexOf("setup-node"));
+  });
+
+  it("carries no if:, so it cannot be skipped into a green pull request", () => {
+    // Job-level `if:` is four spaces in; a step-level one is deeper and is not
+    // what this is about.
+    expect(job).not.toMatch(/^ {4}if:/m);
+  });
+
+  it("lives in a job every gating ruleset requires, so it actually blocks a merge", () => {
+    const name = /^ {4}name: (.+)$/m.exec(job);
+    expect(name, "the lint job has no name:").not.toBeNull();
+    const context = name[1].trim();
+
+    const dir = path.join(repoRoot, "docs/rulesets");
+    const gating = [];
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+      const contexts = [
+        ...JSON.stringify(JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"))).matchAll(
+          /"context":"([^"]+)"/g,
+        ),
+      ].map((m) => m[1]);
+      // The rulesets with no contexts restrict pushes rather than require
+      // checks; excluded by that property rather than by name.
+      if (contexts.length > 0) gating.push([file, contexts]);
+    }
+    expect(gating.length, "no ruleset requires any check").toBeGreaterThan(0);
+    for (const [file, contexts] of gating) {
+      expect(contexts, `${file} does not require the ${context} job`).toContain(context);
+    }
+  });
+});

--- a/scripts/__tests__/install-sh-ascii-guard.test.mjs
+++ b/scripts/__tests__/install-sh-ascii-guard.test.mjs
@@ -184,14 +184,119 @@ describe("the guard cannot report green by accident", () => {
     expect(out).toMatch(/::error/);
   });
 
-  it("self-tests its own detector before it trusts a scan", () => {
-    // The one environmental assumption is that `grep -E` matches the
-    // 0x80-0xFF byte range under `LC_ALL=C`. If that ever stops holding, the
-    // scan matches nothing and the check goes green over a broken installer.
-    const source = fs.readFileSync(GUARD, "utf8");
-    expect(source).toMatch(/BAD_SAMPLE/);
-    expect(source).toMatch(/GOOD_SAMPLE/);
-    expect(source).toMatch(/self-test failed/);
+  // The cases below run the guard. The one they replaced read the guard's
+  // *source* for `BAD_SAMPLE`, `GOOD_SAMPLE` and `self-test failed`, which is
+  // how the defect the review found survived 19 cases: deleting the checks and
+  // leaving the words in a comment passed it green, and `grep`'s error status
+  // being read as "no match" was invisible to it. A property proven by grepping
+  // the implementation is not proven.
+
+  it("fails on a file it cannot read, rather than reporting it clean", () => {
+    // The review's reproduction, exactly: a file that genuinely contains the
+    // bug, made unreadable. Before the fix this printed `OK` and exited 0 —
+    // a green required check over a file nothing had scanned.
+    const file = fixture("unreadable.sh", `say "Downloading $asset${ELLIPSIS}"\n`);
+    fs.chmodSync(file, 0o000);
+    try {
+      const { status, out } = run(file);
+      expect(status, "an unreadable file reported green").not.toBe(0);
+      expect(out).toMatch(/::error/);
+      // Its own message, not the missing-file one: "you pointed the step at the
+      // wrong path" and "CI checked out a file it cannot read" are different
+      // problems, and the reader needs to know which one this is.
+      expect(out).toMatch(/cannot be read|not readable/);
+    } finally {
+      fs.chmodSync(file, 0o644);
+    }
+  });
+
+  it("fails when grep errors, and does not read that as 'no match'", () => {
+    // `grep` exits 0 when it matched, 1 when it did not, and >1 when it could
+    // not answer at all. The `|| true` this replaced mapped >1 onto the same
+    // path as 1, so an unscannable file read as a clean one.
+    //
+    // A `grep` on PATH that errors on a file scan reproduces that third answer
+    // without depending on file permissions or on who the test runs as. It
+    // delegates the guard's stdin self-tests to the real binary, so the script
+    // reaches its scan and it is the scan's status handling under test.
+    const realGrep = spawnSync("sh", ["-c", "command -v grep"], { encoding: "utf8" })
+      .stdout.trim();
+    expect(realGrep, "no grep on PATH to delegate to").toBeTruthy();
+
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-grep-shim-"));
+    const shim = path.join(shimDir, "grep");
+    fs.writeFileSync(
+      shim,
+      [
+        "#!/bin/sh",
+        'last=""',
+        'for a in "$@"; do last="$a"; done',
+        'if [ -f "$last" ]; then',
+        '  echo "grep: $last: Input/output error" >&2',
+        "  exit 2",
+        "fi",
+        `exec ${JSON.stringify(realGrep)} "$@"`,
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(shim, 0o755);
+
+    try {
+      const result = spawnSync("bash", [GUARD, INSTALL_SH], {
+        encoding: "utf8",
+        cwd: repoRoot,
+        env: { ...process.env, PATH: `${shimDir}${path.delimiter}${process.env.PATH}` },
+      });
+      const out = `${result.stdout}${result.stderr}`;
+      expect(result.status, "a grep error reported green").not.toBe(0);
+      expect(out).toMatch(/::error/);
+      expect(out).toMatch(/could not scan|exited 2/);
+      // grep's own diagnostic survives to the log — an exit code on its own
+      // does not tell anyone why the file could not be read.
+      expect(out).toContain("Input/output error");
+    } finally {
+      fs.rmSync(shimDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still passes and still fails normally once those paths exist", () => {
+    // The two branches above must not have cost the ordinary answers: a clean
+    // file exits 0, and a file carrying the bug exits 1 naming its line.
+    expect(run(INSTALL_SH).status, "the shipped installer no longer passes").toBe(0);
+    const bad = run(fixture("still-fails.sh", `say "Downloading $asset${ELLIPSIS}"\n`));
+    expect(bad.status).toBe(1);
+    expect(bad.out).toContain("line=1");
+  });
+
+  it("refuses a target that is a directory rather than scanning nothing", () => {
+    const { status, out } = run(workDir);
+    expect(status, "a directory reported green").not.toBe(0);
+    expect(out).toMatch(/::error/);
+  });
+
+  it("catches its own detector breaking, by running it", () => {
+    // The self-test's purpose: if `grep -E` ever stops matching the 0x80-0xFF
+    // byte range under `LC_ALL=C`, the scan matches nothing and the check goes
+    // green over a broken installer. A `grep` that never matches is exactly
+    // that failure, and the guard must refuse rather than pass.
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "actana-grep-blind-"));
+    const shim = path.join(shimDir, "grep");
+    // Matches nothing, ever — the shape of a locale or byte-range regression.
+    fs.writeFileSync(shim, ["#!/bin/sh", "exit 1", ""].join("\n"));
+    fs.chmodSync(shim, 0o755);
+
+    try {
+      const result = spawnSync("bash", [GUARD, INSTALL_SH], {
+        encoding: "utf8",
+        cwd: repoRoot,
+        env: { ...process.env, PATH: `${shimDir}${path.delimiter}${process.env.PATH}` },
+      });
+      const out = `${result.stdout}${result.stderr}`;
+      expect(result.status, "a detector that matches nothing reported green").not.toBe(0);
+      expect(out).toMatch(/known-bad sample did not match/);
+    } finally {
+      fs.rmSync(shimDir, { recursive: true, force: true });
+    }
   });
 
   it("scans under LC_ALL=C, so 'non-ASCII' means bytes and not the caller's locale", () => {

--- a/scripts/install-sh-ascii-guard.sh
+++ b/scripts/install-sh-ascii-guard.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# The regression guard for #346 — no expansion in `install.sh` may be followed
+# immediately by a non-ASCII byte.
+#
+# What it is guarding against, in one paragraph. macOS ships bash 3.2.57, and
+# its default `LC_CTYPE` is a UTF-8 locale. Under that pair, bash's identifier
+# scan reads past the end of a variable name into the bytes of a following
+# multi-byte character, so `"Downloading $asset…"` is expanded as a variable
+# named `asset?` — and `install.sh` opens with `set -eu`, so an unbound name is
+# not a typo in a message, it is the installer aborting on the first machine
+# the product is ever run on:
+#
+#     bash: line 537: asset?: unbound variable
+#
+# The fix for that line is three ASCII bytes and takes ten seconds; this file
+# is the deliverable. The hazard is invisible on the screen of the person
+# introducing it — a nice-looking `…`, `—` or `→` typed after a variable is
+# indistinguishable from a correct one until it runs on a Mac, and CI runs on
+# Linux under a bash 5 that handles it. So the rule is mechanical and it lives
+# here rather than in a review checklist.
+#
+# **This script only reads.** It never rewrites `install.sh`. That matters for
+# one line in particular: `LINE="x.y.z"` is the release-train stamp that
+# decides which line a fetched copy of the installer installs (ADR 0036 D1, D2)
+# and that `Train rules` asserts against the train's version. It carries no
+# non-ASCII byte, so it passes here like every other ordinary line — but a
+# guard that "fixed" what it found would be a second thing editing that stamp,
+# and there must be exactly one (the cut's `sed`).
+#
+# ── Portability ─────────────────────────────────────────────────────────────
+#
+# bash 3.2 is the target, because the bug being guarded is a bash 3.2 bug and
+# an operator reproducing it on their Mac must be able to run this. Nothing
+# below is newer than 3.2: no `mapfile`, no associative arrays, no `${x^^}`.
+# The scan runs under `LC_ALL=C` so that "non-ASCII" means the bytes 0x80-0xFF
+# and not whatever the caller's locale would fold them into.
+#
+# Usage: scripts/install-sh-ascii-guard.sh [path-to-install.sh]
+set -euo pipefail
+
+TARGET="${1:-install.sh}"
+
+if [ ! -f "$TARGET" ]; then
+  echo "::error title=The installer is missing::$TARGET is not a file, so the expansion guard for #346 has nothing to scan. A guard that reports green over a file it never read is worse than no guard at all."
+  echo "install-sh-ascii-guard: $TARGET does not exist." >&2
+  exit 1
+fi
+
+export LC_ALL=C
+
+# The bytes that are not ASCII, as a literal range for a bracket expression.
+# Built with `printf` rather than written into the pattern, so that this file
+# stays pure ASCII itself — a guard against non-ASCII bytes that carries a pile
+# of them is a guard nobody can grep for.
+NON_ASCII="$(printf '\200-\377')"
+
+# A `$` that opens an expansion, immediately followed by one of those bytes:
+#
+#   $name…      a plain name          — the shape #346 was reported as
+#   ${name}…    a braced name         — safe under the bug as reported, and
+#                                       still refused: the rule people can hold
+#                                       in their head is "put an ASCII byte
+#                                       between an expansion and a `…`", not
+#                                       "…unless you brace it", and the braces
+#                                       are one edit away from being removed
+#   $1…  $@…  $?…                     — positional and special parameters
+#   $…                                 — a bare `$` against a multi-byte byte
+#
+# `$(cmd)…` and `$((x))…` are deliberately not matched: they close on an ASCII
+# `)`, which is itself the separator this rule is asking for.
+EXPANSION='\$([A-Za-z_][A-Za-z0-9_]*|\{[^}]*\}|[0-9*@#?$!-])?'
+PATTERN="$EXPANSION[$NON_ASCII]"
+
+# The detector, tested against a known-bad and a known-good line before it is
+# trusted with the real file. `grep` byte ranges under `LC_ALL=C` are the one
+# assumption this script makes about its environment, and the failure mode of
+# that assumption breaking is a scan that matches nothing and reports green —
+# exactly the silent pass this guard exists to prevent. Two seconds of
+# self-test turns that into a red check with a reason on it.
+BAD_SAMPLE="$(printf 'say "Downloading $asset\342\200\246"')"
+GOOD_SAMPLE='say "Downloading $asset..."'
+
+if ! printf '%s\n' "$BAD_SAMPLE" | grep -qE "$PATTERN"; then
+  echo "::error title=The install.sh expansion guard is broken::Its own known-bad sample did not match, so this scan cannot be trusted and is reporting failure rather than green. \`grep -E\` here does not support the 0x80-0xFF byte range under LC_ALL=C that the check is built on."
+  echo "install-sh-ascii-guard: self-test failed — the known-bad sample did not match." >&2
+  exit 1
+fi
+
+if printf '%s\n' "$GOOD_SAMPLE" | grep -qE "$PATTERN"; then
+  echo "::error title=The install.sh expansion guard is broken::Its own known-good sample matched, so the check would refuse correct files. This is a bug in scripts/install-sh-ascii-guard.sh, not in $TARGET."
+  echo "install-sh-ascii-guard: self-test failed — the known-good sample matched." >&2
+  exit 1
+fi
+
+# `|| true`, because no match is this script's success case and `set -e` would
+# otherwise abort on it.
+HITS="$(grep -nE "$PATTERN" "$TARGET" || true)"
+
+if [ -z "$HITS" ]; then
+  echo "  OK  $TARGET: no expansion is followed immediately by a non-ASCII byte (#346)."
+  exit 0
+fi
+
+echo "$TARGET has an expansion followed immediately by a non-ASCII byte." >&2
+echo "Under bash 3.2 with LC_CTYPE=UTF-8 — the pair every macOS ships — the" >&2
+echo "identifier scan reads past the variable name into the multi-byte" >&2
+echo "character, and 'set -eu' aborts the installer on an unbound variable." >&2
+echo >&2
+
+while IFS= read -r hit; do
+  [ -n "$hit" ] || continue
+  line_no="${hit%%:*}"
+  text="${hit#*:}"
+  echo "  $TARGET:$line_no: $text" >&2
+  echo "::error file=$TARGET,line=$line_no,title=Expansion followed by a non-ASCII byte (#346)::$TARGET line $line_no expands a variable immediately before a non-ASCII character. On macOS bash 3.2 under a UTF-8 locale this reads as a different, unbound variable name and 'set -eu' aborts the install. Put an ASCII byte between them - '...' instead of the ellipsis, or a space before it."
+done <<EOF
+$HITS
+EOF
+
+echo >&2
+echo "Fix: replace the multi-byte character with ASCII ('...'), or put a space" >&2
+echo "between the expansion and it. Then re-run: $0 $TARGET" >&2
+exit 1

--- a/scripts/install-sh-ascii-guard.sh
+++ b/scripts/install-sh-ascii-guard.sh
@@ -40,9 +40,20 @@ set -euo pipefail
 
 TARGET="${1:-install.sh}"
 
+# Three ways a target can be unscannable, and each says which one it was. They
+# are separate messages rather than one, because "you pointed the step at the
+# wrong path" and "CI checked out a file it cannot read" are different problems
+# with different fixes, and a guard that blurs them sends the reader looking in
+# the wrong place.
 if [ ! -f "$TARGET" ]; then
   echo "::error title=The installer is missing::$TARGET is not a file, so the expansion guard for #346 has nothing to scan. A guard that reports green over a file it never read is worse than no guard at all."
-  echo "install-sh-ascii-guard: $TARGET does not exist." >&2
+  echo "install-sh-ascii-guard: $TARGET does not exist or is not a regular file." >&2
+  exit 1
+fi
+
+if [ ! -r "$TARGET" ]; then
+  echo "::error title=The installer cannot be read::$TARGET exists and is not readable, so the expansion guard for #346 could not scan it. This is a hard failure on purpose: an unreadable file and a clean file must never produce the same green check."
+  echo "install-sh-ascii-guard: $TARGET is not readable." >&2
   exit 1
 fi
 
@@ -80,25 +91,84 @@ PATTERN="$EXPANSION[$NON_ASCII]"
 BAD_SAMPLE="$(printf 'say "Downloading $asset\342\200\246"')"
 GOOD_SAMPLE='say "Downloading $asset..."'
 
-if ! printf '%s\n' "$BAD_SAMPLE" | grep -qE "$PATTERN"; then
+# `grep` answers three different questions with its exit status, and this
+# script must never collapse them:
+#
+#   0   it matched          — for the scan below, the guard has found the bug
+#   1   it did not match    — for the scan below, the guard passes
+#   >1  it could not answer — unreadable file, bad pattern, I/O error
+#
+# The third is the one that bites. A `|| true` (which is what this script used
+# to carry) maps 2 onto the same path as 1, so "grep could not read the file"
+# reads as "the file is clean" and the required check goes green over a file
+# nothing ever scanned. Every `grep` here therefore captures the status and
+# branches on all three. `set -o pipefail` makes the pipeline's status grep's.
+bad_status=0
+printf '%s\n' "$BAD_SAMPLE" | grep -qE -- "$PATTERN" || bad_status=$?
+
+if [ "$bad_status" -gt 1 ]; then
+  echo "::error title=The install.sh expansion guard is broken::\`grep\` exited $bad_status on its own known-bad sample, which is an error rather than an answer. The scan is not trustworthy and is reporting failure rather than green."
+  echo "install-sh-ascii-guard: self-test failed — grep exited $bad_status on the known-bad sample." >&2
+  exit 1
+fi
+
+if [ "$bad_status" -ne 0 ]; then
   echo "::error title=The install.sh expansion guard is broken::Its own known-bad sample did not match, so this scan cannot be trusted and is reporting failure rather than green. \`grep -E\` here does not support the 0x80-0xFF byte range under LC_ALL=C that the check is built on."
   echo "install-sh-ascii-guard: self-test failed — the known-bad sample did not match." >&2
   exit 1
 fi
 
-if printf '%s\n' "$GOOD_SAMPLE" | grep -qE "$PATTERN"; then
+good_status=0
+printf '%s\n' "$GOOD_SAMPLE" | grep -qE -- "$PATTERN" || good_status=$?
+
+if [ "$good_status" -gt 1 ]; then
+  echo "::error title=The install.sh expansion guard is broken::\`grep\` exited $good_status on its own known-good sample, which is an error rather than an answer. The scan is not trustworthy and is reporting failure rather than green."
+  echo "install-sh-ascii-guard: self-test failed — grep exited $good_status on the known-good sample." >&2
+  exit 1
+fi
+
+if [ "$good_status" -eq 0 ]; then
   echo "::error title=The install.sh expansion guard is broken::Its own known-good sample matched, so the check would refuse correct files. This is a bug in scripts/install-sh-ascii-guard.sh, not in $TARGET."
   echo "install-sh-ascii-guard: self-test failed — the known-good sample matched." >&2
   exit 1
 fi
 
-# `|| true`, because no match is this script's success case and `set -e` would
-# otherwise abort on it.
-HITS="$(grep -nE "$PATTERN" "$TARGET" || true)"
+# The scan. Its status is captured rather than discarded — see the three
+# answers above. `grep`'s own diagnostic is kept too: it is the sentence that
+# says *why* the file could not be read, and swallowing it would leave the
+# reader with an exit code and nothing else.
+SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/install-sh-ascii-guard.XXXXXX")"
+trap 'rm -f "$SCAN_ERR"' EXIT
 
-if [ -z "$HITS" ]; then
+scan_status=0
+HITS="$(grep -nE -- "$PATTERN" "$TARGET" 2>"$SCAN_ERR")" || scan_status=$?
+
+# Anything grep had to say reaches the log whatever the outcome, so a warning
+# on a run that passed is still visible.
+if [ -s "$SCAN_ERR" ]; then
+  cat "$SCAN_ERR" >&2
+fi
+
+if [ "$scan_status" -gt 1 ]; then
+  detail="$(tr '\n' ' ' <"$SCAN_ERR")"
+  echo "::error title=The install.sh expansion guard could not scan its target::\`grep\` exited $scan_status on $TARGET — an error, not an answer, so nothing was scanned and this check refuses to report green. $detail"
+  echo "install-sh-ascii-guard: grep exited $scan_status on $TARGET; the file was not scanned." >&2
+  exit 1
+fi
+
+if [ "$scan_status" -eq 1 ]; then
   echo "  OK  $TARGET: no expansion is followed immediately by a non-ASCII byte (#346)."
   exit 0
+fi
+
+# Status 0 means grep matched, so there is at least one line to report. An
+# empty capture here would mean grep said "I matched" and named nothing, which
+# is not a state any grep produces — and the one thing that must not happen to
+# it is being read as success.
+if [ -z "$HITS" ]; then
+  echo "::error title=The install.sh expansion guard is broken::\`grep\` reported a match on $TARGET and printed no lines. That is not a state this script can interpret, so it fails rather than guessing."
+  echo "install-sh-ascii-guard: grep exited 0 with no output on $TARGET." >&2
+  exit 1
 fi
 
 echo "$TARGET has an expansion followed immediately by a non-ASCII byte." >&2


### PR DESCRIPTION
Closes #346 once this train promotes.

## The bug

`install.sh:537` read `say "Downloading $asset…"`. macOS ships bash 3.2.57 and defaults `LC_CTYPE` to a UTF-8 locale;
under that pair the identifier scan runs past `asset` into the bytes of the multi-byte ellipsis, looks up a name that
does not exist, and `set -eu` (`install.sh:47`) turns that into an aborted install on the first command the product
asks anyone to run:

```
bash: line 537: asset?: unbound variable
```

Line 537 was the only occurrence in the file — every other non-ASCII character is an em-dash or a box rule in a
comment, or already has a space between it and the expansion before it.

## What is actually in here

The character fix is three bytes. **The deliverable is the regression guard**, because the same three bytes can be
typed back tomorrow by anyone composing a nicer-looking message and no Linux runner would notice: CI runs bash 5,
where those bytes are correct.

- **`scripts/install-sh-ascii-guard.sh`** — scans `install.sh` under `LC_ALL=C` for a `$` expansion (a plain name, a
  braced name, a positional or special parameter, or a bare `$`) immediately followed by a byte in `0x80-0xFF`. It
  fails with the offending line number, as a `::error file=…,line=…` annotation in the Checks tab and in the log, and
  reports every offending line rather than the first.
- **Wired into `Lint` in `ci.yml`**, ahead of `setup-node`. `Lint` is already a required context in all three
  `docs/rulesets/*.json`, so the guard gates from its first run — a job of its own would have been a check context no
  ruleset names, which gates nothing until an admin edits three rulesets.
- **It cannot pass silently.** The detector self-tests against a known-bad and a known-good sample before the scan
  (the `LC_ALL=C` byte range is its one environmental assumption), and a missing file fails rather than reporting a
  green no-op.
- **`scripts/__tests__/install-sh-ascii-guard.test.mjs`** — 19 cases against the real script.

## Two lines this deliberately does not touch

- `install.sh:80` — `LINE="0.4.2"`, the release-train stamp (ADR 0036 D1, D2) that `Train rules` asserts. The guard
  only ever reads, the diff does not go near it, and there is a test asserting both that the stamp passes the scan and
  that a guard run leaves `install.sh` byte-identical.
- `packages/cli/src/actana-fetch-release.ts:95` carries the same `${asset}…` shape in TypeScript, where the bug does
  not exist. Out of scope here.

## bash 3.2

Both `install.sh` and the guard are bash 3.2 clean — no `mapfile`, no `declare -A`, no namerefs, no `${var^^}`. A test
asserts it, because a guard that needed bash 4 could only run where the bug cannot.

## Verification

- `scripts/install-sh-ascii-guard.sh install.sh` → passes on this branch; re-introducing the ellipsis makes it exit 1
  naming line 537, and turns `Unit Tests` red as well.
- Root vitest suite green (751 cases); `commitlint` green over both commits and this title.

Draft on purpose: base is `feat/0.4.2-install-and-identity`, not a train and not `main`.
