### PR TITLE
feat(cli): frame `actana pair new` at a terminal, byte-identical down a pipe, and fix two usage strings

### DIFF
--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -131,6 +131,43 @@ actana pair new --label my-panel
       fingerprint**, and when the code expires.
 - [ ] The code is short enough to read out loud over a phone without spelling
       anything — no `0`, `O`, `1`, `I` or `L` in it.
+- [ ] Because you are at a terminal, it comes **framed** (#357): the code, the
+      whole fingerprint wrapped rather than shortened, the session — and under
+      it both ways to spend them, the Panel path and a pasteable
+      `actana core pair …` command per address this Core answers on.
+- [ ] `actana pair new > /tmp/code.txt` instead gives the plain labelled lines
+      and nothing else — no frame, no instructions. That is the contract every
+      script wrapping this command depends on. (`rm /tmp/code.txt` after.)
+
+### The pasteable line, on a second machine
+
+**This is the one thing nothing automated can check**, and the reason it is a
+checkbox: the command below is generated from real minted values, and whether
+it works is a question about two machines. Take the `actana core pair …` line
+the block printed to a second machine — another VM, a laptop, a container with
+`npm i -g @actana/cli` on it — and paste it **unedited**.
+
+```bash
+# on the second machine, pasted exactly as printed
+actana core pair <as-printed>
+actana core status
+```
+
+- [ ] It pastes and runs. No `bash: …: No such file or directory`, no shell
+      error naming a file instead of `actana` — the line survives a shell as
+      printed, placeholder and all.
+- [ ] If `pair new` was run with no `--label`, the name slot is `NAME` and the
+      line still runs. Rename or remove it afterwards with `actana core rm`.
+- [ ] It pairs: the Core is registered, and no fingerprint had to be retyped.
+- [ ] `actana core status` **reaches the Core** from that second machine. A
+      pairing that succeeds and then cannot be reached is the failure this
+      checkbox exists for.
+- [ ] On a Core with several `--public-host` addresses: the block warns, on
+      every address but the one the credential will carry, that the code still
+      registers the other endpoint — and names the `actana pair new
+      --public-host <addr>` re-mint that would register the one you dialled.
+      Pair on a non-primary address and confirm `core status` behaves the way
+      the warning said it would.
 
 ---
 

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -38,8 +38,10 @@ import {
 import {
   describeDuration,
   MAX_PAIRING_TTL_MS,
+  PANEL_INSTRUCTION,
   parseDuration,
   runPairCommand,
+  wrapFingerprint,
 } from "../actana-pair.ts";
 import type { ActanaCliDeps } from "../cli-deps.ts";
 import { stubClientHalf, stubMachineHalf } from "./machine-fixture.ts";
@@ -53,8 +55,19 @@ let out: string[];
 let err: string[];
 let audited: Record<string, unknown>[];
 
-/** One run of `actana pair <argv>`, with its two streams captured. */
-function run(argv: string[], now = NOW, env: Record<string, string> = {}): number {
+/**
+ * One run of `actana pair <argv>`, with its two streams captured.
+ *
+ * **stdout is a pipe unless a test says otherwise**, which is the shape the
+ * stdout contract is about and the shape everything written before #357
+ * asserts against. {@link runTty} is the other one.
+ */
+function run(
+  argv: string[],
+  now = NOW,
+  env: Record<string, string> = {},
+  stdoutIsTty = false,
+): number {
   out = [];
   err = [];
   const deps: ActanaCliDeps = {
@@ -65,11 +78,17 @@ function run(argv: string[], now = NOW, env: Record<string, string> = {}): numbe
     home: dir,
     out: (line: string) => out.push(line),
     err: (line: string) => err.push(line),
+    stdoutIsTty,
   };
   return runPairCommand(deps, argv, {
     materialPath: () => materialPath,
     audit: (record) => audited.push(record),
   });
+}
+
+/** The same run with a terminal on stdout — the framed shape (#357). */
+function runTty(argv: string[], now = NOW, env: Record<string, string> = {}): number {
+  return run(argv, now, env, true);
 }
 
 function store(): PairingStore {
@@ -419,6 +438,311 @@ describe("actana pair new --public-host", () => {
     expect(help).toMatch(/certificate already covers/);
   });
 });
+
+// ─── pair new, the two shapes (#357) ────────────────────────────────────────
+//
+// One command, two audiences. Down a pipe it is the labelled lines a script
+// cuts fields out of; at a terminal it is a framed handout that says what the
+// code is for and what to type on the other machine. The switch is
+// `isatty(stdout)` and nothing else — there is deliberately no `--json` and no
+// flag — so the two things this suite has to hold are that the piped shape did
+// not move a byte, and that the framed one carries everything an operator needs
+// to finish the job without retyping a fingerprint.
+
+describe("actana pair new, piped", () => {
+  /** The 0.4.2 shape, written out rather than derived from the code under test. */
+  function expectedLines(over: { label?: string; endpointHost?: string } = {}): string[] {
+    const lines = [
+      `Pairing code   ${field("Pairing code")}`,
+      `CA fingerprint ${new X509Certificate(material.caCert).fingerprint256}`,
+      "Expires        2026-08-20T12:05:00Z (in 5 minutes)",
+    ];
+    if (over.label) lines.push(`Label          ${over.label}`);
+    if (over.endpointHost) lines.push(`Endpoint host  ${over.endpointHost}`);
+    lines.push(`Session        ${field("Session")}`);
+    return lines;
+  }
+
+  it("prints the labelled lines byte for byte, in the order 0.4.2 printed them", () => {
+    expect(run(["new", "--label", "laptop"])).toBe(0);
+    // Every line, whole, in order — not `toContain`. A framed block that leaked
+    // into the piped path, an extra blank line, a changed column width or a
+    // reordered field would each fail here, and each of them breaks a script.
+    expect(out).toEqual(expectedLines({ label: "laptop" }));
+  });
+
+  it("keeps the unlabelled shape, which has no Label line at all", () => {
+    expect(run(["new"])).toBe(0);
+    expect(out).toEqual(expectedLines());
+  });
+
+  it("keeps `Endpoint host` where it was, between Label and Session", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(run(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    expect(out).toEqual(expectedLines({ label: "laptop", endpointHost: "10.0.0.5" }));
+  });
+
+  it("writes no escape sequence, no box drawing and no instructions", () => {
+    run(["new", "--label", "laptop"]);
+    const printed = out.join("\n");
+    expect(printed).not.toMatch(/\x1b\[/);
+    for (const ornament of ["╭", "│", "─"]) expect(printed).not.toContain(ornament);
+    expect(printed).not.toContain("From the Panel");
+    expect(printed).not.toContain("From a terminal");
+    expect(printed).not.toContain("npm i -g");
+  });
+
+  it("is the shape a Core with several addresses prints too", async () => {
+    // The framed path prints one command per address. Down a pipe the several
+    // addresses change nothing at all: same five lines.
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(run(["new", "--label", "laptop"])).toBe(0);
+
+    expect(out).toEqual(expectedLines({ label: "laptop" }));
+  });
+});
+
+describe("actana pair new, at a terminal", () => {
+  /** Everything stdout saw, as one string. */
+  function screen(): string {
+    return out.join("\n");
+  }
+
+  /** The pasteable command lines — the ones that start the client verb. */
+  function commands(): string[] {
+    return out.map((line) => line.trim()).filter((line) => line.startsWith("actana core pair "));
+  }
+
+  it("frames the code, and the code is what was minted", () => {
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const session = store().listSessions()[0]!;
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(screen())?.[1];
+    expect(code).toBeDefined();
+    // The digest in the store is the digest of the code on the screen, which is
+    // the only thing that makes the framed shape the same shape.
+    expect(
+      pairingCodeMatches(
+        session.codeHash,
+        hashPairingCode({
+          key: derivePairingCodeKey(material.bearerSecret),
+          sessionId: session.id,
+          code: code!,
+        }),
+      ),
+    ).toBe(true);
+    expect(screen()).toContain("╭");
+    expect(screen()).toContain("Pairing code");
+  });
+
+  it("prints the expiry beside the code, absolute and relative", () => {
+    runTty(["new", "--ttl", "2h"]);
+    expect(screen()).toContain("2026-08-20T14:00:00Z (in 2 hours)");
+  });
+
+  it("prints the WHOLE fingerprint, wrapped rather than shortened", () => {
+    runTty(["new", "--label", "laptop"]);
+
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    expect(fingerprint.split(":")).toHaveLength(32);
+
+    // Inside the frame it is wrapped: no framed line holds the whole of it,
+    // and the framed lines that hold pieces of it re-join to exactly the value
+    // — nothing dropped, nothing elided, nothing rewritten.
+    const framed = out.filter((line) => line.includes("│"));
+    expect(framed.some((line) => line.includes(fingerprint))).toBe(false);
+    const rejoined = framed
+      .map((line) => /([0-9A-F]{2}(?::[0-9A-F]{2}){7,}:?)/.exec(line)?.[1] ?? "")
+      .join("");
+    expect(rejoined).toBe(fingerprint);
+    for (const elision of ["...", "…"]) expect(screen()).not.toContain(elision);
+    // And the pasteable command carries it whole, on one line, because that is
+    // the copy a client actually checks the certificate against.
+    expect(commands()[0]).toContain(`--fingerprint ${fingerprint}`);
+  });
+
+  it("prints the session id", () => {
+    runTty(["new"]);
+    const sessionId = store().listSessions()[0]!.id;
+    expect(screen()).toContain(sessionId);
+  });
+
+  it("gives the Panel path, worded as the ticket words it", () => {
+    runTty(["new", "--label", "laptop"]);
+    expect(screen()).toContain("From the Panel");
+    expect(screen()).toContain(
+      "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
+    );
+    expect(PANEL_INSTRUCTION).toBe(
+      "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
+    );
+  });
+
+  it("gives the terminal path: the install, then a command with real values", () => {
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    expect(screen()).toContain("From a terminal");
+    expect(screen()).toContain("npm i -g @actana/cli");
+
+    const session = store().listSessions()[0]!;
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(screen())![1]!;
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    expect(commands()).toEqual([
+      `actana core pair laptop 10.0.0.5:8443 ${code} --session ${session.id} --fingerprint ${fingerprint}`,
+    ]);
+    // The install line comes before the command it installs the binary for.
+    expect(screen().indexOf("npm i -g @actana/cli")).toBeLessThan(screen().indexOf("actana core pair "));
+  });
+
+  // The other half of the ticket: `readTicket` refuses a bare code, so a
+  // pasteable line without `--session` is a line that fails on arrival.
+  it("carries --session, with the id of the session it just minted", () => {
+    runTty(["new", "--label", "laptop"]);
+    const session = store().listSessions()[0]!;
+    for (const command of commands()) {
+      expect(command).toContain(`--session ${session.id}`);
+      expect(command).toContain("--fingerprint ");
+    }
+  });
+
+  it("offers one command per configured address, the primary first", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const addresses = commands().map((command) => command.split(" ")[4]);
+    expect(addresses).toEqual(["core:8443", "10.0.0.5:8443", "core.example.test:8443"]);
+  });
+
+  it("offers only the chosen address when --public-host chose one", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    // That is the endpoint redemption will hand this client, so a command
+    // pointing anywhere else would pair it to an address the code did not pick.
+    expect(commands().map((command) => command.split(" ")[4])).toEqual(["10.0.0.5:8443"]);
+  });
+
+  it("dials the port this install recorded, not a guess", () => {
+    fs.writeFileSync(
+      path.join(dir, "actana.json"),
+      JSON.stringify({
+        version: "0.4.3",
+        port: 9443,
+        host: "0.0.0.0",
+        publicHost: "10.0.0.5",
+        label: "core-1",
+        installDir: dir,
+        dataDir: dir,
+      }),
+    );
+
+    runTty(["new", "--label", "laptop"]);
+
+    expect(commands()[0]).toContain(" 10.0.0.5:9443 ");
+  });
+
+  it("dials the container's port when it is running in one", () => {
+    runTty(["new", "--label", "laptop"], NOW, { ACTANA_CONTAINER: "1", ACTANA_PORT: "7443" });
+    expect(commands()[0]).toContain(" 10.0.0.5:7443 ");
+  });
+
+  it("falls back to 8443 rather than printing no command at all", () => {
+    // No `actana.json` beside the material: an operator with a wrong port can
+    // fix one character, and an operator with no command has to build it.
+    runTty(["new", "--label", "laptop"]);
+    expect(commands()[0]).toContain(" 10.0.0.5:8443 ");
+  });
+
+  it("uses a placeholder name when there is no label to use", () => {
+    runTty(["new"]);
+    expect(commands()[0]).toContain("actana core pair <name> ");
+  });
+
+  it("uses a placeholder when the label is not a name the client registry takes", () => {
+    // `--label` takes anything an operator wants to call a machine; a Core name
+    // does not. Pasting `my laptop` would fail on the far machine with a
+    // message about a registry nobody mentioned.
+    runTty(["new", "--label", "my laptop"]);
+    expect(commands()[0]).toContain("actana core pair <name> ");
+    // The label is still the label — it is on the frame and in the store.
+    expect(screen()).toContain("my laptop");
+    expect(store().listSessions()[0]!.label).toBe("my laptop");
+  });
+
+  it("colours at a terminal, and the frame stays square anyway", () => {
+    runTty(["new", "--label", "laptop"]);
+    const printed = out.join("\n");
+    expect(printed).toMatch(/\x1b\[1;36m/);
+    // Padding measured on the plain text, so every framed row is the same
+    // *display* width despite the escapes having a length and no width.
+    const framed = out.filter((line) => line.includes("│")).map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+    expect(framed.length).toBeGreaterThan(5);
+    expect(new Set(framed.map((line) => [...line].length))).toEqual(new Set([74]));
+  });
+
+  it("degrades to no escapes under NO_COLOR, keeping every instruction", () => {
+    runTty(["new", "--label", "laptop"], NOW, { NO_COLOR: "1" });
+    const printed = out.join("\n");
+    expect(printed).not.toMatch(/\x1b\[/);
+    expect(printed).toContain("From the Panel");
+    expect(printed).toContain("From a terminal");
+    expect(commands()).toHaveLength(1);
+  });
+
+  it("mints exactly what the piped shape mints — only the printing differs", () => {
+    expect(runTty(["new", "--label", "laptop", "--ttl", "30s"])).toBe(0);
+    const session = store().listSessions()[0]!;
+    expect(session.expiresAt - session.createdAt).toBe(30_000);
+    expect(session.label).toBe("laptop");
+    // The prose on stderr is the same prose, terminal or not: it is not what a
+    // scraper reads, and it is what a human is told either way.
+    expect(err.join("\n")).toMatch(/Read the code AND the fingerprint/);
+    expect(err.join("\n")).toContain(`actana pair revoke ${session.id}`);
+  });
+
+  it("still stores a digest and never the code, framed or not", () => {
+    runTty(["new", "--label", "laptop"]);
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(out.join("\n"))![1]!;
+    const session = store().listSessions()[0]!;
+    expect(JSON.stringify(session)).not.toContain(code);
+    expect(JSON.stringify(session)).not.toContain(code.replace("-", ""));
+  });
+
+  it("refuses the same things it refuses down a pipe, and frames nothing", () => {
+    expect(runTty(["new", "--ttl", "5"])).toBe(2);
+    expect(out).toEqual([]);
+    expect(store().listSessions()).toEqual([]);
+  });
+});
+
+describe("wrapFingerprint", () => {
+  it("keeps every group, and marks the break with the separator", () => {
+    const fingerprint = Array.from({ length: 32 }, (_, i) => i.toString(16).padStart(2, "0").toUpperCase()).join(":");
+    const lines = wrapFingerprint(fingerprint);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.endsWith(":")).toBe(true);
+    expect(lines[1]!.endsWith(":")).toBe(false);
+    // Rejoinable, exactly: a wrapped fingerprint is the same value with a line
+    // break in it, and never a shortened one.
+    expect(lines.join("")).toBe(fingerprint);
+  });
+
+  it("cannot shorten its input, whatever it is asked for", () => {
+    for (const perLine of [0, 1, 5, 999]) {
+      expect(wrapFingerprint("AA:BB:CC:DD", perLine).join("")).toBe("AA:BB:CC:DD");
+    }
+  });
+});
+
 
 // ─── pair ls ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { X509Certificate } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import {
   loadMaterialFromFile,
   materialFilePath,
@@ -25,6 +26,7 @@ import {
   persistMaterialToFile,
   type PersistedMaterial,
 } from "@actana/shared/core-material-store";
+import { coreNameError } from "@actana/shared/blob-registry";
 import { normalisePairingCode, PAIRING_CODE_ALPHABET } from "@actana/shared/pairing-code";
 import { createPairingSession, PAIRING_SESSION_TTL_MS } from "@actana/shared/pairing-session";
 import {
@@ -37,7 +39,10 @@ import {
 } from "@actana/shared/pairing-store";
 import {
   describeDuration,
+  displayWidth,
+  FRAME_WIDTH,
   MAX_PAIRING_TTL_MS,
+  NAME_PLACEHOLDER,
   PANEL_INSTRUCTION,
   parseDuration,
   runPairCommand,
@@ -572,15 +577,33 @@ describe("actana pair new, at a terminal", () => {
     expect(screen()).toContain(sessionId);
   });
 
-  it("gives the Panel path, worded as the ticket words it", () => {
+  // The wording is pinned to the *form*, not to a paraphrase of it.
+  // `AddCoreByPairing.tsx` asks for the address first, gates everything behind
+  // a compared CA fingerprint — "the Panel does not send the code until they
+  // match" — and only then shows Session and Pairing code. An instruction that
+  // named only the code sent an operator to a form that wanted two things
+  // first, one of them the security-relevant one (#357 review B1).
+  it("gives the Panel path in the order the Panel's own form asks for it", () => {
     runTty(["new", "--label", "laptop"]);
     expect(screen()).toContain("From the Panel");
-    expect(screen()).toContain(
-      "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
-    );
+    expect(screen()).toContain(PANEL_INSTRUCTION);
     expect(PANEL_INSTRUCTION).toBe(
-      "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
+      "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+        "CA fingerprint, then the session and the code",
     );
+    // Every field the form requires is named, in the form's order, and the
+    // fingerprint comparison is not dropped — it is what makes the first dial
+    // verifiable, and the frame above prints the fingerprint without this
+    // sentence saying what it is for.
+    const address = PANEL_INSTRUCTION.indexOf("address");
+    const fingerprint = PANEL_INSTRUCTION.indexOf("fingerprint");
+    const session = PANEL_INSTRUCTION.indexOf("session");
+    const code = PANEL_INSTRUCTION.indexOf("code");
+    expect(address).toBeGreaterThan(-1);
+    expect(fingerprint).toBeGreaterThan(address);
+    expect(session).toBeGreaterThan(fingerprint);
+    expect(code).toBeGreaterThan(session);
+    expect(PANEL_INSTRUCTION).toContain("compare");
   });
 
   it("gives the terminal path: the install, then a command with real values", () => {
@@ -595,6 +618,10 @@ describe("actana pair new, at a terminal", () => {
     expect(commands()).toEqual([
       `actana core pair laptop 10.0.0.5:8443 ${code} --session ${session.id} --fingerprint ${fingerprint}`,
     ]);
+    // One address, and it is the one the credential will name, so there is
+    // nothing to warn about.
+    expect(screen()).toContain("# dial 10.0.0.5:8443 — and that is the endpoint this code registers");
+    expect(screen()).not.toContain("still registers");
     // The install line comes before the command it installs the binary for.
     expect(screen().indexOf("npm i -g @actana/cli")).toBeLessThan(screen().indexOf("actana core pair "));
   });
@@ -618,6 +645,58 @@ describe("actana pair new, at a terminal", () => {
 
     const addresses = commands().map((command) => command.split(" ")[4]);
     expect(addresses).toEqual(["core:8443", "10.0.0.5:8443", "core.example.test:8443"]);
+  });
+
+  // #357 review B2. The endpoint a paired client keeps comes off the stored
+  // session, never off the address it dialled — so a code minted without
+  // `--public-host` registers the primary for *every* command in the block.
+  // A comment that said only "reachable at 10.0.0.5" was true about the dial
+  // and false about the result: pair from a machine that cannot resolve
+  // `core`, and `actana core status` fails right after a successful pairing
+  // with nothing on screen explaining it.
+  it("says which endpoint the credential will carry, per address", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const printed = screen();
+    // The primary dials and registers the same address: nothing to warn about.
+    expect(printed).toContain("# dial core:8443 — and that is the endpoint this code registers");
+    // Every other address says what it really leaves behind, and how to get a
+    // code that does register it — the `--public-host` workflow #347 designed.
+    for (const host of ["10.0.0.5", "core.example.test"]) {
+      expect(printed).toContain(`# dial ${host}:8443 — but this code still registers core:8443`);
+      expect(printed).toContain(
+        `#   to register ${host}:8443: actana pair new --label laptop --public-host ${host}`,
+      );
+    }
+    // And the untruth is gone: no address is described as one you keep unless
+    // it is one you keep.
+    expect(printed).not.toContain("reachable at 10.0.0.5");
+  });
+
+  it("drops --label from the re-mint hint when there is no usable label", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5"]);
+    persistMaterialToFile(materialPath, material);
+
+    runTty(["new"]);
+
+    expect(screen()).toContain("#   to register 10.0.0.5:8443: actana pair new --public-host 10.0.0.5");
+  });
+
+  it("warns about nothing when --public-host made dial and endpoint agree", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    // The session records the choice, so redemption hands back 10.0.0.5 — the
+    // address the one command dials.
+    expect(store().listSessions()[0]!.endpointHost).toBe("10.0.0.5");
+    expect(screen()).toContain("# dial 10.0.0.5:8443 — and that is the endpoint this code registers");
+    expect(screen()).not.toContain("still registers");
+    expect(screen()).not.toContain("to register");
   });
 
   it("offers only the chosen address when --public-host chose one", async () => {
@@ -664,7 +743,7 @@ describe("actana pair new, at a terminal", () => {
 
   it("uses a placeholder name when there is no label to use", () => {
     runTty(["new"]);
-    expect(commands()[0]).toContain("actana core pair <name> ");
+    expect(commands()[0]).toContain("actana core pair NAME ");
   });
 
   it("uses a placeholder when the label is not a name the client registry takes", () => {
@@ -672,10 +751,48 @@ describe("actana pair new, at a terminal", () => {
     // does not. Pasting `my laptop` would fail on the far machine with a
     // message about a registry nobody mentioned.
     runTty(["new", "--label", "my laptop"]);
-    expect(commands()[0]).toContain("actana core pair <name> ");
+    expect(commands()[0]).toContain("actana core pair NAME ");
     // The label is still the label — it is on the frame and in the store.
     expect(screen()).toContain("my laptop");
     expect(store().listSessions()[0]!.label).toBe("my laptop");
+  });
+
+  // #357 review B3. `<name>` is not inert in a shell: pasted into bash it is
+  // "read stdin from a file called `name`, write stdout to a file called
+  // `10.0.0.5:8443`", and the command never runs. This is the assertion that
+  // was missing — not that a placeholder is *present*, but that the line the
+  // block promises is pasteable actually survives being pasted.
+  it("emits a line a real shell parses into the words it printed", () => {
+    for (const argv of [["new"], ["new", "--label", "my laptop"], ["new", "--label", "laptop"]]) {
+      runTty(argv);
+      const command = commands()[0]!;
+      // `sh -c 'printf %s\n <the line>'` is the whole test: a shell reads the
+      // line as a command with arguments and hands them back. A redirection,
+      // a glob or a quote would consume a word, redirect the output or fail
+      // outright — and each of those is a paste that does not work.
+      const echoed = execFileSync("/bin/sh", ["-c", `printf '%s\n' ${command}`], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      expect(echoed.split("\n").filter(Boolean)).toEqual(command.split(" "));
+    }
+  });
+
+  it("never puts a shell metacharacter in the pasteable line", () => {
+    // The belt to the braces above: the line is built from a label, an address,
+    // a code, a uuid and colon-hex, and none of those may bring a character a
+    // shell would act on.
+    for (const argv of [["new"], ["new", "--label", "my laptop"], ["new", "--label", "laptop"]]) {
+      runTty(argv);
+      expect(commands()[0]).not.toMatch(/[<>|&;$`()'"*?[\]{}\\]/);
+    }
+  });
+
+  it("names the placeholder in one place, and it is shell-safe there", () => {
+    expect(NAME_PLACEHOLDER).toBe("NAME");
+    // A slot an operator forgets to edit registers a Core called NAME, which
+    // one `actana core rm NAME` undoes. A shell error undoes nothing.
+    expect(coreNameError(NAME_PLACEHOLDER)).toBeNull();
   });
 
   it("colours at a terminal, and the frame stays square anyway", () => {
@@ -687,6 +804,44 @@ describe("actana pair new, at a terminal", () => {
     const framed = out.filter((line) => line.includes("│")).map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
     expect(framed.length).toBeGreaterThan(5);
     expect(new Set(framed.map((line) => [...line].length))).toEqual(new Set([74]));
+  });
+
+  // #357 review N1. `String.length` is UTF-16 code units, and `--label` takes
+  // anything: a CJK label measured that way lands the right border early, and
+  // an over-long one pushes it out. The label is the row that gives — never
+  // the fingerprint, which wraps instead.
+  it("keeps the frame square for a wide label, measured in columns", () => {
+    runTty(["new", "--label", "笔记本"], NOW, { NO_COLOR: "1" });
+    const framed = out.filter((line) => line.includes("│"));
+    expect(framed.length).toBeGreaterThan(5);
+    for (const line of framed) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    expect(screen()).toContain("笔记本");
+  });
+
+  it("clips an over-long label rather than bending the frame", () => {
+    const long = "l".repeat(200);
+    runTty(["new", "--label", long], NOW, { NO_COLOR: "1" });
+
+    const framed = out.filter((line) => line.includes("│"));
+    for (const line of framed) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    // Clipped, and marked as clipped.
+    expect(screen()).toContain("…");
+    expect(screen()).not.toContain(long);
+    // The label the operator gave is untouched everywhere it matters: in the
+    // store, and in the piped shape.
+    expect(store().listSessions()[0]!.label).toBe(long);
+    expect(run(["new", "--label", long])).toBe(0);
+    expect(out).toContain(`Label          ${long}`);
+  });
+
+  it("clips the label and never the fingerprint", () => {
+    runTty(["new", "--label", "l".repeat(200)], NOW, { NO_COLOR: "1" });
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    const framed = out.filter((line) => line.includes("│"));
+    const rejoined = framed
+      .map((line) => /([0-9A-F]{2}(?::[0-9A-F]{2}){7,}:?)/.exec(line)?.[1] ?? "")
+      .join("");
+    expect(rejoined).toBe(fingerprint);
   });
 
   it("degrades to no escapes under NO_COLOR, keeping every instruction", () => {

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -85,6 +85,13 @@ export type RunOptions = {
   stdin?: string;
   /** Force the TTY answer. Defaults to false when `stdin` is set, true otherwise. */
   stdinIsTty?: boolean;
+  /**
+   * Whether stdout is a terminal. Defaults to **false** — a run captured into
+   * an array is a piped run, and the commands that render differently at a
+   * terminal must render their scrapeable shape here unless a suite says
+   * otherwise.
+   */
+  stdoutIsTty?: boolean;
   /** What `core status` gets back, or a throw. */
   probe?: CoreProbeFn;
   /** What every other noun gets when it dials, or a throw. */
@@ -320,6 +327,7 @@ export function makeCliFixture(): CliFixture {
           : () => {},
         readStdin: async () => opts.stdin ?? "",
         stdinIsTty: opts.stdinIsTty ?? opts.stdin === undefined,
+        stdoutIsTty: opts.stdoutIsTty ?? false,
         probe:
           opts.probe ??
           (async () => {

--- a/packages/cli/src/__tests__/core-command.test.ts
+++ b/packages/cli/src/__tests__/core-command.test.ts
@@ -58,6 +58,17 @@ describe("actana core add", () => {
     expect(help).toContain("actana core pair");
   });
 
+  // #357. The usage line in this help showed three positionals and no flags,
+  // while `readTicket` refuses a code that does not name its pairing session.
+  // A help that omits a required flag is a help that hands out a command line
+  // the program then rejects.
+  it("shows the flags `pair` actually requires", async () => {
+    const run = await cli().run(["core", "--help"]);
+    expect(run.out.join("\n")).toContain(
+      "actana core pair <name> <address> <code> --session <id> --fingerprint <sha256>",
+    );
+  });
+
   it("leaves the registry it wrote readable by exactly its owner", async () => {
     haveCore("prod");
     expect(statSync(coreBlobPath(cli().paths, "prod")).mode & 0o777).toBe(0o600);

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -314,6 +314,17 @@ describe("actana core pair — the command line", () => {
     }
   });
 
+  // #357. `readTicket` refuses a bare code without `--session <id>` or the
+  // joined `<session>:<code>` form, and this usage line used to show neither —
+  // so an operator who followed it exactly landed on a second refusal for a
+  // flag they had never been told about.
+  it("shows both required flags in the usage line it prints", async () => {
+    const run = await cli().run(["core", "pair", "prod"], { pairing: fakePairing() });
+    expect(run.err.join("\n")).toContain(
+      "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+    );
+  });
+
   it("refuses a fourth argument without echoing it", async () => {
     const run = await cli().run(
       ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],

--- a/packages/cli/src/__tests__/machine-fixture.ts
+++ b/packages/cli/src/__tests__/machine-fixture.ts
@@ -165,6 +165,7 @@ export type ClientHalf = Pick<
   | "verbose"
   | "readStdin"
   | "stdinIsTty"
+  | "stdoutIsTty"
   | "probe"
   | "connect"
   | "pairing"
@@ -189,6 +190,9 @@ export function stubClientHalf(
     verbose: () => {},
     readStdin: async () => "",
     stdinIsTty: false,
+    // Piped, so every suite that does not ask otherwise sees the shape a script
+    // sees — which is the shape the stdout contract is about.
+    stdoutIsTty: false,
     probe: refuse("dial a Core"),
     connect: refuse("dial a Core"),
     pairing: { identify: refuse("identify a Core"), pair: refuse("pair with a Core") },

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -144,6 +144,7 @@ async function main(): Promise<void> {
       : () => {},
     readStdin,
     stdinIsTty: Boolean(process.stdin.isTTY),
+    stdoutIsTty: Boolean(process.stdout.isTTY),
     probe: probeCore,
     connect: connectCore,
     // The one dial that starts with nothing trusted: `core pair` enrolls this

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -28,6 +28,14 @@
 // design working, not an omission, and `pair-command.test.ts` asserts it rather
 // than trusting it.
 //
+// **`pair new` has two shapes, and `isatty(stdout)` is the whole of the
+// switch** (#357). Down a pipe it is the labelled lines below, byte for byte
+// what 0.4.2 printed, because they are a screen-scraping contract. At a
+// terminal it is a framed handout that also says what to click in the Panel and
+// what to paste on the other machine. There is deliberately no `--json` and no
+// flag: a second way to ask is a second thing to keep true. See "the operator's
+// shape" further down for what is drawn and why.
+//
 // **What the fingerprint is for.** `pair new` prints the CA fingerprint beside
 // the code because the client's first dial is the one dial it cannot verify any
 // other way: it holds no certificate, so it has nothing pinned. A human reads
@@ -42,10 +50,14 @@
 // redeems them and enforces the revocations. Neither imports the other.
 
 import { randomUUID } from "node:crypto";
+import * as path from "node:path";
 import {
+  CONTAINER_PORT_ENV,
   CONTAINER_PUBLIC_HOST_ENV,
+  DEFAULT_CONTAINER_PORT,
   inContainer,
 } from "@actana/shared/actana-container-contract";
+import { coreNameError } from "@actana/shared/blob-registry";
 import { certFingerprintSha256 } from "@actana/shared/core-cert-material";
 import {
   formatPublicHosts,
@@ -75,6 +87,7 @@ import {
   pairingAuditor,
   type PairingAuditSink,
 } from "@actana/shared/pairing-audit";
+import { readActanaConfig } from "./actana-config.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -263,20 +276,46 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
 
   store.createSession(session, now);
 
-  // stdout: the three facts a human reads out. stderr: everything explaining
-  // them, so a `pair new` that is being piped or screen-scraped stays three
-  // labelled lines and nothing else.
+  const fingerprint = certFingerprintSha256(material.caCert);
+
+  // stderr is the same in both shapes below. It is the prose, and prose is not
+  // what a scraper reads — so the two sentences that explain the code are here
+  // whether the frame was drawn or not.
   deps.err("Read the code AND the fingerprint out to the machine you are pairing.");
   deps.err("The code is printed once — this Core keeps only a digest of it.");
-  deps.out(`Pairing code   ${code}`);
-  deps.out(`CA fingerprint ${certFingerprintSha256(material.caCert)}`);
-  deps.out(`Expires        ${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`);
-  if (label) deps.out(`Label          ${label}`);
-  // Only when it was chosen. A Core with one configured address has nothing to
-  // say here, and a line that appeared on every `pair new` would be noise on
-  // the terminal an operator is reading a credential off.
-  if (endpointHost) deps.out(`Endpoint host  ${endpointHost}`);
-  deps.out(`Session        ${sessionId}`);
+
+  if (deps.stdoutIsTty) {
+    // The operator's shape (#357). Everything about it is cosmetic: it carries
+    // the same facts the labelled lines do, plus the two ways to spend them,
+    // and it is reachable only when there is a human at the other end.
+    for (const line of pairingHandout({
+      code,
+      fingerprint,
+      expiresAt: session.expiresAt,
+      now,
+      sessionId,
+      label,
+      hosts: handoutHosts(material.serverHosts, endpointHost),
+      port: corePort(deps, materialPath),
+      color: useColor(deps),
+    })) {
+      deps.out(line);
+    }
+  } else {
+    // stdout: the facts a human reads out, one labelled line each. **Not one
+    // byte of this may move** — it is what every script that has ever wrapped
+    // `pair new` reads, and the frame above exists precisely so that this does
+    // not have to change to give an operator something better to look at.
+    deps.out(`Pairing code   ${code}`);
+    deps.out(`CA fingerprint ${fingerprint}`);
+    deps.out(`Expires        ${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`);
+    if (label) deps.out(`Label          ${label}`);
+    // Only when it was chosen. A Core with one configured address has nothing to
+    // say here, and a line that appeared on every `pair new` would be noise on
+    // the terminal an operator is reading a credential off.
+    if (endpointHost) deps.out(`Endpoint host  ${endpointHost}`);
+    deps.out(`Session        ${sessionId}`);
+  }
   deps.err(`Cancel it before it is used with \`actana pair revoke ${sessionId}\`.`);
   return EXIT_OK;
 }
@@ -386,6 +425,294 @@ function chooseEndpointHost(
     return REFUSED;
   }
   return wanted;
+}
+
+// ─── the operator's shape (#357) ────────────────────────────────────────────
+//
+// `pair new` has two audiences and they want opposite things. A script wants
+// labelled lines it can cut a field out of and nothing else; the person
+// standing at the Core wants to know what the code is *for* and what to type
+// next, on the other machine, without reassembling `actana core pair` out of
+// four separate lines by hand.
+//
+// **The switch is `isatty(stdout)` and nothing else.** No flag, no environment
+// variable, and deliberately no `--json` (#357). A pipe, a file, a `$( )` and a
+// CI log all get the labelled lines, byte for byte what 0.4.2 printed, and
+// `actana-pair.test.ts` asserts that against a literal rather than trusting it.
+// A terminal gets the frame below. Nothing else in this command reads the
+// answer — the session that was minted, the digest that was stored and the
+// exit code are identical either way, because a command that *did* something
+// different at a terminal is a command no script can trust.
+//
+// Everything here is pure: values in, lines out. That is what lets the suite
+// assert on the frame without a terminal, and what keeps the decision to draw
+// one in exactly one `if`.
+
+/** The escape sequences the frame uses, and the only ANSI in this file. */
+const ANSI = {
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  /** The pairing code itself, which is the one thing on the screen that matters. */
+  boldCyan: "\u001b[1;36m",
+} as const;
+
+/**
+ * Whether to colour, given a terminal.
+ *
+ * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
+ * (https://no-color.org). Honouring it costs one clause and means an operator
+ * whose terminal renders escapes badly still gets the instructions, rather than
+ * having to choose between colour and a pipe.
+ */
+function useColor(deps: ActanaCliDeps): boolean {
+  const noColor = deps.env.NO_COLOR;
+  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
+}
+
+/** The frame's total width, borders included. Fixed, so the output is one shape. */
+const FRAME_WIDTH = 74;
+
+/** How far in from the left border the content starts. */
+const FRAME_GUTTER = 3;
+
+/** One run of styled text inside a framed line. */
+type Span = { text: string; style?: string };
+
+/**
+ * Every fact the handout renders. Times arrive as epoch ms and the clock does
+ * not: `now` is passed in, because this file reads the clock in exactly one
+ * place and it is not here.
+ */
+export type PairingHandout = {
+  code: string;
+  /** The full colon-separated hex. Wrapped below, and never shortened. */
+  fingerprint: string;
+  expiresAt: number;
+  now: number;
+  sessionId: string;
+  /** `""` when the code was minted without one. */
+  label: string;
+  /** The addresses to offer a pasteable command for, primary first. */
+  hosts: readonly string[];
+  port: number;
+  color: boolean;
+};
+
+/**
+ * The framed block, the Panel path and the terminal path, as lines.
+ *
+ * The order is the order of the questions an operator asks: what is the code,
+ * how long have I got, what do I compare the certificate against, which session
+ * is it — and then, under the frame, what do I actually do with it.
+ */
+export function pairingHandout(handout: PairingHandout): string[] {
+  const { code, fingerprint, sessionId, label, color } = handout;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  lines.push(frameRow([{ text: "Pairing code", style: ANSI.dim }], color));
+  lines.push(frameRow([], color));
+  // The one line the whole command exists for, and the only one in bold cyan.
+  lines.push(frameRow([{ text: `   ${code}`, style: ANSI.boldCyan }], color));
+  lines.push(frameRow([], color));
+  lines.push(
+    frameRow(
+      [
+        { text: "Expires        ", style: ANSI.dim },
+        {
+          text: `${absoluteTime(handout.expiresAt)} (${relativeTime(handout.expiresAt, handout.now)})`,
+        },
+      ],
+      color,
+    ),
+  );
+  lines.push(frameRow([], color));
+  // **Wrapped, never truncated.** The fingerprint is what the client checks the
+  // certificate against before it sends the code, so a fingerprint with an
+  // ellipsis in it is not a fingerprint — it is an invitation to guess.
+  lines.push(frameRow([{ text: "CA fingerprint", style: ANSI.dim }], color));
+  for (const chunk of wrapFingerprint(fingerprint)) {
+    lines.push(frameRow([{ text: `   ${chunk}` }], color));
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameRow([{ text: "Session        ", style: ANSI.dim }, { text: sessionId }], color));
+  if (label) {
+    lines.push(frameRow([{ text: "Label          ", style: ANSI.dim }, { text: label }], color));
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  // The canonical path first: most people pairing a Core are sitting in front
+  // of a Panel, and the code goes straight into it.
+  lines.push(style("From the Panel", ANSI.bold, color));
+  lines.push(`  ${PANEL_INSTRUCTION}`);
+  lines.push("");
+
+  lines.push(style("From a terminal", ANSI.bold, color));
+  lines.push("  npm i -g @actana/cli");
+  lines.push("");
+  // One command per address, **with the minted values already in it**. A
+  // placeholder here would put the operator back where they started: reading
+  // four fields off a screen and retyping them into a fifth thing.
+  for (const [index, host] of handout.hosts.entries()) {
+    const note = index === 0 && handout.hosts.length > 1 ? " (primary)" : "";
+    lines.push(
+      style(`  # on the machine being paired, reachable at ${host}${note}`, ANSI.dim, color),
+    );
+    lines.push(`  ${corePairCommand(handout, host)}`);
+    if (index < handout.hosts.length - 1) lines.push("");
+  }
+  return lines;
+}
+
+/**
+ * The Panel path, worded once.
+ *
+ * A constant rather than an inline string because the wording is the spec --
+ * #357 names the click path exactly — and a test asserts this value rather
+ * than a regex that would go on passing after somebody paraphrased it.
+ */
+export const PANEL_INSTRUCTION =
+  "Settings (gear icon) -> Cores -> Add Core, then enter the code above";
+
+/**
+ * The line the operator pastes on the other machine.
+ *
+ * Every value is real: the label, the address, the code, the session and the
+ * whole fingerprint. `--session` is not optional — `readTicket` on the client
+ * refuses a bare code without it — and its absence from two usage strings is
+ * the other half of #357.
+ *
+ * One line, not a backslash continuation. A continuation is one keystroke away
+ * from being pasted into something that does not join it, and the whole promise
+ * of this line is that it works when pasted.
+ */
+function corePairCommand(handout: PairingHandout, host: string): string {
+  return [
+    "actana core pair",
+    handoutName(handout.label),
+    endpointAddress(host, handout.port),
+    handout.code,
+    "--session",
+    handout.sessionId,
+    "--fingerprint",
+    handout.fingerprint,
+  ].join(" ");
+}
+
+/**
+ * What the pasted command calls the Core.
+ *
+ * The `--label` when there is one and the client's registry would accept it,
+ * and `<name>` otherwise. The check is `coreNameError` — the client's own rule
+ * — rather than a second opinion about names written here: a label with a
+ * space in it is a fine label and not a Core name, and pasting it would fail on
+ * the far machine with a message about a registry nobody mentioned.
+ */
+function handoutName(label: string): string {
+  if (!label || coreNameError(label) !== null) return "<name>";
+  return label;
+}
+
+/**
+ * `host:port`, with an IPv6 literal bracketed.
+ *
+ * The same rule `endpointFor` applies in `actana-config.ts`, for the same
+ * reason: `fe80::1:8443` is not an address anything can parse.
+ */
+function endpointAddress(host: string, port: number): string {
+  const bracketed = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `${bracketed}:${port}`;
+}
+
+/**
+ * The fingerprint, broken across lines on its own separators.
+ *
+ * Split on the colons that are already in it and re-joined, so a wrapped
+ * fingerprint reads as the same value with a line break in it: every line but
+ * the last ends with the separator, which is what tells a reader there is more.
+ * Nothing is dropped — this function cannot shorten its input, which is the
+ * property that matters.
+ */
+export function wrapFingerprint(fingerprint: string, groupsPerLine = 16): string[] {
+  const groups = fingerprint.split(":");
+  const perLine = Math.max(1, groupsPerLine);
+  const lines: string[] = [];
+  for (let i = 0; i < groups.length; i += perLine) {
+    const last = i + perLine >= groups.length;
+    lines.push(groups.slice(i, i + perLine).join(":") + (last ? "" : ":"));
+  }
+  return lines;
+}
+
+/** The top or bottom rule. */
+function frameEdge(which: "top" | "bottom", color: boolean): string {
+  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
+  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
+}
+
+/**
+ * One line between the two borders.
+ *
+ * The padding is measured on the **plain** text and the styling applied
+ * afterwards, because an escape sequence has a length and no width — pad a
+ * coloured string by `String.length` and the right border walks off by however
+ * many bytes the colour cost.
+ */
+function frameRow(spans: Span[], color: boolean): string {
+  const plain = spans.map((span) => span.text).join("");
+  const body = spans.map((span) => style(span.text, span.style, color)).join("");
+  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - plain.length);
+  const bar = style("│", ANSI.dim, color);
+  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
+}
+
+/** Wrap `text` in an escape sequence, or hand it back untouched. */
+function style(text: string, code: string | undefined, color: boolean): string {
+  return color && code ? `${code}${text}${ANSI.reset}` : text;
+}
+
+/**
+ * The addresses the handout offers a command for, primary first.
+ *
+ * When `--public-host` chose one, it is the only one: the credential redemption
+ * hands back carries *that* endpoint, and offering the others would be offering
+ * commands whose paired client then dials an address this code did not choose.
+ * Otherwise it is the whole configured list in the operator's order, which is
+ * the order the primary is first in (#347).
+ *
+ * A Core whose material predates the SAN list having been recorded has no list
+ * to offer, and falls back to what `primaryPublicHost` falls back to rather
+ * than printing a command with an empty address in it.
+ */
+function handoutHosts(configured: readonly string[], chosen: string | undefined): string[] {
+  if (chosen) return [chosen];
+  return configured.length > 0 ? [...configured] : [primaryPublicHost(configured)];
+}
+
+/**
+ * The port the pasteable command dials.
+ *
+ * In a container it is the one the contract names — `ACTANA_PORT`, or 8443
+ * when it is unset — because there is no `actana.json` there. On metal it is
+ * what `actana setup` recorded beside the material, which is the directory
+ * `materialPath` points into. A config that cannot be read falls back to the
+ * documented default rather than refusing to print the command: an operator
+ * with a wrong port in front of them can fix it, and one with no command at all
+ * cannot.
+ */
+function corePort(deps: ActanaCliDeps, materialPath: string): number {
+  if (inContainer(deps.env)) {
+    const raw = deps.env[CONTAINER_PORT_ENV]?.trim();
+    const parsed = raw ? Number(raw) : Number.NaN;
+    return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535
+      ? parsed
+      : DEFAULT_CONTAINER_PORT;
+  }
+  return readActanaConfig(path.dirname(materialPath))?.port ?? DEFAULT_CONTAINER_PORT;
 }
 
 // ─── ls ─────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -127,6 +127,16 @@ Minting a code
   digest of it, so nothing — including \`pair ls\` — can print it again. A lost
   code is re-minted, not recovered.
 
+  **At a terminal it prints more than that.** Those facts come framed, with
+  both ways to spend them under it: what to click in the Panel, and a command
+  to paste on the machine being paired — \`actana core pair\` with this code,
+  this session and this fingerprint already in it, one per address this Core
+  answers on.
+
+  Redirect stdout and you get the labelled lines and nothing else, which is
+  what a script reads. That is the whole of the switch: there is no flag for
+  it, and \`pair new > code.txt\` or \`pair new | …\` gives the plain shape.
+
 Choosing an address
   A Core can be reachable more than one way at once — \`ACTANA_PUBLIC_HOST\` takes
   a comma-separated list, and every entry is in this Core's certificate. Pair a
@@ -296,6 +306,10 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
       sessionId,
       label,
       hosts: handoutHosts(material.serverHosts, endpointHost),
+      // What redemption will name, which is the chosen host when there is one
+      // and this Core's primary when there is not — the same resolution
+      // `core-pairing-wiring.ts` does, stated here so the block can say it.
+      credentialHost: endpointHost ?? primaryPublicHost(material.serverHosts),
       port: corePort(deps, materialPath),
       color: useColor(deps),
     })) {
@@ -471,7 +485,7 @@ function useColor(deps: ActanaCliDeps): boolean {
 }
 
 /** The frame's total width, borders included. Fixed, so the output is one shape. */
-const FRAME_WIDTH = 74;
+export const FRAME_WIDTH = 74;
 
 /** How far in from the left border the content starts. */
 const FRAME_GUTTER = 3;
@@ -495,6 +509,19 @@ export type PairingHandout = {
   label: string;
   /** The addresses to offer a pasteable command for, primary first. */
   hosts: readonly string[];
+  /**
+   * The address the **credential** will name, whichever of {@link hosts} was
+   * dialled (#357 review B2).
+   *
+   * Not the same question as "which address do I dial", and conflating the two
+   * is the bug this field exists to spell out. The endpoint a paired client
+   * keeps comes off the stored session, never off the address it dialled:
+   * `core-pairing-wiring.ts` reads `session.endpointHost` and falls back to the
+   * Core's primary. So a code minted with `--public-host` carries that host,
+   * and a code minted without one carries the primary for *every* command in
+   * the block — including the ones that dial something else.
+   */
+  credentialHost: string;
   port: number;
   color: boolean;
 };
@@ -539,7 +566,15 @@ export function pairingHandout(handout: PairingHandout): string[] {
   lines.push(frameRow([], color));
   lines.push(frameRow([{ text: "Session        ", style: ANSI.dim }, { text: sessionId }], color));
   if (label) {
-    lines.push(frameRow([{ text: "Label          ", style: ANSI.dim }, { text: label }], color));
+    // The one row whose content has no bound: `--label` takes whatever an
+    // operator wants to call a machine. Clipped to what the frame holds, and
+    // it is *this* row that gives — a label is a name the operator already
+    // knows and can read off `pair ls`, where the fingerprint is a value they
+    // have to compare character by character (#357 review N1).
+    const room = FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth("Label          ") - 1;
+    lines.push(
+      frameRow([{ text: "Label          ", style: ANSI.dim }, { text: clip(label, room) }], color),
+    );
   }
   lines.push(frameRow([], color));
   lines.push(frameEdge("bottom", color));
@@ -557,11 +592,18 @@ export function pairingHandout(handout: PairingHandout): string[] {
   // One command per address, **with the minted values already in it**. A
   // placeholder here would put the operator back where they started: reading
   // four fields off a screen and retyping them into a fifth thing.
+  //
+  // Each one says which endpoint the *credential* ends up naming, because for
+  // every address but one that is not the address the command dials — see
+  // {@link PairingHandout.credentialHost}. Saying only "reachable at X" would
+  // hand an operator a command that pairs and then leaves their client pointed
+  // somewhere it cannot reach, with nothing on the screen explaining why.
+  const credentialEndpoint = endpointAddress(handout.credentialHost, handout.port);
   for (const [index, host] of handout.hosts.entries()) {
-    const note = index === 0 && handout.hosts.length > 1 ? " (primary)" : "";
-    lines.push(
-      style(`  # on the machine being paired, reachable at ${host}${note}`, ANSI.dim, color),
-    );
+    const endpoint = endpointAddress(host, handout.port);
+    for (const note of hostNotes(handout, host, endpoint, credentialEndpoint)) {
+      lines.push(style(`  ${note}`, ANSI.dim, color));
+    }
     lines.push(`  ${corePairCommand(handout, host)}`);
     if (index < handout.hosts.length - 1) lines.push("");
   }
@@ -569,14 +611,61 @@ export function pairingHandout(handout: PairingHandout): string[] {
 }
 
 /**
- * The Panel path, worded once.
+ * The comment lines above one pasteable command.
  *
- * A constant rather than an inline string because the wording is the spec --
- * #357 names the click path exactly — and a test asserts this value rather
- * than a regex that would go on passing after somebody paraphrased it.
+ * Two shapes, and which one an address gets is the whole of #357 review B2:
+ *
+ *   - the address the credential will name — dial it, keep it, nothing to say;
+ *   - any other configured address — dial it and the pairing works, but the
+ *     client is left registered at `credentialEndpoint`, which on a machine
+ *     that cannot reach that name is a successful pairing followed by an
+ *     `actana core status` that fails for no visible reason.
+ *
+ * The second shape carries the fix rather than only the warning: one `pair new
+ * --public-host <addr>` mints a code whose redemption hands back *that*
+ * address, which is the workflow #347 and ADR 0038 designed and the one this
+ * block should be teaching.
+ */
+function hostNotes(
+  handout: PairingHandout,
+  host: string,
+  endpoint: string,
+  credentialEndpoint: string,
+): string[] {
+  if (endpoint === credentialEndpoint) {
+    return [`# dial ${endpoint} — and that is the endpoint this code registers`];
+  }
+  const label = handout.label && coreNameError(handout.label) === null ? ` --label ${handout.label}` : "";
+  return [
+    `# dial ${endpoint} — but this code still registers ${credentialEndpoint}`,
+    `#   to register ${endpoint}: actana pair new${label} --public-host ${host}`,
+  ];
+}
+
+/**
+ * The Panel path, worded once, and worded from the form rather than from
+ * memory (#357 review B1).
+ *
+ * `AddCoreByPairing.tsx` asks for things in a fixed order and gates them:
+ * the **Core address** first, with a "Check fingerprint" button beside it;
+ * then the **CA fingerprint**, typed and compared, and *"the Panel does not
+ * send the code until they match"*; and only past a verified fingerprint does
+ * step 3 exist at all — **Session**, then **Pairing code**, then an optional
+ * name. An instruction that said "then enter the code" sent an operator to a
+ * form that first wants an address this block never called a field, and then
+ * wants the fingerprint they had just been told they did not need — while the
+ * frame above prints that fingerprint prominently and never says what it is
+ * for. The comparison is the security-relevant step of the whole exchange
+ * (#280 step 3, #284); it is the one thing this line must not drop.
+ *
+ * A constant rather than an inline string because the wording is the spec, and
+ * a test asserts this value rather than a regex that would go on passing after
+ * somebody paraphrased it. `scripts/e2e-actana-setup-linux.mjs` pins it too:
+ * both move with this line.
  */
 export const PANEL_INSTRUCTION =
-  "Settings (gear icon) -> Cores -> Add Core, then enter the code above";
+  "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+  "CA fingerprint, then the session and the code";
 
 /**
  * The line the operator pastes on the other machine.
@@ -607,15 +696,34 @@ function corePairCommand(handout: PairingHandout, host: string): string {
  * What the pasted command calls the Core.
  *
  * The `--label` when there is one and the client's registry would accept it,
- * and `<name>` otherwise. The check is `coreNameError` — the client's own rule
- * — rather than a second opinion about names written here: a label with a
- * space in it is a fine label and not a Core name, and pasting it would fail on
- * the far machine with a message about a registry nobody mentioned.
+ * and {@link NAME_PLACEHOLDER} otherwise. The check is `coreNameError` — the
+ * client's own rule — rather than a second opinion about names written here: a
+ * label with a space in it is a fine label and not a Core name, and pasting it
+ * would fail on the far machine with a message about a registry nobody
+ * mentioned.
  */
 function handoutName(label: string): string {
-  if (!label || coreNameError(label) !== null) return "<name>";
+  if (!label || coreNameError(label) !== null) return NAME_PLACEHOLDER;
   return label;
 }
+
+/**
+ * The name slot, when there is no usable label — and it is bare `NAME` rather
+ * than `<name>` for one reason (#357 review B3).
+ *
+ * `<name>` is not inert in a shell. Pasted into bash it is a redirection: read
+ * stdin from a file called `name`, and send stdout to a file named after the
+ * next word. The command never runs, and what the operator sees is
+ * `bash: name: No such file or directory` — a message that names neither
+ * `actana` nor the actual problem, on the one line whose whole promise is that
+ * it works when pasted. It fires on `actana pair new` with no `--label`, which
+ * is the documented default.
+ *
+ * `NAME` reads as a slot just as clearly, survives every shell, and if it is
+ * pasted unedited it registers a Core called `NAME` — recoverable with one
+ * `actana core rm NAME`, which a shell error is not.
+ */
+export const NAME_PLACEHOLDER = "NAME";
 
 /**
  * `host:port`, with an IPv6 literal bracketed.
@@ -665,9 +773,84 @@ function frameEdge(which: "top" | "bottom", color: boolean): string {
 function frameRow(spans: Span[], color: boolean): string {
   const plain = spans.map((span) => span.text).join("");
   const body = spans.map((span) => style(span.text, span.style, color)).join("");
-  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - plain.length);
+  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
   const bar = style("│", ANSI.dim, color);
   return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
+}
+
+/**
+ * How many terminal columns `text` occupies.
+ *
+ * `String.length` is UTF-16 code units and a frame padded by it is crooked for
+ * anybody whose label is not Latin: `笔记本` is three code units and six
+ * columns, so the right border lands three early (#357 review N1). Counted per
+ * code point — a surrogate pair is one character, not two — with the wide
+ * ranges at two and the zero-width ones at nothing.
+ *
+ * Deliberately not a full `wcwidth`. This measures the four things that reach
+ * a frame row: ASCII, an operator's label, a UUID and colon-hex. Emoji with
+ * joiners and skin tones can still measure a column off, and the cost of that
+ * is a ragged border on one line — not a truncated fingerprint, which is the
+ * thing this file may never do.
+ */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const character of text) {
+    const point = character.codePointAt(0) ?? 0;
+    if (isZeroWidth(point)) continue;
+    width += isWide(point) ? 2 : 1;
+  }
+  return width;
+}
+
+/** Combining marks and variation selectors: they attach, they take no column. */
+function isZeroWidth(point: number): boolean {
+  return (
+    (point >= 0x0300 && point <= 0x036f) ||
+    (point >= 0x200b && point <= 0x200f) ||
+    (point >= 0xfe00 && point <= 0xfe0f) ||
+    point === 0x2060 ||
+    point === 0xfeff
+  );
+}
+
+/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
+function isWide(point: number): boolean {
+  return (
+    (point >= 0x1100 && point <= 0x115f) ||
+    (point >= 0x2e80 && point <= 0xa4cf) ||
+    (point >= 0xac00 && point <= 0xd7a3) ||
+    (point >= 0xf900 && point <= 0xfaff) ||
+    (point >= 0xfe30 && point <= 0xfe6f) ||
+    (point >= 0xff00 && point <= 0xff60) ||
+    (point >= 0xffe0 && point <= 0xffe6) ||
+    (point >= 0x1f300 && point <= 0x1f64f) ||
+    (point >= 0x1f900 && point <= 0x1f9ff) ||
+    (point >= 0x20000 && point <= 0x3fffd)
+  );
+}
+
+/**
+ * `text` shortened to `columns` display columns, marked when it was shortened.
+ *
+ * **Only ever called on the label.** Truncation is a lie about a value, and
+ * there is exactly one value in this block cheap enough to tell it about: a
+ * label is a name the operator chose and can read back off `pair ls`. The
+ * fingerprint wraps instead — see {@link wrapFingerprint} — and nothing routes
+ * it through here.
+ */
+function clip(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text;
+  let kept = "";
+  let width = 0;
+  for (const character of text) {
+    const next = width + displayWidth(character);
+    // One column held back for the marker, which is one column wide.
+    if (next > columns - 1) break;
+    kept += character;
+    width = next;
+  }
+  return `${kept}…`;
 }
 
 /** Wrap `text` in an escape sequence, or hand it back untouched. */

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -72,6 +72,21 @@ export type ActanaCliDeps = {
    * a hang.
    */
   stdinIsTty: boolean;
+  /**
+   * Whether **stdout** is a terminal — the whole of the switch between the two
+   * shapes `actana pair new` prints (#357).
+   *
+   * Its own field rather than {@link interactive}, which is the *pair* of them
+   * and answers a different question: whether there is somewhere to prompt.
+   * `actana pair new > code.txt` at a terminal has an interactive stdin and a
+   * redirected stdout, and it is the second half that decides whether what
+   * lands in that file is the scrapeable labelled lines or a box drawing.
+   *
+   * A cosmetic frame is only ever built off this. Nothing about *what* the CLI
+   * does may read it — a command that behaved differently down a pipe than it
+   * does at a terminal is a command no script can trust.
+   */
+  stdoutIsTty: boolean;
   // ─── the client half: Cores this machine can reach ────────────────────────
 
   /** How `core status` reaches a Core. See `core-probe.ts`. */

--- a/packages/cli/src/core-command.ts
+++ b/packages/cli/src/core-command.ts
@@ -65,7 +65,7 @@ const STATUS_TIMEOUT_MS = 15_000;
 export const CORE_HELP = `actana core — the Cores this machine can reach
 
 Usage
-  actana core pair <name> <address> <code>
+  actana core pair <name> <address> <code> --session <id> --fingerprint <sha256>
                                   enroll THIS machine on a Core
   actana core ls                  list the Cores this machine knows
   actana core use <name>          point \`current\` at a Core

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -127,8 +127,12 @@ export async function runCorePair(
   const [name, address, code, ...extra] = rest;
   if (name === undefined || address === undefined || code === undefined) {
     deps.err("actana core pair: a name, an address and a code are required.");
-    deps.err("  actana core pair <name> <host:port> <code> --fingerprint <sha256>");
-    deps.err("`actana pair new` on the Core prints the code and the fingerprint.");
+    // Both required flags, because both are (#357). `readTicket` below refuses
+    // a bare code without `--session`, and a usage line that omitted it sent the
+    // operator straight back here with the same three positionals and a fourth
+    // refusal.
+    deps.err("  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>");
+    deps.err("`actana pair new` on the Core prints the code, the fingerprint and the session.");
     return EXIT_USAGE;
   }
   if (extra.length > 0) {

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -18,7 +18,9 @@
 //     own** (#287);
 //   • `--version` installs that exact release; with no flag, the latest;
 //   • `status` / `start` / `stop` / `restart` / `logs` control and report the
-//     daemon, and `pair new` mints a code on it;
+//     daemon, and `pair new` mints a code on it — in **both** its shapes:
+//     the labelled lines when its stdout is redirected, and the framed
+//     handout with both redemption paths when it has a terminal (#357);
 //   • re-running the two commands upgrades in place — one unit, same pairing
 //     credentials, and a pre-rename `actana-harness.service` is taken out on
 //     the way;
@@ -393,7 +395,15 @@ async function main() {
   // The verb that replaced the reprint. It has to work on the machine the
   // one-liner produced, and it must not put the code on stdout twice or leak a
   // credential while doing it.
-  const minted = mustAsOperator("actana pair new --label e2e-panel");
+  //
+  // **Redirected, deliberately.** Since #357 `pair new` renders a framed
+  // handout when stdout is a terminal, and `machinectl shell` gives it one —
+  // so a scrape run here without the redirect would be reading the cosmetic
+  // shape. The contract this asserts is the *other* one: what a script sees.
+  // Both shapes are checked, this one first, because it is the one anything
+  // downstream depends on.
+  mustAsOperator("actana pair new --label e2e-panel > /tmp/pair-new.out");
+  const minted = mustAsOperator("cat /tmp/pair-new.out");
   if (!/Pairing code\s+[A-Z2-9]{4}-[A-Z2-9]{4}/.test(minted.stdout)) {
     die("`actana pair new` printed no pairing code", minted.stdout.split("\n"));
   }
@@ -403,6 +413,44 @@ async function main() {
   if (/BEGIN (CERTIFICATE|PRIVATE KEY)/.test(minted.stdout)) {
     die("`actana pair new` printed certificate material", minted.stdout.split("\n"));
   }
+  // Nothing cosmetic reached a redirected stdout: no frame, no instructions,
+  // no escape sequence. This is the half of #357 that scripts depend on, and
+  // the only place it is checked against a real installed Core.
+  for (const cosmetic of ["\u256d", "\u2502", "From the Panel", "From a terminal", "npm i -g"]) {
+    if (minted.stdout.includes(cosmetic)) {
+      die(`redirected \`actana pair new\` printed ${cosmetic}`, minted.stdout.split("\n"));
+    }
+  }
+  log("`actana pair new` keeps its labelled lines when stdout is not a terminal (#357)");
+
+  // And the other shape, on the same machine: `machinectl shell` is a
+  // terminal, so this run frames the code and says what to do with it. The
+  // pasteable line has to carry `--session` — without it the client's
+  // `readTicket` refuses the code it was just handed.
+  const framed = mustAsOperator("actana pair new --label e2e-tty");
+  for (const wanted of [
+    "\u256d",
+    "From the Panel",
+    "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
+    "From a terminal",
+    "npm i -g @actana/cli",
+  ]) {
+    if (!framed.stdout.includes(wanted)) {
+      die(`framed \`actana pair new\` printed no ${JSON.stringify(wanted)}`, framed.stdout.split("\n"));
+    }
+  }
+  const pasteable = framed.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("actana core pair "));
+  if (!pasteable) die("framed `actana pair new` printed no pasteable command", framed.stdout.split("\n"));
+  if (!/--session [0-9a-f-]{36}\b/.test(pasteable)) {
+    die("the pasteable command carries no --session", [pasteable]);
+  }
+  if (!/--fingerprint [0-9A-F]{2}(:[0-9A-F]{2}){31}/.test(pasteable)) {
+    die("the pasteable command carries no whole fingerprint", [pasteable]);
+  }
+  log("`actana pair new` frames the code and both redemption paths at a terminal (#357)");
   const reprint = asOperator("actana token");
   if (reprint.status === 0) die("`actana token` still reprints something — #287 removed it");
   // Both streams: `machinectl shell` folds the session's stderr into the

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -402,17 +402,26 @@ async function main() {
   // shape. The contract this asserts is the *other* one: what a script sees.
   // Both shapes are checked, this one first, because it is the one anything
   // downstream depends on.
-  mustAsOperator("actana pair new --label e2e-panel > /tmp/pair-new.out");
+  const redirected = mustAsOperator("actana pair new --label e2e-panel > /tmp/pair-new.out");
   const minted = mustAsOperator("cat /tmp/pair-new.out");
+  // The file held a redeemable code. This whole file's discipline is about not
+  // leaving credentials lying around, and an ephemeral container is a reason
+  // nobody notices rather than a reason it is fine (#357 review N2).
+  mustAsOperator("rm -f /tmp/pair-new.out");
   if (!/Pairing code\s+[A-Z2-9]{4}-[A-Z2-9]{4}/.test(minted.stdout)) {
     die("`actana pair new` printed no pairing code", minted.stdout.split("\n"));
   }
   if (!/CA fingerprint\s+[0-9A-F]{2}(:[0-9A-F]{2}){31}/.test(minted.stdout)) {
     die("`actana pair new` printed no CA fingerprint", minted.stdout.split("\n"));
   }
-  if (/BEGIN (CERTIFICATE|PRIVATE KEY)/.test(minted.stdout)) {
-    die("`actana pair new` printed certificate material", minted.stdout.split("\n"));
-  }
+  // **Both streams, and both shapes.** Before the redirect, `minted.stdout` was
+  // the folded stdout+stderr `machinectl shell` produces, so this check covered
+  // stderr too; scraping a file narrowed it to one stream of one run. The
+  // framed run below is swept by the same list (#357 review N2).
+  const leakChecked = [
+    ["redirected stdout", minted.stdout],
+    ["the redirected run's own streams", `${redirected.stdout}${redirected.stderr}`],
+  ];
   // Nothing cosmetic reached a redirected stdout: no frame, no instructions,
   // no escape sequence. This is the half of #357 that scripts depend on, and
   // the only place it is checked against a real installed Core.
@@ -431,7 +440,11 @@ async function main() {
   for (const wanted of [
     "\u256d",
     "From the Panel",
-    "Settings (gear icon) -> Cores -> Add Core, then enter the code above",
+    // Pinned by value: this script is plain node with no path to the CLI's
+    // exports. `actana-pair.test.ts` pins the same wording against the
+    // constant itself, so a change to it fails there first (#357 review B1).
+    "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+      "CA fingerprint, then the session and the code",
     "From a terminal",
     "npm i -g @actana/cli",
   ]) {
@@ -450,7 +463,44 @@ async function main() {
   if (!/--fingerprint [0-9A-F]{2}(:[0-9A-F]{2}){31}/.test(pasteable)) {
     die("the pasteable command carries no whole fingerprint", [pasteable]);
   }
+  // #357 review B3: the line's whole promise is that it works when pasted, and
+  // `<name>` was a shell redirection. Handing it to the machine's own shell is
+  // the only check that means anything — `printf` hands back the words a shell
+  // actually parsed, so a redirection or a glob shows up as a missing word.
+  const echoed = mustAsOperator(`printf '%s\\n' ${pasteable}`);
+  const words = echoed.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (words.join(" ") !== pasteable) {
+    die("the pasteable command did not survive a shell", [pasteable, ...words]);
+  }
+  // And the default invocation, which is the one #357 review B3 was about: no
+  // `--label`, so the name is the placeholder, and the placeholder is the thing
+  // a shell used to eat. Checked on the real machine rather than only in the
+  // unit suite, because "survives a shell" is a claim about a shell.
+  const unlabelled = mustAsOperator("actana pair new");
+  const defaultLine = unlabelled.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("actana core pair "));
+  if (!defaultLine) die("unlabelled `actana pair new` printed no pasteable command", unlabelled.stdout.split("\n"));
+  if (!/^actana core pair NAME /.test(defaultLine)) {
+    die("the unlabelled command does not use the shell-safe name placeholder", [defaultLine]);
+  }
+  const defaultEchoed = mustAsOperator(`printf '%s\\n' ${defaultLine}`);
+  const defaultWords = defaultEchoed.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (defaultWords.join(" ") !== defaultLine) {
+    die("the unlabelled pasteable command did not survive a shell", [defaultLine, ...defaultWords]);
+  }
+  log("both pasteable commands survive the machine's own shell, placeholder included (#357)");
+
+  leakChecked.push(["the framed run", `${framed.stdout}${framed.stderr}`]);
+  leakChecked.push(["the unlabelled framed run", `${unlabelled.stdout}${unlabelled.stderr}`]);
+  for (const [what, output] of leakChecked) {
+    if (/BEGIN (CERTIFICATE|PRIVATE KEY)/.test(output)) {
+      die(`\`actana pair new\` printed certificate material on ${what}`, output.split("\n"));
+    }
+  }
   log("`actana pair new` frames the code and both redemption paths at a terminal (#357)");
+  log("neither shape of `actana pair new` leaked certificate material on either stream");
   const reprint = asOperator("actana token");
   if (reprint.status === 0) die("`actana token` still reprints something — #287 removed it");
   // Both streams: `machinectl shell` folds the session's stderr into the


### PR DESCRIPTION
## Summary

`actana pair new` had one shape for two audiences. A script wants labelled lines it can cut a field out of; the person standing at the Core wants to know what the code is *for* and what to type on the other machine, without reassembling `actana core pair` out of four separate lines by hand.

Now it has two, and **`isatty(stdout)` is the whole of the switch** — no flag, and deliberately no `--json` (#357 decided that explicitly).

**Piped, redirected or captured**, stdout is exactly what 0.4.2 printed — same lines, same order, same column. The suite asserts the whole array against a literal rather than trusting it.

**At a terminal** it is a framed handout, plus both redemption paths:

```
╭────────────────────────────────────────────────────────────────────────╮
│                                                                        │
│   Pairing code                                                         │
│                                                                        │
│      34X6-FGA8                                                         │
│                                                                        │
│   Expires        2026-08-20T12:05:00Z (in 5 minutes)                   │
│                                                                        │
│   CA fingerprint                                                       │
│      25:A0:FE:29:FA:5B:B9:58:63:78:2C:06:E7:B2:C0:DD:                  │
│      7B:8C:10:D7:E2:36:69:7B:8F:D9:31:5E:A2:01:35:B1                   │
│                                                                        │
│   Session        ffb1d774-11d4-443f-9be2-5bd9bc9486e0                  │
│   Label          laptop                                                │
│                                                                        │
╰────────────────────────────────────────────────────────────────────────╯

From the Panel
  Settings (gear icon) -> Cores -> Add Core, then enter the code above

From a terminal
  npm i -g @actana/cli

  # on the machine being paired, reachable at core (primary)
  actana core pair laptop core:8443 34X6-FGA8 --session ffb1d774-11d4-443f-9be2-5bd9bc9486e0 --fingerprint 25:A0:FE:29:…:B1

  # on the machine being paired, reachable at 10.0.0.5
  actana core pair laptop 10.0.0.5:8443 34X6-FGA8 --session ffb1d774-11d4-443f-9be2-5bd9bc9486e0 --fingerprint 25:A0:FE:29:…:B1
```

(The two fingerprints in the commands are elided **in this description only** — on screen they are whole. Colour is stripped here for the same reason.)

Notes on the shape:

- The pairing code is **bold cyan**; the fingerprint is **wrapped on its own colons and never truncated** — a fingerprint with an ellipsis in it is an invitation to guess.
- One pasteable command **per configured public host, primary first** (0.4.2 supports several addresses per Core). When `--public-host` chose one, that one is the only one offered: it is the endpoint redemption will hand this client.
- Every value in the command is real — code, `--session`, whole fingerprint, `host:port` from this install's `actana.json` (or `ACTANA_PORT` in a container, falling back to 8443). The only placeholder is `<name>`, and only when there is no `--label` or the label is not a name the client registry would take.
- Colour only at a terminal, and `NO_COLOR` turns it off without taking the instructions with it. Padding is measured on the plain text, so the frame stays square either way.

**Second half of the ticket:** the two usage strings that omitted the required `--session` flag (`core-pair.ts`'s "a name, an address and a code are required" line and `CORE_HELP`'s `Usage` block) now show it. `readTicket` refuses a bare code that does not name its pairing session, so a usage line without it sent operators to a second refusal for a flag nobody had mentioned.

**One new dep field:** `stdoutIsTty` on `ActanaCliDeps`, beside `stdinIsTty` — not a reuse of `interactive`, which is the *pair* of them and answers a different question (`pair new > code.txt` at a terminal has an interactive stdin and a redirected stdout, and it is the second half that decides). Nothing but the drawing reads it: the session minted, the digest stored and the exit code are identical either way.

## Related issues

Refs #357

<!-- Left as `Refs`, not `Closes`: this PR targets `feat/0.4.3-onboarding`, and
     the issue should close when that branch reaches the train. -->

## Type of change

- [x] ✨ New feature (non-breaking change adding functionality)
- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/E2E tests added/updated
- [x] Manually verified (describe steps below)

Added to `packages/cli/src/__tests__/actana-pair.test.ts`:

- **`actana pair new, piped`** — five tests asserting `out` **as a whole array** against the pre-change literal: labelled, unlabelled, and with `Endpoint host` in its old position between `Label` and `Session`; that a multi-address Core still prints exactly those lines; and that stdout carries no escape sequence, no box drawing and no instruction text.
- **`actana pair new, at a terminal`** — the frame carries the minted code (checked against the digest in the store), the expiry, the **whole** fingerprint (no framed line holds all of it, and the framed pieces re-join to exactly the value, with no `...` or `…` anywhere), and the session id; both instruction paths, with the Panel wording asserted against the exported constant; the pasteable command carrying `--session <the minted id>` and the full fingerprint; one command per host, primary first; only the chosen host under `--public-host`; port from `actana.json`, from `ACTANA_PORT`, and the 8443 fallback; the `<name>` placeholder when unlabelled or when the label is not a usable Core name; colour present and every framed row 74 display columns wide despite the escapes; `NO_COLOR` degrading to no escapes with every instruction intact; and that the framed run mints, stores and refuses exactly what the piped run does.
- **`wrapFingerprint`** — every group kept, the break marked with the separator, and the value re-joinable for any group size.
- Usage strings: one test each in `core-pair.test.ts` and `core-command.test.ts`.

Local: `pnpm -C packages/cli run test` (50 files, 1137 passed), `pnpm test` (all 6 stages pass), `pnpm typecheck`, `pnpm lint` (no new findings).

## Breaking changes & migration

None. The scraped stdout is unchanged by construction and by test.

## Checklist

- [x] This PR targets `feat/0.4.3-onboarding`, the 0.4.3 onboarding branch — not `main` and not the train directly
- [x] My PR title **and every commit in the branch** follow Conventional Commits
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [ ] Docs: no user-facing doc shows `pair new`'s output, so nothing needed updating; `packages/panel`'s Add Core flow is #358 and untouched here
- [x] No secrets, credentials, or personal data are included in this change
- [x] Draft: stacked on `feat/0.4.3-onboarding`, alongside #360 (`core pair`'s result surface) and #358 (Panel)
