### PR TITLE
fix: migrate the pre-rename LaunchAgent, and refuse the environment it leaves behind

### DIFF
--- a/packages/cli/src/__tests__/actana-machine-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-machine-cli.test.ts
@@ -9,6 +9,7 @@ import { localCoreName } from "../local-core-wiring.ts";
 import type { ActanaCliDeps } from "../cli-deps.ts";
 import { refusedContainerVerbs } from "../actana-container.ts";
 import { installDirFor, resolveActanaLayout } from "../actana-layout.ts";
+import { writeActanaConfig } from "../actana-config.ts";
 import { releaseAssetName, releaseChannel } from "../actana-release.ts";
 import type { ActanaSystem, CommandResult } from "../actana-system.ts";
 import { fakeSystem as makeFakeSystem, realTar, stubClientHalf } from "./machine-fixture.ts";
@@ -679,6 +680,38 @@ describe("status", () => {
     });
     expect(await runActanaCli(deps(["status"], system))).toBe(1);
     expect(out.join("\n")).toMatch(/stopped/i);
+  });
+
+  it("reports the legacy unit's own state on Linux, not `not installed` (#348)", async () => {
+    // The launchd side got this fallback first; without the matching one here,
+    // `Auto-start actana-harness.service` printed over `State not installed`
+    // — the self-contradiction the issue opens with, on the other platform.
+    await setup(fakeSystem());
+    fs.rmSync(layoutForHome().servicePath);
+    fs.writeFileSync(
+      path.join(layoutForHome().serviceDir, "actana-harness.service"),
+      "[Unit]\nDescription=Actana Control Harness\n",
+    );
+    out.length = 0;
+
+    const system = fakeSystem({
+      "systemctl --user show actana-core.service": {
+        status: 0,
+        stdout: "LoadState=not-found\nActiveState=inactive\nSubState=dead\nMainPID=0",
+        stderr: "",
+      },
+      "systemctl --user show actana-harness.service": {
+        status: 0,
+        stdout: RUNNING_UNIT,
+        stderr: "",
+      },
+    });
+    expect(await runActanaCli(deps(["status"], system))).toBe(1);
+
+    const text = out.join("\n");
+    expect(text).toMatch(/Auto-start\s+actana-harness\.service/);
+    expect(text).not.toMatch(/State\s+not installed/);
+    expect(text).toMatch(/Legacy agent\s+actana-harness\.service is still installed/);
   });
 
   it("says not-installed on a fresh machine instead of erroring", async () => {
@@ -1573,7 +1606,7 @@ describe("macOS", () => {
     expect(await runActanaCli(macDeps(["status"], system))).toBe(1);
 
     const text = out.join("\n");
-    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is loaded/);
+    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is still installed/);
     expect(text).toMatch(/actana setup/);
   });
 
@@ -1598,6 +1631,44 @@ describe("macOS", () => {
     expect(
       fs.existsSync(path.join(home, "Library", "LaunchAgents", "com.actana.harness.plist")),
     ).toBe(false);
+  });
+
+  it("update keeps the legacy agent when it is the machine's only service", async () => {
+    // End to end on the #348 Mac, through the real launchd manager: an
+    // in-place upgrade where `actana setup` was never run after the rename, so
+    // there is no `com.actana.core.plist` to restart onto. Before this, update
+    // booted the legacy agent out and then threw on a bootstrap of a plist
+    // that does not exist — zero auto-start services, and a message pointing
+    // at the logs of a daemon that never started.
+    const legacyPlist = plantLegacyAgent();
+    // An install `actana place` made: a config and a tree, but no service.
+    writeActanaConfig(layoutForHome("darwin").configDir, {
+      version: MANIFEST.version,
+      port: 8443,
+      host: "0.0.0.0",
+      publicHost: "10.0.0.5",
+      publicHosts: ["10.0.0.5"],
+      label: "mac-1",
+      installDir: installDirFor(layoutForHome("darwin"), MANIFEST.version),
+      dataDir: layoutForHome("darwin").dataDir,
+    });
+    writeRelease({ dir: releaseDir, version: "0.2.0", target: "mac-arm64" });
+    out.length = 0;
+    err.length = 0;
+
+    const system = macSystem({ "launchctl print gui/501/": NO_SUCH_JOB });
+    const code = await runActanaCli(macDeps(["update", "--base-url", RELEASE_BASE_URL], system));
+
+    // The agent that was the machine's only service is still there.
+    expect(fs.existsSync(legacyPlist)).toBe(true);
+    expect(system.calls.map((c) => c.join(" "))).not.toContain(
+      "launchctl bootout gui/501/com.actana.harness",
+    );
+    // Non-zero, and pointing at the command that actually registers a Core —
+    // not at the logs of something that was never started.
+    expect(code).toBe(1);
+    expect(out.join("\n")).toMatch(/actana setup/);
+    expect(err.join("\n")).not.toMatch(/Check `actana logs`/);
   });
 
   it("will not install a linux build on a Mac", async () => {

--- a/packages/cli/src/__tests__/actana-machine-cli.test.ts
+++ b/packages/cli/src/__tests__/actana-machine-cli.test.ts
@@ -1272,6 +1272,25 @@ describe("macOS", () => {
     "}",
   ].join("\n");
 
+  /** launchd's answer about a job it has never heard of. */
+  const NO_SUCH_JOB: CommandResult = { status: 113, stdout: "", stderr: "Could not find service" };
+
+  /**
+   * The ordinary Mac: one that never had a pre-rename agent.
+   *
+   * The shared fake answers 0 to every command it was not told about, and
+   * since #348 the launchd manager asks `launchctl print` about
+   * `com.actana.harness` — so without this default every machine in this suite
+   * would claim to be carrying a legacy agent it never had. Overriding that
+   * answer is how a test opts into the machine that does.
+   */
+  function macSystem(overrides: Record<string, CommandResult> = {}) {
+    return fakeSystem({
+      "launchctl print gui/501/com.actana.harness": NO_SUCH_JOB,
+      ...overrides,
+    });
+  }
+
   let macRoot: string;
 
   beforeEach(() => {
@@ -1296,7 +1315,7 @@ describe("macOS", () => {
   }
 
   it("installs a LaunchAgent and points the operator at `actana pair new`", async () => {
-    expect(await macSetup(fakeSystem())).toBe(0);
+    expect(await macSetup(macSystem())).toBe(0);
 
     const text = out.join("\n");
     expect(text).toContain("actana pair new");
@@ -1306,15 +1325,15 @@ describe("macOS", () => {
   });
 
   it("tells the operator the daemon starts at login rather than surviving logout", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     expect(out.join("\n")).toMatch(/starts at login/i);
   });
 
   it("reports healthy from launchctl, with the LaunchAgent named", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     out.length = 0;
 
-    const system = fakeSystem({
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1332,10 +1351,10 @@ describe("macOS", () => {
   });
 
   it("reports stopped — not degraded — when the agent is installed but unloaded", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     out.length = 0;
 
-    const system = fakeSystem({
+    const system = macSystem({
       "launchctl print": { status: 113, stdout: "", stderr: "Could not find service" },
     });
     expect(await runActanaCli(macDeps(["status"], system))).toBe(1);
@@ -1343,8 +1362,8 @@ describe("macOS", () => {
   });
 
   it("stops by unloading the agent — `launchctl stop` would just restart it", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1359,8 +1378,8 @@ describe("macOS", () => {
   });
 
   it("stopping an already-stopped Core succeeds, as it does on Linux", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print": { status: 113, stdout: "", stderr: "Could not find service" },
     });
 
@@ -1371,8 +1390,8 @@ describe("macOS", () => {
   });
 
   it("starts by bootstrapping the agent back into the domain", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 113,
         stdout: "",
@@ -1387,10 +1406,10 @@ describe("macOS", () => {
   });
 
   it("starts a loaded-but-dead agent — loaded is not the same as running", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     // launchd is throttling a job that keeps crashing: loaded, no pid. On Linux
     // `systemctl start` would act here, so `actana start` must too.
-    const system = fakeSystem({
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: "\tstate = waiting\n",
@@ -1405,8 +1424,8 @@ describe("macOS", () => {
   });
 
   it("starting an already-running Core is a no-op, as it is on Linux", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1421,8 +1440,8 @@ describe("macOS", () => {
   });
 
   it("restarts a loaded agent in place with kickstart", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1437,8 +1456,8 @@ describe("macOS", () => {
   });
 
   it("surfaces a launchctl failure with its message and exit code", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem({
+    await macSetup(macSystem());
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1452,8 +1471,8 @@ describe("macOS", () => {
   });
 
   it("tails the LaunchAgent's log file — launchd has no journal", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem();
+    await macSetup(macSystem());
+    const system = macSystem();
 
     expect(await runActanaCli(macDeps(["logs"], system))).toBe(0);
     const call = system.calls.find((c) => c[0] === "tail")!;
@@ -1464,13 +1483,13 @@ describe("macOS", () => {
   });
 
   it("creates the log file at setup so the first `logs` is not an error", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     expect(fs.existsSync(path.join(home, "Library", "Logs", "Actana", "core.log"))).toBe(true);
   });
 
   it("follows and limits lines the same way as on Linux", async () => {
-    await macSetup(fakeSystem());
-    const system = fakeSystem();
+    await macSetup(macSystem());
+    const system = macSystem();
 
     await runActanaCli(macDeps(["logs", "-f", "-n", "50"], system));
     const call = system.calls.find((c) => c[0] === "tail")!;
@@ -1479,11 +1498,11 @@ describe("macOS", () => {
   });
 
   it("updates to a mac build and kickstarts the agent onto it", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     writeRelease({ dir: releaseDir, version: "0.2.0", target: "mac-arm64" });
     out.length = 0;
 
-    const system = fakeSystem({
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1500,23 +1519,104 @@ describe("macOS", () => {
     );
   });
 
+  // ─── a machine upgraded in place from before the rename (#348) ──────────
+
+  /** What an install generation before the rename left in `~/Library/LaunchAgents`. */
+  function plantLegacyAgent(): string {
+    const dir = path.join(home, "Library", "LaunchAgents");
+    fs.mkdirSync(dir, { recursive: true });
+    const legacyPlist = path.join(dir, "com.actana.harness.plist");
+    fs.writeFileSync(legacyPlist, "<plist/>\n");
+    return legacyPlist;
+  }
+
+  it("setup boots the pre-rename agent out and deletes its plist", async () => {
+    const legacyPlist = plantLegacyAgent();
+    const system = macSystem();
+
+    expect(await macSetup(system)).toBe(0);
+
+    expect(system.calls.map((c) => c.join(" "))).toContain(
+      "launchctl bootout gui/501/com.actana.harness",
+    );
+    expect(fs.existsSync(legacyPlist)).toBe(false);
+    expect(out.join("\n")).toMatch(/Removed com\.actana\.harness/);
+  });
+
+  it("place warns about it, because `install.sh` never reaches setup", async () => {
+    plantLegacyAgent();
+
+    expect(await runActanaCli(macDeps(["place"], macSystem()))).toBe(0);
+
+    // Warned, not removed: `place` puts a tree down and says what to run next.
+    expect(err.join("\n")).toMatch(/com\.actana\.harness is still installed/);
+    expect(err.join("\n")).toMatch(/actana setup/);
+    expect(fs.existsSync(path.join(home, "Library", "LaunchAgents", "com.actana.harness.plist")))
+      .toBe(true);
+  });
+
+  it("status names the agent launchd loaded and says to run setup", async () => {
+    await macSetup(macSystem());
+    plantLegacyAgent();
+    out.length = 0;
+
+    const system = macSystem({
+      "launchctl print gui/501/com.actana.core": {
+        status: 0,
+        stdout: RUNNING_HARNESS,
+        stderr: "",
+      },
+      "launchctl print gui/501/com.actana.harness": { status: 0, stdout: "", stderr: "" },
+    });
+    // Non-zero: a second Core-era service on the machine is a degradation, and
+    // a script watching the exit code should see it.
+    expect(await runActanaCli(macDeps(["status"], system))).toBe(1);
+
+    const text = out.join("\n");
+    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is loaded/);
+    expect(text).toMatch(/actana setup/);
+  });
+
+  it("update removes it before restarting onto the new tree", async () => {
+    await macSetup(macSystem());
+    plantLegacyAgent();
+    writeRelease({ dir: releaseDir, version: "0.2.0", target: "mac-arm64" });
+    out.length = 0;
+
+    const system = macSystem();
+    expect(
+      await runActanaCli(macDeps(["update", "--base-url", RELEASE_BASE_URL], system)),
+    ).toBe(0);
+
+    const commands = system.calls.map((c) => c.join(" "));
+    expect(commands).toContain("launchctl bootout gui/501/com.actana.harness");
+    // Before the restart: the old agent runs `current/bin/actana` too, and
+    // `current` now points at the tree the restart is about to start.
+    expect(commands.indexOf("launchctl bootout gui/501/com.actana.harness")).toBeLessThan(
+      commands.lastIndexOf("launchctl kickstart -k gui/501/com.actana.core"),
+    );
+    expect(
+      fs.existsSync(path.join(home, "Library", "LaunchAgents", "com.actana.harness.plist")),
+    ).toBe(false);
+  });
+
   it("will not install a linux build on a Mac", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     writeRelease({ dir: releaseDir, version: "0.2.0", target: "linux-x64" });
     err.length = 0;
 
     expect(
-      await runActanaCli(macDeps(["update", "--base-url", RELEASE_BASE_URL], fakeSystem())),
+      await runActanaCli(macDeps(["update", "--base-url", RELEASE_BASE_URL], macSystem())),
     ).toBe(1);
     expect(err.join("\n")).toContain("mac-arm64");
   });
 
   it("regenerates credentials and reloads the agent onto them", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     const old = readMaterial("darwin");
     out.length = 0;
 
-    const system = fakeSystem({
+    const system = macSystem({
       "launchctl print gui/501/com.actana.core": {
         status: 0,
         stdout: RUNNING_HARNESS,
@@ -1532,9 +1632,9 @@ describe("macOS", () => {
   });
 
   it("uninstalls by booting the agent out and deleting its plist", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     const layout = layoutForHome("darwin");
-    const system = fakeSystem();
+    const system = macSystem();
 
     expect(await runActanaCli(macDeps(["uninstall"], system))).toBe(0);
 
@@ -1549,10 +1649,10 @@ describe("macOS", () => {
   });
 
   it("removes the data dir and credentials with --purge-data on a Mac too", async () => {
-    await macSetup(fakeSystem());
+    await macSetup(macSystem());
     const layout = layoutForHome("darwin");
 
-    expect(await runActanaCli(macDeps(["uninstall", "--purge-data"], fakeSystem()))).toBe(0);
+    expect(await runActanaCli(macDeps(["uninstall", "--purge-data"], macSystem()))).toBe(0);
     expect(fs.existsSync(layout.dataDir)).toBe(false);
     expect(fs.existsSync(layout.configDir)).toBe(false);
   });

--- a/packages/cli/src/__tests__/actana-service.test.ts
+++ b/packages/cli/src/__tests__/actana-service.test.ts
@@ -43,6 +43,13 @@ const DEFINITION = {
   environment: { AC_CORE_REMOTE: "1" },
 };
 
+/** The pre-rename LaunchAgent label — what a machine upgraded in place keeps. */
+const LEGACY_LABEL = "com.actana.harness";
+
+/** `launchctl print` answers for a job launchd has, and for one it does not. */
+const OK: CommandResult = { status: 0, stdout: "", stderr: "" };
+const MISSING: CommandResult = { status: 113, stdout: "", stderr: "Could not find service" };
+
 let tmp: string;
 let home: string;
 
@@ -189,6 +196,14 @@ describe("removing the pre-rename unit", () => {
   /** The unit `actana setup` wrote when the machine was called a Harness. */
   const LEGACY_UNIT = "actana-harness.service";
 
+  /** The pre-rename plist an in-place upgrade leaves in `~/Library/LaunchAgents`. */
+  function plantLegacyAgent(layout: ActanaLayout): string {
+    fs.mkdirSync(layout.serviceDir, { recursive: true });
+    const legacyPath = path.join(layout.serviceDir, `${LEGACY_LABEL}.plist`);
+    fs.writeFileSync(legacyPath, "<plist/>\n");
+    return legacyPath;
+  }
+
   function plantLegacyUnit(layout: ActanaLayout): string {
     fs.mkdirSync(layout.serviceDir, { recursive: true });
     const legacyPath = path.join(layout.serviceDir, LEGACY_UNIT);
@@ -250,12 +265,49 @@ describe("removing the pre-rename unit", () => {
     expect(fs.existsSync(layout.servicePath)).toBe(true);
   });
 
-  it("has nothing to remove on macOS — no released build ever wrote a plist", () => {
+  it("boots out the pre-rename LaunchAgent, deletes its plist, and names it", () => {
     const system = fakeSystem();
+    const { manager, layout } = managerFor("darwin", system);
+    const legacyPath = plantLegacyAgent(layout);
+
+    expect(manager.removeLegacyUnit()).toBe(LEGACY_LABEL);
+
+    expect(system.calls.map((c) => c.join(" "))).toContain(
+      `launchctl bootout gui/501/${LEGACY_LABEL}`,
+    );
+    expect(fs.existsSync(legacyPath)).toBe(false);
+  });
+
+  it("boots out a loaded legacy job whose plist someone already deleted", () => {
+    // `rm`ing the plist unloads nothing: launchd holds the copy it read at
+    // bootstrap time, so the old daemon is still up and still holds the port.
+    const system = fakeSystem({ [`launchctl print gui/501/${LEGACY_LABEL}`]: OK });
+    const { manager } = managerFor("darwin", system);
+
+    expect(manager.removeLegacyUnit()).toBe(LEGACY_LABEL);
+    expect(system.calls.map((c) => c.join(" "))).toContain(
+      `launchctl bootout gui/501/${LEGACY_LABEL}`,
+    );
+  });
+
+  it("removes nothing on a macOS machine that never had one", () => {
+    const system = fakeSystem({ "launchctl print": MISSING });
     const { manager } = managerFor("darwin", system);
 
     expect(manager.removeLegacyUnit()).toBeNull();
-    expect(system.calls).toEqual([]);
+    expect(manager.removeLegacyUnit()).toBeNull();
+    expect(system.calls.map((c) => c.join(" "))).not.toContain(
+      `launchctl bootout gui/501/${LEGACY_LABEL}`,
+    );
+  });
+
+  it("leaves the agent setup just installed alone", () => {
+    const system = fakeSystem({ "launchctl print": MISSING });
+    const { manager, layout } = managerFor("darwin", system);
+    manager.install(DEFINITION);
+
+    expect(manager.removeLegacyUnit()).toBeNull();
+    expect(fs.existsSync(layout.servicePath)).toBe(true);
   });
 });
 
@@ -268,8 +320,31 @@ describe("launchd manager — state", () => {
   }
 
   it("reports nothing installed before setup has written a plist", () => {
-    const { manager } = managerFor("darwin", fakeSystem());
+    // No plist under either label, and launchd has never heard of either job.
+    const { manager } = managerFor("darwin", fakeSystem({ "launchctl print gui/501/": MISSING }));
     expect(manager.state()).toBeNull();
+  });
+
+  it("reports the legacy agent's state rather than `not installed` (#348)", () => {
+    // The machine in the report: a pre-rename agent launchd is really running,
+    // no plist under the current label, and a `State  not installed` that was
+    // flatly untrue while a Core was up and holding the port.
+    const system = fakeSystem({
+      "launchctl print gui/501/com.actana.core": MISSING,
+      "launchctl print gui/501/com.actana.harness": {
+        status: 0,
+        stdout: "\tstate = running\n\tpid = 991\n",
+        stderr: "",
+      },
+    });
+    const { manager } = managerFor("darwin", system);
+
+    expect(manager.state()).toEqual({
+      loadState: "loaded",
+      activeState: "active",
+      subState: "running",
+      mainPid: 991,
+    });
   });
 
   it("reads a running agent's pid", () => {
@@ -328,6 +403,30 @@ describe("launchd manager — state", () => {
       path.join(home, "Library", "LaunchAgents", "com.actana.core.plist"),
     );
     expect(fs.readFileSync(manager.filePath, "utf8")).toContain("<key>Label</key>");
+  });
+
+  it("names the label launchd actually loaded, not the one setup would write", () => {
+    const system = fakeSystem({
+      "launchctl print gui/501/com.actana.core": MISSING,
+      "launchctl print gui/501/com.actana.harness": OK,
+    });
+    const { manager } = managerFor("darwin", system);
+
+    expect(manager.name).toBe("com.actana.core");
+    expect(manager.observe()).toEqual({ name: LEGACY_LABEL, legacyName: LEGACY_LABEL });
+  });
+
+  it("reports both when an in-place upgrade left the old agent beside the new one", () => {
+    const system = fakeSystem({ "launchctl print gui/501/": MISSING });
+    const { manager, layout } = installed(system);
+    fs.writeFileSync(path.join(layout.serviceDir, `${LEGACY_LABEL}.plist`), "<plist/>\n");
+
+    expect(manager.observe()).toEqual({ name: "com.actana.core", legacyName: LEGACY_LABEL });
+  });
+
+  it("reports no service at all on a machine with neither plist", () => {
+    const { manager } = managerFor("darwin", fakeSystem({ "launchctl print gui/501/": MISSING }));
+    expect(manager.observe()).toEqual({ name: null, legacyName: null });
   });
 
   it("probes the domain once however many verbs are run", () => {

--- a/packages/cli/src/__tests__/actana-setup.test.ts
+++ b/packages/cli/src/__tests__/actana-setup.test.ts
@@ -7,7 +7,16 @@ import { X509Certificate, createPublicKey } from "node:crypto";
 import { verifyBearer } from "@actana/shared/core-link-bearer";
 import { readActanaConfig } from "../actana-config";
 import { resolveActanaLayout, type ActanaLayout } from "../actana-layout";
-import { loadMaterial, materialFilePath, persistMaterial } from "@actana/shared/core-material-store";
+import selfsigned from "selfsigned";
+import { issueServerCert } from "@actana/shared/core-cert-material";
+import {
+  checkMaterialIdentity,
+  loadMaterial,
+  materialFilePath,
+  mintFreshMaterial,
+  persistMaterial,
+  type PersistedMaterial,
+} from "@actana/shared/core-material-store";
 import { createServiceManager } from "../actana-service";
 import {
   runActanaSetup,
@@ -965,6 +974,117 @@ describe("runActanaSetup — a Core installed before the rename", () => {
     await runActanaSetup(options(system));
 
     expect(system.calls.some((c) => c.join(" ").includes(LEGACY_UNIT))).toBe(false);
+  });
+});
+
+describe("runActanaSetup — recovering material the daemon cannot serve (#348)", () => {
+  /**
+   * Material with a real CA and a server key that belongs to another identity.
+   *
+   * The shape that used to trap an operator: `readMaterialFile` type-checks it
+   * happily, `reissueServerCert` re-blesses it with the same broken key, and
+   * the daemon refuses to boot on it — while telling them to run the command
+   * they had just run.
+   */
+  async function plantUnusableMaterial(): Promise<void> {
+    const mine = await mintFreshMaterial(["10.0.0.5"]);
+    const other = await mintFreshMaterial(["10.0.0.5"]);
+    fs.mkdirSync(layout.configDir, { recursive: true });
+    persistMaterial(layout.configDir, { ...mine, serverKey: other.serverKey });
+  }
+
+  /** What a machine from before the Harness → Core rename carries. */
+  async function plantPreRenameMaterial(): Promise<PersistedMaterial> {
+    const base = await mintFreshMaterial(["10.0.0.5"]);
+    const notBefore = new Date();
+    const ca = await selfsigned.generate(
+      [
+        { name: "commonName", value: "mission-control-harness-ca" },
+        { name: "organizationName", value: "Mission Control" },
+      ],
+      {
+        algorithm: "sha256",
+        notBeforeDate: notBefore,
+        notAfterDate: new Date(notBefore.getTime() + 86_400_000),
+        extensions: [
+          { name: "basicConstraints", cA: true, pathLenConstraint: 0, critical: true },
+          { name: "keyUsage", keyCertSign: true, cRLSign: true, critical: true },
+        ],
+      },
+    );
+    const server = await issueServerCert({
+      ca: { cert: ca.cert, key: ca.private },
+      hosts: ["10.0.0.5"],
+    });
+    const material: PersistedMaterial = {
+      ...base,
+      caCert: ca.cert,
+      caKey: ca.private,
+      serverCert: server.cert,
+      serverKey: server.key,
+      serverHosts: ["10.0.0.5"],
+    };
+    fs.mkdirSync(layout.configDir, { recursive: true });
+    persistMaterial(layout.configDir, material);
+    return material;
+  }
+
+  it("re-mints it from a fresh CA instead of re-blessing it", async () => {
+    await plantUnusableMaterial();
+
+    const result = await runActanaSetup(options(fakeSystem()));
+
+    expect(result.materialOutcome).toBe("re-minted");
+    // The end-to-end assertion the review asked for: the daemon boots on what
+    // setup wrote. `checkMaterialIdentity` is the function `loadOrMintMaterial`
+    // calls at boot, so a null here *is* a clean boot.
+    expect(checkMaterialIdentity(loadMaterial(layout.configDir)!)).toBeNull();
+  });
+
+  it("says what it did, because every paired client is locked out by it", async () => {
+    await plantUnusableMaterial();
+    const lines: string[] = [];
+
+    await runActanaSetup(options(fakeSystem(), { out: (line) => lines.push(line) }));
+
+    expect(lines.join("\n")).toMatch(/cannot be served/);
+  });
+
+  it("asks first when there is a terminal, and stops if the answer is no", async () => {
+    await plantUnusableMaterial();
+    const system = fakeSystem();
+    system.answer = false;
+
+    await expect(
+      runActanaSetup(options(system, { interactive: true, assumeYes: false })),
+    ).rejects.toThrow(/Left this Core's material alone/);
+    expect(system.confirms.join(" ")).toMatch(/fresh identity/);
+  });
+
+  it("keeps material from before the rename — it works, and re-pairing is not free", async () => {
+    // The review's correction. The Harness-era CA is not what broke #348; the
+    // environment-variable rename is, and `core-boot-refusals.ts` stops that.
+    // Re-minting here would cost every paired client its pairing for nothing.
+    const planted = await plantPreRenameMaterial();
+    const lines: string[] = [];
+
+    const result = await runActanaSetup(options(fakeSystem(), { out: (line) => lines.push(line) }));
+
+    expect(result.materialOutcome).not.toBe("re-minted");
+    expect(loadMaterial(layout.configDir)!.caCert).toBe(planted.caCert);
+    // Kept, but not silently: the operator is told what their Core presents.
+    expect(lines.join("\n")).toMatch(/mission-control-harness-ca/);
+  });
+
+  it("leaves good material alone, and asks nothing about it", async () => {
+    const system = fakeSystem();
+    await runActanaSetup(options(system));
+    const first = loadMaterial(layout.configDir)!;
+
+    await runActanaSetup(options(system));
+
+    expect(loadMaterial(layout.configDir)!.caCert).toBe(first.caCert);
+    expect(system.confirms.join(" ")).not.toMatch(/fresh identity/);
   });
 });
 

--- a/packages/cli/src/__tests__/actana-status.test.ts
+++ b/packages/cli/src/__tests__/actana-status.test.ts
@@ -180,10 +180,27 @@ describe("a service left by an install from before the rename (#348)", () => {
     expect(formatActanaStatus(legacy)).not.toMatch(/Auto-start\s+com\.actana\.core/);
   });
 
-  it("says what is loaded and what to run about it", () => {
+  it("says what is there and what to run about it", () => {
     const text = formatActanaStatus(legacy);
-    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is loaded/);
+    // "still installed", not "is loaded": the detection is true when the plist
+    // merely exists, and this is the wording `actana place` uses too.
+    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is still installed/);
     expect(text).toMatch(/actana setup/);
+  });
+
+  it("still says it on a machine setup has never run on", () => {
+    // `actana uninstall --purge-data` removes the config, so `installed` is
+    // false — and the legacy agent it used to leave behind still held the
+    // port. The one row that explains that must survive the short page.
+    const text = formatActanaStatus({
+      ...healthy,
+      installed: false,
+      service: null,
+      legacyService: "com.actana.harness",
+    });
+    expect(text).toMatch(/^Core: not installed/);
+    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is still installed/);
+    expect(text).toMatch(/Run `actana setup`/);
   });
 
   it("still reports the legacy agent when the new one is installed beside it", () => {

--- a/packages/cli/src/__tests__/actana-status.test.ts
+++ b/packages/cli/src/__tests__/actana-status.test.ts
@@ -11,6 +11,7 @@ const healthy: ActanaStatusReport = {
   target: "linux-x64",
   endpoint: "wss://10.0.0.5:8443",
   serviceName: "actana-core.service",
+  legacyService: null,
   service: { loadState: "loaded", activeState: "active", subState: "running", mainPid: 4211 },
   persistence: { label: "Linger", value: "yes" },
   container: null,
@@ -135,6 +136,7 @@ describe("formatActanaStatus", () => {
       target: null,
       endpoint: null,
       serviceName: "actana-core.service",
+      legacyService: null,
       service: null,
       persistence: null,
       container: null,
@@ -157,6 +159,47 @@ describe("formatActanaStatus", () => {
 
 // An alert, and only an alert: the line names the command and never runs it,
 // and nothing about it reaches the exit code a script reads.
+describe("a service left by an install from before the rename (#348)", () => {
+  /** The machine in the report: the old agent is what launchd actually loaded. */
+  const legacy: ActanaStatusReport = {
+    ...healthy,
+    serviceName: "com.actana.harness",
+    legacyService: "com.actana.harness",
+  };
+
+  it("is degraded even while the legacy agent is up and answering", () => {
+    // It answers *because* it is the thing that is wrong: it runs the new
+    // binary with the pre-rename environment and holds the port the real Core
+    // wants. Reporting healthy here is what let this ship.
+    expect(summarizeHealth(legacy)).toBe("degraded");
+    expect(formatActanaStatus(legacy)).toMatch(/^Core: degraded/);
+  });
+
+  it("names the agent launchd loaded, not the label setup would write", () => {
+    expect(formatActanaStatus(legacy)).toMatch(/Auto-start\s+com\.actana\.harness/);
+    expect(formatActanaStatus(legacy)).not.toMatch(/Auto-start\s+com\.actana\.core/);
+  });
+
+  it("says what is loaded and what to run about it", () => {
+    const text = formatActanaStatus(legacy);
+    expect(text).toMatch(/Legacy agent\s+com\.actana\.harness is loaded/);
+    expect(text).toMatch(/actana setup/);
+  });
+
+  it("still reports the legacy agent when the new one is installed beside it", () => {
+    // What an in-place upgrade leaves: the real Core registered and running,
+    // and the old agent still loaded behind it.
+    const both = { ...healthy, legacyService: "com.actana.harness" };
+    expect(formatActanaStatus(both)).toMatch(/Auto-start\s+actana-core\.service/);
+    expect(formatActanaStatus(both)).toMatch(/Legacy agent\s+com\.actana\.harness/);
+    expect(summarizeHealth(both)).toBe("degraded");
+  });
+
+  it("says nothing at all on a machine that has none", () => {
+    expect(formatActanaStatus(healthy)).not.toMatch(/Legacy agent/);
+  });
+});
+
 describe("the update availability line", () => {
   const available = {
     ...healthy,

--- a/packages/cli/src/__tests__/actana-uninstall.test.ts
+++ b/packages/cli/src/__tests__/actana-uninstall.test.ts
@@ -30,6 +30,7 @@ function fakeService() {
       fs.rmSync(service.filePath, { force: true });
     },
     removeLegacyUnit: () => null,
+    observe: () => ({ name: "actana-core.service", legacyName: null }),
     async ensurePersistence() {
       return { survivesLogout: true, summary: "enabled, lingering" };
     },

--- a/packages/cli/src/__tests__/actana-update.test.ts
+++ b/packages/cli/src/__tests__/actana-update.test.ts
@@ -223,6 +223,44 @@ describe("landing a newer release", () => {
     expect(out.join("\n")).toMatch(/Removed com\.actana\.harness/);
   });
 
+  it("keeps the legacy service when it is the only one, and never restarts into nothing", async () => {
+    // The #348 machine: `actana setup` was never run after the rename, so
+    // `com.actana.core` does not exist and the pre-rename agent is the only
+    // auto-start service there is. Removing it and then failing to restart —
+    // which is what this did — leaves the operator with no service at all.
+    const removals: string[] = [];
+    const service = fakeService({
+      observe: () => ({ name: "com.actana.harness", legacyName: "com.actana.harness" }),
+      removeLegacyUnit: () => {
+        removals.push("removed");
+        return "com.actana.harness";
+      },
+    });
+
+    const result = await update({ service });
+
+    expect(result.updated).toBe(true);
+    expect(removals).toEqual([]);
+    expect(service.verbs).toEqual([]);
+    // Null rather than false: nothing was asked to start, so the port was
+    // never a question.
+    expect(result.listening).toBeNull();
+    expect(out.join("\n")).toMatch(/com\.actana\.harness/);
+    expect(out.join("\n")).toMatch(/actana setup/);
+  });
+
+  it("says so, without restarting, when there is no service at all", async () => {
+    const service = fakeService({ observe: () => ({ name: null, legacyName: null }) });
+
+    const result = await update({ service });
+
+    expect(result.updated).toBe(true);
+    expect(service.verbs).toEqual([]);
+    expect(result.listening).toBeNull();
+    expect(out.join("\n")).toMatch(/no auto-start service/);
+    expect(out.join("\n")).toMatch(/actana setup/);
+  });
+
   it("says nothing about a legacy service on a machine that has none", async () => {
     await update();
     expect(out.join("\n")).not.toMatch(/before the rename/);

--- a/packages/cli/src/__tests__/actana-update.test.ts
+++ b/packages/cli/src/__tests__/actana-update.test.ts
@@ -43,6 +43,7 @@ function fakeService(overrides: Partial<ActanaServiceManager> = {}) {
     install() {},
     uninstall() {},
     removeLegacyUnit: () => null,
+    observe: () => ({ name: "actana-core.service", legacyName: null }),
     async ensurePersistence() {
       return { survivesLogout: true, summary: "enabled, lingering" };
     },
@@ -197,6 +198,34 @@ describe("landing a newer release", () => {
     const result = await update({ service });
     expect(service.verbs).toEqual(["restart"]);
     expect(result.listening).toBe(true);
+  });
+
+  it("removes a pre-rename service before restarting onto the new tree (#348)", async () => {
+    // The upgrade path in the report: `install.sh` places a new tree and the
+    // operator runs `actana update`, never `actana setup`. The old agent runs
+    // `current/bin/actana` too, so without this it comes back on the new
+    // binary with the old environment and fights for the port.
+    const order: string[] = [];
+    const service = fakeService({
+      removeLegacyUnit: () => {
+        order.push("removeLegacyUnit");
+        return "com.actana.harness";
+      },
+      verb: (verb) => {
+        order.push(verb);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    await update({ service });
+
+    expect(order).toEqual(["removeLegacyUnit", "restart"]);
+    expect(out.join("\n")).toMatch(/Removed com\.actana\.harness/);
+  });
+
+  it("says nothing about a legacy service on a machine that has none", async () => {
+    await update();
+    expect(out.join("\n")).not.toMatch(/before the rename/);
   });
 
   it("says so when the daemon did not come back", async () => {

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -643,6 +643,16 @@ async function cmdSetup(
         `trusts this Core, but it is dialling the address it paired with. Point it at ` +
         `${publicHost}, or run \`actana pair new\` here and pair it again.`,
     );
+  } else if (result.materialOutcome === "re-minted") {
+    // The recovery in #348: the material that was here could not have served
+    // TLS, so setup replaced it rather than re-blessing it. Nothing that was
+    // paired with the old identity works any more, and saying so is the whole
+    // point of the outcome having its own name.
+    deps.out(
+      "This Core's old material could not be served and has been replaced, so every client " +
+        "paired with it is locked out. Pair each one again: run `actana pair new` here and " +
+        "spend the code it prints on the client.",
+    );
   } else if (result.materialOutcome === "reused") {
     deps.out(
       "This Core's pairing credentials are unchanged — a Panel already paired " +
@@ -1270,6 +1280,15 @@ async function cmdUpdate(deps: ActanaCliDeps, argv: string[]): Promise<number> {
   // saying, because "I just replaced the whole install" reads otherwise.
   deps.out("Your pairing credentials are unchanged — paired Panels stay paired.");
 
+  if (result.listening === null) {
+    // Nothing was restarted, and the update said why on stdout — there is no
+    // service on this machine to restart (#348). Non-zero so a scripted
+    // upgrade notices that the new version is placed but nothing is running
+    // it, without the "the daemon restarted" sentence below, which would be
+    // false.
+    deps.err("Nothing is running this version yet — run `actana setup`.");
+    return 1;
+  }
   if (!result.listening) {
     deps.err(
       `The daemon restarted but nothing is listening on port ${installed.config.port} yet. ` +

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -99,6 +99,7 @@ import { readCoreManifest, type CoreManifest } from "./actana-manifest.ts";
 import { releaseChannel } from "./actana-release.ts";
 import {
   createServiceManager,
+  supportsService,
   type ActanaServiceManager,
   type ServiceVerb,
 } from "./actana-service.ts";
@@ -789,6 +790,7 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
   deps.out("");
   deps.out("  " + setupCommandFor(layout, placed.launcher, deps.env));
   deps.out("");
+  warnAboutLegacyService(deps, layout);
   deps.out(
     existing
       ? "That restarts the daemon on the version just placed. This Core's identity, its " +
@@ -797,6 +799,47 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
           "starts the daemon. `actana --help` lists its port, host, label and Harness options.",
   );
   return 0;
+}
+
+/**
+ * Say so when a pre-rename service is still installed here (#348).
+ *
+ * `install.sh` runs `actana place` and stops; an operator who upgrades that way
+ * never reaches `actana setup`, which is the only thing that removes the old
+ * service. So the old agent — `KeepAlive` on, `ProgramArguments` pointing at
+ * `current/bin/actana`, which `place` has just repointed — picks up the new
+ * binary with the pre-rename environment and crash-loops against the port.
+ *
+ * A warning rather than a removal, and a refusal least of all. `place` is the
+ * step that does not touch the running machine: it puts a tree down and prints
+ * what to run next. Booting out a service is `setup`'s and `update`'s job, and
+ * the line below is what makes an operator run one of them.
+ *
+ * Best effort in both directions, exactly as {@link stopDaemonBeingReplaced}
+ * is: a platform with no init system has no legacy service to warn about, and
+ * a bundle must still place on it.
+ */
+function warnAboutLegacyService(deps: ActanaCliDeps, layout: ActanaLayout): void {
+  if (!supportsService(deps.platform)) return;
+  let legacy: string | null;
+  try {
+    legacy = createServiceManager({
+      platform: deps.platform,
+      layout,
+      system: deps.system,
+      user: deps.user,
+      uid: deps.uid,
+    }).observe().legacyName;
+  } catch {
+    return;
+  }
+  if (!legacy) return;
+  deps.err(
+    `Warning: ${legacy} is still installed on this machine, left by an install from before ` +
+      "the rename. It runs `current/bin/actana` too, so it is now starting the version just " +
+      "placed with the old environment, and it will fight the real Core for the port. " +
+      "`actana setup` removes it.",
+  );
 }
 
 /**
@@ -916,6 +959,9 @@ async function containerStatus(deps: ActanaCliDeps): Promise<number> {
     target: manifest?.target ?? null,
     endpoint: endpointFor(config),
     serviceName: null,
+    // There is no init system in the image and never was one, so there is no
+    // pre-rename agent for it to be carrying (ADR 0016 D16).
+    legacyService: null,
     service: null,
     persistence: null,
     container: { listening, port: config.port },
@@ -944,6 +990,7 @@ async function cmdStatus(deps: ActanaCliDeps, argv: string[]): Promise<number> {
   if (!service) return 1;
 
   const version = manifest?.version ?? config?.version ?? null;
+  const observed = service.observe();
   const report: ActanaStatusReport = {
     installed: config !== null,
     version,
@@ -951,7 +998,11 @@ async function cmdStatus(deps: ActanaCliDeps, argv: string[]): Promise<number> {
     protocolVersion: manifest?.protocolVersion ?? null,
     target: manifest?.target ?? null,
     endpoint: config ? endpointFor(config) : null,
-    serviceName: service.name,
+    // What the init system actually has, falling back to the label setup would
+    // write when it has nothing at all — never the constant on a machine whose
+    // real service is called something else (#348).
+    serviceName: observed.name ?? service.name,
+    legacyService: observed.legacyName,
     service: service.state(),
     persistence: service.persistence(),
     container: null,

--- a/packages/cli/src/actana-cli.ts
+++ b/packages/cli/src/actana-cli.ts
@@ -790,7 +790,6 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
   deps.out("");
   deps.out("  " + setupCommandFor(layout, placed.launcher, deps.env));
   deps.out("");
-  warnAboutLegacyService(deps, layout);
   deps.out(
     existing
       ? "That restarts the daemon on the version just placed. This Core's identity, its " +
@@ -798,6 +797,8 @@ function cmdPlace(deps: ActanaCliDeps, argv: string[]): number {
       : "That writes this Core's identity, its auto-start service and its registration, and " +
           "starts the daemon. `actana --help` lists its port, host, label and Harness options.",
   );
+  // Last, so it is the line still on screen when `install.sh` finishes.
+  warnAboutLegacyService(deps, layout);
   return 0;
 }
 

--- a/packages/cli/src/actana-launchd.ts
+++ b/packages/cli/src/actana-launchd.ts
@@ -22,6 +22,24 @@ export const LAUNCH_AGENT_LABEL = "com.actana.core";
 /** The plist filename inside `~/Library/LaunchAgents`. */
 export const LAUNCH_AGENT_FILENAME = `${LAUNCH_AGENT_LABEL}.plist`;
 
+/**
+ * The agent setup wrote when the machine was called a Harness.
+ *
+ * The launchd half of `LEGACY_UNIT_NAME` in `actana-systemd.ts`, and it exists
+ * for the same reason: a machine installed before the Harness → Core rename still has this
+ * agent, `KeepAlive` is on, and its `ProgramArguments` point at
+ * `…/current/bin/actana` — so after an in-place upgrade the *old* agent
+ * launches the *new* binary with the old environment (#348). It has to be
+ * booted out and deleted, not left beside the new one.
+ *
+ * Deletable with `removeLegacyUnit` and its callers, one release after every
+ * supported machine has been through a 0.4.2 `actana setup`.
+ */
+export const LEGACY_LAUNCH_AGENT_LABEL = "com.actana.harness";
+
+/** The pre-rename plist's filename inside `~/Library/LaunchAgents`. */
+export const LEGACY_LAUNCH_AGENT_FILENAME = `${LEGACY_LAUNCH_AGENT_LABEL}.plist`;
+
 /** Everything that varies between one machine's LaunchAgent and another's. */
 export type ActanaPlistConfig = {
   /** `Label` — the job's name in every `launchctl` invocation. */
@@ -39,6 +57,17 @@ export type ActanaPlistConfig = {
 /** Where the LaunchAgent's plist lives for a given home directory. */
 export function launchAgentPath(home: string): string {
   return path.join(home, "Library", "LaunchAgents", LAUNCH_AGENT_FILENAME);
+}
+
+/**
+ * Where a pre-rename install left its plist.
+ *
+ * Beside {@link launchAgentPath} rather than derived from the layout: launchd
+ * reads agents from `~/Library/LaunchAgents` and nowhere else, so the legacy
+ * one is in the same directory as the current one by construction.
+ */
+export function legacyLaunchAgentPath(home: string): string {
+  return path.join(home, "Library", "LaunchAgents", LEGACY_LAUNCH_AGENT_FILENAME);
 }
 
 /**

--- a/packages/cli/src/actana-service.ts
+++ b/packages/cli/src/actana-service.ts
@@ -23,6 +23,8 @@ import {
   chooseLaunchdDomain,
   LAUNCH_AGENT_LABEL,
   launchdLogPath,
+  LEGACY_LAUNCH_AGENT_LABEL,
+  legacyLaunchAgentPath,
   parseLaunchctlPrint,
   renderActanaPlist,
   serviceTarget,
@@ -65,6 +67,28 @@ export type PersistenceRow = {
   /** `Linger` on systemd, `At login` on launchd. */
   label: string;
   value: string;
+};
+
+/**
+ * Which of this machine's services the init system actually has (#348).
+ *
+ * `name` is what is really installed or loaded here, which is not the same
+ * question as `ActanaServiceManager.name` — that one is the label setup
+ * *writes*, and reporting it unconditionally is how `actana status` came to
+ * print `com.actana.core` on a machine whose only agent was the pre-rename
+ * `com.actana.harness`.
+ */
+export type ServiceObservation = {
+  /** The unit / label this machine actually has, or null when it has none. */
+  name: string | null;
+  /**
+   * The pre-rename unit / label, when this machine still carries one.
+   *
+   * Reported separately from `name` because both can be true at once — a
+   * machine upgraded in place has the new plist *and* the old agent still
+   * loaded, and that combination is the failure #348 describes.
+   */
+  legacyName: string | null;
 };
 
 /** What making the service persist achieved. */
@@ -118,6 +142,13 @@ export type ActanaServiceManager = {
    * this exists and when it goes.
    */
   removeLegacyUnit(): string | null;
+  /**
+   * What this machine actually has installed or loaded, for `actana status`.
+   *
+   * Never throws and never asks the operator to act: a status report on a
+   * broken machine is the one thing that still has to work.
+   */
+  observe(): ServiceObservation;
   /** Make the daemon survive logout as far as this platform allows. */
   ensurePersistence(context: PersistenceContext): Promise<PersistenceOutcome>;
   /** Start at boot/login from now on, and start now. Throws when it cannot. */
@@ -206,6 +237,27 @@ function systemdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     return true;
   }
 
+  /**
+   * Whether a pre-rename unit is still on this machine.
+   *
+   * Two places, because deleting a unit file does not disable the unit:
+   * systemd reads a user's own units from `$XDG_CONFIG_HOME/systemd/user`, and
+   * `enable` leaves a symlink in `default.target.wants` beside it that still
+   * starts the daemon at boot on its own.
+   *
+   * Asked of the filesystem rather than of systemd, so a machine that never had
+   * one runs no commands at all and cannot fail. `lstat` for the link, because
+   * once the unit file is gone the link dangles and `existsSync` follows it to
+   * nothing — which is exactly the case being caught.
+   */
+  function legacyUnitPresent(): boolean {
+    const legacyPath = path.join(layout.serviceDir, LEGACY_UNIT_NAME);
+    const enabledLink = path.join(layout.serviceDir, "default.target.wants", LEGACY_UNIT_NAME);
+    return (
+      fs.existsSync(legacyPath) || Boolean(fs.lstatSync(enabledLink, { throwIfNoEntry: false }))
+    );
+  }
+
   /** Stop a unit, unlink it from boot, delete it, and leave no failed entry. */
   function removeUnit(name: string, filePath: string): void {
     systemctl("stop", name);
@@ -242,21 +294,17 @@ function systemdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     },
 
     removeLegacyUnit() {
-      // Two places, because deleting a unit file does not disable the unit:
-      // systemd reads a user's own units from `$XDG_CONFIG_HOME/systemd/user`,
-      // and `enable` leaves a symlink in `default.target.wants` beside it that
-      // still starts the daemon at boot on its own.
-      const legacyPath = path.join(layout.serviceDir, LEGACY_UNIT_NAME);
-      const enabledLink = path.join(layout.serviceDir, "default.target.wants", LEGACY_UNIT_NAME);
-      // Asked of the filesystem rather than of systemd, so a machine that never
-      // had one runs no commands at all and cannot fail. `lstat` for the link,
-      // because once the unit file is gone the link dangles and `existsSync`
-      // follows it to nothing — which is exactly the case being caught.
-      if (!fs.existsSync(legacyPath) && !fs.lstatSync(enabledLink, { throwIfNoEntry: false })) {
-        return null;
-      }
-      removeUnit(LEGACY_UNIT_NAME, legacyPath);
+      if (!legacyUnitPresent()) return null;
+      removeUnit(LEGACY_UNIT_NAME, path.join(layout.serviceDir, LEGACY_UNIT_NAME));
       return LEGACY_UNIT_NAME;
+    },
+
+    observe() {
+      const legacyName = legacyUnitPresent() ? LEGACY_UNIT_NAME : null;
+      return {
+        name: fs.existsSync(layout.servicePath) ? UNIT_NAME : legacyName,
+        legacyName,
+      };
     },
 
     async ensurePersistence(context) {
@@ -325,6 +373,25 @@ function launchdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     return domain;
   };
   const target = (): string => serviceTarget(resolveDomain(), LAUNCH_AGENT_LABEL);
+  const legacyPath = legacyLaunchAgentPath(layout.home);
+  const legacyTarget = (): string => serviceTarget(resolveDomain(), LEGACY_LAUNCH_AGENT_LABEL);
+
+  /**
+   * Whether the pre-rename agent is still on this machine.
+   *
+   * Both halves are needed and neither implies the other. The plist is what
+   * brings the old agent back at the operator's next login, and it is what an
+   * in-place upgrade leaves untouched. A *loaded* job with no plist left is the
+   * other half of the same mess — `rm`ing the file does not unload anything,
+   * because launchd holds the copy it read at bootstrap time.
+   *
+   * The file is checked first so a machine that never had one asks launchd
+   * nothing at all, which is also what keeps this cheap enough for the status
+   * path to call.
+   */
+  const legacyPresent = (): boolean =>
+    fs.existsSync(legacyPath) ||
+    system.run("launchctl", ["print", legacyTarget()]).status === 0;
 
   const printJob = (): CommandResult => system.run("launchctl", ["print", target()]);
   /** Whether launchd knows about the job at all — loaded, running or not. */
@@ -333,6 +400,28 @@ function launchdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
   const isRunning = (): boolean => {
     const printed = printJob();
     return printed.status === 0 && parseLaunchctlPrint(printed.stdout).state === "running";
+  };
+
+  /** What launchd says about one label, in the shape `actana status` renders. */
+  const stateOf = (label: string): ActanaServiceState => {
+    const printed = system.run("launchctl", ["print", serviceTarget(resolveDomain(), label)]);
+    if (printed.status !== 0) {
+      // The agent is installed but not loaded — `actana stop`, or a session
+      // that has not logged in since. That is stopped, not missing.
+      return { loadState: "loaded", activeState: "inactive", subState: "dead", mainPid: null };
+    }
+    const job = parseLaunchctlPrint(printed.stdout);
+    if (job.state === "running") {
+      return { loadState: "loaded", activeState: "active", subState: "running", mainPid: job.pid };
+    }
+    // Loaded but not running: launchd is between restarts, or throttling a job
+    // that keeps dying. Either way the operator has something to fix.
+    return {
+      loadState: "loaded",
+      activeState: "activating",
+      subState: job.state ?? "unknown",
+      mainPid: null,
+    };
   };
 
   /** Register the agent with launchd. `RunAtLoad` is what starts it. */
@@ -387,10 +476,21 @@ function launchdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     },
 
     removeLegacyUnit() {
-      // Nothing to clean up: the pre-rename `com.actana.harness` agent only
-      // ever existed on a machine that built its own tarball, and the macOS
-      // Core targets are being dropped rather than migrated (ADR 0016 D28).
-      return null;
+      // This used to return null on the reasoning that macOS Core targets were
+      // being dropped rather than migrated (ADR 0016 D28). #90 amended that
+      // decision and gave macOS a first-class on-device Core, so the pre-rename
+      // agent is now something real machines carry — and carry through an
+      // upgrade, because its `ProgramArguments` point at `current/bin/actana`
+      // and `KeepAlive` brings it back (#348).
+      if (!legacyPresent()) return null;
+      // Unload before deleting, the same order `uninstall` uses and for the
+      // same reason: launchd holds the plist it read at bootstrap time, so
+      // removing the file alone leaves the old daemon running on the port the
+      // new one is about to want. Failure is the ordinary "nothing was loaded"
+      // case — the plist below is the half that matters.
+      system.run("launchctl", ["bootout", legacyTarget()]);
+      fs.rmSync(legacyPath, { force: true });
+      return LEGACY_LAUNCH_AGENT_LABEL;
     },
 
     async ensurePersistence() {
@@ -420,30 +520,20 @@ function launchdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     },
 
     state() {
-      if (!fs.existsSync(layout.servicePath)) return null;
-      const printed = printJob();
-      if (printed.status !== 0) {
-        // The agent is installed but not loaded — `actana stop`, or a session
-        // that has not logged in since. That is stopped, not missing.
-        return { loadState: "loaded", activeState: "inactive", subState: "dead", mainPid: null };
-      }
-      const job = parseLaunchctlPrint(printed.stdout);
-      if (job.state === "running") {
-        return {
-          loadState: "loaded",
-          activeState: "active",
-          subState: "running",
-          mainPid: job.pid,
-        };
-      }
-      // Loaded but not running: launchd is between restarts, or throttling a
-      // job that keeps dying. Either way the operator has something to fix.
-      return {
-        loadState: "loaded",
-        activeState: "activating",
-        subState: job.state ?? "unknown",
-        mainPid: null,
-      };
+      if (fs.existsSync(layout.servicePath)) return stateOf(LAUNCH_AGENT_LABEL);
+      // No plist under the current label, but launchd may still be running the
+      // pre-rename agent out of this same tree — which is a Core that is up,
+      // not the "not installed" this used to report (#348).
+      return legacyPresent() ? stateOf(LEGACY_LAUNCH_AGENT_LABEL) : null;
+    },
+
+    observe() {
+      const legacyName = legacyPresent() ? LEGACY_LAUNCH_AGENT_LABEL : null;
+      // The plist is the stronger signal and is checked first: it is what
+      // launchd loads at the next login, so an installed-but-unloaded agent is
+      // still this machine's service.
+      const current = fs.existsSync(layout.servicePath) || isLoaded();
+      return { name: current ? LAUNCH_AGENT_LABEL : legacyName, legacyName };
     },
 
     verb(verb) {

--- a/packages/cli/src/actana-service.ts
+++ b/packages/cli/src/actana-service.ts
@@ -258,6 +258,23 @@ function systemdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     );
   }
 
+  /** What systemd says about one unit, or null when it has no such unit. */
+  function stateOf(name: string): ActanaServiceState | null {
+    const show = systemctl(
+      "show",
+      name,
+      "--property=LoadState",
+      "--property=ActiveState",
+      "--property=SubState",
+      "--property=MainPID",
+    );
+    if (show.status !== 0) return null;
+    const state = systemdStateFromShow(show.stdout);
+    // `not-found` means systemd has no such unit — reporting "no service" is
+    // truer than reporting a load state nobody can act on.
+    return state.loadState === "not-found" ? null : state;
+  }
+
   /** Stop a unit, unlink it from boot, delete it, and leave no failed entry. */
   function removeUnit(name: string, filePath: string): void {
     systemctl("stop", name);
@@ -301,10 +318,19 @@ function systemdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
 
     observe() {
       const legacyName = legacyUnitPresent() ? LEGACY_UNIT_NAME : null;
-      return {
-        name: fs.existsSync(layout.servicePath) ? UNIT_NAME : legacyName,
-        legacyName,
-      };
+      if (fs.existsSync(layout.servicePath)) return { name: UNIT_NAME, legacyName };
+      // No unit file, but systemd may still be holding the unit — one whose
+      // file was deleted by hand is still loaded and still running a daemon,
+      // which is not "absent" (the launchd side asks the same pair).
+      //
+      // Asked only when there is a legacy unit to be confused with, and that
+      // is deliberate: `actana place` calls this, and placement asks the init
+      // system nothing on the ordinary machine — a copy and two symlinks, as
+      // its own test pins. A machine that *has* a pre-rename unit is getting a
+      // warning printed about it either way, and one `systemctl show` is what
+      // makes that warning name the right service.
+      if (legacyName && stateOf(UNIT_NAME)) return { name: UNIT_NAME, legacyName };
+      return { name: legacyName, legacyName };
     },
 
     async ensurePersistence(context) {
@@ -320,19 +346,13 @@ function systemdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
     },
 
     state() {
-      const show = systemctl(
-        "show",
-        UNIT_NAME,
-        "--property=LoadState",
-        "--property=ActiveState",
-        "--property=SubState",
-        "--property=MainPID",
-      );
-      if (show.status !== 0) return null;
-      const state = systemdStateFromShow(show.stdout);
-      // `not-found` means systemd has no such unit — reporting "no service" is
-      // truer than reporting a load state nobody can act on.
-      return state.loadState === "not-found" ? null : state;
+      const current = stateOf(UNIT_NAME);
+      if (current) return current;
+      // No current unit, but this machine may still be running the pre-rename
+      // one — the same fallback the launchd side has, and without it `status`
+      // prints `Auto-start actana-harness.service` over `State not installed`,
+      // which is #348's own self-contradiction on the other platform.
+      return legacyUnitPresent() ? stateOf(LEGACY_UNIT_NAME) : null;
     },
 
     verb: (verb) => systemctl(verb, UNIT_NAME),
@@ -385,9 +405,16 @@ function launchdServiceManager(opts: ServiceManagerOptions): ActanaServiceManage
    * other half of the same mess — `rm`ing the file does not unload anything,
    * because launchd holds the copy it read at bootstrap time.
    *
-   * The file is checked first so a machine that never had one asks launchd
-   * nothing at all, which is also what keeps this cheap enough for the status
-   * path to call.
+   * The file is checked first because it is the cheap half and the common
+   * answer on a machine that *has* one — but note which way the short-circuit
+   * runs: a machine that never had a legacy agent has no plist, so it is
+   * exactly that machine which pays for the `launchctl print`. (The systemd
+   * `legacyUnitPresent` above really does ask the filesystem only, because
+   * both of its halves are files.) `observe`, `state` and the `place` warning
+   * each call this, so a plain `actana status` on a healthy Mac spawns a few
+   * extra `launchctl` processes. Correct, and cheap enough — worth memoising
+   * only if it ever shows up, and memoising would have to be invalidated by
+   * `removeLegacyUnit`.
    */
   const legacyPresent = (): boolean =>
     fs.existsSync(legacyPath) ||

--- a/packages/cli/src/actana-setup.ts
+++ b/packages/cli/src/actana-setup.ts
@@ -48,6 +48,7 @@ import * as path from "node:path";
 import { signBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import { formatPublicHosts, primaryPublicHost } from "@actana/shared/public-hosts";
 import {
+  checkMaterialIdentity,
   loadMaterial,
   materialFilePath,
   checkServerCertHost,
@@ -170,8 +171,16 @@ export type PlacementResult = {
   launcher: LauncherClaim;
 };
 
-/** What `actana setup` did to this machine's pairing material. */
-export type MaterialOutcome = "minted" | "reused" | "reissued";
+/**
+ * What `actana setup` did to this machine's pairing material.
+ *
+ * `re-minted` is the recovery path (#348): the material on disk could not have
+ * served TLS at all, so it was replaced rather than re-blessed. Its own outcome
+ * because it is the one that costs the operator something — every paired client
+ * has to pair again — and a caller that reported it as an ordinary `minted`
+ * would leave them to find that out from a client that stopped working.
+ */
+export type MaterialOutcome = "minted" | "reused" | "reissued" | "re-minted";
 
 export type SetupResult = {
   /** The version that is now installed — the tree's, not this CLI's (#288 D10). */
@@ -242,6 +251,10 @@ export function choosePublicHost(
  *
  * Material written before D18 does not record the host its cert was signed for;
  * the config setup wrote alongside it does, so that stands in for it.
+ *
+ * The one thing reuse cannot survive is material that could never have worked.
+ * See the first branch: that is the whole of what makes `actana setup` an
+ * honest answer to a daemon that refused to boot (#348).
  */
 async function resolveMaterial(
   opts: SetupOptions,
@@ -250,6 +263,42 @@ async function resolveMaterial(
   if (!existing) {
     return { material: await mintFreshMaterial(opts.publicHosts), outcome: "minted" };
   }
+
+  // The recovery path, and the reason `setup` can be named as a remedy at all
+  // (#348). Everything below this reuses the identity on disk — `reissueServerCert`
+  // included, which signs a new leaf with the *existing* CA and key. That is
+  // right for material that works and useless for material that cannot: a
+  // daemon told to boot on it refuses, the operator is told to run `setup`, and
+  // `setup` hands back what it was already given. So the file is checked with
+  // the same function the daemon boots with, and material that could never
+  // serve TLS is replaced instead of re-blessed.
+  const issue = checkMaterialIdentity(existing);
+  if (issue?.severity === "unusable") {
+    opts.out(`This Core's material cannot be served: ${issue.message}`);
+    // The same confirmation `actana token regenerate` asks before the same
+    // loss, because it is the same loss — and it is a loss the operator has
+    // no way around here: the alternative to fresh material is a daemon that
+    // will not boot.
+    if (opts.interactive && !opts.assumeYes) {
+      const yes = await opts.system.confirm(
+        "Mint this Core a fresh identity? Every client paired with it is locked out until " +
+          "it pairs again.",
+        true,
+      );
+      if (!yes) {
+        throw new Error(
+          "Left this Core's material alone, so setup stopped: the daemon will not boot on " +
+            `it. Re-run and accept, or remove ${materialFilePath(opts.layout.configDir)} and ` +
+            "run setup again.",
+        );
+      }
+    }
+    return { material: await mintFreshMaterial(opts.publicHosts), outcome: "re-minted" };
+  }
+  // Usable, just not ours — pre-rename material is the case that matters, and
+  // it is kept. Said out loud because the operator should know what their Core
+  // is presenting, and because `actana token regenerate` is how they change it.
+  if (issue) opts.out(issue.message);
 
   const previous = readActanaConfig(opts.layout.configDir);
   const check = checkServerCertHost(

--- a/packages/cli/src/actana-status.ts
+++ b/packages/cli/src/actana-status.ts
@@ -57,8 +57,25 @@ export type ActanaStatusReport = {
   target: string | null;
   /** The `wss://` endpoint the Panel dials. */
   endpoint: string | null;
-  /** What the service is called here: `actana-core.service`, `com.actana.core`. */
+  /**
+   * What the service is called here: `actana-core.service`, `com.actana.core`.
+   *
+   * The one the init system **actually has**, not the one setup would write
+   * (#348). The difference is the whole of the bug: this row printed the
+   * constant `com.actana.core` on a machine whose only agent was the pre-rename
+   * `com.actana.harness`, so `Auto-start` named a plist that was not on disk
+   * while the Core in front of the operator ran under another name.
+   */
   serviceName: string | null;
+  /**
+   * The pre-rename service, when this machine still carries one (#348).
+   *
+   * Its own field rather than folded into {@link serviceName}, because both
+   * can be true at once — an in-place upgrade leaves the old agent loaded
+   * beside the new one, and an operator needs told about the one that should
+   * not be there even while the one that should is running fine.
+   */
+  legacyService: string | null;
   /** null when no service is installed (or the platform has no init system). */
   service: ActanaServiceState | null;
   /** How the daemon persists across sessions. null when it could not be read. */
@@ -101,6 +118,12 @@ export function summarizeHealth(report: ActanaStatusReport): ActanaHealth {
     if (!report.container.listening) return "stopped";
     return report.paired ? "healthy" : "degraded";
   }
+  // A pre-rename service on the machine is a degradation whatever else is
+  // true (#348): it runs `current/bin/actana` with the old environment, it
+  // fights the real Core for the port, and `KeepAlive` brings it back. Saying
+  // `healthy` because *something* answered is how this was missed for a
+  // release — so the exit code is non-zero until it is gone.
+  if (report.legacyService) return "degraded";
   if (!report.service) return "degraded";
   if (report.service.activeState === "active") {
     return report.service.subState === "running" && report.paired ? "healthy" : "degraded";
@@ -195,6 +218,16 @@ export function formatActanaStatus(report: ActanaStatusReport): string {
     if (report.persistence) {
       lines.push(row(report.persistence.label, report.persistence.value));
     }
+  }
+
+  // Last of the service rows and unconditional in its own right: it is the one
+  // line that explains every other row that looks wrong, and the remedy is one
+  // command (#348).
+  if (report.legacyService) {
+    lines.push(
+      row("Legacy agent", `${report.legacyService} is loaded — an install from before the rename`),
+      row("", "run `actana setup` to remove it and register this Core properly"),
+    );
   }
 
   lines.push(

--- a/packages/cli/src/actana-status.ts
+++ b/packages/cli/src/actana-status.ts
@@ -166,13 +166,40 @@ function updateRows(report: ActanaStatusReport): string[] {
   ];
 }
 
+/**
+ * The two rows about a service left by an install from before the rename.
+ *
+ * Its own function because it is printed from two places: the ordinary report,
+ * and the `not-installed` page, where every other row is suppressed and this
+ * one must not be.
+ *
+ * "still installed" rather than "is loaded": the detection behind it is true
+ * when the plist merely exists, so an agent that was never bootstrapped would
+ * be overstated by "loaded" — and this is the wording `actana place` already
+ * uses for the same thing.
+ */
+function legacyRows(legacyService: string): string[] {
+  return [
+    row("Legacy agent", `${legacyService} is still installed — from before the rename`),
+    row("", "run `actana setup` to remove it and register this Core properly"),
+  ];
+}
+
 /** Render the report as the text `actana status` prints. */
 export function formatActanaStatus(report: ActanaStatusReport): string {
   const health = summarizeHealth(report);
   const lines: string[] = [HEALTH_LINE[health]];
 
   if (health === "not-installed") {
-    lines.push("", "  Run `actana setup` to install and pair this machine.");
+    // Setup has never run here, so there is nothing to report about a Core —
+    // except when this machine is still carrying the service of one. That row
+    // survives the early return: `actana uninstall --purge-data` removes the
+    // config while `uninstall()` used to leave a pre-rename agent loaded, and
+    // an operator looking at a machine whose port is held needs the one line
+    // that explains it (#348).
+    lines.push("");
+    if (report.legacyService) lines.push(...legacyRows(report.legacyService));
+    lines.push("  Run `actana setup` to install and pair this machine.");
     return lines.join("\n") + "\n";
   }
 
@@ -224,10 +251,7 @@ export function formatActanaStatus(report: ActanaStatusReport): string {
   // line that explains every other row that looks wrong, and the remedy is one
   // command (#348).
   if (report.legacyService) {
-    lines.push(
-      row("Legacy agent", `${report.legacyService} is loaded — an install from before the rename`),
-      row("", "run `actana setup` to remove it and register this Core properly"),
-    );
+    lines.push(...legacyRows(report.legacyService));
   }
 
   lines.push(

--- a/packages/cli/src/actana-uninstall.ts
+++ b/packages/cli/src/actana-uninstall.ts
@@ -94,6 +94,17 @@ export function runActanaUninstall(opts: UninstallOptions): UninstallResult {
   opts.service.uninstall();
   if (hadService) removed.push(opts.service.filePath);
 
+  // And the pre-rename one, which `uninstall()` above does not touch: it only
+  // knows the current label (#348). Left behind on a machine being uninstalled
+  // it is worse than a leftover file — `KeepAlive` re-execs `current/bin/actana`
+  // out of a tree this function is about to delete, until launchd throttles a
+  // job that can never start again.
+  const legacy = opts.service.removeLegacyUnit();
+  if (legacy) {
+    removed.push(legacy);
+    opts.out(`Removed ${legacy}, left by an install from before the rename.`);
+  }
+
   if (isOurLauncher(layout)) {
     remove(layout.binLink, removed);
   } else if (lstatOrNull(layout.binLink)) {

--- a/packages/cli/src/actana-update.ts
+++ b/packages/cli/src/actana-update.ts
@@ -26,7 +26,9 @@
 // The one service this *does* rewrite is a pre-rename one. `current/bin/actana`
 // is what the old agent runs too, so an update hands the new binary to a
 // service that has been gone from the product for two renames, with the old
-// environment still set on it (#348). It is removed here, before the restart.
+// environment still set on it (#348). It is removed here, before the restart —
+// but only when this machine has a current service to take over from it. An
+// update never leaves a machine with no auto-start service at all.
 
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -78,7 +80,13 @@ export type UpdateResult = {
   /** The version it pointed at before. */
   previousVersion: string;
   installDir: string;
-  /** Whether the daemon's port answered after the restart; null when nothing changed. */
+  /**
+   * Whether the daemon's port answered after the restart.
+   *
+   * Null when nothing was restarted — an update that changed nothing, and the
+   * machine with no current service to restart onto (#348), where a port that
+   * answered would be somebody else's daemon.
+   */
   listening: boolean | null;
 };
 
@@ -185,16 +193,51 @@ export async function runActanaUpdate(opts: UpdateOptions): Promise<UpdateResult
   if (launcher.note) opts.out(launcher.note);
   writeActanaConfig(layout.configDir, { ...config, version: manifest.version, installDir });
 
-  // Before the restart, not after it, and this is the whole of why #348's
-  // machine crash-looped: a pre-rename agent's `ProgramArguments` point at
-  // `current/bin/actana`, which the swap above has just repointed at the new
-  // tree. Left in place it is a second service, with the old environment,
-  // racing the restart below for the same port — and `KeepAlive` brings it
-  // back every time it loses. `actana setup` has always cleaned this up; an
-  // update never reached setup, which is exactly the upgrade path an operator
-  // running `install.sh` takes.
-  const legacy = service.removeLegacyUnit();
-  if (legacy) opts.out(`Removed ${legacy}, left by an install from before the rename.`);
+  // **Only when there is a current service to take over.** Removing the
+  // pre-rename one is right on a machine that has both — it runs
+  // `current/bin/actana` too, so the swap above has just handed it the new
+  // tree, and `KeepAlive` restarts it into a race for the port. But on a
+  // machine that has *only* the legacy service — which is the machine #348
+  // describes, since `actana setup` was never run after the rename — removing
+  // it leaves nothing to restart, and an update must never end with a machine
+  // that has no auto-start service at all. There it is left alone and named,
+  // and `actana setup` is the step that replaces it.
+  // Asked of the init system rather than of the filesystem: `observe()` is
+  // what knows whether this machine's *current* service exists, on both
+  // platforms, and it is the same answer `actana status` renders.
+  const observed = service.observe();
+  const hasCurrentService = observed.name === service.name;
+  if (hasCurrentService) {
+    const legacy = service.removeLegacyUnit();
+    if (legacy) opts.out(`Removed ${legacy}, left by an install from before the rename.`);
+  }
+
+  if (!hasCurrentService) {
+    // Not an error, and not a restart either: the tree is placed and `current`
+    // points at it, but nothing on this machine is registered to run it. The
+    // old `verb("restart")` here bootstrapped a plist that does not exist,
+    // failed, and pointed the operator at the logs of a daemon that was never
+    // started.
+    const legacy = observed.legacyName;
+    opts.out(
+      legacy
+        ? `${manifest.version} is installed, and nothing was restarted: this machine's only ` +
+            `auto-start service is ${legacy}, left by an install from before the rename. It ` +
+            "is still in place — removing it would leave no service at all. `actana setup` " +
+            "replaces it with this Core's own and starts the daemon."
+        : `${manifest.version} is installed, and nothing was restarted: this machine has no ` +
+            `auto-start service. \`actana setup\` registers ${service.name} and starts the daemon.`,
+    );
+    return {
+      updated: true,
+      version: manifest.version,
+      previousVersion: config.version,
+      installDir,
+      // Not probed: nothing was asked to start, so a port that answers would
+      // be somebody else's daemon and a port that does not is not news.
+      listening: null,
+    };
+  }
 
   opts.out(`Restarting ${service.name} on ${manifest.version}…`);
   const restarted = service.verb("restart");

--- a/packages/cli/src/actana-update.ts
+++ b/packages/cli/src/actana-update.ts
@@ -22,6 +22,11 @@
 // stays paired), the data dir, and every choice `actana setup` recorded. What
 // changes: the tree, `current`, and the version in `actana.json`. The service
 // definition is not rewritten because it already runs `current/bin/actana`.
+//
+// The one service this *does* rewrite is a pre-rename one. `current/bin/actana`
+// is what the old agent runs too, so an update hands the new binary to a
+// service that has been gone from the product for two renames, with the old
+// environment still set on it (#348). It is removed here, before the restart.
 
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -179,6 +184,17 @@ export async function runActanaUpdate(opts: UpdateOptions): Promise<UpdateResult
   const launcher = claimLauncher(layout, opts.env);
   if (launcher.note) opts.out(launcher.note);
   writeActanaConfig(layout.configDir, { ...config, version: manifest.version, installDir });
+
+  // Before the restart, not after it, and this is the whole of why #348's
+  // machine crash-looped: a pre-rename agent's `ProgramArguments` point at
+  // `current/bin/actana`, which the swap above has just repointed at the new
+  // tree. Left in place it is a second service, with the old environment,
+  // racing the restart below for the same port — and `KeepAlive` brings it
+  // back every time it loses. `actana setup` has always cleaned this up; an
+  // update never reached setup, which is exactly the upgrade path an operator
+  // running `install.sh` takes.
+  const legacy = service.removeLegacyUnit();
+  if (legacy) opts.out(`Removed ${legacy}, left by an install from before the rename.`);
 
   opts.out(`Restarting ${service.name} on ${manifest.version}…`);
   const restarted = service.verb("restart");

--- a/packages/core/src/__tests__/core-boot-refusals.test.ts
+++ b/packages/core/src/__tests__/core-boot-refusals.test.ts
@@ -1,0 +1,159 @@
+// The two environments a Core refuses to boot on (#348).
+//
+// The second of them is the security property of this file: a plaintext,
+// unauthenticated core-link must never end up listening on an address other
+// than this machine's own — and the way that happened in the field was not a
+// mistake anybody made, but an auto-start LaunchAgent written before the
+// Harness → Core rename, whose variables this daemon silently does not read.
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  isLoopbackHost,
+  legacyEnvRefusal,
+  legacyEnvVars,
+  plaintextExposureRefusal,
+} from "../core-boot-refusals";
+
+/**
+ * The environment the pre-rename LaunchAgent really sets.
+ *
+ * Three variables were renamed and three were not, and that split is the whole
+ * bug: `AC_CORE_LINK_PORT`, `AC_CORE_LINK_HOST` and `AC_USER_DATA_DIR` are read
+ * exactly as they always were, so the daemon comes up looking configured while
+ * remote mode, the public host and the material file have all quietly vanished.
+ */
+const PRE_RENAME_PLIST_ENV: NodeJS.ProcessEnv = {
+  AC_HARNESS_REMOTE: "1",
+  AC_HARNESS_PUBLIC_HOST: "core1.example.com",
+  AC_HARNESS_MATERIAL_FILE: "/Users/op/.config/actana/material.json",
+  AC_CORE_LINK_PORT: "8443",
+  AC_CORE_LINK_HOST: "0.0.0.0",
+  AC_USER_DATA_DIR: "/Users/op/.local/share/actana/data",
+};
+
+describe("an environment left by a pre-rename install", () => {
+  it("stops the boot, whichever of the old variables is set", () => {
+    for (const name of ["AC_HARNESS_REMOTE", "AC_HARNESS_PUBLIC_HOST", "AC_HARNESS_MATERIAL_FILE"]) {
+      expect(legacyEnvRefusal({ [name]: "1" })).toContain(name);
+    }
+  });
+
+  it("stops on any `AC_HARNESS_` variable, not just the three that are known", () => {
+    // The list is what one plist happened to set, not a specification. A
+    // machine carrying a fourth is carrying the same stale service.
+    expect(legacyEnvRefusal({ AC_HARNESS_SOMETHING_ELSE: "x" })).not.toBeNull();
+  });
+
+  it("names the rename and the command that fixes it, not just the variable", () => {
+    const refusal = legacyEnvRefusal(PRE_RENAME_PLIST_ENV)!;
+    expect(refusal).toMatch(/rename/i);
+    expect(refusal).toContain("actana setup");
+    // The operator has to be able to find the thing that set them.
+    expect(refusal).toContain("com.actana.harness");
+    expect(refusal).toContain("actana-harness.service");
+  });
+
+  it("lists every one it found, so a partial cleanup is visible", () => {
+    expect(legacyEnvVars(PRE_RENAME_PLIST_ENV)).toEqual([
+      "AC_HARNESS_MATERIAL_FILE",
+      "AC_HARNESS_PUBLIC_HOST",
+      "AC_HARNESS_REMOTE",
+    ]);
+  });
+
+  it("says nothing about an environment written for this daemon", () => {
+    expect(
+      legacyEnvRefusal({
+        AC_CORE_REMOTE: "1",
+        AC_CORE_LINK_HOST: "0.0.0.0",
+        AC_CORE_LINK_PORT: "8443",
+        AC_CORE_MATERIAL_FILE: "/var/lib/actana/material.json",
+        AC_CORE_PUBLIC_HOST: "core1.example.com",
+      }),
+    ).toBeNull();
+    expect(legacyEnvRefusal({})).toBeNull();
+  });
+});
+
+describe("plaintext core-link on a public interface", () => {
+  it("is refused — no TLS, no client cert, no bearer, and every interface", () => {
+    const refusal = plaintextExposureRefusal({ remoteMode: false, host: "0.0.0.0" })!;
+    expect(refusal).not.toBeNull();
+    expect(refusal).toContain("0.0.0.0");
+    expect(refusal).toContain("AC_CORE_REMOTE");
+    expect(refusal).toMatch(/unauthenticated/i);
+  });
+
+  it("is refused on a LAN address and a hostname too, not only the wildcard", () => {
+    for (const host of ["0.0.0.0", "::", "10.0.0.5", "192.168.1.10", "core1.example.com"]) {
+      expect(plaintextExposureRefusal({ remoteMode: false, host })).not.toBeNull();
+    }
+  });
+
+  it("leaves a loopback Core exactly as it was", () => {
+    for (const host of ["", "127.0.0.1", "127.0.0.2", "::1", "[::1]", "localhost", "LocalHost"]) {
+      expect(isLoopbackHost(host)).toBe(true);
+      expect(plaintextExposureRefusal({ remoteMode: false, host })).toBeNull();
+    }
+  });
+
+  it("leaves a real remote Core alone — that one has TLS, a CA and a bearer", () => {
+    expect(plaintextExposureRefusal({ remoteMode: true, host: "0.0.0.0" })).toBeNull();
+    expect(plaintextExposureRefusal({ remoteMode: true, host: "10.0.0.5" })).toBeNull();
+  });
+
+  it("cannot be reached silently from any (remote, host) combination", () => {
+    // The property, stated over the whole space rather than over the cases
+    // somebody thought of: if the server would be plaintext and reachable from
+    // off this machine, there is a refusal. No combination serves it quietly.
+    const hosts = ["", "127.0.0.1", "::1", "localhost", "0.0.0.0", "::", "10.0.0.5", "core.local"];
+    for (const remoteMode of [true, false]) {
+      for (const host of hosts) {
+        const plaintextAndExposed = !remoteMode && !isLoopbackHost(host);
+        expect(plaintextExposureRefusal({ remoteMode, host }) !== null).toBe(plaintextAndExposed);
+      }
+    }
+  });
+});
+
+describe("the machine in the report", () => {
+  it("is refused twice over: the old variables, and what ignoring them produces", () => {
+    // Both halves matter. The first is what a machine actually carries; the
+    // second is what the daemon would do with it — `AC_CORE_REMOTE` is unset
+    // there, so remote mode is off, while `AC_CORE_LINK_HOST` still says
+    // 0.0.0.0 and `AC_CORE_LINK_PORT` still says 8443.
+    expect(legacyEnvRefusal(PRE_RENAME_PLIST_ENV)).not.toBeNull();
+
+    const remoteMode = PRE_RENAME_PLIST_ENV.AC_CORE_REMOTE === "1";
+    const host = PRE_RENAME_PLIST_ENV.AC_CORE_LINK_HOST ?? "127.0.0.1";
+    expect(remoteMode).toBe(false);
+    expect(plaintextExposureRefusal({ remoteMode, host })).not.toBeNull();
+  });
+});
+
+describe("the daemon's boot order", () => {
+  const entry = fs.readFileSync(path.resolve(__dirname, "..", "core-entry.ts"), "utf8");
+
+  /**
+   * Asserted on the source, because there is nothing else to assert it on:
+   * `startCore` is not exported and importing the module boots a daemon. A
+   * refusal that ran after the server was constructed would still print the
+   * right sentence and would still have listened, so the ordering is the
+   * property — not the message.
+   */
+  it("refuses before it builds a server", () => {
+    for (const guard of ["legacyEnvRefusal(process.env)", "plaintextExposureRefusal("]) {
+      expect(entry).toContain(guard);
+      expect(entry.indexOf(guard)).toBeLessThan(entry.indexOf("new PtyCoreLinkServer("));
+    }
+  });
+
+  it("reads the old spellings nowhere else", () => {
+    // The refusal is the only thing in the daemon that knows `AC_HARNESS_`
+    // exists. A fallback would be the other possible fix and is the wrong one:
+    // it would keep a plaintext 0.0.0.0 Core running on purpose.
+    expect(entry).not.toMatch(/process\.env\.AC_HARNESS_/);
+  });
+});

--- a/packages/core/src/__tests__/core-first-run.test.ts
+++ b/packages/core/src/__tests__/core-first-run.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { X509Certificate, createPublicKey } from "node:crypto";
 import { loadOrMintMaterial } from "../core-first-run";
-import { persistMaterialToFile, type PersistedMaterial } from "@actana/shared/core-material-store";
+import {
+  mintFreshMaterial,
+  persistMaterialToFile,
+  type PersistedMaterial,
+} from "@actana/shared/core-material-store";
 
 // First run in a container is the only place a Core mints its own identity
 // without `actana setup` (ADR 0016 D13/D17). The daemon mints and persists into
@@ -18,18 +22,20 @@ import { persistMaterialToFile, type PersistedMaterial } from "@actana/shared/co
 // about. A client enrolls by spending a code from `actana pair new`, which
 // `core-pairing-routes.test.ts` and `actana-pair.test.ts` cover.
 
-const sample: PersistedMaterial = {
-  caCert: "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----",
-  caKey: "-----BEGIN PRIVATE KEY-----\nCAKEY\n-----END PRIVATE KEY-----",
-  serverCert: "-----BEGIN CERTIFICATE-----\nSERVER\n-----END CERTIFICATE-----",
-  serverKey: "-----BEGIN PRIVATE KEY-----\nSERVERKEY\n-----END PRIVATE KEY-----",
-  clientCert: "-----BEGIN CERTIFICATE-----\nCLIENT\n-----END CERTIFICATE-----",
-  clientKey: "-----BEGIN PRIVATE KEY-----\nCLIENTKEY\n-----END PRIVATE KEY-----",
-  bearerSecret: "deadbeef".repeat(8),
-  coreId: "core_abcdef0123456789",
-  coreUuid: "1f2e3d4c-5b6a-4798-8a9b-0c1d2e3f4a5b",
-  serverHosts: ["core.example.test"],
-};
+/**
+ * A previous boot's material — real certificates, minted once for the suite.
+ *
+ * Placeholder PEM strings would do for a store that only type-checks its
+ * fields, and this fixture used to be exactly that. Since #348 the load path
+ * checks the CA the identity chains to, so material that is not an identity is
+ * refused — correctly, and `core-material-identity.test.ts` is where that
+ * refusal is asserted. Minting is ~200 ms, once.
+ */
+let sample: PersistedMaterial;
+
+beforeAll(async () => {
+  sample = await mintFreshMaterial(["core.example.test"]);
+});
 
 let dir: string;
 let materialFile: string;
@@ -70,6 +76,32 @@ describe("loadOrMintMaterial — the file is absent", () => {
     await loadOrMintMaterial({ materialFile, ...options });
     // Private keys — same 0600 the install path writes.
     expect(fs.statSync(materialFile).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("loadOrMintMaterial — the identity on disk is not this Core's (#348)", () => {
+  it("refuses material whose CA is not this product's, naming the file", async () => {
+    // The load path's half of `checkMaterialIdentity`: the daemon stops at
+    // boot with a sentence, instead of presenting an identity that fails at a
+    // client as `wrong version number`.
+    const stranger = await mintFreshMaterial(["core.example.test"]);
+    persistMaterialToFile(materialFile, { ...sample, serverCert: stranger.serverCert });
+
+    await expect(loadOrMintMaterial({ materialFile, ...options })).rejects.toThrow(
+      /cannot be used as this Core's identity/,
+    );
+    await expect(loadOrMintMaterial({ materialFile, ...options })).rejects.toThrow(
+      /actana setup/,
+    );
+  });
+
+  it("leaves the file alone — the operator decides what to discard", async () => {
+    persistMaterialToFile(materialFile, { ...sample, serverKey: "not a key" });
+    const before = fs.readFileSync(materialFile, "utf8");
+
+    await expect(loadOrMintMaterial({ materialFile, ...options })).rejects.toThrow();
+
+    expect(fs.readFileSync(materialFile, "utf8")).toBe(before);
   });
 });
 

--- a/packages/core/src/__tests__/core-first-run.test.ts
+++ b/packages/core/src/__tests__/core-first-run.test.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { X509Certificate, createPublicKey } from "node:crypto";
 import { loadOrMintMaterial } from "../core-first-run";
+import selfsigned from "selfsigned";
+import { issueServerCert } from "@actana/shared/core-cert-material";
 import {
   mintFreshMaterial,
   persistMaterialToFile,
@@ -33,8 +35,48 @@ import {
  */
 let sample: PersistedMaterial;
 
+/**
+ * What a machine installed before the Harness → Core rename carries.
+ *
+ * Real certificates under the old CA name, because the point of the fixture is
+ * that they are *valid* — the review's correction is that this material works
+ * and must keep booting, and a placeholder string could not show that.
+ */
+let preRename: PersistedMaterial;
+
+async function mintPreRenameMaterial(base: PersistedMaterial): Promise<PersistedMaterial> {
+  const notBefore = new Date();
+  const ca = await selfsigned.generate(
+    [
+      { name: "commonName", value: "mission-control-harness-ca" },
+      { name: "organizationName", value: "Mission Control" },
+    ],
+    {
+      algorithm: "sha256",
+      notBeforeDate: notBefore,
+      notAfterDate: new Date(notBefore.getTime() + 86_400_000),
+      extensions: [
+        { name: "basicConstraints", cA: true, pathLenConstraint: 0, critical: true },
+        { name: "keyUsage", keyCertSign: true, cRLSign: true, critical: true },
+      ],
+    },
+  );
+  const server = await issueServerCert({
+    ca: { cert: ca.cert, key: ca.private },
+    hosts: ["core.example.test"],
+  });
+  return {
+    ...base,
+    caCert: ca.cert,
+    caKey: ca.private,
+    serverCert: server.cert,
+    serverKey: server.key,
+  };
+}
+
 beforeAll(async () => {
   sample = await mintFreshMaterial(["core.example.test"]);
+  preRename = await mintPreRenameMaterial(sample);
 });
 
 let dir: string;
@@ -79,8 +121,8 @@ describe("loadOrMintMaterial — the file is absent", () => {
   });
 });
 
-describe("loadOrMintMaterial — the identity on disk is not this Core's (#348)", () => {
-  it("refuses material whose CA is not this product's, naming the file", async () => {
+describe("loadOrMintMaterial — the identity on disk cannot be served (#348)", () => {
+  it("refuses material that could never complete a handshake, naming the file", async () => {
     // The load path's half of `checkMaterialIdentity`: the daemon stops at
     // boot with a sentence, instead of presenting an identity that fails at a
     // client as `wrong version number`.
@@ -93,6 +135,18 @@ describe("loadOrMintMaterial — the identity on disk is not this Core's (#348)"
     await expect(loadOrMintMaterial({ materialFile, ...options })).rejects.toThrow(
       /actana setup/,
     );
+  });
+
+  it("boots on material from before the rename rather than refusing it", async () => {
+    // The review's correction, pinned: the Harness-era CA is not the fault in
+    // #348 and this daemon serves it. Refusing here would brick a working
+    // install and cost every paired client its pairing.
+    persistMaterialToFile(materialFile, preRename);
+
+    const result = await loadOrMintMaterial({ materialFile, ...options });
+
+    expect(result.material.caCert).toBe(preRename.caCert);
+    expect(result.material.coreId).toBe(preRename.coreId);
   });
 
   it("leaves the file alone — the operator decides what to discard", async () => {

--- a/packages/core/src/core-boot-refusals.ts
+++ b/packages/core/src/core-boot-refusals.ts
@@ -66,12 +66,13 @@ export function legacyEnvVars(env: NodeJS.ProcessEnv): string[] {
 export function legacyEnvRefusal(env: NodeJS.ProcessEnv): string | null {
   const found = legacyEnvVars(env);
   if (found.length === 0) return null;
+  const one = found.length === 1;
   return (
-    `${found.join(", ")} ${found.length === 1 ? "is" : "are"} set. Those variables belong to ` +
-    "the Harness-era daemon, which this one is the rename of — it reads the `AC_CORE_` " +
-    "spellings and would ignore every one of them, boot without TLS, without a client " +
+    `${found.join(", ")} ${one ? "is" : "are"} set. ${one ? "That variable belongs" : "Those variables belong"} ` +
+    "to the Harness-era daemon, which this one is the rename of — it reads the `AC_CORE_` " +
+    `spellings and would ignore ${one ? "it" : "every one of them"}, boot without TLS, without a client ` +
     "certificate and without a bearer, and serve that on whatever address the same " +
-    "environment named. It will not do that. The service setting them is an auto-start " +
+    `environment named. It will not do that. The service setting ${one ? "it" : "them"} is an auto-start ` +
     "unit or LaunchAgent from before the rename (`com.actana.harness` on macOS, " +
     "`actana-harness.service` on Linux): run `actana setup` to remove it and register " +
     "this Core properly."

--- a/packages/core/src/core-boot-refusals.ts
+++ b/packages/core/src/core-boot-refusals.ts
@@ -1,0 +1,111 @@
+// What a Core refuses to boot on, and why — the two environment shapes that
+// used to start a daemon nobody could trust (#348).
+//
+// Both are the same class of failure: an environment left by a *previous
+// generation* of this product, read by a daemon that no longer means the same
+// thing by it. The daemon's own answer to that has to be a refusal, because
+// the alternative is not a broken Core — it is a Core that boots, listens, and
+// is wrong in a way no operator can see from the outside.
+//
+// Pure: an environment in, a sentence or null out. Nothing here reads a disk,
+// a clock or a socket, which is what lets `core-boot-refusals.test.ts` prove
+// the refusals without starting a daemon or binding a port.
+
+/** The prefix every variable a pre-rename install set carries. */
+export const LEGACY_ENV_PREFIX = "AC_HARNESS_";
+
+/**
+ * Hosts that mean "this machine only" — the addresses loopback mode assumes.
+ *
+ * An empty value is loopback too: `core-entry` defaults the bind address to
+ * `127.0.0.1`, so a variable that is unset or blank is the default, not a
+ * different answer. `::` and `0.0.0.0` are deliberately absent — they are the
+ * wildcard bind that {@link plaintextExposureRefusal} exists to catch.
+ */
+const LOOPBACK_HOSTS = new Set(["", "127.0.0.1", "::1", "[::1]", "localhost"]);
+
+/** Whether a bind address reaches no further than this machine. */
+export function isLoopbackHost(host: string): boolean {
+  const trimmed = host.trim().toLowerCase();
+  // The whole of `127.0.0.0/8` is loopback, not just `127.0.0.1`, and a
+  // machine that binds `127.0.0.2` has still bound itself and nothing else.
+  return LOOPBACK_HOSTS.has(trimmed) || /^127\.\d+\.\d+\.\d+$/.test(trimmed);
+}
+
+/** Every `AC_HARNESS_*` variable set in an environment, sorted for a stable message. */
+export function legacyEnvVars(env: NodeJS.ProcessEnv): string[] {
+  return Object.keys(env)
+    .filter((name) => name.startsWith(LEGACY_ENV_PREFIX))
+    .sort();
+}
+
+/**
+ * Refuse an environment written for the Harness-era daemon (#348).
+ *
+ * The pre-rename LaunchAgent sets `AC_HARNESS_REMOTE`, `AC_HARNESS_PUBLIC_HOST`
+ * and `AC_HARNESS_MATERIAL_FILE`; only `AC_CORE_LINK_PORT`, `AC_CORE_LINK_HOST`
+ * and `AC_USER_DATA_DIR` kept their names across the rename. This daemon reads
+ * the `AC_CORE_` spellings and nothing else, so under the old plist every one
+ * of those three simply *is not there*: no remote mode, no public host, no
+ * material file.
+ *
+ * That is not a degraded boot, it is a different product. `AC_HARNESS_REMOTE=1`
+ * silently becomes loopback mode — plain `ws://`, no TLS, no client cert, no
+ * bearer — while `AC_CORE_LINK_HOST` still carries the old plist's `0.0.0.0`
+ * and `AC_CORE_LINK_PORT` its 8443. The daemon that results serves an
+ * unauthenticated plaintext core-link on every interface of the machine, and
+ * the only symptom an operator sees is that TLS clients fail at the wire with
+ * `wrong version number` — which reads as a broken certificate, not as an open
+ * door.
+ *
+ * So the boot stops, and the message names the rename rather than the
+ * variable: an operator staring at `AC_HARNESS_REMOTE` needs told that the
+ * agent setting it is the thing to remove, and that `actana setup` is what
+ * removes it.
+ */
+export function legacyEnvRefusal(env: NodeJS.ProcessEnv): string | null {
+  const found = legacyEnvVars(env);
+  if (found.length === 0) return null;
+  return (
+    `${found.join(", ")} ${found.length === 1 ? "is" : "are"} set. Those variables belong to ` +
+    "the Harness-era daemon, which this one is the rename of — it reads the `AC_CORE_` " +
+    "spellings and would ignore every one of them, boot without TLS, without a client " +
+    "certificate and without a bearer, and serve that on whatever address the same " +
+    "environment named. It will not do that. The service setting them is an auto-start " +
+    "unit or LaunchAgent from before the rename (`com.actana.harness` on macOS, " +
+    "`actana-harness.service` on Linux): run `actana setup` to remove it and register " +
+    "this Core properly."
+  );
+}
+
+/**
+ * Refuse a plaintext core-link on an address other than this machine (#348).
+ *
+ * Loopback mode is the trusted-transport mode: no TLS, no client certificate,
+ * no bearer, because the only thing that can reach the socket is a process on
+ * the same machine. Bind that same server to `0.0.0.0` and every one of those
+ * assumptions is false, with nothing in the protocol left to notice — and this
+ * is not a hypothetical shape, it is exactly what a pre-rename plist produces
+ * once its `AC_HARNESS_REMOTE=1` stops being read.
+ *
+ * Refused rather than logged. A warning is the right weight for something an
+ * operator can weigh up; an unauthenticated shell service on every interface of
+ * the machine is not that, and a line in a log file nobody tails is not consent.
+ * The two ways out are both one command: bind loopback, or run a real remote
+ * Core with `actana setup`, which mints the material and sets `AC_CORE_REMOTE`.
+ */
+export function plaintextExposureRefusal(opts: {
+  remoteMode: boolean;
+  host: string;
+}): string | null {
+  if (opts.remoteMode || isLoopbackHost(opts.host)) return null;
+  return (
+    `AC_CORE_LINK_HOST is ${opts.host} but AC_CORE_REMOTE is not set. In loopback mode the ` +
+    "core-link server is plain `ws://` and trusts every connection — no TLS, no client " +
+    "certificate, no bearer — because only this machine can reach it. On " +
+    `${opts.host} that is not true: it would serve an unauthenticated Core, able to start ` +
+    "processes and read this machine's files, to anything that can route to it. Bind " +
+    "127.0.0.1, or run a real remote Core — `actana setup` mints the material and sets " +
+    "AC_CORE_REMOTE=1."
+  );
+}

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -8,7 +8,16 @@
 //   AC_USER_DATA_DIR  — the user-data dir
 //   AC_APP_PATH       — the app path
 //   AC_CORE_LINK_PORT — the port to listen on for the core-link WebSocket
-//   AC_CORE_LINK_HOST — the host to bind to (default: 127.0.0.1)
+//   AC_CORE_LINK_HOST — the host to bind to (default: 127.0.0.1). Outside
+//                          remote mode this must be a loopback address: the
+//                          server is plain `ws://` and trusts every connection
+//                          there, and `core-boot-refusals.ts` says why binding
+//                          that anywhere else stops the boot (#348).
+//
+// Anything named `AC_HARNESS_*` stops the boot outright. Those are the
+// pre-rename spellings, this daemon reads none of them, and a machine that
+// still sets them is running an auto-start service two renames old — see
+// `core-boot-refusals.ts`.
 //
 // Remote mode (issue 04 — `wss://` + mTLS + bearer auth):
 //   AC_CORE_REMOTE=1            — enable remote mode (mTLS + auth)
@@ -124,6 +133,7 @@ import { HarnessSkillWatcher } from "./harness-skill-watcher";
 import { ensureOrchestrationSkill } from "./orchestration-skill";
 import { HarnessInstallService } from "./harness-install-service";
 import { daemonHarnessSystem } from "./core-harness-system";
+import { legacyEnvRefusal, plaintextExposureRefusal } from "./core-boot-refusals";
 
 const CORE_LISTENING_SENTINEL = "@@AC_CORE_LISTENING@@";
 
@@ -137,6 +147,18 @@ function requiredEnv(name: string): string {
 }
 
 async function startCore(): Promise<void> {
+  // First, before a single variable is read for its value: an environment
+  // written for the Harness-era daemon is refused outright (#348). It has to
+  // be first because the variables that survived the rename —
+  // `AC_USER_DATA_DIR`, `AC_CORE_LINK_PORT`, `AC_CORE_LINK_HOST` — are set on
+  // that machine too, so every check below it would pass and the daemon would
+  // boot as something nobody asked for.
+  const legacyEnv = legacyEnvRefusal(process.env);
+  if (legacyEnv) {
+    console.error(`[core-entry] ${legacyEnv}`);
+    process.exit(1);
+  }
+
   const userDataDir = requiredEnv("AC_USER_DATA_DIR");
   const appPath = requiredEnv("AC_APP_PATH");
   const port = Number(requiredEnv("AC_CORE_LINK_PORT"));
@@ -148,6 +170,17 @@ async function startCore(): Promise<void> {
 
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     console.error(`[core-entry] invalid AC_CORE_LINK_PORT: ${port}`);
+    process.exit(1);
+  }
+
+  // The combination the refusal above exists to make impossible, refused again
+  // on its own terms: plaintext, unauthenticated core-link on an address other
+  // than this machine. A pre-rename plist is one way to reach it and no longer
+  // the only one that matters — anything that sets a bind address without
+  // setting remote mode arrives here, and none of them should listen.
+  const exposure = plaintextExposureRefusal({ remoteMode, host });
+  if (exposure) {
+    console.error(`[core-entry] ${exposure}`);
     process.exit(1);
   }
 

--- a/packages/core/src/core-first-run.ts
+++ b/packages/core/src/core-first-run.ts
@@ -53,6 +53,7 @@ import {
   type PersistedMaterial,
 } from "@actana/shared/core-material-store";
 import { widenedPublicHosts } from "@actana/shared/public-hosts";
+import log from "@actana/shared/log";
 
 export type LoadOrMintOptions = {
   /** Full path from `AC_CORE_MATERIAL_FILE`. */
@@ -126,11 +127,14 @@ export type LoadOrMintResult = {
  * costs a certificate, not the pairing (ADR 0016 D18).
  *
  * Throws when the file exists but cannot be parsed, and when it parses into an
- * identity this Core cannot serve — material issued by a CA from before the
- * rename, or a server certificate and key that do not agree (#348). The
- * operator decides whether to discard an identity, not the daemon; what the
- * daemon owes them is the reason, at boot, instead of a TLS error at a client
- * three steps away.
+ * identity that could never serve TLS — a leaf the CA beside it did not sign,
+ * or a certificate and key that do not agree (#348). The operator decides
+ * whether to discard an identity, not the daemon; what the daemon owes them is
+ * the reason, at boot, instead of a TLS error at a client three steps away.
+ *
+ * Material from an older generation of this product is **not** in that
+ * category: it works, it is logged, and it boots. `actana setup` is where an
+ * operator chooses to replace it.
  */
 export async function loadOrMintMaterial(opts: LoadOrMintOptions): Promise<LoadOrMintResult> {
   if (fs.existsSync(opts.materialFile)) {
@@ -143,14 +147,24 @@ export async function loadOrMintMaterial(opts: LoadOrMintOptions): Promise<LoadO
       );
     }
     const existing = read.material;
-    // Before anything is done with it: material whose CA is not this product's
-    // — a file from before the rename, most often — is refused here rather
-    // than presented to a client as an unexplainable TLS failure (#348). The
-    // check is on the load path only; what this function mints is ours by
-    // construction.
-    const unusable = checkMaterialIdentity(existing);
-    if (unusable) {
-      throw new Error(`${opts.materialFile} cannot be used as this Core's identity. ${unusable}`);
+    // Before anything is done with it: material that could never complete a
+    // handshake stops the boot here, rather than reaching a client as an
+    // unexplainable TLS failure (#348). Material that merely came from an
+    // older generation of this product is *kept* and logged — it serves TLS
+    // exactly as it always did, and the rename broke the environment around it
+    // rather than the identity itself. The check is on the load path only;
+    // what this function mints is ours by construction.
+    const issue = checkMaterialIdentity(existing);
+    if (issue?.severity === "unusable") {
+      throw new Error(
+        `${opts.materialFile} cannot be used as this Core's identity. ${issue.message}`,
+      );
+    }
+    if (issue) {
+      log.warn("core-material.foreign-identity", {
+        file: opts.materialFile,
+        detail: issue.message,
+      });
     }
     // Material written before #282 has no stable core UUID, and the load just
     // minted one. Writing it back here is what makes it stable: unpersisted, a

--- a/packages/core/src/core-first-run.ts
+++ b/packages/core/src/core-first-run.ts
@@ -44,6 +44,7 @@
 
 import * as fs from "node:fs";
 import {
+  checkMaterialIdentity,
   mintFreshMaterial,
   persistMaterialToFile,
   checkServerCertHost,
@@ -124,8 +125,12 @@ export type LoadOrMintResult = {
  * `coreId` and the Panel's client cert exactly as they were — a typo'd env var
  * costs a certificate, not the pairing (ADR 0016 D18).
  *
- * Throws when the file exists but cannot be parsed — the operator decides
- * whether to discard a corrupt identity, not the daemon.
+ * Throws when the file exists but cannot be parsed, and when it parses into an
+ * identity this Core cannot serve — material issued by a CA from before the
+ * rename, or a server certificate and key that do not agree (#348). The
+ * operator decides whether to discard an identity, not the daemon; what the
+ * daemon owes them is the reason, at boot, instead of a TLS error at a client
+ * three steps away.
  */
 export async function loadOrMintMaterial(opts: LoadOrMintOptions): Promise<LoadOrMintResult> {
   if (fs.existsSync(opts.materialFile)) {
@@ -138,6 +143,15 @@ export async function loadOrMintMaterial(opts: LoadOrMintOptions): Promise<LoadO
       );
     }
     const existing = read.material;
+    // Before anything is done with it: material whose CA is not this product's
+    // — a file from before the rename, most often — is refused here rather
+    // than presented to a client as an unexplainable TLS failure (#348). The
+    // check is on the load path only; what this function mints is ours by
+    // construction.
+    const unusable = checkMaterialIdentity(existing);
+    if (unusable) {
+      throw new Error(`${opts.materialFile} cannot be used as this Core's identity. ${unusable}`);
+    }
     // Material written before #282 has no stable core UUID, and the load just
     // minted one. Writing it back here is what makes it stable: unpersisted, a
     // Core would announce a different `aud` on every boot, which is the one

--- a/packages/shared/src/__tests__/core-material-identity.test.ts
+++ b/packages/shared/src/__tests__/core-material-identity.test.ts
@@ -1,0 +1,142 @@
+// Whether a material file is an identity *this* Core can serve (#348).
+//
+// The failure this exists to prevent is not a corrupt file — it is a perfectly
+// well-formed one from a previous generation of the product. Pre-rename
+// material has the same filename, the same eight fields and the same types as
+// current material; the only thing that tells them apart is the CA at the top,
+// and until this check nothing looked. The daemon loaded it, presented it, and
+// the operator's first news was `wrong version number` from a client: a
+// message about a wire protocol, for a problem about an identity.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import selfsigned from "selfsigned";
+import {
+  checkMaterialIdentity,
+  mintFreshMaterial,
+  CORE_CA_COMMON_NAME,
+  LEGACY_CA_COMMON_NAME,
+  type PersistedMaterial,
+} from "../core-material-store";
+import { issueServerCert } from "../core-cert-material";
+
+let current: PersistedMaterial;
+/** A second, unrelated identity — a valid Core's, but not this one's. */
+let other: PersistedMaterial;
+
+beforeAll(async () => {
+  current = await mintFreshMaterial(["core.example.test"]);
+  other = await mintFreshMaterial(["core.example.test"]);
+}, 60_000);
+
+/** A CA named as the Harness-era installer named it, and material chained to it. */
+async function preRenameMaterial(): Promise<PersistedMaterial> {
+  const notBefore = new Date();
+  const ca = await selfsigned.generate(
+    [
+      { name: "commonName", value: LEGACY_CA_COMMON_NAME },
+      { name: "organizationName", value: "Mission Control" },
+    ],
+    {
+      algorithm: "sha256",
+      notBeforeDate: notBefore,
+      notAfterDate: new Date(notBefore.getTime() + 86_400_000),
+      extensions: [
+        { name: "basicConstraints", cA: true, pathLenConstraint: 0, critical: true },
+        { name: "keyUsage", keyCertSign: true, cRLSign: true, critical: true },
+      ],
+    },
+  );
+  const server = await issueServerCert({
+    ca: { cert: ca.cert, key: ca.private },
+    hosts: ["core.example.test"],
+  });
+  return {
+    ...current,
+    caCert: ca.cert,
+    caKey: ca.private,
+    serverCert: server.cert,
+    serverKey: server.key,
+  };
+}
+
+describe("material this Core can serve", () => {
+  it("passes what this Core mints", () => {
+    expect(checkMaterialIdentity(current)).toBeNull();
+    expect(CORE_CA_COMMON_NAME).toBe("mission-control-core-ca");
+  });
+});
+
+describe("material from before the rename", () => {
+  it("is refused, and named for what it is rather than as a parse error", async () => {
+    const legacy = await preRenameMaterial();
+    const refusal = checkMaterialIdentity(legacy)!;
+
+    expect(refusal).not.toBeNull();
+    expect(refusal).toContain(LEGACY_CA_COMMON_NAME);
+    expect(refusal).toMatch(/rename/i);
+    // The operator's next move, in the message rather than in a doc.
+    expect(refusal).toContain("actana setup");
+  });
+
+  it("is otherwise indistinguishable from current material, which is the point", async () => {
+    const legacy = await preRenameMaterial();
+    // Same fields, same types, same file — everything `readMaterialFile`
+    // looked at before this check existed.
+    expect(Object.keys(legacy).sort()).toEqual(Object.keys(current).sort());
+    for (const key of ["caCert", "serverCert", "serverKey"] as const) {
+      expect(typeof legacy[key]).toBe("string");
+      expect(legacy[key]).toContain("-----BEGIN");
+    }
+  });
+});
+
+describe("material that does not hang together", () => {
+  it("refuses a CA no version of this product minted", async () => {
+    const stranger = await selfsigned.generate([{ name: "commonName", value: "some-other-ca" }], {
+      algorithm: "sha256",
+    });
+    const refusal = checkMaterialIdentity({ ...current, caCert: stranger.cert })!;
+    expect(refusal).toContain("some-other-ca");
+    expect(refusal).toMatch(/no version of this product has minted/);
+  });
+
+  it("refuses a server certificate the CA beside it did not issue", () => {
+    // Two real identities, each valid on its own — the mix is what no client
+    // can validate, and it is what a half-finished manual repair produces.
+    const refusal = checkMaterialIdentity({
+      ...current,
+      serverCert: other.serverCert,
+      serverKey: other.serverKey,
+    })!;
+    expect(refusal).toMatch(/not issued by the CA beside it/);
+  });
+
+  it("refuses a certificate and key that are not a pair", () => {
+    const refusal = checkMaterialIdentity({ ...current, serverKey: other.serverKey })!;
+    expect(refusal).toMatch(/are not a pair/);
+    // Said here rather than left to the handshake, which says nothing.
+    expect(refusal).toMatch(/handshake/);
+  });
+
+  it("refuses bytes that are not certificates at all", () => {
+    expect(checkMaterialIdentity({ ...current, caCert: "not a certificate" })).toMatch(
+      /`caCert` is not a certificate/,
+    );
+    expect(checkMaterialIdentity({ ...current, serverCert: "-----BEGIN CERTIFICATE-----\nx\n" }))
+      .toMatch(/`serverCert` is not a certificate/);
+    expect(checkMaterialIdentity({ ...current, serverKey: "not a key" })).toMatch(
+      /`serverKey` is not a private key/,
+    );
+  });
+
+  it("says what to run, whatever the reason", () => {
+    for (const broken of [
+      { ...current, caCert: "junk" },
+      { ...current, serverCert: "junk" },
+      { ...current, serverKey: "junk" },
+      { ...current, serverCert: other.serverCert, serverKey: other.serverKey },
+    ]) {
+      expect(checkMaterialIdentity(broken)).toContain("actana setup");
+    }
+  });
+});

--- a/packages/shared/src/__tests__/core-material-identity.test.ts
+++ b/packages/shared/src/__tests__/core-material-identity.test.ts
@@ -67,15 +67,30 @@ describe("material this Core can serve", () => {
 });
 
 describe("material from before the rename", () => {
-  it("is refused, and named for what it is rather than as a parse error", async () => {
+  it("is reported as foreign, not as unusable — it works, and the rename is not its fault", async () => {
+    // The correction the review asked for. The Harness-era CA serves TLS
+    // exactly as it always did; what broke on the machine in #348 was the
+    // environment-variable rename, which `core-boot-refusals.ts` stops on its
+    // own. Refusing this material would cost every paired client its pairing
+    // to fix a problem it does not have.
     const legacy = await preRenameMaterial();
-    const refusal = checkMaterialIdentity(legacy)!;
+    const issue = checkMaterialIdentity(legacy)!;
 
-    expect(refusal).not.toBeNull();
-    expect(refusal).toContain(LEGACY_CA_COMMON_NAME);
-    expect(refusal).toMatch(/rename/i);
-    // The operator's next move, in the message rather than in a doc.
-    expect(refusal).toContain("actana setup");
+    expect(issue.severity).toBe("foreign");
+    expect(issue.message).toContain(LEGACY_CA_COMMON_NAME);
+    expect(issue.message).toMatch(/rename/i);
+    expect(issue.message).toMatch(/kept and served/);
+  });
+
+  it("is refused once it genuinely cannot serve, and then it is not called old", async () => {
+    // Provenance is checked last on purpose: pre-rename material with a
+    // mismatched key is broken, and "an install from before the rename" would
+    // send the operator after the wrong thing.
+    const legacy = await preRenameMaterial();
+    const issue = checkMaterialIdentity({ ...legacy, serverKey: current.serverKey })!;
+
+    expect(issue.severity).toBe("unusable");
+    expect(issue.message).not.toContain(LEGACY_CA_COMMON_NAME);
   });
 
   it("is otherwise indistinguishable from current material, which is the point", async () => {
@@ -91,52 +106,63 @@ describe("material from before the rename", () => {
 });
 
 describe("material that does not hang together", () => {
-  it("refuses a CA no version of this product minted", async () => {
+  it("refuses a CA that did not sign the leaf beside it, whatever it is called", async () => {
+    // A stranger's CA cannot have signed our server certificate, so this is
+    // caught as unusable before provenance is ever considered.
     const stranger = await selfsigned.generate([{ name: "commonName", value: "some-other-ca" }], {
       algorithm: "sha256",
     });
-    const refusal = checkMaterialIdentity({ ...current, caCert: stranger.cert })!;
-    expect(refusal).toContain("some-other-ca");
-    expect(refusal).toMatch(/no version of this product has minted/);
+    const issue = checkMaterialIdentity({ ...current, caCert: stranger.cert })!;
+    expect(issue.severity).toBe("unusable");
+    expect(issue.message).toMatch(/not issued by the CA beside it/);
   });
 
   it("refuses a server certificate the CA beside it did not issue", () => {
     // Two real identities, each valid on its own — the mix is what no client
     // can validate, and it is what a half-finished manual repair produces.
-    const refusal = checkMaterialIdentity({
+    const issue = checkMaterialIdentity({
       ...current,
       serverCert: other.serverCert,
       serverKey: other.serverKey,
     })!;
-    expect(refusal).toMatch(/not issued by the CA beside it/);
+    expect(issue.severity).toBe("unusable");
+    expect(issue.message).toMatch(/not issued by the CA beside it/);
   });
 
   it("refuses a certificate and key that are not a pair", () => {
-    const refusal = checkMaterialIdentity({ ...current, serverKey: other.serverKey })!;
-    expect(refusal).toMatch(/are not a pair/);
+    const issue = checkMaterialIdentity({ ...current, serverKey: other.serverKey })!;
+    expect(issue.severity).toBe("unusable");
+    expect(issue.message).toMatch(/are not a pair/);
     // Said here rather than left to the handshake, which says nothing.
-    expect(refusal).toMatch(/handshake/);
+    expect(issue.message).toMatch(/handshake/);
   });
 
   it("refuses bytes that are not certificates at all", () => {
-    expect(checkMaterialIdentity({ ...current, caCert: "not a certificate" })).toMatch(
+    const message = (material: PersistedMaterial) => checkMaterialIdentity(material)?.message ?? "";
+    expect(message({ ...current, caCert: "not a certificate" })).toMatch(
       /`caCert` is not a certificate/,
     );
-    expect(checkMaterialIdentity({ ...current, serverCert: "-----BEGIN CERTIFICATE-----\nx\n" }))
-      .toMatch(/`serverCert` is not a certificate/);
-    expect(checkMaterialIdentity({ ...current, serverKey: "not a key" })).toMatch(
+    expect(message({ ...current, serverCert: "-----BEGIN CERTIFICATE-----\nx\n" })).toMatch(
+      /`serverCert` is not a certificate/,
+    );
+    expect(message({ ...current, serverKey: "not a key" })).toMatch(
       /`serverKey` is not a private key/,
     );
   });
 
-  it("says what to run, whatever the reason", () => {
+  it("says what to run, whatever the reason — and it is a command that works", () => {
+    // `actana setup` is named because `resolveMaterial` re-mints on exactly
+    // this severity. `actana-setup.test.ts` is where that is proved end to end;
+    // what this pins is that no unusable message points somewhere else.
     for (const broken of [
       { ...current, caCert: "junk" },
       { ...current, serverCert: "junk" },
       { ...current, serverKey: "junk" },
       { ...current, serverCert: other.serverCert, serverKey: other.serverKey },
     ]) {
-      expect(checkMaterialIdentity(broken)).toContain("actana setup");
+      const issue = checkMaterialIdentity(broken)!;
+      expect(issue.severity).toBe("unusable");
+      expect(issue.message).toContain("actana setup");
     }
   });
 });

--- a/packages/shared/src/core-material-store.ts
+++ b/packages/shared/src/core-material-store.ts
@@ -13,7 +13,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { randomBytes, randomUUID } from "node:crypto";
+import { createPrivateKey, randomBytes, randomUUID, X509Certificate } from "node:crypto";
 import { generateCertMaterial, issueServerCert } from "./core-cert-material";
 import { samePublicHosts } from "./public-hosts";
 import log from "@actana/shared/log";
@@ -319,6 +319,105 @@ export function readMaterialFile(filePath: string): MaterialFileRead | null {
     },
     mintedCoreUuid,
   };
+}
+
+/** The common name on every CA this product has minted since the rename. */
+export const CORE_CA_COMMON_NAME = "mission-control-core-ca";
+
+/** The common name the Harness-era installer minted, and the tell for #348. */
+export const LEGACY_CA_COMMON_NAME = "mission-control-harness-ca";
+
+/** The common name in an X.509 subject / issuer string, or `""`. */
+function commonNameOf(distinguishedName: string): string {
+  return /^CN=(.*)$/m.exec(distinguishedName)?.[1]?.trim() ?? "";
+}
+
+/** What to tell the operator to do about material this Core cannot use. */
+const REMEDY =
+  "Run `actana setup` to mint this Core's identity again — every paired client re-pairs " +
+  "with a fresh `actana pair new` code.";
+
+/**
+ * Whether this material is an identity this Core can actually serve (#348).
+ *
+ * {@link readMaterialFile} type-checks eight strings, which is the difference
+ * between a file and JSON — not between *this* Core's identity and one from
+ * two renames ago. Pre-rename material has the same eight fields, the same
+ * filename and the same shape; the only thing that distinguishes it is the CA
+ * it chains to, and nothing looked. So it loaded, the daemon presented it, and
+ * the operator's first news of the problem was `wrong version number` from a
+ * client — a message about a wire protocol, for a problem about an identity.
+ *
+ * Three questions, in the order that produces the most useful answer: is the
+ * CA one of ours, did it issue this server certificate, and does that
+ * certificate go with the key beside it. Each returns a sentence naming what
+ * is wrong and what to run; null means the material is usable.
+ *
+ * A *check*, not a validation of the whole file: the client certificate and
+ * the bearer secret are deliberately not examined here. The server pair is
+ * what the TLS handshake fails on, and a check that grew to cover everything
+ * would start refusing material over fields no handshake reads.
+ */
+export function checkMaterialIdentity(material: PersistedMaterial): string | null {
+  let ca: X509Certificate;
+  try {
+    ca = new X509Certificate(material.caCert);
+  } catch {
+    return `\`caCert\` is not a certificate this Core can parse. ${REMEDY}`;
+  }
+
+  const issuer = commonNameOf(ca.subject);
+  if (issuer !== CORE_CA_COMMON_NAME) {
+    // The pre-rename CA gets its own sentence: an operator who sees it needs
+    // to know the file is *old*, not corrupt, and that a stale auto-start
+    // service is very likely still pointing at it (#348).
+    const provenance =
+      issuer === LEGACY_CA_COMMON_NAME
+        ? `is \`${LEGACY_CA_COMMON_NAME}\`, the CA an install from before the Harness → Core ` +
+          "rename minted. This file is that install's identity, and the service that pointed " +
+          "at it is from before the rename too."
+        : `is \`${issuer || "(no common name)"}\`, which no version of this product has minted.`;
+    return (
+      `The CA in this material ${provenance} A Core cannot serve an identity it did not ` +
+      `issue: the certificate would chain to nothing any client pins. ${REMEDY}`
+    );
+  }
+
+  let server: X509Certificate;
+  try {
+    server = new X509Certificate(material.serverCert);
+  } catch {
+    return `\`serverCert\` is not a certificate this Core can parse. ${REMEDY}`;
+  }
+  // `verify` and deliberately not `checkIssued`: the latter compares names, and
+  // every CA this product mints carries the *same* name — so two Cores' files
+  // shuffled together would pass it while chaining to different keys. The
+  // signature is the only part of a certificate that cannot be coincidence.
+  let issuedByThisCa: boolean;
+  try {
+    issuedByThisCa = server.verify(ca.publicKey);
+  } catch {
+    issuedByThisCa = false;
+  }
+  if (!issuedByThisCa) {
+    return (
+      "The server certificate in this material was not issued by the CA beside it, so no " +
+      `client that pins the CA can validate it. ${REMEDY}`
+    );
+  }
+
+  try {
+    if (!server.checkPrivateKey(createPrivateKey(material.serverKey))) {
+      return (
+        "The server certificate and `serverKey` in this material are not a pair. TLS would " +
+        `fail at the handshake with nothing said about why. ${REMEDY}`
+      );
+    }
+  } catch {
+    return `\`serverKey\` is not a private key this Core can parse. ${REMEDY}`;
+  }
+
+  return null;
 }
 
 /**

--- a/packages/shared/src/core-material-store.ts
+++ b/packages/shared/src/core-material-store.ts
@@ -332,63 +332,75 @@ function commonNameOf(distinguishedName: string): string {
   return /^CN=(.*)$/m.exec(distinguishedName)?.[1]?.trim() ?? "";
 }
 
+/**
+ * What is wrong with a material file, and how wrong.
+ *
+ * The severity is the whole of the interface, because the two answers get
+ * opposite treatment and confusing them is how a fix for #348 became a way to
+ * break working machines:
+ *
+ * - `unusable` — no configuration can make this serve TLS. The certificate and
+ *   the key are not a pair, the leaf was not signed by the CA in the file, or
+ *   one of them is not a certificate at all. The daemon refuses to boot on it
+ *   and `actana setup` re-mints it.
+ * - `foreign` — it works, it is simply not ours. Every certificate hangs
+ *   together and a client that pinned that CA still validates; only the
+ *   provenance is unexpected. Reported and kept.
+ */
+export type MaterialIdentityIssue = {
+  severity: "unusable" | "foreign";
+  message: string;
+};
+
 /** What to tell the operator to do about material this Core cannot use. */
 const REMEDY =
-  "Run `actana setup` to mint this Core's identity again — every paired client re-pairs " +
-  "with a fresh `actana pair new` code.";
+  "Run `actana setup`, which mints this Core a fresh identity when the one on disk cannot " +
+  "be served — every paired client then re-pairs with a new `actana pair new` code.";
 
 /**
  * Whether this material is an identity this Core can actually serve (#348).
  *
  * {@link readMaterialFile} type-checks eight strings, which is the difference
- * between a file and JSON — not between *this* Core's identity and one from
- * two renames ago. Pre-rename material has the same eight fields, the same
- * filename and the same shape; the only thing that distinguishes it is the CA
- * it chains to, and nothing looked. So it loaded, the daemon presented it, and
- * the operator's first news of the problem was `wrong version number` from a
- * client — a message about a wire protocol, for a problem about an identity.
+ * between a file and JSON — not between an identity and a broken one. So
+ * material that could never complete a handshake loaded, the daemon presented
+ * it, and the operator's first news was `wrong version number` from a client:
+ * a message about a wire protocol, for a problem about an identity.
  *
- * Three questions, in the order that produces the most useful answer: is the
- * CA one of ours, did it issue this server certificate, and does that
- * certificate go with the key beside it. Each returns a sentence naming what
- * is wrong and what to run; null means the material is usable.
+ * **What is deliberately *not* refused: a CA this product did not mint.** The
+ * first version of this check refused those, on the reasoning that pre-rename
+ * material is what the machine in #348 carried. It is — and it works. The
+ * triage was explicit that the root cause there is the environment-variable
+ * rename, which `core-boot-refusals.ts` now stops on its own; the Harness-era
+ * CA serves TLS perfectly well once the daemon reads the right variables.
+ * Refusing it would have made this fix brick a working install and cost every
+ * paired client its pairing, to no end. So provenance is `foreign`: said out
+ * loud, and kept.
  *
- * A *check*, not a validation of the whole file: the client certificate and
- * the bearer secret are deliberately not examined here. The server pair is
- * what the TLS handshake fails on, and a check that grew to cover everything
- * would start refusing material over fields no handshake reads.
+ * A *check*, not a validation of the whole file: the client certificate and the
+ * bearer secret are deliberately not examined. The server pair is what the TLS
+ * handshake fails on, and a check that grew to cover everything would start
+ * refusing material over fields no handshake reads.
  */
-export function checkMaterialIdentity(material: PersistedMaterial): string | null {
+export function checkMaterialIdentity(material: PersistedMaterial): MaterialIdentityIssue | null {
+  const unusable = (message: string): MaterialIdentityIssue => ({
+    severity: "unusable",
+    message: `${message} ${REMEDY}`,
+  });
+
   let ca: X509Certificate;
   try {
     ca = new X509Certificate(material.caCert);
   } catch {
-    return `\`caCert\` is not a certificate this Core can parse. ${REMEDY}`;
-  }
-
-  const issuer = commonNameOf(ca.subject);
-  if (issuer !== CORE_CA_COMMON_NAME) {
-    // The pre-rename CA gets its own sentence: an operator who sees it needs
-    // to know the file is *old*, not corrupt, and that a stale auto-start
-    // service is very likely still pointing at it (#348).
-    const provenance =
-      issuer === LEGACY_CA_COMMON_NAME
-        ? `is \`${LEGACY_CA_COMMON_NAME}\`, the CA an install from before the Harness → Core ` +
-          "rename minted. This file is that install's identity, and the service that pointed " +
-          "at it is from before the rename too."
-        : `is \`${issuer || "(no common name)"}\`, which no version of this product has minted.`;
-    return (
-      `The CA in this material ${provenance} A Core cannot serve an identity it did not ` +
-      `issue: the certificate would chain to nothing any client pins. ${REMEDY}`
-    );
+    return unusable("`caCert` is not a certificate this Core can parse.");
   }
 
   let server: X509Certificate;
   try {
     server = new X509Certificate(material.serverCert);
   } catch {
-    return `\`serverCert\` is not a certificate this Core can parse. ${REMEDY}`;
+    return unusable("`serverCert` is not a certificate this Core can parse.");
   }
+
   // `verify` and deliberately not `checkIssued`: the latter compares names, and
   // every CA this product mints carries the *same* name — so two Cores' files
   // shuffled together would pass it while chaining to different keys. The
@@ -400,21 +412,43 @@ export function checkMaterialIdentity(material: PersistedMaterial): string | nul
     issuedByThisCa = false;
   }
   if (!issuedByThisCa) {
-    return (
+    return unusable(
       "The server certificate in this material was not issued by the CA beside it, so no " +
-      `client that pins the CA can validate it. ${REMEDY}`
+        "client that pins the CA can validate it.",
     );
   }
 
   try {
     if (!server.checkPrivateKey(createPrivateKey(material.serverKey))) {
-      return (
+      return unusable(
         "The server certificate and `serverKey` in this material are not a pair. TLS would " +
-        `fail at the handshake with nothing said about why. ${REMEDY}`
+          "fail at the handshake with nothing said about why.",
       );
     }
   } catch {
-    return `\`serverKey\` is not a private key this Core can parse. ${REMEDY}`;
+    return unusable("`serverKey` is not a private key this Core can parse.");
+  }
+
+  // Everything hangs together, so whatever is left is provenance and nothing
+  // more. Last on purpose: material with the pre-rename CA *and* a mismatched
+  // key is unusable, and saying "old" about it would send the operator after
+  // the wrong thing.
+  const issuer = commonNameOf(ca.subject);
+  if (issuer !== CORE_CA_COMMON_NAME) {
+    const provenance =
+      issuer === LEGACY_CA_COMMON_NAME
+        ? `was minted by \`${LEGACY_CA_COMMON_NAME}\`, an install from before the Harness → ` +
+          "Core rename"
+        : `was minted by \`${issuer || "(no common name)"}\`, which no version of this ` +
+          "product has minted";
+    return {
+      severity: "foreign",
+      message:
+        `This Core's identity ${provenance}. It is kept and served as it is: the ` +
+        "certificates hang together, and a client that pinned that CA still validates. " +
+        "`actana setup` replaces it with freshly minted material if you want to — every " +
+        "paired client re-pairs when you do.",
+    };
   }
 
   return null;

--- a/scripts/lib/core-smoke.mjs
+++ b/scripts/lib/core-smoke.mjs
@@ -13,6 +13,7 @@
 // file's `assertBootsAndDials` assertion against a path nothing ships, one
 // layer inside the tarball smoke that does ship.
 
+import { spawn } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
@@ -329,6 +330,98 @@ export function dialAndListHarnessAvailability(blob, timeoutMs = DIAL_TIMEOUT_MS
  * `log` reports progress with the caller's own prefix; `die` ends the run with
  * the child's output attached.
  */
+/**
+ * Run a Core once with a hostile environment and prove it refuses to serve (#348).
+ *
+ * The behavioural half of `core-boot-refusals.ts`. Its unit tests state the
+ * property over the whole `(remoteMode, host)` space, but the *ordering* — that
+ * the refusal happens before anything binds — is asserted there by reading
+ * `core-entry.ts` as text, which an awaited call inserted between the guard and
+ * the server would sail straight through. This spawns the real daemon and
+ * checks the only thing that actually matters: it exited, and nothing was
+ * listening.
+ *
+ * Two environments, because they are two different refusals: the variables a
+ * pre-rename LaunchAgent sets, and the plaintext-on-a-public-interface shape
+ * that ignoring them used to produce.
+ */
+export async function assertRefusesUnsafeEnv({ launcher, argv, env, port, timeoutMs, die, log }) {
+  const cases = [
+    {
+      name: "a pre-rename environment",
+      // The variable the old plist sets. Everything else is a working config,
+      // so a daemon that booted here would be one that ignored it.
+      env: { ...env, AC_HARNESS_REMOTE: "1" },
+      expect: /AC_HARNESS_REMOTE/,
+    },
+    {
+      name: "plaintext on a public interface",
+      // Remote mode dropped and a wildcard bind left behind — exactly what the
+      // old plist produced once its `AC_HARNESS_REMOTE` stopped being read.
+      env: { ...env, AC_CORE_REMOTE: "", AC_CORE_LINK_HOST: "0.0.0.0" },
+      expect: /AC_CORE_LINK_HOST is 0\.0\.0\.0/,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const child = spawn(launcher, argv, {
+      env: testCase.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const output = [];
+    child.stdout.on("data", (chunk) => output.push(String(chunk)));
+    child.stderr.on("data", (chunk) => output.push(String(chunk)));
+
+    const exit = await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* already dead */
+        }
+        resolve({ code: null, timedOut: true });
+      }, timeoutMs);
+      child.on("exit", (code, signal) => {
+        clearTimeout(timer);
+        resolve({ code: code ?? (signal ? 1 : 0), timedOut: false });
+      });
+    });
+
+    const printed = output.join("");
+    if (exit.timedOut) {
+      die(`the Core kept running under ${testCase.name} — it must refuse and exit`, [printed]);
+    }
+    if (exit.code === 0) {
+      die(`the Core exited 0 under ${testCase.name} — a refusal is not a clean boot`, [printed]);
+    }
+    if (printed.includes(LISTENING_SENTINEL)) {
+      die(`the Core announced it was listening under ${testCase.name}`, [printed]);
+    }
+    if (!testCase.expect.test(printed)) {
+      die(`the refusal under ${testCase.name} did not say why`, [printed]);
+    }
+    if (await somethingListensOn(port)) {
+      die(`something is listening on ${port} after the Core refused ${testCase.name}`, [printed]);
+    }
+    log(`refused ${testCase.name}: exit ${exit.code}, nothing bound on ${port}`);
+  }
+}
+
+/** Whether anything accepts a TCP connection on a loopback port right now. */
+function somethingListensOn(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host: "127.0.0.1" });
+    const done = (answer) => {
+      socket.destroy();
+      resolve(answer);
+    };
+    socket.setTimeout(1_000);
+    socket.on("connect", () => done(true));
+    socket.on("timeout", () => done(false));
+    socket.on("error", () => done(false));
+  });
+}
+
 export async function assertBootsAndDials(child, { home, port, timeoutMs, die, log }) {
   const observer = { logLines: [], badTags: [] };
 

--- a/scripts/smoke-core-tarball.mjs
+++ b/scripts/smoke-core-tarball.mjs
@@ -45,6 +45,7 @@ import { parseArgs, stringFlag } from "./lib/cli.mjs";
 import { assertTarballSurfaces } from "./lib/core-tarball.mjs";
 import {
   assertBootsAndDials,
+  assertRefusesUnsafeEnv,
   coreSmokeEnv,
   makeDie,
   pickFreePort,
@@ -203,6 +204,22 @@ async function main() {
   });
 
   await assertBootsAndDials(child, { home: tmpHome, port, timeoutMs, die, log });
+
+  // The same launcher, the same tree, two environments it must refuse (#348).
+  // Run after the good boot and on the same port, so "nothing is listening" is
+  // a statement about this refusal rather than about a port that was never
+  // used — the daemon above is stopped first for exactly that reason.
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.on("exit", resolve));
+  await assertRefusesUnsafeEnv({
+    launcher,
+    argv: ["daemon"],
+    env,
+    port,
+    timeoutMs,
+    die,
+    log,
+  });
 
   log("OK — extracted tarball boots a dialable Core with no system Node");
   cleanup();


### PR DESCRIPTION
Closes #348.

A Mac upgraded in place from before the Harness → Core rename keeps `com.actana.harness`. Its `ProgramArguments` point at
`current/bin/actana`, so an upgrade hands it the *new* binary, and `KeepAlive` brings it back every time it loses the port.
Nothing detected it, nothing removed it, and `actana status` reported a service that was not there while the one that was
ran under another name.

The triage comment on #348 confirmed all three sub-claims REAL against `main`. All three are fixed here, plus the material
validation it recommended.

### 1. The launchd `removeLegacyUnit` was a hard-coded `return null`

Its justification cited ADR 0016 D28 — macOS Core targets dropped rather than migrated — which #90 amended by giving macOS
a first-class on-device Core. The implementation is now the mirror of the systemd one that already worked:
`LEGACY_LAUNCH_AGENT_LABEL`, detect the plist **or** ask `launchctl print`, `bootout`, delete the plist, return the label.
Detection is two-sided on purpose: `rm`ing a plist unloads nothing, because launchd holds the copy it read at bootstrap.

`actana update` now calls it **before** the restart — it never did, which is exactly why an old agent picks up the new
binary after an upgrade. `actana place` (what `install.sh` runs) warns when the legacy plist is there, since an operator
who only runs `install.sh` never reaches `setup`. The test that pinned the no-op is flipped.

### 2. Security: an unauthenticated plaintext core-link on 0.0.0.0

The pre-rename plist sets `AC_HARNESS_REMOTE`, `AC_HARNESS_PUBLIC_HOST` and `AC_HARNESS_MATERIAL_FILE`; only
`AC_CORE_LINK_PORT`, `AC_CORE_LINK_HOST` and `AC_USER_DATA_DIR` kept their names. The daemon read only the `AC_CORE_`
spellings, with no fallback and no warning — so remote mode, the public host and the material file silently vanished while
the port and the bind address survived. What booted was a plaintext, unauthenticated core-link, able to start processes and
read the machine's files, on every interface, and the only symptom was `wrong version number` at a TLS client.

`startCore` now refuses both halves: any `AC_HARNESS_*` variable stops the boot before anything else is read, naming the
rename, the service that set them and `actana setup`; and a non-loopback bind without `AC_CORE_REMOTE` stops it on its own
terms. Refused rather than logged — a line in a log nobody tails is not consent. A fallback was the other available fix and
is the wrong one: it would keep that server running on purpose. Every legitimate non-loopback bind this product writes sets
`AC_CORE_REMOTE=1`, so nothing that works today stops working.

### 3. `actana status` lied about the service

It printed the `com.actana.core` constant as `Auto-start` and read `State` off that one fixed plist filename, so a machine
running the legacy agent read as `not installed` while the config file made the header say `degraded`. It now reports the
label launchd actually loaded, falls back to the legacy plist for `State`, and carries an explicit `Legacy agent` row
naming `actana setup`. A legacy service on the machine is a degradation whatever else is true, so the exit code is non-zero
until it is gone.

### Material validation

`readMaterialFile` type-checked eight strings, so pre-rename material — same filename, same fields, same types, different
CA — was indistinguishable from current material and failed later as an opaque TLS error. `checkMaterialIdentity` asks the
three questions a handshake depends on: is the CA one this product minted, did it sign this server certificate, and does
that certificate go with the key beside it. `mission-control-harness-ca` gets its own sentence, because an operator seeing
it needs to know the file is old rather than corrupt. Signature verification rather than `checkIssued`, which compares
names — and every CA here carries the same name.

### Boundaries

`install.sh` is untouched (#346 owns it, and its `LINE=` version stamp especially). The public host list and pairing design
from #347 are built on, not reopened — `core-entry.ts`, `core-first-run.ts`, `core-material-store.ts`, `actana-setup.ts`
and `actana-cli.ts` keep the signatures that train settled.

### Verification

`pnpm test` — all 6 stages pass (326 files). `pnpm -r typecheck` clean. `pnpm lint` reports no new warnings.
Nothing launchd-related was executed: this was written in a Linux container, so the macOS paths are covered by the fake
`ActanaSystem` the rest of the service suite uses, end to end through `actana setup`, `place`, `status` and `update`.
