### PR TITLE
feat(panel): a first-run pairing wizard — no dashboard until a Core is paired

### DIFF
--- a/packages/panel/src/components/views/CoresSettingsPage.tsx
+++ b/packages/panel/src/components/views/CoresSettingsPage.tsx
@@ -6,6 +6,7 @@ import { Field, SettingsSection } from "~/components/views/SettingsParts";
 import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import { CoreNeedsUpdateNotice } from "~/components/views/CoreNeedsUpdate";
 import { api } from "~/lib/api";
+import { announceCoreRegistryChanged } from "~/lib/core-registry-changed";
 import { formatRelativeTime } from "~/lib/format-relative-time";
 import { coreOrder, type CoreDialStatus, type CoreWithDial } from "~/shared/cores";
 
@@ -74,6 +75,10 @@ export function CoresSettingsPage() {
    */
   const handlePaired = async (core: CoreWithDial) => {
     await refresh();
+    // The fleet just went from N to N+1. Anything else in this tab watching the
+    // registry — the first-run gate above all — re-reads now rather than at its
+    // next poll (#358).
+    announceCoreRegistryChanged();
     toast.success(`Core "${core.label}" paired.`);
   };
 
@@ -110,6 +115,10 @@ export function CoresSettingsPage() {
       await api.removeCore(core.id);
       setPendingRemoval(null);
       await refresh();
+      // And N to N-1. When that leaves zero, the first-run gate is what puts
+      // the pairing wizard back up — the gate is on the count, not on whether
+      // this Panel has ever been paired (#358).
+      announceCoreRegistryChanged();
       toast.success(`Core "${core.label}" removed.`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to remove Core.");

--- a/packages/panel/src/components/views/CoresSettingsPage.tsx
+++ b/packages/panel/src/components/views/CoresSettingsPage.tsx
@@ -7,6 +7,7 @@ import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import { CoreNeedsUpdateNotice } from "~/components/views/CoreNeedsUpdate";
 import { api } from "~/lib/api";
 import { announceCoreRegistryChanged } from "~/lib/core-registry-changed";
+import { ADD_CORE_FIELD_LABEL } from "~/shared/core-onboarding";
 import { formatRelativeTime } from "~/lib/format-relative-time";
 import { coreOrder, type CoreDialStatus, type CoreWithDial } from "~/shared/cores";
 
@@ -173,7 +174,9 @@ export function CoresSettingsPage() {
             )}
           </Field>
 
-          <Field label="Add a Core">
+          {/* Named from the same constant the first-run wizard points at, so
+              the two paths name one place with one string (#358). */}
+          <Field label={ADD_CORE_FIELD_LABEL}>
             <AddCoreByPairing onPaired={handlePaired} />
           </Field>
         </>

--- a/packages/panel/src/components/views/FirstRunGate.tsx
+++ b/packages/panel/src/components/views/FirstRunGate.tsx
@@ -1,0 +1,161 @@
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { api } from "~/lib/api";
+import { onCoreRegistryChanged } from "~/lib/core-registry-changed";
+
+// Lazy, for the same reason the settings overlay is: on every load of a Panel
+// that *has* a fleet — which is every load after the first — the wizard and the
+// pairing form it mounts are bytes nobody will render. The gate itself has to
+// stay eager, because deciding is its whole job and it decides before anything
+// paints; it is a `listCores()` and a branch, and costs the entry chunk nothing.
+const FirstRunWizard = lazy(() =>
+  import("~/components/views/FirstRunWizard").then((m) => ({ default: m.FirstRunWizard })),
+);
+
+/**
+ * The gate (#358): a Panel that knows no Cores shows the pairing wizard, and
+ * a Panel that knows one shows the app.
+ *
+ * **The condition is the count, not the calendar.** This is not a first-run
+ * flag, not a "seen it" preference, and not something the operator can be past.
+ * It is a live read of the Core registry, so a fresh Panel lands in the wizard
+ * and a Panel whose last Core was forgotten goes back to it — the same rule
+ * answering both, because they are the same state. There is nothing to reset
+ * and nothing to migrate.
+ *
+ * **It replaces the shell rather than covering it.** `children` here is the
+ * entire app — top bar, project rail, router outlet, settings overlay — and at
+ * zero Cores none of it mounts. That is what makes this a gate rather than a
+ * modal: there is no route to type, no escape key, no click-outside, and no
+ * dead dashboard behind the wizard to glimpse. The only exit is a paired Core.
+ *
+ * The one screen this does *not* stand in front of is `/login` and `/setup`:
+ * `__root.tsx` renders those outside the shell entirely, so an operator still
+ * creates their account first and meets the wizard immediately after.
+ */
+
+/**
+ * How often to re-ask, absent an announcement.
+ *
+ * The same fifteen seconds `useCores` polls on, and for the same reason: only
+ * an operator changes this registry. The poll is the backstop for a change this
+ * tab did not make; the announcement below is what makes the changes it *did*
+ * make instant.
+ */
+const REGISTRY_POLL_MS = 15_000;
+
+export function FirstRunGate({ children }: { children: ReactNode }) {
+  const { count, error, refresh } = useCoreRegistry();
+
+  /**
+   * The pairing form's `onPaired`, and the reason it is awaited.
+   *
+   * `AddCoreByPairing` holds its busy state until this resolves, so re-reading
+   * the registry here — rather than optimistically counting the Core it just
+   * handed us — means the form stays visibly mid-pairing right up to the moment
+   * the dashboard is genuinely unlocked. The alternative flashes an empty
+   * wizard between the pairing landing and the count catching up, which reads
+   * as a failure of the thing that just succeeded.
+   *
+   * Counting the returned Core instead would also be the gate believing
+   * something other than the registry, which is the one thing it must not do.
+   */
+  const handlePaired = useCallback(async () => {
+    await refresh();
+  }, [refresh]);
+
+  // Not yet known, and no reason to think it is unknowable: draw nothing.
+  // Rendering the wizard here would flash it at every operator with a fleet on
+  // every load, and rendering the shell would flash a dashboard at operators
+  // with none — the two mistakes this component exists to prevent.
+  if (count === null && error === null) return null;
+
+  // A registry we could not read is not a registry with no Cores in it, but it
+  // is certainly not one we can unlock a dashboard on. The wizard is the honest
+  // screen for it, and it says which of the two happened.
+  if (count === null || count === 0) {
+    return (
+      <Suspense fallback={null}>
+        <FirstRunWizard onPaired={handlePaired} registryError={error} />
+      </Suspense>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+/**
+ * How many Cores this Panel is paired with, kept fresh.
+ *
+ * Deliberately not `useCores`. That hook is built for the Cores list: it holds
+ * the rows, folds live dial pushes into them, and refreshes on a nonce. This
+ * needs none of the rows and cannot use a nonce, because the gate has to be
+ * able to *wait* for a re-read — `onPaired` is a promise the pairing form is
+ * holding its busy state on, and a nonce cannot be awaited. What is shared is
+ * the thing that matters: both ask `api.listCores()`, so there is one answer
+ * about the fleet and no second source of truth for it.
+ *
+ * `count` is null until a read succeeds, and never returns to null afterwards:
+ * a poll that fails leaves the last known count standing, so a Panel with a
+ * fleet does not get thrown into the wizard by one bad request.
+ */
+function useCoreRegistry(): {
+  count: number | null;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const [count, setCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const mounted = useRef(true);
+  // Monotonic, so a slow poll that lands after a fast explicit refresh cannot
+  // overwrite the newer answer with its older one — which, on this component,
+  // would mean re-locking a dashboard that had just been unlocked.
+  const issued = useRef(0);
+  const settled = useRef(0);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    issued.current += 1;
+    const seq = issued.current;
+    try {
+      const { cores } = await api.listCores();
+      if (!mounted.current || seq < settled.current) return;
+      settled.current = seq;
+      setCount(cores.length);
+      setError(null);
+    } catch (err) {
+      if (!mounted.current || seq < settled.current) return;
+      settled.current = seq;
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), REGISTRY_POLL_MS);
+    // Pairing or forgetting a Core anywhere in this tab is the whole reason
+    // this number changes. Waiting out the poll for it would leave the gate
+    // visibly wrong for up to fifteen seconds.
+    const stop = onCoreRegistryChanged(() => void refresh());
+    return () => {
+      clearInterval(timer);
+      stop();
+    };
+  }, [refresh]);
+
+  return { count, error, refresh };
+}

--- a/packages/panel/src/components/views/FirstRunGate.tsx
+++ b/packages/panel/src/components/views/FirstRunGate.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import { api } from "~/lib/api";
 import { onCoreRegistryChanged } from "~/lib/core-registry-changed";
+import { readCachedCoreCount, writeCachedCoreCount } from "~/lib/shell-query-cache";
+import { CORES_POLL_MS } from "~/lib/use-fleet";
 
 // Lazy, for the same reason the settings overlay is: on every load of a Panel
 // that *has* a fleet — which is every load after the first — the wizard and the
@@ -41,16 +43,6 @@ const FirstRunWizard = lazy(() =>
  * creates their account first and meets the wizard immediately after.
  */
 
-/**
- * How often to re-ask, absent an announcement.
- *
- * The same fifteen seconds `useCores` polls on, and for the same reason: only
- * an operator changes this registry. The poll is the backstop for a change this
- * tab did not make; the announcement below is what makes the changes it *did*
- * make instant.
- */
-const REGISTRY_POLL_MS = 15_000;
-
 export function FirstRunGate({ children }: { children: ReactNode }) {
   const { count, error, refresh } = useCoreRegistry();
 
@@ -71,10 +63,11 @@ export function FirstRunGate({ children }: { children: ReactNode }) {
     await refresh();
   }, [refresh]);
 
-  // Not yet known, and no reason to think it is unknowable: draw nothing.
-  // Rendering the wizard here would flash it at every operator with a fleet on
-  // every load, and rendering the shell would flash a dashboard at operators
-  // with none — the two mistakes this component exists to prevent.
+  // Genuinely unknown: no live answer yet *and* nothing cached to stand in for
+  // one, which is the first load in this browser and no other. Drawing the
+  // wizard here would flash it at every operator with a fleet, and drawing the
+  // shell would flash a dashboard at operators with none — the two mistakes
+  // this component exists to prevent. Every other load paints on the seed.
   if (count === null && error === null) return null;
 
   // A registry we could not read is not a registry with no Cores in it, but it
@@ -99,22 +92,32 @@ export function FirstRunGate({ children }: { children: ReactNode }) {
  * needs none of the rows and cannot use a nonce, because the gate has to be
  * able to *wait* for a re-read — `onPaired` is a promise the pairing form is
  * holding its busy state on, and a nonce cannot be awaited. What is shared is
- * the thing that matters: both ask `api.listCores()`, so there is one answer
- * about the fleet and no second source of truth for it.
+ * the thing that matters: both ask `api.listCores()` and both pace themselves
+ * off `CORES_POLL_MS`, so there is one answer about the fleet, one cadence, and
+ * no second source of truth for either.
  *
- * `count` is null until a read succeeds, and never returns to null afterwards:
- * a poll that fails leaves the last known count standing, so a Panel with a
- * fleet does not get thrown into the wizard by one bad request.
+ * `count` starts at whatever this browser was last told (`readCachedCoreCount`)
+ * so a paired Panel paints its shell on the first client render, the same
+ * bargain `installShellQueryCache` makes for projects, groups and settings. The
+ * seed is never an answer: the live read lands on the same tick and corrects
+ * it, and a *stale* seed can only cost one frame in either direction.
+ *
+ * After that it never returns to null: a poll that fails leaves the last known
+ * count standing, so a Panel with a fleet is not thrown into the wizard by one
+ * bad request.
  */
 function useCoreRegistry(): {
   count: number | null;
   error: string | null;
   refresh: () => Promise<void>;
 } {
-  const [count, setCount] = useState<number | null>(null);
+  const [count, setCount] = useState<number | null>(() => readCachedCoreCount() ?? null);
   const [error, setError] = useState<string | null>(null);
 
   const mounted = useRef(true);
+  // What the last settled read said, readable from inside `refresh` without
+  // making it depend on — and be rebuilt by — the state it sets.
+  const known = useRef<number | null>(count);
   // Monotonic, so a slow poll that lands after a fast explicit refresh cannot
   // overwrite the newer answer with its older one — which, on this component,
   // would mean re-locking a dashboard that had just been unlocked.
@@ -132,11 +135,33 @@ function useCoreRegistry(): {
     issued.current += 1;
     const seq = issued.current;
     try {
-      const { cores } = await api.listCores();
+      let next = (await api.listCores()).cores.length;
+      /**
+       * Tearing down a live session takes two answers, not one.
+       *
+       * Locking the gate unmounts the whole shell: every open terminal panel,
+       * every websocket, whatever the operator was mid-way through. The gate
+       * already refuses to do that on a *failed* read; an empty successful one
+       * deserves the same suspicion, because a Panel server that restarts
+       * against an empty or unmigrated data directory answers 200 with nothing
+       * in it and would take the session down with no prompt and no undo.
+       *
+       * So an empty answer that would close the gate is re-asked, and only two
+       * consecutive empty successes lock it. This buys exactly what it says: a
+       * single anomalous 200 cannot end a session. It does not defend against a
+       * registry that is genuinely and persistently empty — nothing short of
+       * asking the operator could, and a Panel whose Cores are really gone
+       * belongs in the wizard.
+       */
+      if (next === 0 && (known.current ?? 0) > 0) {
+        next = (await api.listCores()).cores.length;
+      }
       if (!mounted.current || seq < settled.current) return;
       settled.current = seq;
-      setCount(cores.length);
+      known.current = next;
+      setCount(next);
       setError(null);
+      writeCachedCoreCount(next);
     } catch (err) {
       if (!mounted.current || seq < settled.current) return;
       settled.current = seq;
@@ -144,18 +169,53 @@ function useCoreRegistry(): {
     }
   }, []);
 
+  // Gated means "the wizard is what is on screen": no fleet known, or none at
+  // all. It decides how hard this hook works — see the two effects below.
+  const gated = count === null || count === 0;
+
   useEffect(() => {
     void refresh();
-    const timer = setInterval(() => void refresh(), REGISTRY_POLL_MS);
     // Pairing or forgetting a Core anywhere in this tab is the whole reason
-    // this number changes. Waiting out the poll for it would leave the gate
+    // this number changes. Waiting out a poll for it would leave the gate
     // visibly wrong for up to fifteen seconds.
-    const stop = onCoreRegistryChanged(() => void refresh());
-    return () => {
-      clearInterval(timer);
-      stop();
-    };
+    return onCoreRegistryChanged(() => void refresh());
   }, [refresh]);
+
+  /**
+   * The poll runs **only while the gate is up**.
+   *
+   * Once unlocked there is nothing here worth a standing timer: every registry
+   * change this tab makes arrives on the event above, and the shell that is now
+   * mounted is already reading the same endpoint through `useCores`. A third
+   * recurring `listCores()` for the life of the tab bought nothing but load.
+   */
+  useEffect(() => {
+    if (!gated) return;
+    const timer = setInterval(() => void refresh(), CORES_POLL_MS);
+    return () => clearInterval(timer);
+  }, [gated, refresh]);
+
+  /**
+   * What the dropped poll would have caught: a Core forgotten in *another* tab.
+   *
+   * The event is window-scoped, so it does not cross tabs, and the requirement
+   * is about the count rather than about which tab did the forgetting. Re-asking
+   * when this tab comes back to the front covers it at the only moment it
+   * matters — when someone is looking at this Panel — and costs nothing while
+   * they are not.
+   */
+  useEffect(() => {
+    if (gated) return;
+    const recheck = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    window.addEventListener("focus", recheck);
+    document.addEventListener("visibilitychange", recheck);
+    return () => {
+      window.removeEventListener("focus", recheck);
+      document.removeEventListener("visibilitychange", recheck);
+    };
+  }, [gated, refresh]);
 
   return { count, error, refresh };
 }

--- a/packages/panel/src/components/views/FirstRunWizard.tsx
+++ b/packages/panel/src/components/views/FirstRunWizard.tsx
@@ -1,15 +1,18 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Btn } from "~/components/ui/Btn";
 import { Icon } from "~/components/ui/Icon";
 import { TextField } from "~/components/ui/TextField";
 import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import {
-  CORE_INSTALL_PATHS,
+  ADD_CORE_LOCATION,
   PAIR_NEW_OUTPUT,
   composePairNewCommand,
+  coreInstallPaths,
+  labelRefusal,
   pairNewCommand,
 } from "~/shared/core-onboarding";
 import type { CoreWithDial } from "~/shared/cores";
+import { CURRENT_MC_VERSION } from "~/queries/mission-control-version";
 
 /**
  * The first-run pairing wizard (#358) — what a Panel with no Cores shows
@@ -237,12 +240,15 @@ function StepRail({ step, onStep }: { step: StepIndex; onStep: (next: StepIndex)
  * which is the same place any other surface would read them from.
  */
 function InstallStep() {
+  // The Compose line is pinned to this Panel's own line, so the Core it brings
+  // up is built from the same train — see `coreInstallPaths`.
+  const paths = coreInstallPaths(CURRENT_MC_VERSION);
   return (
     <StepBody
       title="Install the Core on the machine you want to drive"
       lede="A Core is the daemon that owns the repository and runs the Harnesses. It goes on the machine with your code — a laptop, a workstation, a build box — not on this Panel. Pick whichever path fits that machine."
     >
-      {CORE_INSTALL_PATHS.map((path) => (
+      {paths.map((path) => (
         <div key={path.id} data-install-path={path.id} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 13, fontWeight: 600 }}>{path.title}</div>
           <Prose>{path.blurb}</Prose>
@@ -261,11 +267,13 @@ function InstallStep() {
  *
  * The command is built from what the operator types, so `--label` is a thing
  * they have chosen rather than a flag they were shown and skipped. Under it,
- * the four lines `pair new` prints and what each one is for: three of them are
- * typed into step 3, and an operator who knows that reads the terminal once
- * instead of three times.
+ * every line `pair new` prints and what each one is for — including `Label`,
+ * which that command always produces because it always carries `--label`. An
+ * operator who knows which lines matter reads the terminal once instead of
+ * three times.
  */
 function MintStep({ label, onLabel }: { label: string; onLabel: (next: string) => void }) {
+  const refusal = labelRefusal(label);
   return (
     <StepBody
       title="Mint a pairing code on that machine"
@@ -279,7 +287,26 @@ function MintStep({ label, onLabel }: { label: string; onLabel: (next: string) =
         hint="Optional, and worth setting: it is what `actana pair ls` calls this Panel on the Core later."
         autoComplete="off"
         spellCheck={false}
+        ariaInvalid={refusal !== null}
       />
+      {/* A name the Core would refuse never reaches the command block: the
+          placeholder is printed instead, and the reason is said here. Printing
+          the refused form would be the Panel handing over a command that fails
+          on paste — the one failure `labelRefusal` exists to prevent. */}
+      {refusal && (
+        <div
+          role="alert"
+          data-label-refusal
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 11.5,
+            lineHeight: 1.5,
+            color: "var(--danger, #e5484d)",
+          }}
+        >
+          {refusal}
+        </div>
+      )}
       <CommandLine command={pairNewCommand(label)} />
       <Prose>Or, if that Core came up under Docker Compose:</Prose>
       <CommandLine command={composePairNewCommand(label)} />
@@ -338,9 +365,9 @@ function RedeemStep({ onPaired }: { onPaired: (core: CoreWithDial) => Promise<vo
     >
       <AddCoreByPairing onPaired={onPaired} />
       <Aside>
-        This is the same form as <strong>Settings → Cores → Add Core</strong>, which is where every
-        Core after this one is paired. The gear icon in the top bar is waiting for you on the other
-        side of this step.
+        This is the same form as <strong>{ADD_CORE_LOCATION}</strong>, which is where every Core
+        after this one is paired. The gear icon in the top bar is waiting for you on the other side
+        of this step.
       </Aside>
     </StepBody>
   );
@@ -433,12 +460,23 @@ function Aside({ children }: { children: React.ReactNode }) {
  */
 function CommandLine({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
+  // The "copied" flash outlives the step it was clicked on: copy on step 1,
+  // press Next inside a second and a half, and the timer would fire into an
+  // unmounted tree. Held so it can be cancelled.
+  const flash = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (flash.current !== null) clearTimeout(flash.current);
+    },
+    [],
+  );
 
   const copy = () => {
     void navigator.clipboard?.writeText(command).then(
       () => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        if (flash.current !== null) clearTimeout(flash.current);
+        flash.current = setTimeout(() => setCopied(false), 1500);
       },
       () => undefined,
     );

--- a/packages/panel/src/components/views/FirstRunWizard.tsx
+++ b/packages/panel/src/components/views/FirstRunWizard.tsx
@@ -1,0 +1,496 @@
+import { useState } from "react";
+import { Btn } from "~/components/ui/Btn";
+import { Icon } from "~/components/ui/Icon";
+import { TextField } from "~/components/ui/TextField";
+import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
+import {
+  CORE_INSTALL_PATHS,
+  PAIR_NEW_OUTPUT,
+  composePairNewCommand,
+  pairNewCommand,
+} from "~/shared/core-onboarding";
+import type { CoreWithDial } from "~/shared/cores";
+
+/**
+ * The first-run pairing wizard (#358) — what a Panel with no Cores shows
+ * instead of a dashboard.
+ *
+ * **This is composition, not a second pairing implementation.** Step 3 mounts
+ * the very `AddCoreByPairing` that Settings → Cores → Add Core mounts, with the
+ * same props and the same `onPaired` contract, so the fingerprint-before-code
+ * ordering, the mismatch refusal, and every failure sentence are that
+ * component's, once. Nothing about redeeming a code is decided here. What this
+ * file adds is the two things a fresh operator is missing and a settings page
+ * cannot give them: the order to do things in, and the commands to run on the
+ * *other* machine.
+ *
+ * **There is no way out of it that is not a paired Core.** No skip, no "later",
+ * no dismiss, and no route past it — see `FirstRunGate`, which renders this
+ * instead of the app shell rather than over it. That is not a stance about
+ * onboarding; it is what the product is. A Panel is a window onto machines it
+ * is paired with, and paired with none it has nothing to draw. An empty
+ * dashboard would be a screen whose every affordance is dead.
+ *
+ * Moving between steps 1, 2 and 3 is free, in both directions. Steps 1 and 2
+ * are reference — an operator who already installed the Core last week should
+ * not have to scroll past its install command — and moving between them
+ * reaches the Panel's dashboard exactly as often as standing still does: never.
+ */
+
+/** The three steps, in the order the machine has to do them. */
+const STEPS = [
+  { id: "install", title: "Install the Core", blurb: "on the machine you want to drive" },
+  { id: "mint", title: "Mint a pairing code", blurb: "on that machine, in its terminal" },
+  { id: "redeem", title: "Redeem it here", blurb: "in this Panel, with what it printed" },
+] as const;
+
+type StepIndex = 0 | 1 | 2;
+
+export function FirstRunWizard({
+  onPaired,
+  registryError = null,
+}: {
+  /**
+   * The same contract `CoresSettingsPage` fulfils: the Core the redemption
+   * produced, and a promise the pairing form waits on before it lets go of its
+   * busy state. The gate resolves it once it has re-read the registry, so the
+   * form stays visibly mid-pairing until the dashboard is genuinely unlocked
+   * rather than blinking through an empty wizard on the way.
+   */
+  onPaired: (core: CoreWithDial) => Promise<void>;
+  /**
+   * Why the Core registry could not be read, if it could not be. Shown rather
+   * than swallowed: "no Cores" and "could not ask" look identical from here,
+   * and an operator who is about to be told to install a Core deserves to know
+   * which of the two they are looking at.
+   */
+  registryError?: string | null;
+}) {
+  const [step, setStep] = useState<StepIndex>(0);
+  // The name this Panel will be called on the Core, folded live into the mint
+  // command. Kept here rather than inside step 2 so stepping away and back
+  // does not silently drop what was typed.
+  const [label, setLabel] = useState("");
+
+  return (
+    <div
+      data-first-run-wizard
+      style={{
+        position: "fixed",
+        inset: 0,
+        overflowY: "auto",
+        background: "var(--surface-1)",
+        color: "var(--text)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 780,
+          margin: "0 auto",
+          padding: "48px 24px 64px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 22,
+        }}
+      >
+        <Header />
+        {registryError && <RegistryErrorBox message={registryError} />}
+        <StepRail step={step} onStep={setStep} />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {step === 0 && <InstallStep />}
+          {step === 1 && <MintStep label={label} onLabel={setLabel} />}
+          {step === 2 && <RedeemStep onPaired={onPaired} />}
+        </div>
+
+        <Footer step={step} onStep={setStep} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What this screen is and why it is the whole screen.
+ *
+ * The second sentence is the one that matters: an operator who thinks the Panel
+ * is broken will go looking for the way past it, and there isn't one. Saying so
+ * plainly is cheaper than letting them find out.
+ */
+function Header() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--text-dim)",
+        }}
+      >
+        Actana Control
+      </div>
+      <h1 style={{ fontSize: 24, fontWeight: 650, margin: 0, letterSpacing: "-0.01em" }}>
+        Pair your first Core
+      </h1>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 13.5,
+          lineHeight: 1.55,
+          color: "var(--text-dim)",
+          maxWidth: 620,
+        }}
+      >
+        A Panel drives machines called Cores — this one is paired with none, so there is nothing
+        for it to show yet. Three steps, run on the machine you want to drive and finished here.
+        The Panel opens on the first Core that pairs.
+      </p>
+    </div>
+  );
+}
+
+/** The registry read that failed, said out loud rather than read as emptiness. */
+function RegistryErrorBox({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      data-first-run-registry-error
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: "var(--danger, #e5484d)",
+        padding: "10px 12px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--danger, #e5484d)",
+        borderRadius: 7,
+      }}
+    >
+      This Panel could not read its own list of Cores, so it cannot tell an empty fleet from an
+      unanswered question: {message}
+    </div>
+  );
+}
+
+/** The three steps as a rail — where you are, and what is still ahead. */
+function StepRail({ step, onStep }: { step: StepIndex; onStep: (next: StepIndex) => void }) {
+  return (
+    <ol
+      style={{
+        listStyle: "none",
+        display: "flex",
+        gap: 8,
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {STEPS.map((entry, index) => {
+        const active = index === step;
+        return (
+          <li key={entry.id} style={{ flex: 1, minWidth: 0 }}>
+            <button
+              type="button"
+              onClick={() => onStep(index as StepIndex)}
+              aria-current={active ? "step" : undefined}
+              style={{
+                width: "100%",
+                textAlign: "left",
+                display: "flex",
+                flexDirection: "column",
+                gap: 3,
+                padding: "10px 12px",
+                cursor: "pointer",
+                background: active ? "var(--surface-0)" : "transparent",
+                border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 7,
+                color: "inherit",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: 10,
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                  color: active ? "var(--accent-ink)" : "var(--text-dim)",
+                }}
+              >
+                Step {index + 1}
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>{entry.title}</span>
+              <span style={{ fontSize: 11.5, color: "var(--text-dim)" }}>{entry.blurb}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+/**
+ * Step 1 — put a Core on a machine.
+ *
+ * Both documented paths, side by side, because the Panel cannot see the machine
+ * and so cannot choose. The commands come from `~/shared/core-onboarding`,
+ * which is the same place any other surface would read them from.
+ */
+function InstallStep() {
+  return (
+    <StepBody
+      title="Install the Core on the machine you want to drive"
+      lede="A Core is the daemon that owns the repository and runs the Harnesses. It goes on the machine with your code — a laptop, a workstation, a build box — not on this Panel. Pick whichever path fits that machine."
+    >
+      {CORE_INSTALL_PATHS.map((path) => (
+        <div key={path.id} data-install-path={path.id} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ fontSize: 13, fontWeight: 600 }}>{path.title}</div>
+          <Prose>{path.blurb}</Prose>
+          {path.commands.map((command) => (
+            <CommandLine key={command} command={command} />
+          ))}
+          {path.note && <Aside>{path.note}</Aside>}
+        </div>
+      ))}
+    </StepBody>
+  );
+}
+
+/**
+ * Step 2 — mint a code on that machine.
+ *
+ * The command is built from what the operator types, so `--label` is a thing
+ * they have chosen rather than a flag they were shown and skipped. Under it,
+ * the four lines `pair new` prints and what each one is for: three of them are
+ * typed into step 3, and an operator who knows that reads the terminal once
+ * instead of three times.
+ */
+function MintStep({ label, onLabel }: { label: string; onLabel: (next: string) => void }) {
+  return (
+    <StepBody
+      title="Mint a pairing code on that machine"
+      lede="Back on the Core's terminal. This prints a one-time code that this Panel redeems — it is single-use, it expires in five minutes by default, and the Core keeps only a digest of it, so it is printed exactly once."
+    >
+      <TextField
+        label="Name this Panel will have on that Core"
+        value={label}
+        onChange={onLabel}
+        placeholder="my-panel"
+        hint="Optional, and worth setting: it is what `actana pair ls` calls this Panel on the Core later."
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <CommandLine command={pairNewCommand(label)} />
+      <Prose>Or, if that Core came up under Docker Compose:</Prose>
+      <CommandLine command={composePairNewCommand(label)} />
+
+      <div style={{ fontSize: 13, fontWeight: 600, marginTop: 4 }}>What it prints, and why</div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          padding: "12px 14px",
+          background: "var(--surface-0)",
+          border: "1px solid var(--border)",
+          borderRadius: 7,
+        }}
+      >
+        {PAIR_NEW_OUTPUT.map((line) => (
+          <div key={line.label} style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            <div
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: 11.5,
+                color: "var(--text)",
+                wordBreak: "break-all",
+              }}
+            >
+              {line.label} <span style={{ color: "var(--accent-ink)" }}>{line.sample}</span>
+            </div>
+            <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--text-dim)" }}>
+              {line.meaning}
+            </div>
+          </div>
+        ))}
+      </div>
+      <Aside>
+        Those values are stand-ins — nothing has been minted for you. Read the real ones off that
+        machine&apos;s terminal.
+      </Aside>
+    </StepBody>
+  );
+}
+
+/**
+ * Step 3 — the redemption, which is `AddCoreByPairing` and nothing else.
+ *
+ * The one thing this step adds is naming where the same form lives once the
+ * wizard is gone. An operator who pairs a second Core next month should look
+ * for Settings → Cores → Add Core and not for this screen, which they will
+ * never see again unless they forget every Core they have.
+ */
+function RedeemStep({ onPaired }: { onPaired: (core: CoreWithDial) => Promise<void> }) {
+  return (
+    <StepBody
+      title="Redeem the code here"
+      lede="Give the Panel the Core's address, compare the fingerprint it is presented against the one on that terminal, and only then enter the code. The Panel does not send the code until the two match."
+    >
+      <AddCoreByPairing onPaired={onPaired} />
+      <Aside>
+        This is the same form as <strong>Settings → Cores → Add Core</strong>, which is where every
+        Core after this one is paired. The gear icon in the top bar is waiting for you on the other
+        side of this step.
+      </Aside>
+    </StepBody>
+  );
+}
+
+/** Back / forward. There is no third button, and there never will be. */
+function Footer({ step, onStep }: { step: StepIndex; onStep: (next: StepIndex) => void }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+      <Btn
+        variant="frame"
+        size="sm"
+        onClick={() => onStep((step - 1) as StepIndex)}
+        disabled={step === 0}
+      >
+        Back
+      </Btn>
+      {step < 2 ? (
+        <Btn variant="primary" size="sm" onClick={() => onStep((step + 1) as StepIndex)}>
+          Next
+        </Btn>
+      ) : (
+        <span style={{ fontFamily: "var(--mono)", fontSize: 11.5, color: "var(--text-dim)" }}>
+          The Panel opens as soon as a Core pairs.
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** One step's frame: a heading, a sentence, and whatever the step is made of. */
+function StepBody({
+  title,
+  lede,
+  children,
+}: {
+  title: string;
+  lede: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        padding: "18px 20px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: 9,
+      }}
+    >
+      <h2 style={{ fontSize: 15.5, fontWeight: 650, margin: 0 }}>{title}</h2>
+      <Prose>{lede}</Prose>
+      {children}
+    </section>
+  );
+}
+
+function Prose({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: "var(--text-dim)" }}>
+      {children}
+    </p>
+  );
+}
+
+function Aside({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 11.5,
+        lineHeight: 1.5,
+        color: "var(--text-dim)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One pasteable command.
+ *
+ * A copy button rather than prose for the same reason `CoreNeedsUpdateNotice`
+ * has one: the command is going to be pasted into a terminal on a *different*
+ * machine, often read off a phone, and retyping a `curl … | bash` one-liner by
+ * eye is how an operator ends up debugging their own typo.
+ */
+function CommandLine({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(command).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => undefined,
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "7px 9px",
+        background: "var(--surface-1)",
+        border: "1px solid var(--border)",
+        borderRadius: 5,
+      }}
+    >
+      <code
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: "var(--mono)",
+          fontSize: 11.5,
+          color: "var(--text)",
+          overflowX: "auto",
+          whiteSpace: "pre",
+        }}
+      >
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={`Copy: ${command}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "3px 7px",
+          background: "transparent",
+          border: "1px solid var(--border)",
+          borderRadius: 4,
+          color: "var(--text-dim)",
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          cursor: "pointer",
+          flexShrink: 0,
+        }}
+      >
+        <Icon name={copied ? "check" : "copy"} size={11} />
+        {copied ? "copied" : "copy"}
+      </button>
+    </div>
+  );
+}

--- a/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
+++ b/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CoreWithDial } from "~/shared/cores";
 import type { CorePairingFailureCode, CorePairingRefusal } from "~/shared/core-pairing";
@@ -52,6 +52,10 @@ const api = {
   renameCore: vi.fn(),
   removeCore: vi.fn(async () => undefined),
   getKeybindings: vi.fn(async () => ({ bindings: {} })),
+  // Not this suite's subject: `ConfirmDialog` renders a `CardFrame`, whose glow
+  // reads settings through react-query. Stubbed so opening the removal dialog
+  // is about the removal.
+  getSettings: vi.fn(async () => ({})),
 };
 
 const toasts = { success: vi.fn(), error: vi.fn() };
@@ -59,17 +63,24 @@ const toasts = { success: vi.fn(), error: vi.fn() };
 vi.mock("~/lib/api", () => ({ api, ApiError }));
 vi.mock("sonner", () => ({ toast: toasts }));
 
+const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
 const { CoresSettingsPage } = await import("../CoresSettingsPage");
 const { KeybindingsProvider } = await import("~/lib/keybindings/store");
 const { pairingFailureMessage } = await import("~/shared/core-pairing");
+const { CORE_REGISTRY_CHANGED_EVENT } = await import("~/lib/design-meta");
 
 let CORES: CoreWithDial[] = [];
 
 async function openPage(): Promise<void> {
+  // A query client because the removal dialog's `CardFrame` reads settings
+  // through one; retries off so a stubbed failure is a failure now.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
-    <KeybindingsProvider>
-      <CoresSettingsPage />
-    </KeybindingsProvider>,
+    <QueryClientProvider client={client}>
+      <KeybindingsProvider>
+        <CoresSettingsPage />
+      </KeybindingsProvider>
+    </QueryClientProvider>,
   );
   await act(async () => {});
 }
@@ -453,5 +464,82 @@ describe("adding a Core by short code (#286)", () => {
       expect(state()).toBe("unchecked");
       expect(screen.queryByLabelText("Pairing code")).toBeNull();
     });
+  });
+});
+
+/**
+ * The registry announcements (#358).
+ *
+ * Pairing and forgetting are the only two things in this tree that change how
+ * many Cores this Panel has, and the first-run gate decides whether there is a
+ * dashboard at all on exactly that number. The gate's own suite drives the
+ * event directly; without these, the two halves of `remove → announce → wizard`
+ * are each proven and never meet, and dropping either call here would go
+ * unnoticed — degrading silently to "the wizard comes back within fifteen
+ * seconds" rather than at once.
+ */
+describe("telling the rest of the tab that the registry moved (#358)", () => {
+  let announced: Mock<() => void>;
+  // The listener is its own binding rather than the spy itself: a `vi.fn()` is
+  // not typed as an `EventListener`, and both add and remove need one identity.
+  let onAnnounce: () => void;
+
+  beforeEach(() => {
+    CORES = [];
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    api.inspectCoreForPairing.mockImplementation(async () => ({
+      identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+    }));
+    api.pairCore.mockImplementation(async () => ({ core: paired() }));
+    api.removeCore.mockImplementation(async () => undefined);
+    announced = vi.fn<() => void>();
+    onAnnounce = () => {
+      announced();
+    };
+    window.addEventListener(CORE_REGISTRY_CHANGED_EVENT, onAnnounce);
+  });
+
+  afterEach(() => {
+    window.removeEventListener(CORE_REGISTRY_CHANGED_EVENT, onAnnounce);
+    cleanup();
+  });
+
+  it("announces when a pairing lands", async () => {
+    await openPage();
+    await verify();
+    type("Session", "ps_abc");
+    type("Pairing code", "k7rp-9x4t");
+    await click("Pair Core");
+
+    expect(api.pairCore).toHaveBeenCalled();
+    expect(announced).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces when a Core is forgotten — the last one is what puts the wizard back", async () => {
+    CORES = [paired("prod-vm-1")];
+    await openPage();
+
+    await click("Remove Core prod-vm-1");
+    CORES = [];
+    // The dialog's own button. The row's is named "Remove Core prod-vm-1", so
+    // this exact name reaches only the confirmation.
+    await click("Remove Core");
+
+    expect(api.removeCore).toHaveBeenCalledWith("core_new");
+    expect(announced).toHaveBeenCalledTimes(1);
+  });
+
+  it("says nothing when the removal failed", async () => {
+    // The count did not move, so nothing should be told that it did — a gate
+    // that re-read here would spend a request to learn what it already knew.
+    CORES = [paired("prod-vm-1")];
+    await openPage();
+    api.removeCore.mockRejectedValueOnce(new Error("core is busy"));
+
+    await click("Remove Core prod-vm-1");
+    await click("Remove Core");
+
+    expect(announced).not.toHaveBeenCalled();
   });
 });

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -64,6 +64,9 @@ vi.mock("~/lib/api", () => ({ api, ApiError }));
 
 const { FirstRunGate } = await import("../FirstRunGate");
 const { announceCoreRegistryChanged } = await import("~/lib/core-registry-changed");
+const { writeCachedCoreCount } = await import("~/lib/shell-query-cache");
+const { CURRENT_MC_VERSION } = await import("~/queries/mission-control-version");
+const { ADD_CORE_LOCATION, composeUpCoreCommand } = await import("~/shared/core-onboarding");
 // Warm the chunk the gate loads lazily. `FirstRunWizard` is imported with
 // `React.lazy` — it has no business in the entry bundle of a Panel that has a
 // fleet — and an unpopulated module registry means React suspends on a promise
@@ -125,6 +128,9 @@ async function pair(): Promise<void> {
 describe("the first-run gate (#358)", () => {
   beforeEach(() => {
     CORES = [];
+    // The gate seeds its first render from a localStorage count, so a value one
+    // test wrote would decide the next test's first paint.
+    window.localStorage.clear();
     vi.clearAllMocks();
     api.listCores.mockImplementation(async () => ({ cores: CORES }));
     api.inspectCoreForPairing.mockImplementation(async () => ({
@@ -164,6 +170,41 @@ describe("the first-run gate (#358)", () => {
       expect(dashboard()).toBeNull();
     });
 
+    it("paints the shell on the first render when this browser has seen a fleet", async () => {
+      // The seed is the whole point: without it every load of every Panel
+      // blanks until `listCores()` answers, which is a network round-trip in
+      // front of the shell to protect a state only a first-ever load is in.
+      writeCachedCoreCount(2);
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      render(
+        <FirstRunGate>
+          <div data-testid={DASHBOARD}>Fleet</div>
+        </FirstRunGate>,
+      );
+      // No flush: this has to be true of the first client render, not of the
+      // render after a promise settles.
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("paints the wizard on the first render when this browser has seen none", async () => {
+      writeCachedCoreCount(0);
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("keeps the seed honest — the live read corrects it", async () => {
+      // A cached count is a memory, not an answer. An operator who forgot their
+      // last Core from another browser must not be handed a dashboard.
+      writeCachedCoreCount(3);
+      CORES = [];
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
     it("never unlocks on a registry read it could not make", async () => {
       api.listCores.mockRejectedValue(new Error("panel unreachable"));
       await mount();
@@ -177,13 +218,21 @@ describe("the first-run gate (#358)", () => {
   });
 
   describe("it is a gate, not a suggestion", () => {
-    it("offers nothing that skips, dismisses or defers it", async () => {
+    it("offers nothing that skips, dismisses or defers it, on any step", async () => {
+      // A keyword scan cannot prove absence on its own — "Go to Panel" would
+      // pass it — which is why the structural test below is the one doing the
+      // work. What this catches is an escape hatch added later by someone who
+      // named it the obvious thing, and it now looks at all three steps rather
+      // than only at the one that happens to be open on mount.
       await mount();
-      const escapes = screen
-        .getAllByRole("button")
-        .map((button) => `${button.textContent ?? ""} ${button.getAttribute("aria-label") ?? ""}`)
-        .filter((name) => /skip|dismiss|later|not now|close|continue anyway|explore/i.test(name));
-      expect(escapes).toEqual([]);
+      for (const step of [1, 2, 3] as const) {
+        await goToStep(step);
+        const escapes = screen
+          .getAllByRole("button")
+          .map((button) => `${button.textContent ?? ""} ${button.getAttribute("aria-label") ?? ""}`)
+          .filter((name) => /skip|dismiss|later|not now|close|continue anyway|explore/i.test(name));
+        expect(escapes).toEqual([]);
+      }
     });
 
     it("keeps the dashboard away on every step of the way through it", async () => {
@@ -211,6 +260,27 @@ describe("the first-run gate (#358)", () => {
       expect(dashboard()).toBeNull();
     });
 
+    it("does not tear down a live session on a single empty answer", async () => {
+      // Locking the gate unmounts the shell — every terminal, every socket. A
+      // Panel server that restarts against an empty or unmigrated data
+      // directory answers 200 with nothing in it, and one such answer must not
+      // end a session with no prompt and no undo.
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      api.listCores.mockResolvedValueOnce({ cores: [] });
+      const before = api.listCores.mock.calls.length;
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+      await flush();
+
+      expect(api.listCores.mock.calls.length).toBe(before + 2);
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
     it("does not throw a paired Panel into the wizard over one failed poll", async () => {
       CORES = [core()];
       await mount();
@@ -236,9 +306,19 @@ describe("the first-run gate (#358)", () => {
         ),
       ).toBeTruthy();
       expect(screen.getByText("actana setup")).toBeTruthy();
-      expect(
-        screen.getByText("docker compose -f deploy/docker-compose.yml up -d"),
-      ).toBeTruthy();
+      expect(screen.getByText(composeUpCoreCommand(CURRENT_MC_VERSION))).toBeTruthy();
+    });
+
+    it("brings up the Core alone, at a tag that resolves", async () => {
+      // The reader of this screen already has a Panel. A bare `up -d` would
+      // start the file's `panel` service too — clashing with theirs on 7420 or
+      // shadowing it — and `:latest` does not resolve until a release exists.
+      await mount();
+      await goToStep(1);
+      const compose = screen.getByText(/docker compose .* up -d/);
+      expect(compose.textContent?.endsWith("up -d core")).toBe(true);
+      expect(compose.textContent).toContain(`ACTANA_TAG=beta-${CURRENT_MC_VERSION}`);
+      expect(screen.queryByText("docker compose -f deploy/docker-compose.yml up -d")).toBeNull();
     });
 
     it("names the mint command on step 2, and what each line it prints is for", async () => {
@@ -248,6 +328,25 @@ describe("the first-run gate (#358)", () => {
       expect(screen.getByText(/^Pairing code/)).toBeTruthy();
       expect(screen.getByText(/^CA fingerprint/)).toBeTruthy();
       expect(screen.getByText(/^Session/)).toBeTruthy();
+      // The command taught here always carries `--label`, so `pair new` always
+      // prints a `Label` line. Leaving it out left one line on the operator's
+      // terminal that this screen did not account for.
+      expect(screen.getByText(/^Label/)).toBeTruthy();
+    });
+
+    it("refuses to print a command the Core would reject, and says why", async () => {
+      await mount();
+      await goToStep(2);
+      await act(async () => {
+        type("Name this Panel will have on that Core", "-panel");
+      });
+      // `pair new` reads a value starting with `-` as another option, in both
+      // flag forms, and quoting cannot help. So the placeholder is printed.
+      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.queryByText(/--label\s+'?-panel/)).toBeNull();
+      expect(document.querySelector("[data-label-refusal]")?.textContent).toMatch(
+        /cannot start with/,
+      );
     });
 
     it("rewrites the mint command as the operator names this Panel", async () => {
@@ -291,7 +390,7 @@ describe("the first-run gate (#358)", () => {
       expect(document.querySelector("[data-fingerprint-state]")?.getAttribute("data-fingerprint-state")).toBe(
         "unchecked",
       );
-      expect(screen.getByText(/Settings → Cores → Add Core/)).toBeTruthy();
+      expect(screen.getByText(ADD_CORE_LOCATION)).toBeTruthy();
     });
 
     it("posts the same body Settings posts", async () => {

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -1,0 +1,334 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CoreWithDial } from "~/shared/cores";
+
+/**
+ * The first-run gate (#358) — the Panel shows the pairing wizard, and nothing
+ * else, until it knows a Core.
+ *
+ * What these tests hold it to is the gate itself, because that is the part that
+ * can be wrong in a way nobody notices: that zero Cores means the wizard *and
+ * not the dashboard*, that a successful pairing is the only thing that opens
+ * the app, that the condition is the live count rather than a first-run flag —
+ * so forgetting the last Core puts the wizard back — and that the redemption
+ * step is the same `AddCoreByPairing` Settings mounts rather than a second
+ * implementation of the most safety-critical flow in the product.
+ */
+
+const PRESENTED =
+  "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+const ORIGIN = "https://prod-vm-1.internal:7777";
+
+/** The client's error type, as `~/lib/api` declares it. */
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+function core(label = "prod-vm-1"): CoreWithDial {
+  return {
+    id: "core_new",
+    endpoint: "wss://prod-vm-1.internal:7777",
+    label,
+    lastEventId: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    dial: { coreId: "core_new", state: "connecting", lastSeenAt: null },
+  };
+}
+
+let CORES: CoreWithDial[] = [];
+
+const api = {
+  listCores: vi.fn(async (): Promise<{ cores: CoreWithDial[] }> => ({ cores: CORES })),
+  inspectCoreForPairing: vi.fn(async (_address: string) => ({
+    identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+  })),
+  pairCore: vi.fn(async (_body: unknown): Promise<{ core: CoreWithDial }> => {
+    // The registry is what the gate reads, so a pairing that "succeeds" has to
+    // land in it — anything else would let the gate pass on a promise rather
+    // than on a Core.
+    CORES = [core()];
+    return { core: core() };
+  }),
+};
+
+vi.mock("~/lib/api", () => ({ api, ApiError }));
+
+const { FirstRunGate } = await import("../FirstRunGate");
+const { announceCoreRegistryChanged } = await import("~/lib/core-registry-changed");
+// Warm the chunk the gate loads lazily. `FirstRunWizard` is imported with
+// `React.lazy` — it has no business in the entry bundle of a Panel that has a
+// fleet — and an unpopulated module registry means React suspends on a promise
+// the loader resolves on its own schedule rather than on this tick.
+await import("../FirstRunWizard");
+
+const DASHBOARD = "the-dashboard";
+
+/** Settle the registry read, and the lazy wizard behind it. */
+async function flush(): Promise<void> {
+  await act(async () => {});
+}
+
+async function mount(): Promise<void> {
+  render(
+    <FirstRunGate>
+      <div data-testid={DASHBOARD}>Fleet</div>
+    </FirstRunGate>,
+  );
+  await flush();
+}
+
+function wizard(): HTMLElement | null {
+  return document.querySelector("[data-first-run-wizard]");
+}
+
+function dashboard(): HTMLElement | null {
+  return screen.queryByTestId(DASHBOARD);
+}
+
+function type(label: string | RegExp, value: string): void {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+async function click(name: string | RegExp): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+/** Walk the wizard to a given step. Steps are reference; step 3 is the act. */
+async function goToStep(n: 1 | 2 | 3): Promise<void> {
+  await click(new RegExp(`Step ${n}`));
+}
+
+/** The whole redemption, exactly as an operator does it in Settings. */
+async function pair(): Promise<void> {
+  await goToStep(3);
+  type("Core address", "prod-vm-1.internal:7777");
+  await click("Check fingerprint");
+  await act(async () => {
+    type("CA fingerprint from `actana pair new`", PRESENTED);
+  });
+  type("Session", "ps_abc");
+  type("Pairing code", "k7rp-9x4t");
+  await click("Pair Core");
+}
+
+describe("the first-run gate (#358)", () => {
+  beforeEach(() => {
+    CORES = [];
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    api.inspectCoreForPairing.mockImplementation(async () => ({
+      identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+    }));
+    api.pairCore.mockImplementation(async () => {
+      CORES = [core()];
+      return { core: core() };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("what a Panel shows for a given fleet", () => {
+    it("shows the wizard, and no dashboard at all, when it knows zero Cores", async () => {
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+      expect(screen.getByRole("heading", { name: "Pair your first Core" })).toBeTruthy();
+    });
+
+    it("shows the app, and no wizard, once it knows one", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("shows neither until the registry has answered", async () => {
+      // A wizard flashed at an operator with a fleet, or a dashboard flashed at
+      // one without, are the two mistakes this component exists to prevent.
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      await mount();
+      expect(wizard()).toBeNull();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("never unlocks on a registry read it could not make", async () => {
+      api.listCores.mockRejectedValue(new Error("panel unreachable"));
+      await mount();
+      expect(dashboard()).toBeNull();
+      expect(wizard()).toBeTruthy();
+      // "No Cores" and "could not ask" are different things, and the operator
+      // about to be told to install a Core is owed the difference.
+      const box = document.querySelector("[data-first-run-registry-error]");
+      expect(box?.textContent).toContain("panel unreachable");
+    });
+  });
+
+  describe("it is a gate, not a suggestion", () => {
+    it("offers nothing that skips, dismisses or defers it", async () => {
+      await mount();
+      const escapes = screen
+        .getAllByRole("button")
+        .map((button) => `${button.textContent ?? ""} ${button.getAttribute("aria-label") ?? ""}`)
+        .filter((name) => /skip|dismiss|later|not now|close|continue anyway|explore/i.test(name));
+      expect(escapes).toEqual([]);
+    });
+
+    it("keeps the dashboard away on every step of the way through it", async () => {
+      await mount();
+      for (const step of [1, 2, 3, 2, 1] as const) {
+        await goToStep(step);
+        expect(dashboard()).toBeNull();
+        expect(wizard()).toBeTruthy();
+      }
+    });
+
+    it("comes back when the last Core is forgotten, because the gate is the count", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      // Settings → Cores → Remove, as far as this component can see it.
+      CORES = [];
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+      await flush();
+
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("does not throw a paired Panel into the wizard over one failed poll", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      api.listCores.mockRejectedValueOnce(new Error("socket hang up"));
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+  });
+
+  describe("what the operator is told to run on the Core", () => {
+    it("hands over both install paths on step 1", async () => {
+      await mount();
+      await goToStep(1);
+      expect(
+        screen.getByText(
+          "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+        ),
+      ).toBeTruthy();
+      expect(screen.getByText("actana setup")).toBeTruthy();
+      expect(
+        screen.getByText("docker compose -f deploy/docker-compose.yml up -d"),
+      ).toBeTruthy();
+    });
+
+    it("names the mint command on step 2, and what each line it prints is for", async () => {
+      await mount();
+      await goToStep(2);
+      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText(/^Pairing code/)).toBeTruthy();
+      expect(screen.getByText(/^CA fingerprint/)).toBeTruthy();
+      expect(screen.getByText(/^Session/)).toBeTruthy();
+    });
+
+    it("rewrites the mint command as the operator names this Panel", async () => {
+      await mount();
+      await goToStep(2);
+      await act(async () => {
+        type("Name this Panel will have on that Core", "the office");
+      });
+      // Quoted, because it is going to be pasted into a shell.
+      expect(screen.getByText("actana pair new --label 'the office'")).toBeTruthy();
+      expect(screen.queryByText("actana pair new --label <name>")).toBeNull();
+    });
+
+    it("keeps every command copyable, since it is pasted on another machine", async () => {
+      await mount();
+      await goToStep(2);
+      const copy = screen.getByRole("button", {
+        name: "Copy: actana pair new --label <name>",
+      });
+      const writeText = vi.fn(async () => undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+      await act(async () => {
+        fireEvent.click(copy);
+      });
+      expect(writeText).toHaveBeenCalledWith("actana pair new --label <name>");
+    });
+  });
+
+  describe("redeeming the code", () => {
+    it("is the Settings pairing form, not a second one", async () => {
+      await mount();
+      await goToStep(3);
+      // The ordering `AddCoreByPairing` owns: an address, a fingerprint that
+      // has been looked at, and only then a code. If this step had forked the
+      // flow, this is where the fork would show.
+      expect(screen.getByLabelText("Core address")).toBeTruthy();
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+      expect(document.querySelector("[data-fingerprint-state]")?.getAttribute("data-fingerprint-state")).toBe(
+        "unchecked",
+      );
+      expect(screen.getByText(/Settings → Cores → Add Core/)).toBeTruthy();
+    });
+
+    it("posts the same body Settings posts", async () => {
+      await mount();
+      await pair();
+      expect(api.pairCore).toHaveBeenCalledWith({
+        address: "prod-vm-1.internal:7777",
+        code: "k7rp-9x4t",
+        sessionId: "ps_abc",
+        expectedFingerprint: PRESENTED,
+        label: "",
+      });
+    });
+
+    it("unlocks the dashboard on the first Core that pairs", async () => {
+      await mount();
+      expect(dashboard()).toBeNull();
+
+      await pair();
+
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("stays put when the code is refused", async () => {
+      await mount();
+      api.pairCore.mockRejectedValueOnce(
+        new ApiError("that code has been used", 400, {
+          failure: "refused",
+          error: "that code has been used",
+        }),
+      );
+      await pair();
+
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+      expect(screen.getByRole("alert").textContent).toContain("that code has been used");
+    });
+  });
+});

--- a/packages/panel/src/lib/core-registry-changed.ts
+++ b/packages/panel/src/lib/core-registry-changed.ts
@@ -1,0 +1,32 @@
+import { CORE_REGISTRY_CHANGED_EVENT } from "~/lib/design-meta";
+
+/**
+ * "The Core registry just changed — ask again."
+ *
+ * The registry only ever changes because an operator paired a Core or forgot
+ * one, so the read paths that watch it poll slowly (`useCores`, fifteen
+ * seconds), which is right for a list and wrong for a gate. The first-run gate
+ * decides whether this Panel shows a dashboard at all; up to fifteen seconds of
+ * wizard after a pairing landed, or of dashboard after the last Core was
+ * forgotten, is the gate being wrong about the only thing it decides.
+ *
+ * So the two gestures that change the registry say so, and whoever is watching
+ * re-reads. This is a nudge, not a channel: nothing is carried and nothing is
+ * cached, because the answer to "how many Cores are there" belongs to the
+ * server and a count riding an event would be a second source of truth for the
+ * one number the gate must not be wrong about. The event says *ask again*.
+ *
+ * Window-scoped, so it reaches every component in this tab and no further.
+ * Another tab's pairing is picked up by the poll, as it always was.
+ */
+export function announceCoreRegistryChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(CORE_REGISTRY_CHANGED_EVENT));
+}
+
+/** Listen for {@link announceCoreRegistryChanged}. Returns the unsubscribe. */
+export function onCoreRegistryChanged(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  window.addEventListener(CORE_REGISTRY_CHANGED_EVENT, listener);
+  return () => window.removeEventListener(CORE_REGISTRY_CHANGED_EVENT, listener);
+}

--- a/packages/panel/src/lib/design-meta.ts
+++ b/packages/panel/src/lib/design-meta.ts
@@ -63,6 +63,19 @@ export type OpenSettingsEventDetail = { panel?: string };
  * before navigating away. Listened to by SettingsPanel. */
 export const CLOSE_SETTINGS_EVENT = "mc:close-settings";
 
+/**
+ * Dispatched whenever the Core registry gained or lost a row — a pairing that
+ * landed, a Core that was forgotten. Listened to by `~/lib/core-registry-changed`,
+ * which is what makes the first-run gate turn over at once rather than at the
+ * next registry poll.
+ *
+ * It carries no payload deliberately: the answer to "how many Cores are there"
+ * belongs to the server, and a count riding an event would be a second source
+ * of truth for the one number the gate is not allowed to be wrong about. The
+ * event says *ask again*, nothing more.
+ */
+export const CORE_REGISTRY_CHANGED_EVENT = "mc:core-registry-changed";
+
 export const ICON_COLORS = ["#ff5a1f", "#8ab4ff", "#c792ea", "#ff9466", "#f472b6", "#34d399", "#fb923c"];
 export const GROUP_COLORS = ["#ff5a1f", "#8ab4ff", "#c792ea", "#ff9466", "#f472b6", "#34d399", "#fb923c"];
 

--- a/packages/panel/src/lib/shell-query-cache.ts
+++ b/packages/panel/src/lib/shell-query-cache.ts
@@ -9,6 +9,16 @@ export const SHELL_QUERY_CACHE_KEYS = {
   projects: "mc:shell-cache:projects:v1",
   groups: "mc:shell-cache:groups:v1",
   settings: "mc:shell-cache:settings:v1",
+  /**
+   * How many Cores this Panel was paired with, last time anyone asked.
+   *
+   * Read by the first-run gate (#358) so a Panel with a fleet paints its shell
+   * on the first client render instead of blanking for a round trip — the same
+   * bargain the three keys above make, for the one number that decides whether
+   * there is a shell to paint at all. It is a seed and never an answer: the
+   * live `listCores()` corrects it on the same tick it lands.
+   */
+  coreCount: "mc:shell-cache:core-count:v1",
 } as const;
 
 type CacheEnvelope<T> = {
@@ -79,6 +89,16 @@ export function readCachedGroups(): Group[] | undefined {
 export function readCachedSettings(): AppSettings | undefined {
   const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.settings);
   return isObject(data) ? (data as AppSettings) : undefined;
+}
+
+/** The seeded Core count, or undefined when this browser has never been told. */
+export function readCachedCoreCount(): number | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.coreCount);
+  return typeof data === "number" && Number.isInteger(data) && data >= 0 ? data : undefined;
+}
+
+export function writeCachedCoreCount(count: number): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.coreCount, count);
 }
 
 export function writeCachedProjects(projects: ProjectWithCounts[]): void {

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -25,7 +25,14 @@ import type { ProjectPresentation } from "~/db/schema";
 // is for Core-side content the event stream doesn't cover.
 
 const FLEET_POLL_MS = 15_000;
-const CORES_POLL_MS = 15_000;
+/**
+ * How often the registry is re-read, absent something saying it changed.
+ *
+ * Exported because the first-run gate polls the same registry for the same
+ * reason and had hand-copied the number (#358 review): one cadence, one place
+ * to change it, and no comment claiming two constants agree.
+ */
+export const CORES_POLL_MS = 15_000;
 
 /** Event kinds that change what a `tasksList` would return. */
 const TASK_EVENT_KINDS = /^(task:|session:|pty:)/;

--- a/packages/panel/src/routes/__root.tsx
+++ b/packages/panel/src/routes/__root.tsx
@@ -47,6 +47,7 @@ import {
 import { useSettings, useProjects } from "~/queries";
 import { ProviderUsageIndicator } from "~/components/views/ProviderUsageIndicator";
 import { UpdateBanner } from "~/components/views/UpdateBanner";
+import { FirstRunGate } from "~/components/views/FirstRunGate";
 import {
   normalizeSettingsPanelId,
   type SettingsPanelId,
@@ -149,7 +150,19 @@ function RootComponent() {
                      * slot for an app-wide skeleton if we want one later.
                      */}
                     <ClientOnly fallback={null}>
-                      <Shell />
+                      {/*
+                       * The pairing gate (#358). A Panel that knows no Cores
+                       * has nothing to draw, so it draws the wizard *instead
+                       * of* the shell rather than over it: no top bar, no
+                       * rail, no outlet, and so no route or keystroke that
+                       * reaches a dead dashboard. It sits inside ClientOnly
+                       * because the registry read is a client read like every
+                       * other, and inside the providers because the pairing
+                       * form it mounts is the same one Settings mounts.
+                       */}
+                      <FirstRunGate>
+                        <Shell />
+                      </FirstRunGate>
                     </ClientOnly>
                   </HeaderActionsProvider>
                 </GroupsDialogProvider>

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  CORE_INSTALL_PATHS,
+  PAIR_NEW_OUTPUT,
+  composePairNewCommand,
+  pairNewCommand,
+} from "../core-onboarding";
+
+/**
+ * The Core-side commands the first-run wizard teaches (#358).
+ *
+ * These are pasted into a terminal on a machine this Panel cannot see, so the
+ * only thing standing between a wrong string here and an operator debugging
+ * their own install is this file.
+ */
+
+describe("the mint command", () => {
+  it("names `--label` even when no name has been chosen", () => {
+    // Dropping the flag would be the easy thing to do and would teach an
+    // operator to skip the one field that makes `actana pair ls` readable.
+    expect(pairNewCommand("")).toBe("actana pair new --label <name>");
+    expect(pairNewCommand("   ")).toBe("actana pair new --label <name>");
+  });
+
+  it("folds the chosen name in, untouched when a shell would not mind", () => {
+    expect(pairNewCommand("my-panel")).toBe("actana pair new --label my-panel");
+    expect(pairNewCommand("  home_panel.2  ")).toBe("actana pair new --label home_panel.2");
+  });
+
+  it("quotes a name a shell would otherwise split or eat", () => {
+    // Pasted unquoted, `pair new` would take "the" and refuse "office".
+    expect(pairNewCommand("the office")).toBe("actana pair new --label 'the office'");
+    expect(pairNewCommand("mehdi's mac")).toBe(`actana pair new --label 'mehdi'\\''s mac'`);
+    expect(pairNewCommand("a;rm -rf b")).toBe("actana pair new --label 'a;rm -rf b'");
+  });
+
+  it("has a Compose form that runs the same command inside the Core container", () => {
+    expect(composePairNewCommand("my-panel")).toBe(
+      "docker compose -f deploy/docker-compose.yml exec core actana pair new --label my-panel",
+    );
+  });
+});
+
+describe("what the wizard puts on screen", () => {
+  it("offers both documented install paths, each with something to paste", () => {
+    expect(CORE_INSTALL_PATHS.map((path) => path.id)).toEqual(["installer", "compose"]);
+    for (const path of CORE_INSTALL_PATHS) expect(path.commands.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the installer's two commands, in the order that works", () => {
+    const installer = CORE_INSTALL_PATHS.find((path) => path.id === "installer");
+    expect(installer?.commands).toEqual([
+      "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+      "actana setup",
+    ]);
+  });
+
+  it("explains every line `pair new` prints, and invents no credentials", () => {
+    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toEqual([
+      "Pairing code",
+      "CA fingerprint",
+      "Expires",
+      "Session",
+    ]);
+    for (const line of PAIR_NEW_OUTPUT) expect(line.meaning.trim()).not.toBe("");
+  });
+});

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -1,8 +1,15 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
-  CORE_INSTALL_PATHS,
+  ADD_CORE_FIELD_LABEL,
+  ADD_CORE_LOCATION,
   PAIR_NEW_OUTPUT,
   composePairNewCommand,
+  composeUpCoreCommand,
+  coreImageTag,
+  coreInstallPaths,
+  labelRefusal,
   pairNewCommand,
 } from "../core-onboarding";
 
@@ -12,7 +19,96 @@ import {
  * These are pasted into a terminal on a machine this Panel cannot see, so the
  * only thing standing between a wrong string here and an operator debugging
  * their own install is this file.
+ *
+ * **The `pair new` block is checked against the CLI, not against itself.** The
+ * first version of this suite asserted `PAIR_NEW_OUTPUT`'s labels against a
+ * literal copy of `PAIR_NEW_OUTPUT`'s own contents — a tautology that pinned
+ * the module to itself, said nothing about what `actana pair new` prints, and
+ * is exactly why a missing `Label` line survived review. So the expectations
+ * below are *read out of `packages/cli`*: the label set from the contract the
+ * CLI's own suite pins for this invocation, and the order from the printer.
+ * Neither can be satisfied by editing this package. #357 is about to reframe
+ * that output; when it does, this suite is what goes red.
  */
+
+const VERSION = "0.4.3";
+
+/** `packages/cli/src/__tests__/actana-pair.test.ts`, read as text. */
+const CLI_TEST = readCli("__tests__/actana-pair.test.ts");
+/** `packages/cli/src/actana-pair.ts`, read as text. */
+const CLI_PRINTER = readCli("actana-pair.ts");
+
+function readCli(relative: string): string {
+  const path = fileURLToPath(new URL(`../../../../cli/src/${relative}`, import.meta.url));
+  const source = readFileSync(path, "utf8");
+  // A file that moved must fail loudly here rather than quietly stop covering
+  // anything — a check that silently no longer checks is worse than none.
+  if (source.trim() === "") throw new Error(`${relative} is empty`);
+  return source;
+}
+
+/**
+ * The stdout contract the CLI's suite pins for `pair new --label <name>` — the
+ * exact invocation this wizard teaches.
+ *
+ * Lifted from its assertion that every stdout line matches
+ * `/^(Pairing code|CA fingerprint|Expires|Label|Session) /`.
+ */
+function cliPinnedLabels(): string[] {
+  const match = /\/\^\(([^)]+)\)\s\//.exec(CLI_TEST);
+  if (!match) {
+    throw new Error(
+      "could not find the pinned stdout contract in actana-pair.test.ts — if that assertion moved or changed shape, this test has to follow it",
+    );
+  }
+  return match[1].split("|");
+}
+
+/**
+ * The order `actana-pair.ts` writes those lines in, read off the `deps.out`
+ * calls themselves. `Endpoint host` is dropped: it is printed only for
+ * `--public-host`, which this wizard does not teach.
+ */
+function printerOrder(pinned: string[]): string[] {
+  const emitted = [...CLI_PRINTER.matchAll(/deps\.out\(`([A-Za-z][A-Za-z ]*?) +\$\{/g)].map(
+    (m) => m[1],
+  );
+  if (emitted.length === 0) throw new Error("found no `deps.out` label lines in actana-pair.ts");
+  return emitted.filter((label) => pinned.includes(label));
+}
+
+describe("the `pair new` output block, against the CLI itself", () => {
+  it("explains every line that invocation prints, and invents none", () => {
+    expect(new Set(PAIR_NEW_OUTPUT.map((line) => line.label))).toEqual(new Set(cliPinnedLabels()));
+  });
+
+  it("lists them in the order the terminal shows them", () => {
+    // The wizard is a recognition aid; a set in the wrong order is a worse one.
+    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toEqual(printerOrder(cliPinnedLabels()));
+  });
+
+  it("includes `Label`, because the command it teaches always carries `--label`", () => {
+    // Named on its own: it is the line the first version of this block missed,
+    // and the one an operator sees only when they follow the wizard's command.
+    expect(cliPinnedLabels()).toContain("Label");
+    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toContain("Label");
+  });
+
+  it("samples the shapes an operator has to recognise", () => {
+    const sample = (label: string) =>
+      PAIR_NEW_OUTPUT.find((line) => line.label === label)?.sample ?? "";
+    // `absoluteTime` emits ISO-8601 in UTC, with the milliseconds stripped.
+    expect(sample("Expires")).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \(.+\)$/);
+    // `randomUUID()` — 36 characters, no prefix. A short stand-in invites
+    // truncating the real one into the redeem step's Session box.
+    expect(sample("Session")).toHaveLength(36);
+    expect(sample("Session")).toMatch(/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/);
+  });
+
+  it("says something about every line", () => {
+    for (const line of PAIR_NEW_OUTPUT) expect(line.meaning.trim()).not.toBe("");
+  });
+});
 
 describe("the mint command", () => {
   it("names `--label` even when no name has been chosen", () => {
@@ -41,27 +137,77 @@ describe("the mint command", () => {
   });
 });
 
+describe("a name the Core would refuse", () => {
+  it("is refused here, with the reason", () => {
+    expect(labelRefusal("-panel")).toMatch(/cannot start with/);
+    expect(labelRefusal("  -panel")).toMatch(/cannot start with/);
+  });
+
+  it("never reaches the printed command", () => {
+    // The CLI's option parser refuses any `--label` value starting with `-`,
+    // in both flag forms, and quoting cannot help because the shell strips the
+    // quotes first. Emitting it would hand the operator a command that fails on
+    // paste — with the Panel to blame for printing it.
+    expect(pairNewCommand("-panel")).toBe("actana pair new --label <name>");
+    expect(composePairNewCommand("-panel")).toContain("--label <name>");
+  });
+
+  it("still refuses it in the CLI's own parser, which is why this exists", () => {
+    // Read from the CLI rather than asserted from memory: if that guard is ever
+    // relaxed, this stops being a rule the Panel has to enforce.
+    expect(CLI_PRINTER).toContain('value.startsWith("-")');
+  });
+
+  it("lets every ordinary name through", () => {
+    for (const name of ["my-panel", "panel-1", "the office", "a_b.c"]) {
+      expect(labelRefusal(name)).toBeNull();
+    }
+  });
+});
+
 describe("what the wizard puts on screen", () => {
   it("offers both documented install paths, each with something to paste", () => {
-    expect(CORE_INSTALL_PATHS.map((path) => path.id)).toEqual(["installer", "compose"]);
-    for (const path of CORE_INSTALL_PATHS) expect(path.commands.length).toBeGreaterThan(0);
+    const paths = coreInstallPaths(VERSION);
+    expect(paths.map((path) => path.id)).toEqual(["installer", "compose"]);
+    for (const path of paths) expect(path.commands.length).toBeGreaterThan(0);
   });
 
   it("keeps the installer's two commands, in the order that works", () => {
-    const installer = CORE_INSTALL_PATHS.find((path) => path.id === "installer");
+    const installer = coreInstallPaths(VERSION).find((path) => path.id === "installer");
     expect(installer?.commands).toEqual([
       "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
       "actana setup",
     ]);
   });
 
-  it("explains every line `pair new` prints, and invents no credentials", () => {
-    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toEqual([
-      "Pairing code",
-      "CA fingerprint",
-      "Expires",
-      "Session",
-    ]);
-    for (const line of PAIR_NEW_OUTPUT) expect(line.meaning.trim()).not.toBe("");
+  it("brings up the Core service alone, never a second Panel", () => {
+    // `docker compose … up -d` starts the whole file, `panel` included. That is
+    // the README's command, for a reader who has no Panel; here the reader is
+    // looking at one, and a bare `up -d` would clash with it on 7420 or shadow
+    // it — with this screen having told them to do it.
+    const compose = coreInstallPaths(VERSION).find((path) => path.id === "compose");
+    const up = compose?.commands.find((command) => command.includes("up -d"));
+    expect(up).toBe(composeUpCoreCommand(VERSION));
+    expect(up?.endsWith("up -d core")).toBe(true);
+    expect(compose?.commands.join("\n")).not.toMatch(/up -d(\s|$)(?!core)/);
+  });
+
+  it("pins an image tag rather than falling through to a `:latest` that 404s", () => {
+    const up = composeUpCoreCommand(VERSION);
+    expect(up.startsWith(`ACTANA_TAG=${coreImageTag(VERSION)} `)).toBe(true);
+    expect(coreImageTag("0.4.3")).toBe("beta-0.4.3");
+    // And the note has to explain the tag, or the operator cannot correct it
+    // once a release exists.
+    const compose = coreInstallPaths(VERSION).find((path) => path.id === "compose");
+    expect(compose?.note).toContain("ACTANA_TAG");
+    expect(compose?.note).toContain(VERSION);
+  });
+
+  it("tracks the Panel's own line rather than a hard-coded version", () => {
+    expect(composeUpCoreCommand("9.9.9")).toContain("ACTANA_TAG=beta-9.9.9");
+  });
+
+  it("names the canonical Add-a-Core location once", () => {
+    expect(ADD_CORE_LOCATION).toBe(`Settings → Cores → ${ADD_CORE_FIELD_LABEL}`);
   });
 });

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -11,9 +11,12 @@
 // somewhere a test can read it.
 //
 // Their source of truth is the repository's own install documentation
-// (`README.md` §Quickstart, `INSTALL.md` §Step 1–3). When those change, these
-// change with them; a wizard that teaches a command the docs no longer print
-// is worse than no wizard at all.
+// (`README.md` §Quickstart, `INSTALL.md` §Step 1–3) and, for the `pair new`
+// output block, `packages/cli/src/actana-pair.ts` itself. When those change,
+// these change with them; a wizard that teaches a command the docs no longer
+// print, or describes output the CLI no longer emits, is worse than no wizard
+// at all. `__tests__/core-onboarding.test.ts` reads the CLI's own pinned
+// contract rather than a copy of this file, so that drift is a red suite.
 
 /** One documented way to put a Core on a machine. */
 export type CoreInstallPath = {
@@ -30,39 +33,84 @@ export type CoreInstallPath = {
 };
 
 /**
+ * The image tag the Compose file should be pinned to, for a Panel on this
+ * version.
+ *
+ * `deploy/docker-compose.yml` defaults both services to `:latest`, and
+ * `README.md` §Quickstart is explicit that `:latest` 404s until the first
+ * release is published — the images publish as `beta-x.y.z` off the open train
+ * and are retagged `x.y.z` plus `latest` only when that train is released. So
+ * the wizard prints a tag rather than the bare default, and it prints *this
+ * Panel's own line*: pairing a Core built from a different line than the Panel
+ * driving it is the one thing `ACTANA_TAG` exists to prevent
+ * (`deploy/docker-compose.yml`, "one variable, both services").
+ *
+ * Derived rather than hard-coded, so the wizard cannot go stale against the
+ * train it ships on.
+ */
+export function coreImageTag(panelVersion: string): string {
+  return `beta-${panelVersion}`;
+}
+
+/** The Compose line that brings up **only the Core**, pinned to that tag. */
+export function composeUpCoreCommand(panelVersion: string): string {
+  return `ACTANA_TAG=${coreImageTag(panelVersion)} docker compose -f deploy/docker-compose.yml up -d core`;
+}
+
+/**
  * The two install paths, in the order the README offers them.
  *
  * Both are here rather than one being chosen for the operator, because the
  * choice is about their machine and the Panel cannot see their machine. The
  * blurbs are the README's own "Which one?" paragraph, split in two.
+ *
+ * **The Compose path brings up `core` and nothing else.** `README.md`'s
+ * `docker compose … up -d` starts the whole file — a Panel *and* a Core — which
+ * is the right command in the README, where the reader has no Panel yet, and
+ * the wrong one here, where by definition they are already looking at one. Left
+ * bare it would either clash with their Panel on 7420 or shadow it, and the
+ * screen would have told them to do it. Naming the `core` service is the whole
+ * difference (`deploy/docker-compose.yml`, the `core:` service).
  */
-export const CORE_INSTALL_PATHS: readonly CoreInstallPath[] = [
-  {
-    id: "installer",
-    title: "Installer — a machine that already has your code",
-    blurb:
-      "Linux, or macOS on arm64, as your own user and without sudo. Two commands, because installing is not activating: the first places the Core bundle and the `actana` CLI, the second turns the machine into a Core.",
-    commands: [
-      "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
-      "actana setup",
-    ],
-    note: "The installer prints the exact `actana setup` line to run — run the line it printed, not this one, if the two differ.",
-  },
-  {
-    id: "compose",
-    title: "Docker Compose — a Core beside this Panel",
-    blurb:
-      "The whole product on one host, which is the quickest way to see a Session run. The Core comes up on the same network as the Panel you are looking at.",
-    commands: [
-      "git clone https://github.com/actana/control && cd control",
-      "docker compose -f deploy/docker-compose.yml up -d",
-    ],
-    note: null,
-  },
-];
+export function coreInstallPaths(panelVersion: string): readonly CoreInstallPath[] {
+  return [
+    {
+      id: "installer",
+      title: "Installer — a machine that already has your code",
+      blurb:
+        "Linux, or macOS on arm64, as your own user and without sudo. Two commands, because installing is not activating: the first places the Core bundle and the `actana` CLI, the second turns the machine into a Core.",
+      commands: [
+        "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+        "actana setup",
+      ],
+      note: "The installer prints the exact `actana setup` line to run — run the line it printed, not this one, if the two differ.",
+    },
+    {
+      id: "compose",
+      title: "Docker Compose — a Core beside this Panel",
+      blurb:
+        "A Core on the same Compose file as this Panel, and only the Core: the file also defines a `panel` service, and you are already looking at a Panel. Quickest way to see a Session run if this Panel is itself a container.",
+      commands: [
+        "git clone https://github.com/actana/control && cd control",
+        composeUpCoreCommand(panelVersion),
+      ],
+      note: `\`ACTANA_TAG\` pins both services to one line, and it is set here because the file's default is \`:latest\`, which does not resolve until a release is published. \`${coreImageTag(panelVersion)}\` is the line this Panel is on. Once a release exists, that line's tag is \`${panelVersion}\`.`,
+    },
+  ];
+}
 
 /** The Compose prefix that runs a Core-side command inside the Core container. */
 export const COMPOSE_EXEC_PREFIX = "docker compose -f deploy/docker-compose.yml exec core";
+
+/**
+ * What the canonical Add-a-Core surface is called, so the wizard and the
+ * settings page name one place with one string (#358 asks for exactly that).
+ *
+ * `CoresSettingsPage` renders the field, and the wizard's redeem step points at
+ * it; both read these rather than each spelling it out.
+ */
+export const ADD_CORE_FIELD_LABEL = "Add a Core";
+export const ADD_CORE_LOCATION = `Settings → Cores → ${ADD_CORE_FIELD_LABEL}`;
 
 /**
  * What `actana pair new --label <name>` writes to stdout, as an operator will
@@ -70,9 +118,23 @@ export const COMPOSE_EXEC_PREFIX = "docker compose -f deploy/docker-compose.yml 
  *
  * A sample rather than live values, because the Panel is on the wrong machine
  * to have any: nothing here has been minted, and the point of showing it is
- * that the person watching the Panel recognises the four facts when they scroll
- * past on the Core's terminal. Three of them are typed back into the redeem
- * step; the fourth is a deadline.
+ * that the person watching the Panel recognises these lines when they scroll
+ * past on the Core's terminal. Four of them are typed back into the redeem
+ * step or checked against it; one is a deadline.
+ *
+ * **The set is the set that command prints, not a shorter one.** `pair new`
+ * emits `Label` whenever `--label` is given, and the wizard always teaches
+ * `--label` — so `Label` belongs here, between `Expires` and `Session`, in the
+ * order `packages/cli/src/actana-pair.ts` writes them. (`Endpoint host` is the
+ * sixth line and is not here: it appears only for `--public-host`, which this
+ * wizard does not teach.) The CLI's own suite pins that set for this exact
+ * invocation, and `__tests__/core-onboarding.test.ts` reads it from there.
+ *
+ * **The shapes are what recognition runs on**, so they match the real printer
+ * even though the values do not: an ISO-8601 expiry (`absoluteTime`), and a
+ * 36-character UUID session (`randomUUID`). A short prefixed stand-in would
+ * invite an operator to truncate a UUID into the Session box and fail a
+ * redemption for a reason nothing on screen explains.
  *
  * The values are obvious fakes on purpose. An operator who pastes `K7RP-9X4T`
  * gets a refusal, which is the correct outcome and a cheaper one than a sample
@@ -98,20 +160,48 @@ export const PAIR_NEW_OUTPUT: readonly PairNewOutputLine[] = [
     label: "CA fingerprint",
     sample: "AA:BB:CC:…:99",
     meaning:
-      "That Core's certificate authority. You compare it against the fingerprint this Panel shows you *before* the code is sent, which is what makes the pairing safe over a network you do not trust.",
+      "That Core's certificate authority, as 32 colon-separated bytes. You compare it against the fingerprint this Panel shows you *before* the code is sent, which is what makes the pairing safe over a network you do not trust.",
   },
   {
     label: "Expires",
-    sample: "2026-08-31 14:32 UTC (in 5 minutes)",
+    sample: "2026-08-31T14:32:07Z (in 5 minutes)",
     meaning:
-      "The deadline. Five minutes by default; `--ttl` moves it. Past it, mint another.",
+      "The deadline, in UTC. Five minutes by default; `--ttl` moves it. Past it, mint another.",
+  },
+  {
+    label: "Label",
+    sample: "my-panel",
+    meaning:
+      "The name you passed to `--label`, echoed back. It is what that Core calls this Panel in `actana pair ls`, and it is the Core's record — not the name this Panel will show you, which you choose in the last box below.",
   },
   {
     label: "Session",
-    sample: "ps_7f2c1a9e",
-    meaning: "The pairing session the code belongs to. It goes in the Session box below.",
+    sample: "7f2c1a9e-4b60-4c3d-9f21-8e5a7c0d1b34",
+    meaning:
+      "The pairing session the code belongs to — a full 36-character UUID. It goes in the Session box below, whole.",
   },
 ];
+
+/**
+ * Why a typed name cannot go into `--label`, or null if it can.
+ *
+ * There is exactly one such reason and it is not a style rule: `actana pair
+ * new`'s option parser refuses any value that starts with `-`, in **both** flag
+ * forms — `--label -panel` and `--label=-panel` hit the same guard
+ * (`actana-pair.ts`, "needs a value"). Quoting does not help either, because
+ * the shell strips the quotes before the CLI ever sees the token.
+ *
+ * So it has to be caught here, on the Panel side. Emitting the command anyway
+ * would produce precisely the failure {@link pairNewCommand} exists to prevent:
+ * an operator pasting exactly what the Panel printed and being refused by the
+ * Core for it.
+ */
+export function labelRefusal(label: string): string | null {
+  if (label.trim().startsWith("-")) {
+    return "A name cannot start with “-”. `actana pair new` reads it as another option and refuses the command — in both `--label -x` and `--label=-x` form, and quoting does not help because the shell strips the quotes first.";
+  }
+  return null;
+}
 
 /**
  * The mint command, with the operator's chosen name folded in.
@@ -120,7 +210,8 @@ export const PAIR_NEW_OUTPUT: readonly PairNewOutputLine[] = [
  * name is worth choosing rather than defaulting; an empty box therefore prints
  * the placeholder rather than dropping the flag, because a wizard that teaches
  * `actana pair new` teaches an operator to skip the one thing that makes their
- * pairing list readable later.
+ * pairing list readable later. A name the Core would refuse
+ * ({@link labelRefusal}) prints the placeholder too — never the refused form.
  */
 export function pairNewCommand(label: string): string {
   return `actana pair new --label ${labelArgument(label)}`;
@@ -132,8 +223,8 @@ export function composePairNewCommand(label: string): string {
 }
 
 /**
- * The `--label` argument: a placeholder when nothing is typed, and otherwise
- * the name, quoted only when a shell would need it.
+ * The `--label` argument: a placeholder when nothing usable is typed, and
+ * otherwise the name, quoted only when a shell would need it.
  *
  * Quoting matters because this string is going to be pasted into a terminal.
  * A name with a space in it silently becomes two arguments, and `pair new`
@@ -142,7 +233,7 @@ export function composePairNewCommand(label: string): string {
  */
 function labelArgument(label: string): string {
   const trimmed = label.trim();
-  if (trimmed === "") return "<name>";
+  if (trimmed === "" || labelRefusal(trimmed) !== null) return "<name>";
   if (/^[A-Za-z0-9._:@%+,/=-]+$/.test(trimmed)) return trimmed;
   return `'${trimmed.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -1,0 +1,148 @@
+// What an operator has to do on the *other* machine before this Panel is
+// worth anything — as data, so the first-run wizard and any future surface
+// print the same commands.
+//
+// The Panel's whole shape is that the machine doing the work is somewhere
+// else. Every string in this file is therefore a **Core-side** command: it is
+// pasted into a terminal on the machine being paired, never run by the Panel
+// and never run by the browser. That is why they live beside `cores.ts`'s
+// `CORE_UPDATE_COMMAND` rather than in a component — a command an operator
+// pastes on another machine is a fact about the product, and it belongs
+// somewhere a test can read it.
+//
+// Their source of truth is the repository's own install documentation
+// (`README.md` §Quickstart, `INSTALL.md` §Step 1–3). When those change, these
+// change with them; a wizard that teaches a command the docs no longer print
+// is worse than no wizard at all.
+
+/** One documented way to put a Core on a machine. */
+export type CoreInstallPath = {
+  /** Stable handle, used as a React key and as a test's grip on the block. */
+  id: "installer" | "compose";
+  /** What this path is, in the operator's terms. */
+  title: string;
+  /** Which machine it suits — the choice, not the mechanics. */
+  blurb: string;
+  /** The lines to paste, in order. Each is copyable on its own. */
+  commands: readonly string[];
+  /** The one thing that trips people up on this path, or null. */
+  note: string | null;
+};
+
+/**
+ * The two install paths, in the order the README offers them.
+ *
+ * Both are here rather than one being chosen for the operator, because the
+ * choice is about their machine and the Panel cannot see their machine. The
+ * blurbs are the README's own "Which one?" paragraph, split in two.
+ */
+export const CORE_INSTALL_PATHS: readonly CoreInstallPath[] = [
+  {
+    id: "installer",
+    title: "Installer — a machine that already has your code",
+    blurb:
+      "Linux, or macOS on arm64, as your own user and without sudo. Two commands, because installing is not activating: the first places the Core bundle and the `actana` CLI, the second turns the machine into a Core.",
+    commands: [
+      "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+      "actana setup",
+    ],
+    note: "The installer prints the exact `actana setup` line to run — run the line it printed, not this one, if the two differ.",
+  },
+  {
+    id: "compose",
+    title: "Docker Compose — a Core beside this Panel",
+    blurb:
+      "The whole product on one host, which is the quickest way to see a Session run. The Core comes up on the same network as the Panel you are looking at.",
+    commands: [
+      "git clone https://github.com/actana/control && cd control",
+      "docker compose -f deploy/docker-compose.yml up -d",
+    ],
+    note: null,
+  },
+];
+
+/** The Compose prefix that runs a Core-side command inside the Core container. */
+export const COMPOSE_EXEC_PREFIX = "docker compose -f deploy/docker-compose.yml exec core";
+
+/**
+ * What `actana pair new --label <name>` writes to stdout, as an operator will
+ * see it, and what each line is for.
+ *
+ * A sample rather than live values, because the Panel is on the wrong machine
+ * to have any: nothing here has been minted, and the point of showing it is
+ * that the person watching the Panel recognises the four facts when they scroll
+ * past on the Core's terminal. Three of them are typed back into the redeem
+ * step; the fourth is a deadline.
+ *
+ * The values are obvious fakes on purpose. An operator who pastes `K7RP-9X4T`
+ * gets a refusal, which is the correct outcome and a cheaper one than a sample
+ * that could be mistaken for a real code.
+ */
+export type PairNewOutputLine = {
+  /** The label as `pair new` prints it, left-aligned in a fixed column. */
+  label: string;
+  /** A stand-in value — never a real credential. */
+  sample: string;
+  /** What the operator does with it. */
+  meaning: string;
+};
+
+export const PAIR_NEW_OUTPUT: readonly PairNewOutputLine[] = [
+  {
+    label: "Pairing code",
+    sample: "K7RP-9X4T",
+    meaning:
+      "The one-time code. Single-use, expires, and dies after five wrong guesses. It is printed once — the Core keeps only a digest — so a lost code is re-minted by running the command again.",
+  },
+  {
+    label: "CA fingerprint",
+    sample: "AA:BB:CC:…:99",
+    meaning:
+      "That Core's certificate authority. You compare it against the fingerprint this Panel shows you *before* the code is sent, which is what makes the pairing safe over a network you do not trust.",
+  },
+  {
+    label: "Expires",
+    sample: "2026-08-31 14:32 UTC (in 5 minutes)",
+    meaning:
+      "The deadline. Five minutes by default; `--ttl` moves it. Past it, mint another.",
+  },
+  {
+    label: "Session",
+    sample: "ps_7f2c1a9e",
+    meaning: "The pairing session the code belongs to. It goes in the Session box below.",
+  },
+];
+
+/**
+ * The mint command, with the operator's chosen name folded in.
+ *
+ * `--label` is what the Core will call this Panel in `actana pair ls`, so the
+ * name is worth choosing rather than defaulting; an empty box therefore prints
+ * the placeholder rather than dropping the flag, because a wizard that teaches
+ * `actana pair new` teaches an operator to skip the one thing that makes their
+ * pairing list readable later.
+ */
+export function pairNewCommand(label: string): string {
+  return `actana pair new --label ${labelArgument(label)}`;
+}
+
+/** The same command, for a Core that came up under Compose. */
+export function composePairNewCommand(label: string): string {
+  return `${COMPOSE_EXEC_PREFIX} ${pairNewCommand(label)}`;
+}
+
+/**
+ * The `--label` argument: a placeholder when nothing is typed, and otherwise
+ * the name, quoted only when a shell would need it.
+ *
+ * Quoting matters because this string is going to be pasted into a terminal.
+ * A name with a space in it silently becomes two arguments, and `pair new`
+ * would take the first and reject the second — a failure the operator would
+ * blame on the Panel, having pasted exactly what it printed.
+ */
+function labelArgument(label: string): string {
+  const trimmed = label.trim();
+  if (trimmed === "") return "<name>";
+  if (/^[A-Za-z0-9._:@%+,/=-]+$/.test(trimmed)) return trimmed;
+  return `'${trimmed.replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
## Summary

A Panel that knows **zero Cores** now draws a three-step pairing wizard instead of the app shell, and keeps drawing it
until a Core pairs. The three steps are the three things that have to happen — install the Core on the machine you want
to drive, mint a code there, redeem it here — and each one carries the **Core-side commands** for that step, copyable,
because the person reading the Panel is not sitting at the machine they are pairing.

The gate is the **live Core count**, not a first-run flag: a freshly created Operator lands in the wizard rather than on
an empty dashboard, and a Panel whose last Core is forgotten goes straight back to it. One rule answers both, because
they are the same state — nothing to reset, nothing to migrate.

It **replaces** the shell rather than covering it. At zero Cores the top bar, the project rail, the router outlet and
the settings overlay do not mount at all, so there is no route to type, no key to press and no dead dashboard to glimpse
behind it. There is no skip, no "later" and no dismiss affordance anywhere on the screen.

Step 3 is `AddCoreByPairing` — **the same component `Settings → Cores → Add Core` mounts**, with the same `onPaired`
contract — so the fingerprint-before-code ordering, the mismatch refusal and every failure sentence stay written once.
This PR is composition and guidance around that form, not a second implementation of the most safety-critical flow in
the product. `CoresSettingsPage` keeps its own `AddCoreByPairing` and its behaviour is unchanged; the two paths name the
same canonical location, and the wizard says so out loud.

**Base is `feat/0.4.3-onboarding`, not the open train and not `main`** — this is one of the 0.4.3 onboarding tickets and
stacks on that branch alongside #357. Left as a **draft** deliberately.

### What changed

| File | |
| --- | --- |
| `src/shared/core-onboarding.ts` | new — the Core-side commands as data: both documented install paths, the `pair new` output lines and what each is for, and `pairNewCommand(label)` with shell quoting |
| `src/components/views/FirstRunWizard.tsx` | new — the three steps, the copyable command blocks, the live `--label` rewrite, and `AddCoreByPairing` as step 3 |
| `src/components/views/FirstRunGate.tsx` | new — the gate: a live `listCores()` count decides wizard vs. app; lazy-loads the wizard so a Panel with a fleet never ships those bytes |
| `src/lib/core-registry-changed.ts` | new — a payload-free "ask again" nudge, so a Core paired or forgotten is seen at once rather than at the next 15s poll |
| `src/routes/__root.tsx` | the gate wraps `<Shell />` inside `ClientOnly`; `/login` and `/setup` render outside it, untouched |
| `src/components/views/CoresSettingsPage.tsx` | announces the registry change after a pair and after a remove — two lines; the Add Core flow itself is untouched |
| `src/lib/design-meta.ts` | the event name, beside the other window events |

## Related issues

Closes #358

Companion to #357 (`actana pair new` framed TTY output). No CLI surface is touched here — #357 and #360 own those, and
this branch changes nothing outside `packages/panel`.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [ ] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/E2E tests added/updated
- [ ] Manually verified (describe steps below)

`src/components/views/__tests__/first-run-gate.test.tsx` — 22 tests driving the real gate against a mocked
`~/lib/api`, including the two the issue turns on:

- **zero Cores renders the wizard and not the dashboard** — the wizard is on screen, the child the gate wraps is not;
- **a successful pairing unlocks the dashboard** — the full redemption (address → check fingerprint → compare → session
  + code → Pair Core) through the real `AddCoreByPairing`, after which the child renders and the wizard is gone.

Plus: a paired Panel paints its shell on the *first* client render from the cached count, and the live read still
corrects a stale seed back into the wizard; a single empty successful read does not tear down a live session, two
consecutive ones do; a registry read that failed never unlocks the dashboard and says which of "no Cores" and "could
not ask" happened; one failed poll does not throw a paired Panel back into the wizard; forgetting the last Core brings
the wizard back; the Compose step brings up `core` alone at a tag that resolves; a name starting with `-` prints the
placeholder and the reason rather than a command the Core refuses; the dashboard stays away on every step and on the
way back; the mint command is rewritten and shell-quoted as the operator types a name; commands are copyable; and the
redeem step posts the same body `Settings → Cores` posts. No button on any of the three steps matches skip / dismiss /
later / close / continue-anyway — a keyword scan, which cannot prove absence on its own; the hardness is proven
structurally, by the gate returning the wizard *instead of* its children.

`src/shared/__tests__/core-onboarding.test.ts` — 19 tests. The `pair new` block is checked **against `packages/cli`**,
not against a copy of itself: the label set is read out of the contract the CLI's own suite pins for this invocation,
and the order out of the printer's `deps.out` calls, so drift from the real printer fails this suite. Verified by
deleting the `Label` entry and watching three tests fail.

`src/components/views/__tests__/cores-settings-pairing.test.tsx` — 39 tests, three of them new: pairing announces,
removal announces, and a failed removal announces nothing.

Full `packages/panel` suite: **146 files, 1535 tests, all passing.** `pnpm -r typecheck` clean. `pnpm lint`: 0 errors
(46 pre-existing warnings, unchanged in count, none in the files this PR adds or edits).

Not verified by running the app against a live Core — the gate and the wizard are exercised at the component level only.

## Screenshots / recordings

None — no browser was driven for this change.

## Checklist

- [ ] This PR targets the **open train** (`beta/x.y.z`), not `main` — deliberately not: it targets
      `feat/0.4.3-onboarding`, the 0.4.3 onboarding branch this ticket belongs to. `Train rules` passes on that base
      (it is neither `main`, a train, nor a release line, so the branch model does not constrain it); the train rule
      applies when the onboarding branch itself is proposed.
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name follows the
      branching convention — all three commits and the title were run through this repo's own `commitlint.config.mjs`.
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [ ] I updated documentation (README, docs/, changelog entry) where relevant — out of scope by instruction: this branch
      is confined to `packages/panel`, and `README.md` / `INSTALL.md` already document every command the wizard prints.
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (or this PR is marked as draft/stacked) — stacked on `feat/0.4.3-onboarding`
      and left as a draft.

