### PR TITLE
docs: DOCKERHUB_TOKEN is Read, Write, Delete — the descriptions PATCH is a delete-scope call

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -699,9 +699,13 @@ jobs:
   # every delete call, it refuses to run when empty, and it is unit-tested
   # against a release repository being handed to it by name.
   #
-  # The credential is a *second* token, not the one the image push uses. That
-  # is the point: the push credential never gains delete, and the delete
-  # credential never appears in a job that touches a release repository.
+  # The credential is a *second* token, not the one the image push uses. Both
+  # carry delete now — the description PATCH in `descriptions` is a delete-scope
+  # call, so `DOCKERHUB_TOKEN` is `Read, Write, Delete` too (#359) — and the
+  # second token therefore buys separation rather than a narrower scope: it is
+  # the only credential pointed at a delete endpoint, it never appears in a job
+  # that touches a release repository, and it can be revoked or rotated without
+  # taking the publishing path down with it.
   dev-tag-sweep:
     name: Sweep the -dev image tags
     if: >-
@@ -797,7 +801,9 @@ jobs:
           DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
           OWNER: ${{ github.repository_owner }}
           # The same one PAT the image push uses — *not* the cleanup token.
-          # Descriptions are a write to a page, not a delete.
+          # It needs `Read, Write, Delete`: the PATCH below is a delete-scope
+          # call on the Hub API, and a `Read & Write` token 403s on it while
+          # image pushes keep working (#359). See docs/REPO_SETUP.md section 2.
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
@@ -857,7 +863,7 @@ jobs:
                   "https://hub.docker.com/v2/repositories/${namespace}/${repo}/")"
 
             if [[ "$status" != "200" ]]; then
-              echo "::error title=Failed to update $repo::HTTP $status — $(cat /tmp/resp.json)"
+              echo "::error title=Failed to update $repo::HTTP $status — $(cat /tmp/resp.json). A 403 'insufficient scope' here means DOCKERHUB_TOKEN is scoped Read & Write: this PATCH is a delete-scope call, so the token needs Read, Write, Delete (#359). Image pushes succeed on the narrower scope, which is why they stay green. See docs/REPO_SETUP.md section 2."
               return 1
             fi
             echo "✅ ${namespace}/${repo} — $bytes bytes of README, short description set"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -819,7 +819,7 @@ jobs:
             | jq -r '.token // empty')"
 
           if [[ -z "$jwt" ]]; then
-            echo "::error title=Docker Hub auth failed::Could not exchange DOCKERHUB_USERNAME/DOCKERHUB_TOKEN for a JWT. This endpoint rejects organization access tokens ('Cannot log into an organization account') — use a PERSONAL access token with Read & Write scope, from an account with Admin on the org. That one token serves the image push as well."
+            echo "::error title=Docker Hub auth failed::Could not exchange DOCKERHUB_USERNAME/DOCKERHUB_TOKEN for a JWT. This endpoint rejects organization access tokens ('Cannot log into an organization account') — use a PERSONAL access token with Read, Write, Delete scope, from an account with Admin on the org. That one token serves the image push as well."
             exit 1
           fi
 

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -41,7 +41,7 @@ section is what each one is.
 | --- | --- | --- |
 | `DOCKERHUB_USERNAME` | Secret | Publishing `panel` and `core` to Docker Hub, and syncing each image's README |
 | `DOCKERHUB_TOKEN` | Secret | Same — one **personal** access token, `Read, Write, Delete`, not the account password |
-| `DOCKERHUB_CLEANUP_TOKEN` | Secret | The weekly `-dev` tag sweep, and nothing else — a **second**, delete-capable PAT |
+| `DOCKERHUB_CLEANUP_TOKEN` | Secret | The weekly `-dev` tag sweep, and nothing else — a **second** PAT, the only one pointed at a delete endpoint |
 | `NPM_TOKEN` | Secret | Publishing `@actana/sdk` and `@actana/cli` to npm from `release.yml` |
 | `APP_ID` | Secret | The GitHub App's numeric id. Every job in `promote.yml` that pushes |
 | `APP_PRIVATE_KEY` | Secret | That App's private key, the whole PEM. Same jobs — **both or neither** |
@@ -144,13 +144,19 @@ green on the first try and filled all four pages.
 Two consequences worth stating plainly:
 
 - **Never swap this secret for a narrower token.** It is the same credential
-  that pushes `panel`, `core`, `panel-dev` and `core-dev`, so narrowing it back
-  to `Read & Write` blanks the four pages again, and narrowing it below that
-  breaks every image push too.
-- **If you use a fine-grained (repository-scoped) token instead**, it needs the
-  **Repository Edit** permission on all four repositories, not just Read and
-  Write — Edit is what covers the description `PATCH`. The classic PAT above is
-  what this repository is set up and proved against.
+  that pushes `panel`, `core`, `panel-dev` and `core-dev`. Narrowing it back to
+  `Read & Write` does not blank the pages — the `PATCH` 403s and writes nothing,
+  so the last text written stays up while the weekly chore goes red and the four
+  pages quietly stop tracking `docs/images/`. That is harder to notice than a
+  blank page, not easier. Narrowing it below that breaks every image push too.
+- **There is no repository-scoped alternative to reach for.** A Docker Hub PAT
+  carries an account-wide permission level rather than a repository list, and
+  per-repository scoping needs an organization access token — the one credential
+  the `/v2/users/login` exchange rejects outright, above
+  ([ADR 0023](adr/0023-release-trains-and-digest-promotion.md) D38, *the
+  delete-capable credential*; [ADR 0016](adr/0016-the-0-1-0-shape.md) D31). So
+  this token can delete anywhere the account can reach. That is a property to
+  manage — one owner, recorded and rotated — not one to scope away.
 
 ### Rotating it — the token belongs to a person
 
@@ -165,8 +171,10 @@ the push, which is the worst moment to find out.
       an account that leaves as a compromised credential: revoke first,
       re-provision second
 
-To rotate, create the new token first — overwriting the secret is atomic, so
-nothing is unpublishable in between:
+To rotate, create the new token first — with the same **Read, Write, Delete**
+scope, because a rotation that quietly narrows it reintroduces
+[#359](https://github.com/actana/control/issues/359) — and overwrite second;
+overwriting the secret is atomic, so nothing is unpublishable in between:
 
 ```bash
 gh secret set DOCKERHUB_USERNAME --repo actana/control
@@ -205,17 +213,27 @@ what bounds the blast radius of the delete credential below.
       [`core-dev.md`](images/core-dev.md); typing something now only creates a
       thing to disagree with
 
-### `DOCKERHUB_CLEANUP_TOKEN` — the second, delete-capable token
+### `DOCKERHUB_CLEANUP_TOKEN` — the second token, the one aimed at deletes
 
 The weekly `dev-tag-sweep` chore deletes stale `pr-*` and `sha-*` tags from
 `panel-dev` and `core-dev`, and it runs on its own credential rather than on the
-push token. It is therefore a **second** PAT, and it is the more dangerous of
-the two in what it is *pointed at*: Docker Hub personal access tokens carry an
-account-wide permission level rather than a repository list, so either token
-could delete from `actana/panel` and `actana/core` — this is the only one aimed
-at a delete endpoint, and Docker Hub has no undelete.
+push token. Both tokens carry delete — the descriptions `PATCH` above is why the
+push token does — so the second PAT does not buy a narrower scope. It buys two
+things that survive that:
 
-The only thing preventing that is the hard-coded, exact-match repository
+- **Blast radius.** It appears in exactly one job, the weekly sweep, and never
+  in a job that pushes or promotes. The push token is on every PR build, train
+  build, release and promotion; keeping the one credential that is aimed at a
+  delete endpoint out of all of those is the point.
+- **Independent rotation.** It can be revoked the moment the sweep misbehaves,
+  without taking the publishing path down with it.
+
+What it does *not* buy is containment by scope: Docker Hub personal access
+tokens carry an account-wide permission level rather than a repository list, so
+either token could delete from `actana/panel` and `actana/core`, and Docker Hub
+has no undelete.
+
+The only thing bounding the sweep is the hard-coded, exact-match repository
 allowlist in `scripts/lib/dev-tag-sweep.mjs` — re-asserted before every delete
 call, refusing to run when empty, and unit-tested against a release repository
 handed to it by name ([ADR

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -40,7 +40,7 @@ section is what each one is.
 | Name | Kind | Needed for |
 | --- | --- | --- |
 | `DOCKERHUB_USERNAME` | Secret | Publishing `panel` and `core` to Docker Hub, and syncing each image's README |
-| `DOCKERHUB_TOKEN` | Secret | Same — one **personal** access token, `Read & Write`, not the account password |
+| `DOCKERHUB_TOKEN` | Secret | Same — one **personal** access token, `Read, Write, Delete`, not the account password |
 | `DOCKERHUB_CLEANUP_TOKEN` | Secret | The weekly `-dev` tag sweep, and nothing else — a **second**, delete-capable PAT |
 | `NPM_TOKEN` | Secret | Publishing `@actana/sdk` and `@actana/cli` to npm from `release.yml` |
 | `APP_ID` | Secret | The GitHub App's numeric id. Every job in `promote.yml` that pushes |
@@ -99,7 +99,7 @@ The scope itself must exist and the account must own it before the first
 release. `npm access list packages @actana` answers that, and an npm 404 on
 `@actana/sdk` before the first publish is expected rather than a problem.
 
-### It must be a *personal* access token, and one token does both jobs
+### It must be a *personal* access token, `Read, Write, Delete`, and one token does both jobs
 
 Pushing an image and editing a repository's description go through different
 systems: the image push authenticates to the **registry**, where an
@@ -110,10 +110,13 @@ API**, whose `/v2/users/login` endpoint refuses organization accounts outright �
 {"detail":"Cannot log into an organization account"}
 ```
 
-So an OAT would mean paying for a Docker Team or Business subscription **and
-still** provisioning a PAT. One PAT does both instead: create it under your
-**Account settings → Personal access tokens** with **Read & Write** scope, from
-an account with **Admin** on the org, and set `DOCKERHUB_USERNAME` to that
+So a Docker Hub **organization access token is not an option here** — it is
+rejected by the `/v2/users/login` JWT exchange no matter how it is scoped, and
+using one would mean paying for a Docker Team or Business subscription **and
+still** provisioning a PAT. Do not let anyone talk you into an OAT for this
+secret. One classic PAT does both jobs instead: create it under your **Account
+settings → Personal access tokens** with **Read, Write, Delete** scope, from an
+account with **Admin** on the org, and set `DOCKERHUB_USERNAME` to that
 account's own username (not the org — the org goes in `DOCKERHUB_NAMESPACE`).
 
 ```bash
@@ -124,6 +127,30 @@ gh variable set DOCKERHUB_NAMESPACE --repo actana/control --body actana
 
 A wrong pairing is the single most common way to get
 `unauthorized: incorrect username or password` from an otherwise correct setup.
+
+**`Read, Write, Delete` is the scope, and `Read & Write` is not enough.** The
+image pushes are satisfied by `Read & Write`, so a token scoped that way looks
+correct right up to the weekly `descriptions` chore, which fails every one of
+its four `PATCH /v2/repositories/…` calls with `HTTP 403 — access denied:
+insufficient scope` while the pushes keep working
+([#359](https://github.com/actana/control/issues/359)). Writing a repository's
+description is a delete-scope call on the Hub API. This was proved on the token
+itself rather than reasoned about: on 2026-08-31 the scope of the existing
+`DOCKERHUB_TOKEN` was widened to `Read, Write, Delete` in Docker Hub with **the
+secret value unchanged**, and the next dispatched run
+([33396982252](https://github.com/actana/control/actions/runs/33396982252)) went
+green on the first try and filled all four pages.
+
+Two consequences worth stating plainly:
+
+- **Never swap this secret for a narrower token.** It is the same credential
+  that pushes `panel`, `core`, `panel-dev` and `core-dev`, so narrowing it back
+  to `Read & Write` blanks the four pages again, and narrowing it below that
+  breaks every image push too.
+- **If you use a fine-grained (repository-scoped) token instead**, it needs the
+  **Repository Edit** permission on all four repositories, not just Read and
+  Write — Edit is what covers the description `PATCH`. The classic PAT above is
+  what this repository is set up and proved against.
 
 ### Rotating it — the token belongs to a person
 
@@ -181,11 +208,12 @@ what bounds the blast radius of the delete credential below.
 ### `DOCKERHUB_CLEANUP_TOKEN` — the second, delete-capable token
 
 The weekly `dev-tag-sweep` chore deletes stale `pr-*` and `sha-*` tags from
-`panel-dev` and `core-dev`, and delete is a permission the push token must never
-have. It is therefore a **second** PAT, and it is the more dangerous of the two:
-Docker Hub personal access tokens carry an account-wide permission level rather
-than a repository list, so this one can delete from `actana/panel` and
-`actana/core` as well, and Docker Hub has no undelete.
+`panel-dev` and `core-dev`, and it runs on its own credential rather than on the
+push token. It is therefore a **second** PAT, and it is the more dangerous of
+the two in what it is *pointed at*: Docker Hub personal access tokens carry an
+account-wide permission level rather than a repository list, so either token
+could delete from `actana/panel` and `actana/core` — this is the only one aimed
+at a delete endpoint, and Docker Hub has no undelete.
 
 The only thing preventing that is the hard-coded, exact-match repository
 allowlist in `scripts/lib/dev-tag-sweep.mjs` — re-asserted before every delete


### PR DESCRIPTION
Closes #359 (docs half — the ops half was already done live, see below).

## What was wrong

A Docker Hub PAT scoped `Read & Write` pushes images fine and then fails every
`PATCH /v2/repositories/…` in the `descriptions` chore with `HTTP 403 — access
denied: insufficient scope` (runs 32703975988, 33394103716). Writing a
repository description on the Hub API is a **delete-scope** call, so the four
Docker Hub pages have been blank since launch. Two places asserted the wrong
scope; both are corrected here.

## Proof, not inference

On 2026-08-31 the scope of the **existing** `DOCKERHUB_TOKEN` was widened to
`Read, Write, Delete` in Docker Hub with the **secret value unchanged**, and the
next dispatched run — [33396982252](https://github.com/actana/control/actions/runs/33396982252)
— went green on the first try (`Docker Hub descriptions` ✓ in 9s) and filled all
four pages. The scope was the only variable.

## The two files

**`docs/REPO_SETUP.md` §2** — the secrets table, the subsection heading and the
"create it under Account settings → Personal access tokens" line now all say
`Read, Write, Delete`, plus what the old text left a reader to guess:

- a Docker Hub **organization access token is never the answer here** — the
  `/v2/users/login` JWT exchange rejects it however it is scoped, so nobody
  should be steered to an OAT;
- this **same secret drives the image pushes**, so it must never be swapped for
  a narrower token;
- a **fine-grained token**, if anyone reaches for one instead, needs the
  **Repository Edit** permission on all four repositories — Edit is what covers
  the description `PATCH`.

One neighbouring sentence in the same section moved with the facts: the
`DOCKERHUB_CLEANUP_TOKEN` subsection claimed delete "is a permission the push
token must never have", which was true only while the push token was scoped
narrower. It is restated as what still holds — the sweep is the only thing aimed
at a delete endpoint, and the allowlist in `scripts/lib/dev-tag-sweep.mjs` is
what bounds it. Leaving it would have made §2 contradict itself two screens
apart.

**`.github/workflows/housekeeping.yml`** — one string, the `descriptions` job's
JWT-exchange failure message, `Read & Write` → `Read, Write, Delete`. No steps,
no triggers, no logic.

## Scope and boundaries

- Docs only. Exactly two files. No workflow logic changed.
- `packages/cli` and `packages/panel` (parallel tickets) untouched.
- Base is `feat/0.4.3-onboarding`, not `main` and not the beta train. Draft on
  purpose.

## Known follow-up, deliberately not in this PR

The same stale `Read & Write` phrasing survives in three other error messages —
`container-image.yml:259`, `container-image.yml:699` and `release.yml:383`, plus
`beta-release.yml:601`. Issue #359 names only the two places fixed here and the
brief for this change fixed the file boundary at two, so those are left for a
follow-up ticket rather than widened into here.
