### PR TITLE
feat(cli): frame every `actana core pair` result — one remedy per failure, the pipe unchanged

### DIFF
--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -171,9 +171,15 @@ actana core status
 - [ ] Because you are at a terminal on that machine too, the pairing **result**
       comes framed (#360): a green `✓`, the endpoint, an honest `Current` row,
       where the credential landed at mode 0600 — and under it `actana core
-      status`, `actana project ls`, `actana harness ls` and `actana session
-      start`. Run the four. They are the checkbox: a next step that does not
-      work is worse than no next step.
+      status`, `actana project ls`, `actana harness ls`, `actana session
+      start` and `actana core shell`. Run all five. They are the checkbox: a
+      next step that does not work is worse than no next step.
+- [ ] The `Sent as` row names what this machine put in the request — the
+      `--label` you passed, or its hostname. It claims nothing about the Core,
+      and it should not: `actana pair ls` **on the Core** lists the label the
+      *code* was minted with, which is a different string. Check both screens
+      and confirm the client never told you to look for a name that is not
+      there (#366 review 2).
 - [ ] Pair a **second** Core on that machine. The block says `current` is still
       the first one and offers `actana core use <name>` — it does not claim a
       `current` the pairing did not take.
@@ -185,9 +191,15 @@ actana core status
       red, and ends in `actana pair new --label <name>` plus the reminder to
       re-run with the NEW code *and* the NEW session — not prose alone.
 - [ ] Run it against a port nothing listens on. That refusal says **dial**
-      failure rather than refusal, keeps the code alive, and offers `getent
-      hosts` / `nc -vz` — a different remedy from the one above, which is the
-      whole point of the table.
+      failure rather than refusal, scopes the "your code is still good"
+      promise to *if nothing answered*, and offers `getent hosts` / `nc -vz` —
+      a different remedy from the one above, which is the whole point of the
+      table.
+- [ ] Run it with a `--fingerprint` that is wrong by one byte. The refusal is
+      framed and **the box holds**: the real SDK sentence carries two full
+      95-column fingerprints, both wrapped on their own colons and neither
+      shortened, and every border lands in the same column (#366 review 1).
+      This is the one screen an operator compares character by character.
 - [ ] `NO_COLOR=1` on any of the above: same words, same box, no escapes.
 
 ---

--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -168,6 +168,27 @@ actana core status
       --public-host <addr>` re-mint that would register the one you dialled.
       Pair on a non-primary address and confirm `core status` behaves the way
       the warning said it would.
+- [ ] Because you are at a terminal on that machine too, the pairing **result**
+      comes framed (#360): a green `✓`, the endpoint, an honest `Current` row,
+      where the credential landed at mode 0600 — and under it `actana core
+      status`, `actana project ls`, `actana harness ls` and `actana session
+      start`. Run the four. They are the checkbox: a next step that does not
+      work is worse than no next step.
+- [ ] Pair a **second** Core on that machine. The block says `current` is still
+      the first one and offers `actana core use <name>` — it does not claim a
+      `current` the pairing did not take.
+- [ ] `actana core pair … > /tmp/paired.txt 2>&1` instead gives the two plain
+      lines and nothing else — no frame, no next steps, on either stream. That
+      is the contract every script wrapping this command depends on.
+      (`rm /tmp/paired.txt` after.)
+- [ ] Run it once more with the **same, now spent** code. The refusal is framed,
+      red, and ends in `actana pair new --label <name>` plus the reminder to
+      re-run with the NEW code *and* the NEW session — not prose alone.
+- [ ] Run it against a port nothing listens on. That refusal says **dial**
+      failure rather than refusal, keeps the code alive, and offers `getent
+      hosts` / `nc -vz` — a different remedy from the one above, which is the
+      whole point of the table.
+- [ ] `NO_COLOR=1` on any of the above: same words, same box, no escapes.
 
 ---
 

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -17,6 +17,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { existsSync, statSync } from "node:fs";
 import { coreBlobPath, readCurrentCore } from "../blob-registry.ts";
+import { displayWidth, FRAME_WIDTH } from "../cli-frame.ts";
+import { corePairingOutcome } from "../core-pair-results.ts";
 import { resolveCore } from "../core-resolution.ts";
 import { CorePairingError, type CorePairingFailure } from "@actana/sdk/core-pairing.ts";
 import {
@@ -508,5 +510,455 @@ describe("actana core pair — what it says", () => {
     const run = await cli().run(["core", "wat"]);
     expect(run.code).toBe(EXIT_USAGE);
     expect(run.err.join("\n")).toContain("Verbs: pair, ls");
+  });
+});
+
+// ─── the two shapes (#360) ──────────────────────────────────────────────────
+//
+// One command, two audiences — the client half of the split #357 made on the
+// Core. Down a pipe `core pair` is the lines 0.4.2 printed and nothing else; at
+// a terminal it is a framed result that says what just happened and what to
+// type next. The switch is `isatty(stdout)` and nothing else, so the two things
+// this suite has to hold are that the piped shape did not move a byte, and that
+// the framed one carries a concrete remedy for every class of failure rather
+// than the prose that sent an operator to the help.
+
+/** The escape byte, built rather than typed, so no raw control byte is in this file. */
+const ESC = String.fromCharCode(0x1b);
+const GREEN = `${ESC}[32m`;
+const RED = `${ESC}[31m`;
+
+/** The three arguments for a second Core, so the pointer has something to keep. */
+function sparePairArgv(): string[] {
+  return [
+    "core",
+    "pair",
+    "spare",
+    "core.test:8443",
+    CODE,
+    "--session",
+    SESSION,
+    "--fingerprint",
+    PAIRED_FINGERPRINT,
+  ];
+}
+
+/** Every failure the SDK distinguishes and that a fake Core can be told to raise. */
+const SDK_FAILURES: CorePairingFailure[] = [
+  "bad-address",
+  "unreachable",
+  "not-pairable",
+  "no-ca-presented",
+  "fingerprint-mismatch",
+  "hostname-mismatch",
+  "certificate-invalid",
+  "refused",
+  "rate-limited",
+  "rejected",
+  "core-error",
+  "malformed-response",
+];
+
+describe("actana core pair, piped", () => {
+  it("prints the two success lines byte for byte, in the order 0.4.2 printed them", async () => {
+    const run = await cli().run(pairArgv(), { pairing: fakePairing() });
+
+    expect(run.code).toBe(EXIT_OK);
+    // Whole, in order — not `toContain`. A framed block that leaked into the
+    // piped path, an extra blank line, a reworded pointer note or a fourth line
+    // would each fail here, and each of them breaks a script.
+    expect(run.out).toEqual([
+      'Paired Core "prod" → wss://core.test:8443',
+      '`current` now points at "prod".',
+    ]);
+    expect(run.err).toEqual([]);
+  });
+
+  it("keeps the second-Core shape, which names the pointer it did not move", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    const second = await cli().run(sparePairArgv(), { pairing: fakePairing() });
+
+    expect(second.out).toEqual([
+      'Paired Core "spare" → wss://core.test:8443',
+      '`current` is still "prod" — `actana core use spare` to switch.',
+    ]);
+  });
+
+  it("keeps the re-pair shape, which is one line and no pointer note at all", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    const again = await cli().run(pairArgv(), { pairing: fakePairing() });
+
+    // `current` already names this Core, so 0.4.2 said nothing about it. The
+    // framed block *does* have a row for it, and this is the assertion that
+    // keeps that row from leaking down here.
+    expect(again.out).toEqual(['Replaced Core "prod" → wss://core.test:8443']);
+  });
+
+  it("writes no escape sequence, no box drawing and no next steps", async () => {
+    const run = await cli().run(pairArgv(), { pairing: fakePairing() });
+    const printed = [...run.out, ...run.err].join("\n");
+
+    expect(printed).not.toMatch(/\x1b\[/);
+    for (const ornament of ["╭", "╰", "│", "─", "✓", "✗"]) expect(printed).not.toContain(ornament);
+    expect(printed).not.toContain("Next steps");
+    expect(printed).not.toContain("actana core status");
+  });
+
+  it("gives every SDK failure exactly the two lines it gave in 0.4.2", async () => {
+    for (const failure of SDK_FAILURES) {
+      const run = await cli().run(pairArgv(), { pairing: fakePairing({ fails: failure }) });
+      // Two lines: the SDK's sentence, then the one-line next step. Exactly two
+      // — the remedy the frame adds is three or four more, and none of them may
+      // appear here.
+      expect(run.err, `${failure} did not print the 0.4.2 pair of lines`).toEqual([
+        `actana core pair: the fake Core answered ${failure}`,
+        corePairingOutcome(failure).next,
+      ]);
+      expect(run.out).toEqual([]);
+    }
+  });
+
+  it("pins two of those next-step lines by value, not by the table that writes them", async () => {
+    // The table is the code under test, so a suite that only compared against
+    // it would pass on a rewrite of every line in it. Two spelled out: the
+    // class an operator hits most, and the one that matters most.
+    const refused = await cli().run(pairArgv(), { pairing: fakePairing({ fails: "refused" }) });
+    expect(refused.err[1]).toBe(
+      "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
+    );
+
+    const mismatch = await cli().run(pairArgv(), { pairing: fakePairing({ fails: "fingerprint-mismatch" }) });
+    expect(mismatch.err[1]).toBe(
+      "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
+        "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
+    );
+  });
+
+  it("gives every refusal this file words itself exactly the lines it gave in 0.4.2", async () => {
+    const missing = await cli().run(["core", "pair", "prod"], { pairing: fakePairing() });
+    expect(missing.err).toEqual([
+      "actana core pair: a name, an address and a code are required.",
+      "  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+      "`actana pair new` on the Core prints the code, the fingerprint and the session.",
+    ]);
+
+    const extra = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(extra.err).toEqual([
+      "actana core pair: too many arguments — expected <name> <address> <code>.",
+    ]);
+
+    const badName = await cli().run(
+      ["core", "pair", "bad name", "core.test:8443", CODE, "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(badName.err).toEqual([
+      "actana core pair: a Core name starts with a letter or digit and holds only letters, digits, dot, dash and underscore.",
+    ]);
+
+    const noSession = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(noSession.err).toEqual([
+      "actana core pair: a pairing code names the pairing session it belongs to.",
+      "Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.",
+    ]);
+
+    const disagree = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(disagree.err).toEqual([
+      "actana core pair: the code names one pairing session and `--session` names another.",
+      "Drop `--session`, or pass the bare code beside it — they have to agree.",
+    ]);
+
+    const shape = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", "no", "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(shape.err).toEqual([
+      "actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.",
+      "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
+    ]);
+  });
+
+  it("is the same piped shape with NO_COLOR set as without it", async () => {
+    const plain = await cli().run(pairArgv(), { pairing: fakePairing() });
+    cli().cleanup();
+    fixture = null;
+    const noColor = await cli().run(pairArgv(), { pairing: fakePairing(), env: { NO_COLOR: "1" } });
+    expect(noColor.out).toEqual(plain.out);
+  });
+});
+
+describe("actana core pair, at a terminal", () => {
+  /** The framed lines of a run — the ones the border is drawn on. */
+  function framed(lines: string[]): string[] {
+    return lines.filter((line) => /^[╭│╰]/.test(line));
+  }
+
+  /**
+   * Everything a run said, as one line of prose.
+   *
+   * The escapes come off and every run of whitespace becomes one space, so a
+   * sentence can be asserted as the sentence it is rather than as the shape a
+   * 74-column wrap happened to give it. Asserting the wrap instead would make
+   * every one of these tests fail on a reworded neighbour.
+   */
+  function prose(lines: string[]): string {
+    return lines
+      .join(" ")
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      // The border too: a sentence wrapped across two framed rows has a bar,
+      // two runs of padding and a gutter in the middle of it.
+      .replace(/[│╭╮╰╯─]/g, " ")
+      .replace(/\s+/g, " ");
+  }
+
+  it("frames the success, marks it green, and names the Core and its endpoint", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = run.out.join("\n");
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(screen).toContain("╭");
+    expect(screen).toContain("╰");
+    expect(screen).toContain('Paired Core "prod"');
+    expect(screen).toContain("wss://core.test:8443");
+    // Green, and only on the marker — nothing on a success is red.
+    expect(screen).toContain(`${GREEN}✓`);
+    expect(screen).not.toContain(RED);
+  });
+
+  it("claims `current` only for a Core that actually became current", async () => {
+    const first = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    expect(first.out.join("\n")).toContain('"prod" — every later verb talks to this Core');
+
+    // The second pairing does not move the pointer, and the block has to say so
+    // rather than congratulating an operator on a `current` they do not have.
+    const second = await cli().run(sparePairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = second.out.join("\n");
+    expect(readCurrentCore(cli().paths)).toBe("prod");
+    expect(screen).toContain('still "prod" — this pairing did not change it');
+    expect(screen).not.toContain("every later verb talks to this Core");
+    // And the first thing it offers is the command that fixes it.
+    expect(screen).toContain("actana core use spare");
+  });
+
+  it("offers `core use` only when there is a pointer to move", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    expect(run.out.join("\n")).not.toContain("actana core use prod");
+  });
+
+  it("ends in the four verbs a freshly paired Core exists for", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = run.out.join("\n");
+
+    expect(screen).toContain("Next steps");
+    for (const verb of [
+      "actana core status",
+      "actana project ls",
+      "actana harness ls",
+      "actana session start <project>",
+    ]) {
+      expect(screen, `the success block does not teach ${verb}`).toContain(verb);
+    }
+    // In that order: verify, then look around, then do something.
+    expect(screen.indexOf("actana core status")).toBeLessThan(screen.indexOf("actana project ls"));
+    expect(screen.indexOf("actana project ls")).toBeLessThan(screen.indexOf("actana harness ls"));
+    expect(screen.indexOf("actana harness ls")).toBeLessThan(screen.indexOf("actana session start"));
+    // And the Panel, which is the other thing to pair with the same Core.
+    expect(screen).toContain("Settings -> Cores");
+  });
+
+  it("says where the credential landed and at what mode, and never what is in it", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+
+    const inFrame = run.out
+      .map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""))
+      .filter((line) => line.startsWith("│"))
+      .map((line) => line.replace(/^│\s*/, "").replace(/\s*│$/, ""))
+      .join("");
+    expect(inFrame).toContain(coreBlobPath(cli().paths, "prod"));
+    expect(prose(run.out)).toContain("(mode 0600)");
+    for (const secret of SENTINELS) expect(run.all).not.toContain(secret);
+  });
+
+  it("frames every failure class, each with a marker and something to type", async () => {
+    for (const failure of SDK_FAILURES) {
+      const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing({ fails: failure }) });
+      const screen = run.err.join("\n");
+
+      expect(run.code, `${failure} exited ${run.code}`).toBe(corePairingOutcome(failure).exit);
+      expect(screen, `${failure} was not framed`).toContain("╭");
+      expect(screen, `${failure} carried no red marker`).toContain(`${RED}✗`);
+      expect(screen, `${failure} offered no remedy section`).toContain("What to do");
+      // The acceptance criterion in full: every class ends with a copyable
+      // command, not only an explanation. A command line is the one that is
+      // indented two and carries no escape — the notes under it are dim.
+      const commands = run.err.filter((line) => /^ {2}\S/.test(line) && !line.startsWith(ESC));
+      expect(commands.length, `${failure} ended with an explanation and nothing to type`).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives no two failure classes the same remedy", async () => {
+    // The point of the table: "ask for a fresh code" and "check the port is
+    // open" are answers to different problems, and a surface that gave both to
+    // both would be the prose it replaced.
+    const seen = new Map<string, string>();
+    for (const failure of SDK_FAILURES) {
+      const remedy = corePairingOutcome(failure)
+        .steps.map((step) => `${step.command ?? ""}|${step.note}`)
+        .join("\n");
+      expect(seen.has(remedy), `${failure} repeats ${seen.get(remedy)}'s remedy`).toBe(false);
+      seen.set(remedy, failure);
+    }
+  });
+
+  it("tells an expired or unknown code how to mint a fresh one, and to re-run with it", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing({ fails: "refused" }) });
+    const screen = run.err.join("\n");
+
+    expect(screen).toContain("actana pair new --label <name>");
+    const said = prose(run.err);
+    expect(said).toContain("expired, already spent, never issued, or out of attempts");
+    // The mistake this exists to stop: a new code with yesterday's session.
+    expect(said).toContain("NEW code");
+    expect(said).toContain("NEW --session");
+    expect(said).toContain("the old session will not redeem the new code");
+  });
+
+  it("explains the fingerprint comparison and warns against going round it", async () => {
+    const run = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "fingerprint-mismatch" }),
+    });
+    const screen = run.err.join("\n");
+
+    const said = prose(run.err);
+    expect(said).toContain("compared against the one you gave, and the two differ");
+    expect(said).toContain("The code was not sent");
+    expect(said).toContain("no flag that skips the comparison");
+    expect(said).toContain("somebody sitting between you and the right one");
+    expect(screen).toContain("actana pair new --label <name>");
+  });
+
+  it("separates a dial failure from a refusal, and says what to check", async () => {
+    const unreachable = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "unreachable" }),
+    });
+    const dial = prose(unreachable.err);
+    expect(dial).toContain("a dial failure, not a refusal");
+    expect(dial).toContain("no attempt was spent");
+    expect(dial).toContain("getent hosts <host>");
+    expect(dial).toContain("nc -vz <host> <port>");
+    expect(dial).toContain("HTTPS_PROXY");
+    // Nothing about minting a fresh code: the code in the operator's hand is
+    // still good, and sending them back to the Core would waste the trip.
+    expect(dial).not.toContain("actana pair new");
+
+    const answered = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "not-pairable" }),
+    });
+    const stillWrong = prose(answered.err);
+    expect(stillWrong).toContain("The dial worked");
+    expect(stillWrong).toContain("actana update");
+    expect(stillWrong).not.toContain("getent hosts");
+  });
+
+  it("points a bare code at both the flag and the joined form the usage line shows", async () => {
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+      { stdoutIsTty: true, pairing: fakePairing() },
+    );
+    const screen = run.err.join("\n");
+
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(screen).toContain(
+      "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+    );
+    expect(screen).toContain(
+      "actana core pair <name> <host:port> <session>:<code> --fingerprint <sha256>",
+    );
+    expect(prose(run.err)).toContain("prints the session id on its own line");
+  });
+
+  it("wraps a credential path too long for the frame instead of overflowing it", async () => {
+    // A deep home directory is ordinary, and the row that reassures an
+    // operator their credential exists is the row most likely to be long.
+    const deep = "d".repeat(30);
+    const run = await cli().run(
+      ["core", "pair", deep, "core.test:8443", CODE, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } },
+    );
+
+    for (const line of framed(run.out)) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    const inFrame = framed(run.out)
+      .map((line) => line.replace(/^│\s*/, "").replace(/\s*│$/, ""))
+      .join("");
+    // Wrapped, never shortened: the whole path is still there.
+    expect(inFrame).toContain(coreBlobPath(cli().paths, deep));
+  });
+
+  it("keeps every framed line exactly the frame's width", async () => {
+    // Measured under NO_COLOR, because `displayWidth` counts columns and an
+    // escape sequence has none — the padding is computed on the plain text and
+    // this is the assertion that says so.
+    const runs = [
+      await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } }),
+      await cli().run(pairArgv(), {
+        stdoutIsTty: true,
+        pairing: fakePairing({ fails: "refused" }),
+        env: { NO_COLOR: "1" },
+      }),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+        { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } },
+      ),
+    ];
+    for (const run of runs) {
+      const lines = framed([...run.out, ...run.err]);
+      expect(lines.length).toBeGreaterThan(3);
+      for (const line of lines) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    }
+  });
+
+  it("degrades to no escapes under NO_COLOR, keeping every instruction", async () => {
+    const coloured = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    // Back to nothing registered, so the second run is the same first pairing
+    // in the same fixture — same credential path, same `current` sentence, and
+    // a comparison that is about the escapes and nothing else.
+    await cli().run(["core", "rm", "prod"]);
+    const plain = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing(),
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(coloured.out.join("\n")).toMatch(/\x1b\[/);
+    expect(plain.out.join("\n")).not.toMatch(/\x1b\[/);
+    // Same block, same words, same commands — only the escapes are gone.
+    expect(plain.out).toEqual(coloured.out.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "")));
+    // And the padding was computed on the plain text: strip the escapes off
+    // the coloured run and its borders still land in the same column. That is
+    // the property a frame padded by `String.length` would fail.
+    for (const line of framed(coloured.out)) {
+      expect(displayWidth(line.replace(/\x1b\[[0-9;]*m/g, ""))).toBe(FRAME_WIDTH);
+    }
+  });
+
+  it("never prints the pairing code, framed or not", async () => {
+    for (const stdoutIsTty of [true, false]) {
+      cli().cleanup();
+      fixture = null;
+      const run = await cli().run(pairArgv(), { stdoutIsTty, pairing: fakePairing() });
+      expect(run.all, "the pairing code reached an output sink").not.toContain(CODE);
+      expect(run.all.toUpperCase(), "the pairing code reached an output sink").not.toContain("ABCD");
+    }
   });
 });

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -774,6 +774,28 @@ describe("actana core pair, at a terminal", () => {
     expect(screen).toContain("Settings -> Cores");
   });
 
+  it("names this machine as the Core will list it, from --label or the hostname", async () => {
+    // The one row about the far end. It is the name an operator looks for in
+    // `actana pair ls` on the Core when they come to revoke this client, and a
+    // certificate serial is not a name anybody recognises.
+    const labelled = await cli().run(pairArgv(["--label", "ada-laptop"]), {
+      stdoutIsTty: true,
+      pairing: fakePairing(),
+    });
+    expect(prose(labelled.out)).toContain("Label ada-laptop — this machine, in the Core's `pair ls`");
+
+    // With no --label the hostname is the honest default, and it is the value
+    // that was actually sent — not something this block made up to fill a row.
+    const pairing = fakePairing();
+    const bare = await cli().run(pairArgv(), { stdoutIsTty: true, pairing });
+    expect(pairing.paired[0]?.label).toBeTruthy();
+    expect(prose(bare.out)).toContain(`Label ${pairing.paired[0]?.label} —`);
+
+    // And nothing about it reaches the piped shape.
+    const piped = await cli().run(pairArgv(["--label", "ada-laptop"]), { pairing: fakePairing() });
+    expect(piped.out.join("\n")).not.toContain("ada-laptop");
+  });
+
   it("says where the credential landed and at what mode, and never what is in it", async () => {
     const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
 

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -18,7 +18,8 @@ import { describe, it, expect, afterEach } from "vitest";
 import { existsSync, statSync } from "node:fs";
 import { coreBlobPath, readCurrentCore } from "../blob-registry.ts";
 import { displayWidth, FRAME_WIDTH } from "../cli-frame.ts";
-import { corePairingOutcome } from "../core-pair-results.ts";
+import { corePairingOutcome, corePairSuccessBlock } from "../core-pair-results.ts";
+import { wrapText } from "../cli-frame.ts";
 import { resolveCore } from "../core-resolution.ts";
 import { CorePairingError, type CorePairingFailure } from "@actana/sdk/core-pairing.ts";
 import {
@@ -546,6 +547,15 @@ function sparePairArgv(): string[] {
 /** Every failure the SDK distinguishes and that a fake Core can be told to raise. */
 const SDK_FAILURES: CorePairingFailure[] = [
   "bad-address",
+  // Both added after #366 review 8. `fingerprint-unconfirmed` the fake has
+  // always been able to raise — the older table below proves it — and
+  // `bad-fingerprint` had never been covered by any list at all, so neither
+  // sat inside the byte-identity loop, the something-to-type loop or the
+  // distinct-remedy check. `bad-code` stays out on purpose: it is intercepted
+  // before the SDK's message can quote the code, so its first line is this
+  // package's own and the loop's literal would not describe it.
+  "bad-fingerprint",
+  "fingerprint-unconfirmed",
   "unreachable",
   "not-pairable",
   "no-ca-presented",
@@ -763,6 +773,9 @@ describe("actana core pair, at a terminal", () => {
       "actana project ls",
       "actana harness ls",
       "actana session start <project>",
+      // #360 names this beside `session start`, and #366 review 4 caught it
+      // missing.
+      "actana core shell",
     ]) {
       expect(screen, `the success block does not teach ${verb}`).toContain(verb);
     }
@@ -770,26 +783,32 @@ describe("actana core pair, at a terminal", () => {
     expect(screen.indexOf("actana core status")).toBeLessThan(screen.indexOf("actana project ls"));
     expect(screen.indexOf("actana project ls")).toBeLessThan(screen.indexOf("actana harness ls"));
     expect(screen.indexOf("actana harness ls")).toBeLessThan(screen.indexOf("actana session start"));
+    expect(screen.indexOf("actana session start")).toBeLessThan(screen.indexOf("actana core shell"));
     // And the Panel, which is the other thing to pair with the same Core.
     expect(screen).toContain("Settings -> Cores");
   });
 
-  it("names this machine as the Core will list it, from --label or the hostname", async () => {
-    // The one row about the far end. It is the name an operator looks for in
-    // `actana pair ls` on the Core when they come to revoke this client, and a
-    // certificate serial is not a name anybody recognises.
+  it("reports the name it sent as a local fact, claiming nothing about the Core", async () => {
+    // #366 review 2. The row used to say this name was "this machine, in the
+    // Core's `pair ls`", and that is false — the Core stores the *session*
+    // label there. So the row now states only what is true on this side, and
+    // this test pins the absence of the claim as hard as the presence of the
+    // value: a reworded row that quietly grew the claim back would fail here.
     const labelled = await cli().run(pairArgv(["--label", "ada-laptop"]), {
       stdoutIsTty: true,
       pairing: fakePairing(),
     });
-    expect(prose(labelled.out)).toContain("Label ada-laptop — this machine, in the Core's `pair ls`");
+    const said = prose(labelled.out);
+    expect(said).toContain("Sent as ada-laptop — the name this machine gave");
+    expect(said).not.toContain("pair ls");
+    expect(said).not.toContain("revoke");
 
-    // With no --label the hostname is the honest default, and it is the value
-    // that was actually sent — not something this block made up to fill a row.
+    // The value is the one that actually crossed the seam, not one this block
+    // made up to fill a row — asserted against what the SDK was handed.
     const pairing = fakePairing();
     const bare = await cli().run(pairArgv(), { stdoutIsTty: true, pairing });
     expect(pairing.paired[0]?.label).toBeTruthy();
-    expect(prose(bare.out)).toContain(`Label ${pairing.paired[0]?.label} —`);
+    expect(prose(bare.out)).toContain(`Sent as ${pairing.paired[0]?.label} —`);
 
     // And nothing about it reaches the piped shape.
     const piped = await cli().run(pairArgv(["--label", "ada-laptop"]), { pairing: fakePairing() });
@@ -875,7 +894,14 @@ describe("actana core pair, at a terminal", () => {
     });
     const dial = prose(unreachable.err);
     expect(dial).toContain("a dial failure, not a refusal");
-    expect(dial).toContain("no attempt was spent");
+    // #366 review 3: the guarantee is conditional, because this class also
+    // covers a drop *after* the code went out — one timer spans the whole
+    // exchange, the Core's signing included. An unconditional "your code is
+    // still good" here costs the operator a second trip.
+    expect(dial).toContain("If nothing answered, nothing was sent");
+    expect(dial).toContain("the connection dropped part-way through");
+    expect(dial).toContain("mint a fresh one");
+    expect(dial).not.toContain("the code was never sent, no attempt was spent");
     expect(dial).toContain("getent hosts <host>");
     expect(dial).toContain("nc -vz <host> <port>");
     expect(dial).toContain("HTTPS_PROXY");
@@ -925,6 +951,87 @@ describe("actana core pair, at a terminal", () => {
       .join("");
     // Wrapped, never shortened: the whole path is still there.
     expect(inFrame).toContain(coreBlobPath(cli().paths, deep));
+  });
+
+  // #366 review 1. The old width test only ever rendered `the fake Core
+  // answered <failure>` — a headline far too short to break anything — so it
+  // looked like it covered the frame and did not. The SDK's real
+  // `fingerprint-mismatch` sentence carries **two** 95-column colon-hex
+  // fingerprints with no space and no slash in them, and that is the one class
+  // on this screen whose whole subject is a value compared character by
+  // character. Built here to the SDK's own format rather than imported, so a
+  // change to that format shows up as a diff a reader has to look at.
+  function sdkFingerprintMismatch(): CorePairingError {
+    const presented = PAIRED_FINGERPRINT;
+    const expected = PAIRED_FINGERPRINT.split(":").reverse().join(":");
+    return new CorePairingError(
+      "fingerprint-mismatch",
+      `https://core.test:8443 presented a certificate authority with fingerprint ${presented}, ` +
+        `but ${expected} was expected — the pairing code was not sent`,
+    );
+  }
+
+  it("holds the frame around the SDK's real fingerprint-mismatch sentence", async () => {
+    const err = sdkFingerprintMismatch();
+    const run = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ failsWith: err }),
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(run.code).toBe(EXIT_PAIR_FINGERPRINT_MISMATCH);
+    const lines = framed(run.err);
+    expect(lines.length).toBeGreaterThan(3);
+    for (const line of lines) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+
+    // Wrapped, never shortened — and this is the class where that matters most:
+    // an operator is being asked to compare these two values by eye, and a
+    // fingerprint with an ellipsis in it is an invitation to guess.
+    const said = prose(run.err).replace(/ /g, "");
+    expect(said).toContain(PAIRED_FINGERPRINT.replace(/ /g, ""));
+    expect(said).toContain(PAIRED_FINGERPRINT.split(":").reverse().join(":"));
+    expect(said).not.toContain("…");
+  });
+
+  it("holds the frame around every refusal this file words itself", async () => {
+    // #366 review 9: five of these were never rendered by any test, so the
+    // width invariant was unproven for exactly the blocks whose step lists this
+    // PR wrote from scratch.
+    const tty = { stdoutIsTty: true, env: { NO_COLOR: "1" } } as const;
+    const runs = [
+      await cli().run(["core", "pair", "prod"], { ...tty, pairing: fakePairing() }),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "bad name", "core.test:8443", CODE, "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", "no", "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(pairArgv(), {
+        ...tty,
+        pairing: fakePairing({ failsWith: new TypeError("cannot read properties of undefined") }),
+      }),
+    ];
+
+    for (const [index, run] of runs.entries()) {
+      const lines = framed(run.err);
+      expect(lines.length, `refusal ${index} was not framed`).toBeGreaterThan(3);
+      for (const line of lines) {
+        expect(displayWidth(line), `refusal ${index}: "${line}"`).toBe(FRAME_WIDTH);
+      }
+      // And each still ends in something to type.
+      const commands = run.err.filter((line) => /^ {2}\S/.test(line));
+      expect(commands.length, `refusal ${index} had nothing to type`).toBeGreaterThan(0);
+    }
   });
 
   it("keeps every framed line exactly the frame's width", async () => {
@@ -981,6 +1088,112 @@ describe("actana core pair, at a terminal", () => {
       const run = await cli().run(pairArgv(), { stdoutIsTty, pairing: fakePairing() });
       expect(run.all, "the pairing code reached an output sink").not.toContain(CODE);
       expect(run.all.toUpperCase(), "the pairing code reached an output sink").not.toContain("ABCD");
+    }
+  });
+});
+
+// ─── the pure renderers, called directly (#366 review 7) ───────────────────
+//
+// Two properties that `runCorePair` cannot reach. Both modules are pure —
+// values in, lines out — so calling them is the whole of the setup, and a
+// branch nothing exercises is a branch nobody knows the shape of.
+
+describe("corePairSuccessBlock, directly", () => {
+  /** A block with every field filled, so a test can vary exactly one. */
+  function block(over: Partial<Parameters<typeof corePairSuccessBlock>[0]> = {}): string[] {
+    return corePairSuccessBlock({
+      name: "prod",
+      endpoint: "wss://core.test:8443",
+      replaced: false,
+      label: "bkp-07",
+      current: "prod",
+      credentialPath: "/home/ada/.config/actana/cores/prod.txt",
+      color: false,
+      ...over,
+    });
+  }
+
+  it("says nothing is selected when the pointer is gone, rather than naming one", () => {
+    // Unreachable through the verb: `runCorePair` writes the pointer when
+    // nothing holds it and then reads it back. It is reachable in the world —
+    // a concurrent `actana core rm` between those two lines — and the honest
+    // answer is that nothing is selected, not a name that is not there.
+    const said = block({ current: null }).join("\n");
+
+    expect(said).toContain("nothing is selected yet");
+    expect(said).not.toContain("every later verb talks to this Core");
+    // And it offers the command that fixes it, because it is not current.
+    expect(said).toContain("actana core use prod");
+  });
+
+  it("keeps the frame at width for all three pointer states", () => {
+    for (const current of ["prod", "other", null]) {
+      for (const line of block({ current }).filter((one) => /^[╭│╰]/.test(one))) {
+        expect(displayWidth(line), `current=${current}: "${line}"`).toBe(FRAME_WIDTH);
+      }
+    }
+  });
+});
+
+describe("wrapText, on the values a frame actually holds", () => {
+  /** Every wrap is lossless: the pieces put back together are the input. */
+  function rejoined(text: string, columns: number): string {
+    return wrapText(text, columns).join("").replace(/ /g, "");
+  }
+
+  it("breaks colon-hex on its colons, and loses nothing", () => {
+    const fingerprint = PAIRED_FINGERPRINT;
+    const lines = wrapText(fingerprint, 40);
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(40);
+    // Every line but the last ends on the separator, which is what tells a
+    // reader the value continues.
+    for (const line of lines.slice(0, -1)) expect(line.endsWith(":")).toBe(true);
+    expect(lines.join("")).toBe(fingerprint);
+  });
+
+  it("breaks a path on its slashes, and loses nothing", () => {
+    const path = "/home/ada.mcdonald/.config/actana/cores/a-rather-long-core-name.txt";
+    const lines = wrapText(path, 30);
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(30);
+    expect(lines.join("")).toBe(path);
+  });
+
+  it("breaks a URL on either separator", () => {
+    const url = "https://a-very-long-host-name.example.invalid:8443/v1/pairing/redeem";
+    expect(rejoined(url, 24)).toBe(url);
+    for (const line of wrapText(url, 24)) expect(displayWidth(line)).toBeLessThanOrEqual(24);
+  });
+
+  it("leaves a word with neither separator whole and over-long, never cut", () => {
+    // The residual, pinned so it stays a decision rather than a surprise: there
+    // is nowhere left to break that would not put a line ending inside a name,
+    // and a ragged border is a cheaper failure than a value that cannot be
+    // trusted. Documented on `wrapText` in exactly these terms.
+    const unbreakable = "z".repeat(90);
+    const lines = wrapText(`before ${unbreakable} after`, 40);
+
+    expect(lines).toContain(unbreakable);
+    expect(lines.join(" ")).toContain(unbreakable);
+    expect(lines.join("")).not.toContain("…");
+  });
+
+  it("never drops a character, whatever it is handed", () => {
+    for (const text of [
+      PAIRED_FINGERPRINT,
+      "/a/b/c/d/e/f/g/h",
+      "wss://core.test:8443",
+      "a b c",
+      "",
+      "::::",
+      "////",
+    ]) {
+      expect(rejoined(text, 8), `wrapText dropped part of ${JSON.stringify(text)}`).toBe(
+        text.replace(/ /g, ""),
+      );
     }
   });
 });

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -98,7 +98,6 @@ import {
   FRAME_WIDTH,
   style,
   useColor,
-  type Span,
 } from "./cli-frame.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -88,9 +88,28 @@ import {
   type PairingAuditSink,
 } from "@actana/shared/pairing-audit";
 import { readActanaConfig } from "./actana-config.ts";
+import {
+  ANSI,
+  clip,
+  displayWidth,
+  frameEdge,
+  frameRow,
+  FRAME_GUTTER,
+  FRAME_WIDTH,
+  style,
+  useColor,
+  type Span,
+} from "./cli-frame.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
+
+// The frame's own vocabulary, re-exported because it is part of what this
+// module prints and `actana-pair.test.ts` measures the handout with it. The
+// definitions moved to `cli-frame.ts` when `actana core pair` grew a frame of
+// its own (#360) — there is one border width in this program, not two.
+export { displayWidth, FRAME_WIDTH } from "./cli-frame.ts";
+
 
 export const PAIR_HELP = `actana pair — enroll a client on THIS machine's Core
 
@@ -462,37 +481,6 @@ function chooseEndpointHost(
 // assert on the frame without a terminal, and what keeps the decision to draw
 // one in exactly one `if`.
 
-/** The escape sequences the frame uses, and the only ANSI in this file. */
-const ANSI = {
-  reset: "\u001b[0m",
-  bold: "\u001b[1m",
-  dim: "\u001b[2m",
-  /** The pairing code itself, which is the one thing on the screen that matters. */
-  boldCyan: "\u001b[1;36m",
-} as const;
-
-/**
- * Whether to colour, given a terminal.
- *
- * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
- * (https://no-color.org). Honouring it costs one clause and means an operator
- * whose terminal renders escapes badly still gets the instructions, rather than
- * having to choose between colour and a pipe.
- */
-function useColor(deps: ActanaCliDeps): boolean {
-  const noColor = deps.env.NO_COLOR;
-  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
-}
-
-/** The frame's total width, borders included. Fixed, so the output is one shape. */
-export const FRAME_WIDTH = 74;
-
-/** How far in from the left border the content starts. */
-const FRAME_GUTTER = 3;
-
-/** One run of styled text inside a framed line. */
-type Span = { text: string; style?: string };
-
 /**
  * Every fact the handout renders. Times arrive as epoch ms and the clock does
  * not: `now` is passed in, because this file reads the clock in exactly one
@@ -754,108 +742,6 @@ export function wrapFingerprint(fingerprint: string, groupsPerLine = 16): string
     lines.push(groups.slice(i, i + perLine).join(":") + (last ? "" : ":"));
   }
   return lines;
-}
-
-/** The top or bottom rule. */
-function frameEdge(which: "top" | "bottom", color: boolean): string {
-  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
-  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
-}
-
-/**
- * One line between the two borders.
- *
- * The padding is measured on the **plain** text and the styling applied
- * afterwards, because an escape sequence has a length and no width — pad a
- * coloured string by `String.length` and the right border walks off by however
- * many bytes the colour cost.
- */
-function frameRow(spans: Span[], color: boolean): string {
-  const plain = spans.map((span) => span.text).join("");
-  const body = spans.map((span) => style(span.text, span.style, color)).join("");
-  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
-  const bar = style("│", ANSI.dim, color);
-  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
-}
-
-/**
- * How many terminal columns `text` occupies.
- *
- * `String.length` is UTF-16 code units and a frame padded by it is crooked for
- * anybody whose label is not Latin: `笔记本` is three code units and six
- * columns, so the right border lands three early (#357 review N1). Counted per
- * code point — a surrogate pair is one character, not two — with the wide
- * ranges at two and the zero-width ones at nothing.
- *
- * Deliberately not a full `wcwidth`. This measures the four things that reach
- * a frame row: ASCII, an operator's label, a UUID and colon-hex. Emoji with
- * joiners and skin tones can still measure a column off, and the cost of that
- * is a ragged border on one line — not a truncated fingerprint, which is the
- * thing this file may never do.
- */
-export function displayWidth(text: string): number {
-  let width = 0;
-  for (const character of text) {
-    const point = character.codePointAt(0) ?? 0;
-    if (isZeroWidth(point)) continue;
-    width += isWide(point) ? 2 : 1;
-  }
-  return width;
-}
-
-/** Combining marks and variation selectors: they attach, they take no column. */
-function isZeroWidth(point: number): boolean {
-  return (
-    (point >= 0x0300 && point <= 0x036f) ||
-    (point >= 0x200b && point <= 0x200f) ||
-    (point >= 0xfe00 && point <= 0xfe0f) ||
-    point === 0x2060 ||
-    point === 0xfeff
-  );
-}
-
-/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
-function isWide(point: number): boolean {
-  return (
-    (point >= 0x1100 && point <= 0x115f) ||
-    (point >= 0x2e80 && point <= 0xa4cf) ||
-    (point >= 0xac00 && point <= 0xd7a3) ||
-    (point >= 0xf900 && point <= 0xfaff) ||
-    (point >= 0xfe30 && point <= 0xfe6f) ||
-    (point >= 0xff00 && point <= 0xff60) ||
-    (point >= 0xffe0 && point <= 0xffe6) ||
-    (point >= 0x1f300 && point <= 0x1f64f) ||
-    (point >= 0x1f900 && point <= 0x1f9ff) ||
-    (point >= 0x20000 && point <= 0x3fffd)
-  );
-}
-
-/**
- * `text` shortened to `columns` display columns, marked when it was shortened.
- *
- * **Only ever called on the label.** Truncation is a lie about a value, and
- * there is exactly one value in this block cheap enough to tell it about: a
- * label is a name the operator chose and can read back off `pair ls`. The
- * fingerprint wraps instead — see {@link wrapFingerprint} — and nothing routes
- * it through here.
- */
-function clip(text: string, columns: number): string {
-  if (displayWidth(text) <= columns) return text;
-  let kept = "";
-  let width = 0;
-  for (const character of text) {
-    const next = width + displayWidth(character);
-    // One column held back for the marker, which is one column wide.
-    if (next > columns - 1) break;
-    kept += character;
-    width = next;
-  }
-  return `${kept}…`;
-}
-
-/** Wrap `text` in an escape sequence, or hand it back untouched. */
-function style(text: string, code: string | undefined, color: boolean): string {
-  return color && code ? `${code}${text}${ANSI.reset}` : text;
 }
 
 /**

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -93,9 +93,9 @@ import {
   clip,
   displayWidth,
   frameEdge,
+  FRAME_CONTENT_WIDTH,
+  FRAME_HEADING,
   frameRow,
-  FRAME_GUTTER,
-  FRAME_WIDTH,
   style,
   useColor,
 } from "./cli-frame.ts";
@@ -108,7 +108,6 @@ import type { ActanaCliDeps } from "./cli-deps.ts";
 // definitions moved to `cli-frame.ts` when `actana core pair` grew a frame of
 // its own (#360) — there is one border width in this program, not two.
 export { displayWidth, FRAME_WIDTH } from "./cli-frame.ts";
-
 
 export const PAIR_HELP = `actana pair — enroll a client on THIS machine's Core
 
@@ -558,7 +557,7 @@ export function pairingHandout(handout: PairingHandout): string[] {
     // it is *this* row that gives — a label is a name the operator already
     // knows and can read off `pair ls`, where the fingerprint is a value they
     // have to compare character by character (#357 review N1).
-    const room = FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth("Label          ") - 1;
+    const room = FRAME_CONTENT_WIDTH - displayWidth("Label          ");
     lines.push(
       frameRow([{ text: "Label          ", style: ANSI.dim }, { text: clip(label, room) }], color),
     );
@@ -569,11 +568,11 @@ export function pairingHandout(handout: PairingHandout): string[] {
 
   // The canonical path first: most people pairing a Core are sitting in front
   // of a Panel, and the code goes straight into it.
-  lines.push(style("From the Panel", ANSI.bold, color));
+  lines.push(style("From the Panel", FRAME_HEADING, color));
   lines.push(`  ${PANEL_INSTRUCTION}`);
   lines.push("");
 
-  lines.push(style("From a terminal", ANSI.bold, color));
+  lines.push(style("From a terminal", FRAME_HEADING, color));
   lines.push("  npm i -g @actana/cli");
   lines.push("");
   // One command per address, **with the minted values already in it**. A

--- a/packages/cli/src/cli-frame.ts
+++ b/packages/cli/src/cli-frame.ts
@@ -1,0 +1,194 @@
+// The framed, coloured shapes this CLI draws **only when stdout is a terminal**.
+//
+// These primitives arrived with `actana pair new` (#357) and lived inside
+// `actana-pair.ts` because there was one framed block in the program. #360 adds
+// the second one — `actana core pair`, the other end of the same exchange — and
+// two copies of a border width, a padding rule and a colour table is how the two
+// ends of one handshake start drawing different boxes. So they are here, and
+// both callers import them.
+//
+// **The gate is `isatty(stdout)` and nothing else.** No flag, no environment
+// variable beyond `NO_COLOR`, and deliberately no `--json`. A pipe, a file, a
+// `$( )` and a CI log get exactly the lines the command printed before any of
+// this existed; a terminal gets the frame. Nothing about *what* a command does
+// may read that answer — a command that behaved differently down a pipe than it
+// does at a terminal is a command no script can trust — and nothing here can
+// help it to, because everything in this file is pure: values in, lines out.
+// That is also what lets the suites assert on a frame without a terminal.
+
+import type { ActanaCliDeps } from "./cli-deps.ts";
+
+/** The escape sequences the frames use, and the only ANSI in this package. */
+export const ANSI = {
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  /** A value that is the whole point of the screen — a pairing code. */
+  boldCyan: "\u001b[1;36m",
+  /** The marker on a block that says something worked. */
+  green: "\u001b[32m",
+  /** The marker on a block that says something did not. */
+  red: "\u001b[31m",
+} as const;
+
+/**
+ * Whether to colour, given a terminal.
+ *
+ * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
+ * (https://no-color.org). Honouring it costs one clause and means an operator
+ * whose terminal renders escapes badly still gets the instructions, rather than
+ * having to choose between colour and a pipe.
+ */
+export function useColor(deps: ActanaCliDeps): boolean {
+  const noColor = deps.env.NO_COLOR;
+  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
+}
+
+/** The frame's total width, borders included. Fixed, so the output is one shape. */
+export const FRAME_WIDTH = 74;
+
+/** How far in from the left border the content starts. */
+export const FRAME_GUTTER = 3;
+
+/**
+ * How many columns a framed row's content may occupy.
+ *
+ * The two borders, the gutter, and one column held back on the right so the
+ * closing bar is never flush against a word.
+ */
+export const FRAME_CONTENT_WIDTH = FRAME_WIDTH - 2 - FRAME_GUTTER - 1;
+
+/** One run of styled text inside a framed line. */
+export type Span = { text: string; style?: string };
+
+/** The top or bottom rule. */
+export function frameEdge(which: "top" | "bottom", color: boolean): string {
+  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
+  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
+}
+
+/**
+ * One line between the two borders.
+ *
+ * The padding is measured on the **plain** text and the styling applied
+ * afterwards, because an escape sequence has a length and no width — pad a
+ * coloured string by `String.length` and the right border walks off by however
+ * many bytes the colour cost.
+ */
+export function frameRow(spans: Span[], color: boolean): string {
+  const plain = spans.map((span) => span.text).join("");
+  const body = spans.map((span) => style(span.text, span.style, color)).join("");
+  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
+  const bar = style("│", ANSI.dim, color);
+  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
+}
+
+/**
+ * How many terminal columns `text` occupies.
+ *
+ * `String.length` is UTF-16 code units and a frame padded by it is crooked for
+ * anybody whose label is not Latin: three CJK characters are three code units
+ * and six columns, so the right border lands three early (#357 review N1).
+ * Counted per code point — a surrogate pair is one character, not two — with
+ * the wide ranges at two and the zero-width ones at nothing.
+ *
+ * Deliberately not a full `wcwidth`. This measures the handful of things that
+ * reach a frame row: ASCII, an operator's label, a UUID, colon-hex and a tick.
+ * Emoji with joiners and skin tones can still measure a column off, and the
+ * cost of that is a ragged border on one line — not a truncated fingerprint,
+ * which is the thing these callers may never do.
+ */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const character of text) {
+    const point = character.codePointAt(0) ?? 0;
+    if (isZeroWidth(point)) continue;
+    width += isWide(point) ? 2 : 1;
+  }
+  return width;
+}
+
+/** Combining marks and variation selectors: they attach, they take no column. */
+function isZeroWidth(point: number): boolean {
+  return (
+    (point >= 0x0300 && point <= 0x036f) ||
+    (point >= 0x200b && point <= 0x200f) ||
+    (point >= 0xfe00 && point <= 0xfe0f) ||
+    point === 0x2060 ||
+    point === 0xfeff
+  );
+}
+
+/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
+function isWide(point: number): boolean {
+  return (
+    (point >= 0x1100 && point <= 0x115f) ||
+    (point >= 0x2e80 && point <= 0xa4cf) ||
+    (point >= 0xac00 && point <= 0xd7a3) ||
+    (point >= 0xf900 && point <= 0xfaff) ||
+    (point >= 0xfe30 && point <= 0xfe6f) ||
+    (point >= 0xff00 && point <= 0xff60) ||
+    (point >= 0xffe0 && point <= 0xffe6) ||
+    (point >= 0x1f300 && point <= 0x1f64f) ||
+    (point >= 0x1f900 && point <= 0x1f9ff) ||
+    (point >= 0x20000 && point <= 0x3fffd)
+  );
+}
+
+/**
+ * `text` shortened to `columns` display columns, marked when it was shortened.
+ *
+ * **Only ever called on something the operator can read back somewhere else.**
+ * Truncation is a lie about a value, and the values worth telling it about are
+ * names — a label is a name the operator chose and can read off `pair ls`. A
+ * fingerprint wraps instead, and nothing routes one through here.
+ */
+export function clip(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text;
+  let kept = "";
+  let width = 0;
+  for (const character of text) {
+    const next = width + displayWidth(character);
+    // One column held back for the marker, which is one column wide.
+    if (next > columns - 1) break;
+    kept += character;
+    width = next;
+  }
+  return `${kept}…`;
+}
+
+/** Wrap `text` in an escape sequence, or hand it back untouched. */
+export function style(text: string, code: string | undefined, color: boolean): string {
+  return color && code ? `${code}${text}${ANSI.reset}` : text;
+}
+
+/**
+ * `text` broken across lines at spaces, measured in display columns.
+ *
+ * Prose is the one thing a frame holds that has no natural break in it: a label
+ * is short, a fingerprint splits on its own colons, and a diagnostic relayed
+ * from the SDK is a sentence of whatever length that sentence is. A word longer
+ * than the whole line — a URL, an address — goes on a line of its own and is
+ * left over-long rather than cut, because **this function may not shorten its
+ * input**: every caller is printing something an operator has to read exactly,
+ * and a wrap that drops characters is a truncation wearing a different name. A
+ * ragged border is the acceptable cost; a lost character is not.
+ */
+export function wrapText(text: string, columns: number): string[] {
+  const width = Math.max(1, columns);
+  const lines: string[] = [];
+  let line = "";
+  for (const word of text.split(/\s+/).filter((piece) => piece !== "")) {
+    if (line === "") {
+      line = word;
+      continue;
+    }
+    if (displayWidth(`${line} ${word}`) <= width) line = `${line} ${word}`;
+    else {
+      lines.push(line);
+      line = word;
+    }
+  }
+  if (line !== "") lines.push(line);
+  return lines.length > 0 ? lines : [""];
+}

--- a/packages/cli/src/cli-frame.ts
+++ b/packages/cli/src/cli-frame.ts
@@ -58,6 +58,21 @@ export const FRAME_GUTTER = 3;
  */
 export const FRAME_CONTENT_WIDTH = FRAME_WIDTH - 2 - FRAME_GUTTER - 1;
 
+/**
+ * The style a section heading **under** a frame carries.
+ *
+ * `From the Panel` on the Core's handout and `Next steps` on the client's
+ * result are the same element doing the same job, and #366's review caught them
+ * rendering differently — one bold, one dim — which is the exact drift this
+ * module exists to stop. Bold, because that is what #364 shipped and `pair new`
+ * has an operator reading it in the wild today; a heading that is dimmer than
+ * the prose beneath it is also the wrong way round.
+ *
+ * Field labels *inside* a frame stay {@link ANSI.dim}. They are a column, not a
+ * heading — the eye finds them by position.
+ */
+export const FRAME_HEADING = ANSI.bold;
+
 /** One run of styled text inside a framed line. */
 export type Span = { text: string; style?: string };
 
@@ -140,8 +155,9 @@ function isWide(point: number): boolean {
  *
  * **Only ever called on something the operator can read back somewhere else.**
  * Truncation is a lie about a value, and the values worth telling it about are
- * names — a label is a name the operator chose and can read off `pair ls`. A
- * fingerprint wraps instead, and nothing routes one through here.
+ * names — a label is a name the operator chose and can read back from where
+ * they chose it. A fingerprint wraps instead, and nothing routes one through
+ * here.
  */
 export function clip(text: string, columns: number): string {
   if (displayWidth(text) <= columns) return text;
@@ -166,21 +182,34 @@ export function style(text: string, code: string | undefined, color: boolean): s
  * `text` broken across lines at spaces, measured in display columns.
  *
  * Prose is the one thing a frame holds that has no natural break in it: a label
- * is short, a fingerprint splits on its own colons, and a diagnostic relayed
- * from the SDK is a sentence of whatever length that sentence is.
+ * is short, and a diagnostic relayed from the SDK is a sentence of whatever
+ * length that sentence is — with, sometimes, an unbreakable value sitting in
+ * the middle of it.
  *
  * **This function may not shorten its input.** Every caller is printing
- * something an operator has to read exactly — a path to their own credential, a
- * URL, an address — and a wrap that drops characters is a truncation wearing a
- * different name. So a word too long for a line of its own is broken on its
- * slashes rather than cut, which is the same move `wrapFingerprint` makes on
- * colons: the separator stays at the end of the line, so a reader can see there
- * is more. That is not an edge case. A credential lands under the operator's
- * home directory, and a home directory deep enough to overflow a 74-column box
- * is an ordinary machine, not a pathological one.
+ * something an operator has to read exactly — a path to their own credential,
+ * an address, a fingerprint they are being asked to *compare* — and a wrap that
+ * drops characters is a truncation wearing a different name.
  *
- * A word with no slash in it and no room to fit is left over-long. A ragged
- * border is the acceptable cost; a lost character is not.
+ * So a word too long for a line of its own is broken on {@link WORD_BREAKS} —
+ * `/`, `:` and `.`, the separators the values reaching a frame are built out
+ * of: a path, an origin, a `host:port`, colon-hex, a domain name. The
+ * separator stays at the end of the line it breaks after, which is what tells a
+ * reader the value continues — the same move `wrapFingerprint` makes on the
+ * Core's side.
+ *
+ * Neither is an edge case. A credential lands under the operator's home
+ * directory, and a home deep enough to overflow a 74-column box is an ordinary
+ * machine; the SDK's `fingerprint-mismatch` sentence carries **two** 95-column
+ * colon-hex fingerprints, and that is the one class on this screen whose whole
+ * subject is a value being compared character by character (#366 review 1).
+ *
+ * **The residual, stated rather than hidden:** a word with neither separator in
+ * it and no room to fit is left whole and over-long, and the border beside it
+ * runs one column past the rest. That is deliberate. There is nowhere left to
+ * break that would not put a line ending in the middle of a name, and a ragged
+ * border is a cheaper failure than a value an operator cannot trust. It is
+ * pinned by a test so it stays a decision.
  */
 export function wrapText(text: string, columns: number): string[] {
   const width = Math.max(1, columns);
@@ -199,9 +228,10 @@ export function wrapText(text: string, columns: number): string[] {
       continue;
     }
     // Too long for any line. Break it where it has a break, and leave the last
-    // chunk open so anything after it — `(mode 0600)`, a trailing note — can
-    // share that line rather than starting another.
-    const chunks = breakOnSlashes(word, width);
+    // chunk open so anything after it — `(mode 0600)`, `was expected — the
+    // pairing code was not sent` — can share that line rather than starting
+    // another.
+    const chunks = breakLongWord(word, width);
     lines.push(...chunks.slice(0, -1));
     line = chunks.at(-1) ?? "";
   }
@@ -210,20 +240,44 @@ export function wrapText(text: string, columns: number): string[] {
 }
 
 /**
- * One over-long word, split on its slashes, each line keeping its separator.
+ * The separators an over-long word may be broken after.
+ *
+ * Three, because between them they are what every unbreakable value this
+ * program prints is built out of:
+ *
+ *   - `/` — a filesystem path, and the path half of a URL;
+ *   - `:` — `host:port`, an `https://` scheme, and colon-hex: a SHA-256
+ *     fingerprint is 95 columns and is the reason this list is not just `/`
+ *     (#366 review 1);
+ *   - `.` — a domain name, which is the long slash-free value an endpoint row
+ *     is made of and the one the review asked about by name. Found by a test:
+ *     `https://a-very-long-host-name.example.invalid:8443/…` has 38 columns
+ *     between its `//` and its port, and neither of the first two separators
+ *     is anywhere in them.
+ *
+ * A sentence-ending full stop is a break point too, in principle. In practice
+ * it never is: a word is only broken here when it is longer on its own than
+ * the whole line, and the last word of a sentence is not.
+ */
+const WORD_BREAKS = /(?<=[/:.])/;
+
+/**
+ * One over-long word, split after its separators, each line keeping its own.
  *
  * The separator stays at the end of the line it breaks after, which is what
  * tells a reader that the value continues — the same reason `wrapFingerprint`
- * keeps its colons. A single segment with no slash and no room is handed back
- * over-long: there is nowhere left to break, and breaking anyway would put a
- * line ending in the middle of a directory name.
+ * keeps its colons on the Core's side.
+ *
+ * **Lossless by construction.** The split is a zero-width lookbehind, so the
+ * pieces are the input partitioned rather than tokenised: nothing is consumed
+ * as a delimiter and `chunks.join("")` is the word it was handed. A word with
+ * no separator in it comes back as one over-long chunk — see the residual in
+ * {@link wrapText}.
  */
-function breakOnSlashes(word: string, width: number): string[] {
-  const parts = word.split("/");
+function breakLongWord(word: string, width: number): string[] {
   const chunks: string[] = [];
   let chunk = "";
-  for (const [index, part] of parts.entries()) {
-    const piece = index < parts.length - 1 ? `${part}/` : part;
+  for (const piece of word.split(WORD_BREAKS)) {
     if (piece === "") continue;
     if (chunk !== "" && displayWidth(chunk + piece) > width) {
       chunks.push(chunk);

--- a/packages/cli/src/cli-frame.ts
+++ b/packages/cli/src/cli-frame.ts
@@ -167,28 +167,70 @@ export function style(text: string, code: string | undefined, color: boolean): s
  *
  * Prose is the one thing a frame holds that has no natural break in it: a label
  * is short, a fingerprint splits on its own colons, and a diagnostic relayed
- * from the SDK is a sentence of whatever length that sentence is. A word longer
- * than the whole line — a URL, an address — goes on a line of its own and is
- * left over-long rather than cut, because **this function may not shorten its
- * input**: every caller is printing something an operator has to read exactly,
- * and a wrap that drops characters is a truncation wearing a different name. A
- * ragged border is the acceptable cost; a lost character is not.
+ * from the SDK is a sentence of whatever length that sentence is.
+ *
+ * **This function may not shorten its input.** Every caller is printing
+ * something an operator has to read exactly — a path to their own credential, a
+ * URL, an address — and a wrap that drops characters is a truncation wearing a
+ * different name. So a word too long for a line of its own is broken on its
+ * slashes rather than cut, which is the same move `wrapFingerprint` makes on
+ * colons: the separator stays at the end of the line, so a reader can see there
+ * is more. That is not an edge case. A credential lands under the operator's
+ * home directory, and a home directory deep enough to overflow a 74-column box
+ * is an ordinary machine, not a pathological one.
+ *
+ * A word with no slash in it and no room to fit is left over-long. A ragged
+ * border is the acceptable cost; a lost character is not.
  */
 export function wrapText(text: string, columns: number): string[] {
   const width = Math.max(1, columns);
   const lines: string[] = [];
   let line = "";
   for (const word of text.split(/\s+/).filter((piece) => piece !== "")) {
-    if (line === "") {
+    const candidate = line === "" ? word : `${line} ${word}`;
+    if (displayWidth(candidate) <= width) {
+      line = candidate;
+      continue;
+    }
+    if (line !== "") lines.push(line);
+    line = "";
+    if (displayWidth(word) <= width) {
       line = word;
       continue;
     }
-    if (displayWidth(`${line} ${word}`) <= width) line = `${line} ${word}`;
-    else {
-      lines.push(line);
-      line = word;
-    }
+    // Too long for any line. Break it where it has a break, and leave the last
+    // chunk open so anything after it — `(mode 0600)`, a trailing note — can
+    // share that line rather than starting another.
+    const chunks = breakOnSlashes(word, width);
+    lines.push(...chunks.slice(0, -1));
+    line = chunks.at(-1) ?? "";
   }
   if (line !== "") lines.push(line);
   return lines.length > 0 ? lines : [""];
+}
+
+/**
+ * One over-long word, split on its slashes, each line keeping its separator.
+ *
+ * The separator stays at the end of the line it breaks after, which is what
+ * tells a reader that the value continues — the same reason `wrapFingerprint`
+ * keeps its colons. A single segment with no slash and no room is handed back
+ * over-long: there is nowhere left to break, and breaking anyway would put a
+ * line ending in the middle of a directory name.
+ */
+function breakOnSlashes(word: string, width: number): string[] {
+  const parts = word.split("/");
+  const chunks: string[] = [];
+  let chunk = "";
+  for (const [index, part] of parts.entries()) {
+    const piece = index < parts.length - 1 ? `${part}/` : part;
+    if (piece === "") continue;
+    if (chunk !== "" && displayWidth(chunk + piece) > width) {
+      chunks.push(chunk);
+      chunk = "";
+    }
+    chunk += piece;
+  }
+  if (chunk !== "") chunks.push(chunk);
+  return chunks.length > 0 ? chunks : [word];
 }

--- a/packages/cli/src/core-pair-results.ts
+++ b/packages/cli/src/core-pair-results.ts
@@ -1,0 +1,768 @@
+// What `actana core pair` says when it is done — the success block, and every
+// class of refusal (#360).
+//
+// **The client end of #357.** `actana pair new` grew two shapes on the Core:
+// labelled lines down a pipe, a framed handout at a terminal, with `isatty`
+// as the whole of the switch. This is the same command one machine over. The
+// operator has just carried a code, a fingerprint and a session across the
+// room, and the moment they find out whether it worked is the moment that most
+// needs to say what to do next — on success because there is a Core to use now
+// and nothing on the screen saying how, and on failure because "refused" is
+// the same word for an expired code, a spent one and a typo.
+//
+// **Everything here is pure: values in, lines out.** No `deps`, no clock, no
+// filesystem, no decision about whether to draw. `core-pair.ts` owns the one
+// `if` that reads `stdoutIsTty`, and this module cannot see it — which is what
+// lets the suite assert on a frame without a terminal, and what keeps the
+// piped path provably a different set of strings rather than the same strings
+// with the ornaments stripped off.
+//
+// **The piped contract lives in `core-pair.ts`, not here.** Nothing in this
+// file is ever printed when stdout is not a terminal: down a pipe the command
+// emits exactly the lines 0.4.2 emitted, and `core-pair.test.ts` asserts them
+// whole against a literal. Adding a line here cannot move a byte of that.
+//
+// **Nothing secret reaches these strings.** Not the credential, not the private
+// key, and not the pairing code — the code is a bearer secret for as long as
+// its session is open, so it is not echoed in a confirmation and not quoted in
+// a diagnostic. That is why every "mint a fresh one" step below names the
+// command rather than the value, and why the success block says where the
+// credential landed and never what is in it.
+
+import {
+  ANSI,
+  frameEdge,
+  frameRow,
+  FRAME_CONTENT_WIDTH,
+  style,
+  wrapText,
+  type Span,
+} from "./cli-frame.ts";
+import type { CorePairingErrorDetail, CorePairingFailure } from "@actana/sdk/core-pairing.ts";
+import {
+  EXIT_PAIR_CERTIFICATE_INVALID,
+  EXIT_PAIR_CORE_ERROR,
+  EXIT_PAIR_FINGERPRINT_MISMATCH,
+  EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+  EXIT_PAIR_HOSTNAME_MISMATCH,
+  EXIT_PAIR_MALFORMED_RESPONSE,
+  EXIT_PAIR_NO_CA,
+  EXIT_PAIR_NOT_PAIRABLE,
+  EXIT_PAIR_RATE_LIMITED,
+  EXIT_PAIR_REFUSED,
+  EXIT_PAIR_REJECTED,
+  EXIT_PAIR_UNREACHABLE,
+  EXIT_USAGE,
+} from "./exit-codes.ts";
+
+/**
+ * One thing to do next: the line to type, and why.
+ *
+ * The command comes first and unstyled, because it is the thing that gets
+ * selected with a mouse — dimming a line an operator is about to copy is how a
+ * terminal theme turns an instruction into something unreadable. The note is
+ * indented under it and dim, because it is read once.
+ *
+ * A step with no command is prose that earns its place: a warning, or a fact
+ * that changes what the operator should type rather than being typed itself.
+ */
+export type CorePairStep = {
+  /** The line to type, exactly as it should be typed. Never styled. */
+  command?: string;
+  /** What it is for. Wrapped, dim. */
+  note: string;
+};
+
+/** How wide the prose under a frame may run. No border to keep it inside. */
+const PROSE_WIDTH = 76;
+
+/** The column the success block's values start in. */
+const FIELD_WIDTH = 13;
+
+/**
+ * The command that mints a replacement, which is the answer to half the
+ * failures below.
+ *
+ * One constant because it is one instruction: an expired code, a spent code, a
+ * code the Core has never heard of and a fingerprint that has moved on all end
+ * the same way — somebody walks back to the Core and mints a new one. The
+ * three values that come back travel together, which is the part an operator
+ * gets wrong: re-running with a new code and yesterday's `--session` fails in
+ * exactly the way that sent them here.
+ */
+const REMINT = "actana pair new --label <name>";
+
+/** The usage line, as `core-pair.ts` and `CORE_HELP` both print it. */
+const PAIR_USAGE = "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>";
+
+/** The same call with the session carried inside the code instead. */
+const PAIR_USAGE_JOINED = "actana core pair <name> <host:port> <session>:<code> --fingerprint <sha256>";
+
+/** The step every re-mint ends with. Stated once; it is the same mistake each time. */
+const REMINT_RERUN: CorePairStep = {
+  note:
+    "Re-run with the NEW code, the NEW --session and the fingerprint printed beside them. A code and " +
+    "its session are one credential — the old session will not redeem the new code.",
+};
+
+// ─── the success block ──────────────────────────────────────────────────────
+
+/**
+ * Everything the success block renders.
+ *
+ * `current` is the pointer **read back after the write**, not the name that was
+ * just paired and not a guess about what the write did. `core pair` makes a
+ * Core current only when nothing was, so on any machine with a Core already
+ * registered the honest answer is "no" — and a block that congratulated an
+ * operator on a `current` they do not have would send them to `core status`
+ * against the wrong Core, which is the confusion this whole ticket is about.
+ */
+export type CorePairSuccess = {
+  name: string;
+  endpoint: string;
+  /** Whether a Core of this name was already registered. Chooses one word. */
+  replaced: boolean;
+  /** What `current` names now. `null` when nothing does. */
+  current: string | null;
+  /** Where the credential landed. The path, at mode 0600 — never the contents. */
+  credentialPath: string;
+  color: boolean;
+};
+
+/**
+ * The framed confirmation, and the next steps under it.
+ *
+ * The frame answers "what just happened" and the section under it answers "what
+ * do I do now", which is the same division `pair new`'s handout uses: facts
+ * inside the border, commands outside it where they are long enough to need the
+ * room and must survive being copied.
+ */
+export function corePairSuccessBlock(result: CorePairSuccess): string[] {
+  const { color } = result;
+  const isCurrent = result.current === result.name;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  lines.push(
+    frameRow(
+      [
+        { text: "✓ ", style: ANSI.green },
+        { text: `${result.replaced ? "Replaced" : "Paired"} Core "${result.name}"` },
+      ],
+      color,
+    ),
+  );
+  lines.push(frameRow([], color));
+  lines.push(...field("Endpoint", result.endpoint, color));
+  lines.push(...field("Current", currentSentence(result, isCurrent), color));
+  // Reassurance, not a secret: the operator has just been told a credential
+  // exists and has no way to see that it does. The path and the mode are the
+  // whole of what can be said about it — the blob itself never reaches an
+  // output sink, `--verbose` included.
+  lines.push(...field("Credential", `${result.credentialPath} (mode 0600)`, color));
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  lines.push(style("Next steps", ANSI.dim, color));
+  lines.push(...stepLines(nextSteps(result, isCurrent), color));
+  return lines;
+}
+
+/**
+ * What the `Current` row says, which is a claim this block has to have earned.
+ *
+ * Three answers, and the middle one is the reason the field exists: pairing a
+ * second Core on a machine that already has one changes nothing about
+ * `current`, and the operator's very next command will talk to the other Core
+ * unless this line tells them so.
+ */
+function currentSentence(result: CorePairSuccess, isCurrent: boolean): string {
+  if (isCurrent) return `"${result.name}" — every later verb talks to this Core`;
+  if (result.current === null) return "nothing is selected yet";
+  return `still "${result.current}" — this pairing did not change it`;
+}
+
+/**
+ * The four verbs a freshly paired Core exists for, in the order they are useful.
+ *
+ * Verify, then look around, then do something: `core status` is the one that
+ * says the link works at all, `project ls` and `harness ls` are the two things
+ * a Session needs to name, and `session start` is the first real action. An
+ * operator who has just carried a code across a room has earned a screen that
+ * does not make them go and read the help.
+ */
+function nextSteps(result: CorePairSuccess, isCurrent: boolean): CorePairStep[] {
+  const steps: CorePairStep[] = [];
+  if (!isCurrent) {
+    // First, because every verb below it reads `current`, and running them
+    // now would report on a Core the operator did not just pair.
+    steps.push({
+      command: `actana core use ${result.name}`,
+      note: "Point `current` at it. Everything below talks to `current` until you do, or pass --core each time.",
+    });
+  }
+  steps.push({
+    command: "actana core status",
+    note: "Reach the Core and report what it says. The check that the link works end to end.",
+  });
+  steps.push({
+    command: "actana project ls",
+    note: "The Projects on this Core. A Session needs one to run in.",
+  });
+  steps.push({
+    command: "actana harness ls",
+    note: "Which agents this Core can actually run right now, and which it is missing.",
+  });
+  steps.push({
+    command: 'actana session start <project> "<prompt>"',
+    note: "The first real thing to run on it. Prints the Session id and exits.",
+  });
+  steps.push({
+    note:
+      "The Panel pairs with this same Core from its Settings -> Cores screen, with a code of its own — " +
+      "`actana pair new` on the Core mints that one too.",
+  });
+  return steps;
+}
+
+// ─── the refusals ───────────────────────────────────────────────────────────
+
+/** A framed refusal: what happened, and what to do about it. */
+export type CorePairRefusal = {
+  /**
+   * What went wrong, beside the marker.
+   *
+   * Wrapped rather than assumed to fit, because for most classes this is the
+   * SDK's own sentence and the SDK writes for a library's caller, not for a
+   * 74-column box. A headline that ran off the border would be the one line on
+   * the screen an operator cannot read.
+   */
+  headline: string;
+  /** Anything further, as paragraphs, wrapped inside the frame. May be empty. */
+  detail: readonly string[];
+  /** What to do next. Never empty — a refusal with no remedy is the bug #360 fixes. */
+  steps: readonly CorePairStep[];
+  color: boolean;
+};
+
+/**
+ * The framed refusal, and the steps under it.
+ *
+ * The same shape as the success block on purpose. An operator who has seen one
+ * has seen the other, and the marker is the only thing they have to read to
+ * know which of the two they are looking at.
+ */
+export function corePairRefusalBlock(refusal: CorePairRefusal): string[] {
+  const { color } = refusal;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  // The marker takes two columns, so the wrap is measured against what is left
+  // and the continuations line up under the first word rather than under the ✗.
+  const headline = wrapText(refusal.headline, FRAME_CONTENT_WIDTH - 2);
+  for (const [index, line] of headline.entries()) {
+    const spans: Span[] =
+      index === 0 ? [{ text: "✗ ", style: ANSI.red }, { text: line }] : [{ text: `  ${line}` }];
+    lines.push(frameRow(spans, color));
+  }
+  for (const paragraph of refusal.detail) {
+    lines.push(frameRow([], color));
+    for (const line of wrapText(paragraph, FRAME_CONTENT_WIDTH)) {
+      lines.push(frameRow([{ text: line }], color));
+    }
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  lines.push(style("What to do", ANSI.dim, color));
+  lines.push(...stepLines(refusal.steps, color));
+  return lines;
+}
+
+// ─── the failure table ──────────────────────────────────────────────────────
+
+/** What an operator should do next about a failure, and what this process exits with. */
+export type CorePairingOutcome = {
+  /** The code from `exit-codes.ts`. Contract: a script may branch on it. */
+  exit: number;
+  /**
+   * One line saying what to do next. Never quotes the code or any credential.
+   *
+   * **This is the piped shape and it may not move.** It is the second of the two
+   * lines a redirected `core pair` writes to stderr, it is what every script
+   * that has ever grepped a pairing failure reads, and the framed block exists
+   * precisely so that it does not have to change to give an operator more.
+   */
+  next: string;
+  /**
+   * The same advice as commands, for the framed shape only.
+   *
+   * Every entry is reachable — a step that names a flag nobody has or a verb
+   * that does not exist is worse than the prose it replaced, because prose does
+   * not look like something to paste.
+   */
+  steps: readonly CorePairStep[];
+};
+
+/**
+ * Every failure the SDK distinguishes, given a number, a next step and a remedy.
+ *
+ * One `switch` with no `default`, so a failure added to `CorePairingFailure`
+ * stops this file compiling until somebody decides what an operator should do
+ * about it — which is the only way a list like this stays honest.
+ *
+ * The `steps` are the #360 half. The rule they follow: **each distinguishable
+ * failure gets its own concrete remedy**, not a shared one. "Ask for a fresh
+ * code" and "check the port is open" are the correct answers to two different
+ * problems, and a table that gave both answers to both would be back where the
+ * prose started.
+ */
+export function corePairingOutcome(
+  failure: CorePairingFailure,
+  detail: CorePairingErrorDetail = {},
+): CorePairingOutcome {
+  switch (failure) {
+    case "bad-address":
+      return {
+        exit: EXIT_USAGE,
+        next: "An address is host:port — the Core's TLS port, the one `actana status` reports on the Core.",
+        steps: [
+          {
+            note:
+              "An address is host:port and nothing else — not a URL, not a bare hostname, and not the " +
+              "Panel's port.",
+          },
+          {
+            command: "actana status",
+            note: "On the Core: it reports the address and the TLS port that Core actually listens on.",
+          },
+        ],
+      };
+    case "bad-code":
+      return {
+        exit: EXIT_USAGE,
+        next: "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
+        steps: [
+          {
+            note:
+              "A pairing code is eight characters, written XXXX-XXXX. Hyphen and case are yours to get " +
+              "wrong; the shape is not. Nothing was dialled and no attempt was spent.",
+          },
+          {
+            command: REMINT,
+            note: "On the Core: mints a fresh code and prints the session and fingerprint that belong to it.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "bad-fingerprint":
+      return {
+        exit: EXIT_USAGE,
+        next: "A fingerprint is 32 bytes of hex, as AA:BB:… — copy the line `actana pair new` printed.",
+        steps: [
+          {
+            note:
+              "A fingerprint is 32 bytes of hex written AA:BB:… — copy the whole line, colons included, " +
+              "with nothing elided. `pair new` wraps it and never shortens it, so what is on that screen " +
+              "is the whole value.",
+          },
+          { command: REMINT, note: "On the Core: prints the current fingerprint again if the line was lost." },
+        ],
+      };
+    case "unreachable":
+      return {
+        exit: EXIT_PAIR_UNREACHABLE,
+        next: "Check the Core is running and that address reaches it — `actana status` on the Core says where it listens.",
+        steps: [
+          {
+            // The distinction the whole class turns on: a dial that never
+            // landed has spent nothing, so the code in the operator's hand is
+            // still good and re-minting one would be wasted effort.
+            note:
+              "Nothing answered at that address. This is a dial failure, not a refusal — the code was " +
+              "never sent, no attempt was spent, and the code you were given is still good.",
+          },
+          { command: "getent hosts <host>", note: "Does the name resolve, and to the machine you mean?" },
+          {
+            command: "nc -vz <host> <port>",
+            note:
+              "Is the TLS port open from here? A firewall, a NAT, or a container port that was never " +
+              "published all look exactly like this.",
+          },
+          {
+            command: "actana status",
+            note: "On the Core: whether it is running, and which address and port it is listening on.",
+          },
+          {
+            note:
+              "A proxy named in HTTPS_PROXY, or SNI rewritten by something in front of the Core, lands " +
+              "here too — the dial reaches a machine, just not that one.",
+          },
+        ],
+      };
+    case "not-pairable":
+      return {
+        exit: EXIT_PAIR_NOT_PAIRABLE,
+        next: "Something answered there but it has no pairing endpoint — check it is a Core, and update it if it is old.",
+        steps: [
+          {
+            // The other side of `unreachable`: the dial worked. Something is
+            // listening and it refused to be a Core, which is a different fix.
+            note:
+              "Something answered and it has no pairing endpoint. The dial worked — so this is not a " +
+              "network problem: either that is not a Core, or it is one too old to pair.",
+          },
+          { command: "actana status", note: "On the Core: which version it is running." },
+          { command: "actana update", note: "On the Core: brings it onto a build that pairs." },
+          {
+            note:
+              "If it is not a Core, check the port. A reverse proxy or another service sitting on that " +
+              "port answers in exactly this way.",
+          },
+        ],
+      };
+    case "no-ca-presented":
+      return {
+        exit: EXIT_PAIR_NO_CA,
+        next: "Nothing was presented to compare against the fingerprint — check the address is the Core's own TLS port.",
+        steps: [
+          {
+            note:
+              "Nothing was presented to compare the fingerprint against, so there was nothing to pin and " +
+              "the code was not sent.",
+          },
+          {
+            note:
+              "Check the address is the Core's own TLS port — a plain-HTTP port, or a proxy terminating " +
+              "TLS in front of the Core with its own certificate, both end here.",
+          },
+          { command: "actana status", note: "On the Core: the TLS port it presents its own authority on." },
+        ],
+      };
+    case "fingerprint-unconfirmed":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+        next: "Pass `--fingerprint <sha256>` — the code is never sent to a certificate authority nobody confirmed.",
+        steps: [
+          {
+            note:
+              "The code is never sent to a certificate authority nobody confirmed, and there is no flag " +
+              "that waives that. Absent is not waived.",
+          },
+          {
+            command: PAIR_USAGE,
+            note: "Pass the fingerprint `actana pair new` printed on the Core, whole and unedited.",
+          },
+          {
+            note:
+              "Or run this where there is a terminal: without --fingerprint it prints the authority the " +
+              "Core presents and asks you to compare it yourself.",
+          },
+        ],
+      };
+    case "fingerprint-mismatch":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
+        next:
+          "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
+          "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
+        steps: [
+          {
+            note:
+              "The SHA-256 fingerprint of the certificate authority that address presents was compared " +
+              "against the one you gave, and the two differ. The code was not sent.",
+          },
+          {
+            // The warning is the point of the class. Everything else in this
+            // command is a convenience; this comparison is the security
+            // argument, and the failure mode is an operator looking for a way
+            // past it.
+            note:
+              "Do not look for a way around this. There is no flag that skips the comparison and none " +
+              "will be added: an unverified authority is the exact thing pairing exists to rule out, and " +
+              "a mismatch is either the wrong machine answering or somebody sitting between you and the " +
+              "right one.",
+          },
+          {
+            command: REMINT,
+            note:
+              "On the Core: prints the fingerprint that Core is presenting today. Compare it against " +
+              "yours by eye before you retry — material reissued since you wrote yours down is " +
+              "indistinguishable from an impostor at this end.",
+          },
+        ],
+      };
+    case "hostname-mismatch":
+      return {
+        exit: EXIT_PAIR_HOSTNAME_MISMATCH,
+        next: "That is the right Core on an address its certificate does not cover — dial the one it was set up for.",
+        steps: [
+          {
+            note:
+              "The right Core, reached at an address its certificate does not cover. The authority " +
+              "matched; the name did not.",
+          },
+          { command: "actana status", note: "On the Core: the addresses its certificate was issued for. Dial one of those." },
+          {
+            note:
+              "If the address you need is genuinely missing, it has to be added to the certificate on " +
+              "the Core — re-running `actana setup` with it is what does that.",
+          },
+        ],
+      };
+    case "certificate-invalid":
+      return {
+        exit: EXIT_PAIR_CERTIFICATE_INVALID,
+        next: "The right Core, with a certificate that cannot be used — check the clock on both machines, then reissue it.",
+        steps: [
+          {
+            note:
+              "The right Core, with a certificate that cannot be used. Most often a clock: a certificate " +
+              "is not yet valid, or has expired, according to whichever of the two machines is wrong.",
+          },
+          { command: "date -u", note: "On both machines. They should agree to within a minute." },
+          {
+            note:
+              "If the clocks agree, the Core's material has genuinely expired and needs reissuing on the " +
+              "Core before anything can pair with it.",
+          },
+        ],
+      };
+    case "refused":
+      return {
+        exit: EXIT_PAIR_REFUSED,
+        next: "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
+        steps: [
+          {
+            // The Core deliberately will not say which of the four. Saying so
+            // here is what stops an operator re-typing a code they think is
+            // merely mistyped when it has in fact expired.
+            note:
+              "The Core would not redeem that code: expired, already spent, never issued, or out of " +
+              "attempts. It does not say which — telling an unauthenticated caller apart from a guesser " +
+              "is how codes get guessed. The Core's audit log says.",
+          },
+          {
+            command: REMINT,
+            note: "On the Core: mints a fresh code and prints the session and fingerprint beside it.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "rate-limited":
+      return {
+        exit: EXIT_PAIR_RATE_LIMITED,
+        next:
+          detail.retryAfterSeconds === undefined
+            ? "Wait, then try again with a fresh code."
+            : `Wait ${detail.retryAfterSeconds} seconds, then try again with a fresh code.`,
+        steps: [
+          {
+            note:
+              detail.retryAfterSeconds === undefined
+                ? "The Core is refusing redemptions from here for now. Wait before trying again."
+                : `The Core is refusing redemptions from here for now. Wait ${detail.retryAfterSeconds} ` +
+                  "seconds before trying again.",
+          },
+          {
+            command: REMINT,
+            note:
+              "On the Core, after the wait: every failed redemption spends one of the session's five " +
+              "attempts, so a fresh code is the retry that reliably works.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "rejected":
+      return {
+        exit: EXIT_PAIR_REJECTED,
+        next: "The Core would not accept the request itself — that is a bug on this side. Please report it.",
+        steps: [
+          {
+            note:
+              "The Core would not accept the request this build sent. That is a defect here, not " +
+              "something to work around: no code, address or fingerprint changes it.",
+          },
+          {
+            command: `${PAIR_USAGE} --verbose`,
+            note:
+              "Re-run with --verbose and report what it prints, with the exit code. It names the steps " +
+              "and never prints the code, the key or the credential.",
+          },
+        ],
+      };
+    case "core-error":
+      return {
+        exit: EXIT_PAIR_CORE_ERROR,
+        next: "The Core failed while handling this — `actana logs` on the Core has the reason; nothing here does.",
+        steps: [
+          {
+            note:
+              "The Core failed while handling this. Nothing on this side knows why, and nothing on this " +
+              "side can be changed to fix it.",
+          },
+          { command: "actana logs", note: "On the Core: the reason will be there." },
+        ],
+      };
+    case "malformed-response":
+      return {
+        exit: EXIT_PAIR_MALFORMED_RESPONSE,
+        next: "Something answered that is not a Core, or is not one this build understands. Check the address.",
+        steps: [
+          {
+            note:
+              "Something answered and what came back was not a pairing response this build understands. " +
+              "Either it is not a Core, or the two ends are too far apart in version.",
+          },
+          { command: "actana status", note: "On the Core: its version." },
+          { command: "actana --version", note: "Here: this build's. Update whichever of the two is older." },
+        ],
+      };
+  }
+}
+
+// ─── the refusals this file words itself ────────────────────────────────────
+//
+// Four shapes that never reach the SDK, because they are caught before anything
+// is dialled. They are worded here rather than relayed for the reason the module
+// header gives: the SDK's own messages quote what they were handed, which is
+// correct for a library and wrong for a CLI whose stderr is a terminal, a CI
+// log and a shell history at once.
+
+/** The three positionals are missing, or one of them is. */
+export const MISSING_ARGUMENTS_STEPS: readonly CorePairStep[] = [
+  {
+    command: PAIR_USAGE,
+    note:
+      "The order is the order they are read out: what this machine will call the Core, where the Core " +
+      "is, and the code.",
+  },
+  {
+    command: REMINT,
+    note: "On the Core: prints the code, the session and the fingerprint — all three of the values this needs.",
+  },
+];
+
+/** A fourth positional turned up. Never echoed — it may be the code. */
+export const TOO_MANY_ARGUMENTS_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "Three positionals, then flags. A code pasted twice, or an address repeated after the code, lands " +
+      "here. The extra word is not echoed back — it may be the code, and a code in a shell history is a " +
+      "code that leaked.",
+  },
+  { command: PAIR_USAGE, note: "The shape it wants." },
+];
+
+/**
+ * A bare code that does not name its pairing session.
+ *
+ * Both spellings, because both work and an operator has been handed one of
+ * them: `pair new` prints the session on its own line, and the joined form is
+ * what the framed handout pastes. Showing only the flag sends somebody holding
+ * a joined string back to the Core for nothing.
+ */
+export const MISSING_SESSION_STEPS: readonly CorePairStep[] = [
+  {
+    command: PAIR_USAGE,
+    note: "`actana pair new` prints the session id on its own line, beside the code. This is the form the usage line shows.",
+  },
+  {
+    command: PAIR_USAGE_JOINED,
+    note:
+      "Or the joined <session>:<code> form, which carries the session inside the code — that is what the " +
+      "pasteable command in `pair new`'s framed handout uses. Either works; both are the same two values.",
+  },
+];
+
+/** The code names one session and `--session` names another. */
+export const SESSION_DISAGREEMENT_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "The code carries one pairing session and --session names another. They have to agree, and this " +
+      "will not guess which of the two you meant.",
+  },
+  { command: PAIR_USAGE, note: "The bare code, with the session beside it." },
+  { command: PAIR_USAGE_JOINED, note: "Or the joined form on its own, with no --session at all." },
+];
+
+/** A name the registry will not take. */
+export function badNameSteps(nameError: string): readonly CorePairStep[] {
+  return [
+    { note: `${nameError[0]?.toUpperCase() ?? ""}${nameError.slice(1)}.` },
+    {
+      note:
+        "A name this registry will not take is a name `core ls`, `core use`, `core rm`, `core status`, " +
+        "`core shell` and `core exec` could not reach afterwards, so it is refused before anything is " +
+        "dialled.",
+    },
+    { command: PAIR_USAGE, note: "Pick another name. Nothing else about the pairing changes." },
+  ];
+}
+
+/** Anything that is not a `CorePairingError` — a defect, not an operator error. */
+export const DEFECT_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "That is not an operator error: it is a fault in this build, and no code, address or fingerprint " +
+      "changes it.",
+  },
+  {
+    command: `${PAIR_USAGE} --verbose`,
+    note:
+      "Re-run with --verbose and report what it prints, with the exit code. It never prints the code, " +
+      "the key or the credential.",
+  },
+];
+
+// ─── rendering ──────────────────────────────────────────────────────────────
+
+/**
+ * One framed field: a dim label in its column, the value beside it, wrapped.
+ *
+ * Continuations line up under the value rather than under the label, so a
+ * wrapped endpoint still reads as one field. A value with no space in it — a
+ * long path — runs past the border rather than being cut: `wrapText` cannot
+ * shorten its input, and a ragged border is cheaper than a path an operator
+ * cannot copy.
+ */
+function field(label: string, value: string, color: boolean): string[] {
+  const room = FRAME_CONTENT_WIDTH - FIELD_WIDTH;
+  const wrapped = wrapText(value, room);
+  return wrapped.map((line, index) => {
+    const spans: Span[] =
+      index === 0
+        ? [{ text: label.padEnd(FIELD_WIDTH), style: ANSI.dim }, { text: line }]
+        : [{ text: " ".repeat(FIELD_WIDTH) }, { text: line }];
+    return frameRow(spans, color);
+  });
+}
+
+/**
+ * The steps under a frame: the command flush and unstyled, the note under it.
+ *
+ * Unstyled because the command is what gets selected with a mouse, and a dim
+ * escape around it is how a low-contrast terminal theme turns an instruction
+ * into something that cannot be read. The note is dim because it is read once.
+ */
+export function stepLines(steps: readonly CorePairStep[], color: boolean): string[] {
+  const lines: string[] = [];
+  for (const [index, step] of steps.entries()) {
+    if (index > 0) lines.push("");
+    if (step.command !== undefined) {
+      lines.push(`  ${step.command}`);
+      for (const line of wrapText(step.note, PROSE_WIDTH - 4)) {
+        lines.push(style(`    ${line}`, ANSI.dim, color));
+      }
+    } else {
+      for (const line of wrapText(step.note, PROSE_WIDTH - 2)) {
+        lines.push(style(`  ${line}`, ANSI.dim, color));
+      }
+    }
+  }
+  return lines;
+}

--- a/packages/cli/src/core-pair-results.ts
+++ b/packages/cli/src/core-pair-results.ts
@@ -31,6 +31,7 @@
 
 import {
   ANSI,
+  clip,
   frameEdge,
   frameRow,
   FRAME_CONTENT_WIDTH,
@@ -122,6 +123,20 @@ export type CorePairSuccess = {
   endpoint: string;
   /** Whether a Core of this name was already registered. Chooses one word. */
   replaced: boolean;
+  /**
+   * What this machine is called **on the Core** — `--label`, or its hostname.
+   *
+   * The one fact on this block about the far end rather than this one, and it
+   * is here because it is the name an operator will look for when they come
+   * to revoke this client: the Core lists it in `actana pair ls` beside a
+   * certificate serial, and a serial is not something anybody recognises.
+   *
+   * Deliberately **not** the LABEL column of `actana core ls`, which means
+   * the Core's own alias and stays empty for a paired credential — see the
+   * `writeCoreBlob` call in `core-pair.ts`. Same word, opposite end of the
+   * link, which is why the row says which end it is talking about.
+   */
+  label: string;
   /** What `current` names now. `null` when nothing does. */
   current: string | null;
   /** Where the credential landed. The path, at mode 0600 — never the contents. */
@@ -155,6 +170,12 @@ export function corePairSuccessBlock(result: CorePairSuccess): string[] {
   );
   lines.push(frameRow([], color));
   lines.push(...field("Endpoint", result.endpoint, color));
+  // Clipped, and it is this row that gives: a label is a name the operator
+  // chose and can read back off `pair ls`, where every other value here is one
+  // they have to be able to copy.
+  lines.push(
+    ...field("Label", `${clip(result.label, 28)} — this machine, in the Core's \`pair ls\``, color),
+  );
   lines.push(...field("Current", currentSentence(result, isCurrent), color));
   // Reassurance, not a secret: the operator has just been told a credential
   // exists and has no way to see that it does. The path and the mode are the

--- a/packages/cli/src/core-pair-results.ts
+++ b/packages/cli/src/core-pair-results.ts
@@ -33,8 +33,9 @@ import {
   ANSI,
   clip,
   frameEdge,
-  frameRow,
   FRAME_CONTENT_WIDTH,
+  FRAME_HEADING,
+  frameRow,
   style,
   wrapText,
   type Span,
@@ -124,17 +125,24 @@ export type CorePairSuccess = {
   /** Whether a Core of this name was already registered. Chooses one word. */
   replaced: boolean;
   /**
-   * What this machine is called **on the Core** — `--label`, or its hostname.
+   * The name this machine put in the pairing request — `--label`, or its
+   * hostname when the flag was not given.
    *
-   * The one fact on this block about the far end rather than this one, and it
-   * is here because it is the name an operator will look for when they come
-   * to revoke this client: the Core lists it in `actana pair ls` beside a
-   * certificate serial, and a serial is not something anybody recognises.
+   * **A purely local fact, and the row is worded to claim nothing else**
+   * (#366 review 2). The first version of this row said it was "this machine,
+   * in the Core's `pair ls`", and that is false: `core-pairing-routes.ts`
+   * builds `PairedClient.label` from **`session.label`** — the name the *Core*
+   * operator typed at `actana pair new --label <name>` — and this value
+   * reaches the Core only as the certificate CN, and only in the sub-case
+   * where the session carried no label at all. `actana pair revoke` matches on
+   * `client.label` and on a `CN=`-prefixed subject, so it would not have found
+   * this name either. A row whose stated purpose was revocation and which
+   * could not be revoked by is worse than no row.
    *
-   * Deliberately **not** the LABEL column of `actana core ls`, which means
-   * the Core's own alias and stays empty for a paired credential — see the
-   * `writeCoreBlob` call in `core-pair.ts`. Same word, opposite end of the
-   * link, which is why the row says which end it is talking about.
+   * What it is good for is the case an operator did not choose: no `--label`,
+   * so this machine sent its hostname and nothing on the screen said so. That
+   * is a fact about **this** side, it is checkable here, and it is all this
+   * row now says.
    */
   label: string;
   /** What `current` names now. `null` when nothing does. */
@@ -170,12 +178,15 @@ export function corePairSuccessBlock(result: CorePairSuccess): string[] {
   );
   lines.push(frameRow([], color));
   lines.push(...field("Endpoint", result.endpoint, color));
-  // Clipped, and it is this row that gives: a label is a name the operator
-  // chose and can read back off `pair ls`, where every other value here is one
-  // they have to be able to copy.
-  lines.push(
-    ...field("Label", `${clip(result.label, 28)} — this machine, in the Core's \`pair ls\``, color),
-  );
+  // "Sent as", not "Label", because there are two LABEL columns in this
+  // program already — `core ls`'s, which means the *Core's* own alias, and
+  // `pair ls`'s on the Core, which means the *session's*. This is neither. It
+  // is what left this machine, and the row says only that.
+  //
+  // Clipped, and it is this row that gives: it is a name the operator either
+  // typed or can read off `hostname`, where every other value here is one they
+  // have to be able to copy.
+  lines.push(...field("Sent as", `${clip(result.label, 30)} — the name this machine gave`, color));
   lines.push(...field("Current", currentSentence(result, isCurrent), color));
   // Reassurance, not a secret: the operator has just been told a credential
   // exists and has no way to see that it does. The path and the mode are the
@@ -186,7 +197,7 @@ export function corePairSuccessBlock(result: CorePairSuccess): string[] {
   lines.push(frameEdge("bottom", color));
   lines.push("");
 
-  lines.push(style("Next steps", ANSI.dim, color));
+  lines.push(style("Next steps", FRAME_HEADING, color));
   lines.push(...stepLines(nextSteps(result, isCurrent), color));
   return lines;
 }
@@ -198,6 +209,15 @@ export function corePairSuccessBlock(result: CorePairSuccess): string[] {
  * second Core on a machine that already has one changes nothing about
  * `current`, and the operator's very next command will talk to the other Core
  * unless this line tells them so.
+ *
+ * **The third is defensive and says so** (#366 review 7). `runCorePair` writes
+ * the pointer when nothing holds it and then reads it back, so a `null` here
+ * means the pointer was cleared between those two lines — a concurrent
+ * `actana core rm`, or a registry that has gone missing underneath the write.
+ * Rare, not impossible, and the honest thing to print is that nothing is
+ * selected rather than a name that is not. It is unreachable through the verb,
+ * so the suite renders it by calling this block directly: a branch nothing
+ * exercises is a branch nobody knows the shape of.
  */
 function currentSentence(result: CorePairSuccess, isCurrent: boolean): string {
   if (isCurrent) return `"${result.name}" — every later verb talks to this Core`;
@@ -239,6 +259,15 @@ function nextSteps(result: CorePairSuccess, isCurrent: boolean): CorePairStep[] 
   steps.push({
     command: 'actana session start <project> "<prompt>"',
     note: "The first real thing to run on it. Prints the Session id and exits.",
+  });
+  // Named in #360 beside `session start` as the other first real action, and
+  // dropped from the first cut of this list — silently, which is the part the
+  // review was right about (#366 review 4). It is the interactive half of the
+  // same idea: `session start` hands work to an agent, `core shell` puts the
+  // operator on the machine themselves.
+  steps.push({
+    command: "actana core shell",
+    note: "Or an interactive shell on the Core, to look around it yourself.",
   });
   steps.push({
     note:
@@ -299,7 +328,7 @@ export function corePairRefusalBlock(refusal: CorePairRefusal): string[] {
   lines.push(frameEdge("bottom", color));
   lines.push("");
 
-  lines.push(style("What to do", ANSI.dim, color));
+  lines.push(style("What to do", FRAME_HEADING, color));
   lines.push(...stepLines(refusal.steps, color));
   return lines;
 }
@@ -403,9 +432,24 @@ export function corePairingOutcome(
             // The distinction the whole class turns on: a dial that never
             // landed has spent nothing, so the code in the operator's hand is
             // still good and re-minting one would be wasted effort.
+            //
+            // **Scoped, because this class is not only the dial** (#366 review
+            // 3). `postRedemption` reports `transport` — and so `unreachable` —
+            // from its error handler, which is armed across `req.end(body)` as
+            // well as before it: one 15s timer covers the whole exchange
+            // including the Core signing the certificate, so a slow Core or a
+            // reset mid-flight lands here with the session already spent. A
+            // block that promised the code was good would send that operator
+            // back for a `refused` and a second trip.
             note:
-              "Nothing answered at that address. This is a dial failure, not a refusal — the code was " +
-              "never sent, no attempt was spent, and the code you were given is still good.",
+              "Nothing answered at that address — a dial failure, not a refusal. If nothing answered, " +
+              "nothing was sent: no attempt was spent and the code you were given is still good.",
+          },
+          {
+            note:
+              "If instead the connection dropped part-way through, the Core may have redeemed the code " +
+              "before the answer was lost. A retry that comes back refused means exactly that — mint a " +
+              "fresh one rather than reading it as a second network fault.",
           },
           { command: "getent hosts <host>", note: "Does the name resolve, and to the machine you mean?" },
           {
@@ -770,7 +814,7 @@ function field(label: string, value: string, color: boolean): string[] {
  * escape around it is how a low-contrast terminal theme turns an instruction
  * into something that cannot be read. The note is dim because it is read once.
  */
-export function stepLines(steps: readonly CorePairStep[], color: boolean): string[] {
+function stepLines(steps: readonly CorePairStep[], color: boolean): string[] {
   const lines: string[] = [];
   for (const [index, step] of steps.entries()) {
     if (index > 0) lines.push("");

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -245,9 +245,9 @@ export async function runCorePair(
       name,
       endpoint: blob.endpoint,
       replaced: replacing,
-      // What was sent to the Core as this machine's name, which is what the
-      // operator will look for in `actana pair ls` there — not the empty
-      // LABEL this registry stores, which means the Core's own alias.
+      // What this machine put in the request, and nothing more is claimed of
+      // it (#366 review 2). The Core keeps the *session* label in its
+      // `pair ls`, not this one — see `CorePairSuccess.label`.
       label: args.label ?? deps.hostname,
       // **Read back, not inferred.** The block says which Core is current now,
       // and that is a claim about what is on disk — `writeCurrentCore` above

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -46,19 +46,33 @@
 // whose `bad-code` message quotes what it was handed — correct for a library
 // whose caller decides where text goes, wrong for a CLI whose stderr is a
 // terminal, a CI log and a shell history at once.
+//
+// **Two shapes, and `isatty(stdout)` is the whole of the switch (#360).** Down
+// a pipe this is what 0.4.2 printed and nothing else: one or two lines on a
+// success, one or two on a refusal, in the same words and the same order. At a
+// terminal both come framed — a green tick over the endpoint, an honest
+// `current` row and the four verbs a paired Core exists for; a red cross over
+// the reason and, for every class of failure, the command that fixes *that*
+// class. No flag chooses between them and deliberately no `--json`, exactly as
+// `actana pair new` decides it one machine over. `core-pair-results.ts` builds
+// both blocks and can see none of this; the one `if` per site is here.
+//
+// **What the command does is identical either way.** The credential that lands,
+// the `current` pointer, the exit code and what crosses the seam are the same
+// bytes at a terminal and down a pipe, because a command that *did* something
+// different at a terminal is a command no script can trust.
 
 import {
   CorePairingError,
   fetchCorePairingIdentity,
   pairWithCore,
   parsePairingTicket,
-  type CorePairingErrorDetail,
-  type CorePairingFailure,
   type CorePairingIdentity,
   type PairWithCoreOptions,
 } from "@actana/sdk/core-pairing.ts";
 import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
 import {
+  coreBlobPath,
   coreExists,
   coreNameError,
   readCurrentCore,
@@ -66,22 +80,25 @@ import {
   writeCurrentCore,
   type RegistryPaths,
 } from "./blob-registry.ts";
+import { useColor } from "./cli-frame.ts";
+import {
+  badNameSteps,
+  corePairingOutcome,
+  corePairRefusalBlock,
+  corePairSuccessBlock,
+  DEFECT_STEPS,
+  MISSING_ARGUMENTS_STEPS,
+  MISSING_SESSION_STEPS,
+  SESSION_DISAGREEMENT_STEPS,
+  TOO_MANY_ARGUMENTS_STEPS,
+  type CorePairStep,
+} from "./core-pair-results.ts";
 import { encodeRegistrationBlobText } from "./registration-blob-file.ts";
 import {
   EXIT_FAILURE,
   EXIT_OK,
-  EXIT_PAIR_CERTIFICATE_INVALID,
-  EXIT_PAIR_CORE_ERROR,
   EXIT_PAIR_FINGERPRINT_MISMATCH,
   EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
-  EXIT_PAIR_HOSTNAME_MISMATCH,
-  EXIT_PAIR_MALFORMED_RESPONSE,
-  EXIT_PAIR_NO_CA,
-  EXIT_PAIR_NOT_PAIRABLE,
-  EXIT_PAIR_RATE_LIMITED,
-  EXIT_PAIR_REFUSED,
-  EXIT_PAIR_REJECTED,
-  EXIT_PAIR_UNREACHABLE,
   EXIT_USAGE,
 } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -126,20 +143,34 @@ export async function runCorePair(
 ): Promise<number> {
   const [name, address, code, ...extra] = rest;
   if (name === undefined || address === undefined || code === undefined) {
-    deps.err("actana core pair: a name, an address and a code are required.");
-    // Both required flags, because both are (#357). `readTicket` below refuses
-    // a bare code without `--session`, and a usage line that omitted it sent the
-    // operator straight back here with the same three positionals and a fourth
-    // refusal.
-    deps.err("  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>");
-    deps.err("`actana pair new` on the Core prints the code, the fingerprint and the session.");
-    return EXIT_USAGE;
+    return refuse(deps, {
+      // Both required flags, because both are (#357). `readTicket` below
+      // refuses a bare code without `--session`, and a usage line that omitted
+      // it sent the operator straight back here with the same three
+      // positionals and a fourth refusal.
+      plain: [
+        "actana core pair: a name, an address and a code are required.",
+        "  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+        "`actana pair new` on the Core prints the code, the fingerprint and the session.",
+      ],
+      headline: "A name, an address and a code are required.",
+      detail: [
+        "Nothing was dialled. These are the three values `actana pair new` reads out on the Core, " +
+          "in the order it reads them.",
+      ],
+      steps: MISSING_ARGUMENTS_STEPS,
+      exit: EXIT_USAGE,
+    });
   }
   if (extra.length > 0) {
-    // Never the value: an operator who typed the code twice, or put it after
-    // the address a second time, would have it echoed back at them.
-    deps.err("actana core pair: too many arguments — expected <name> <address> <code>.");
-    return EXIT_USAGE;
+    return refuse(deps, {
+      // Never the value: an operator who typed the code twice, or put it after
+      // the address a second time, would have it echoed back at them.
+      plain: ["actana core pair: too many arguments — expected <name> <address> <code>."],
+      headline: "Too many arguments — expected <name> <address> <code>.",
+      steps: TOO_MANY_ARGUMENTS_STEPS,
+      exit: EXIT_USAGE,
+    });
   }
 
   // The registry's own name validation, first and with its own wording: a name
@@ -147,8 +178,12 @@ export async function runCorePair(
   // `rm`, `status`, `shell` or `exec` could reach afterwards.
   const nameError = coreNameError(name);
   if (nameError) {
-    deps.err(`actana core pair: ${nameError}.`);
-    return EXIT_USAGE;
+    return refuse(deps, {
+      plain: [`actana core pair: ${nameError}.`],
+      headline: `That is not a name this registry will take — ${nameError}.`,
+      steps: badNameSteps(nameError),
+      exit: EXIT_USAGE,
+    });
   }
 
   // The ticket first, before anything is dialled and before an operator is
@@ -200,13 +235,40 @@ export async function runCorePair(
   writeCoreBlob(paths, name, encodeRegistrationBlobText({ ...blob, label: "" }));
   deps.verbose(`stored at ${paths.coresDir}/${name}.txt, mode 0600`);
 
-  const current = readCurrentCore(paths);
-  if (current === null) writeCurrentCore(paths, name);
+  const before = readCurrentCore(paths);
+  if (before === null) writeCurrentCore(paths, name);
 
+  if (deps.stdoutIsTty) {
+    // The operator's shape (#360). Cosmetic, and reachable only when there is
+    // a human at the other end: same credential, same pointer, same exit code.
+    for (const line of corePairSuccessBlock({
+      name,
+      endpoint: blob.endpoint,
+      replaced: replacing,
+      // **Read back, not inferred.** The block says which Core is current now,
+      // and that is a claim about what is on disk — `writeCurrentCore` above
+      // runs only when nothing was selected, so on a machine that already had
+      // a Core the honest answer is somebody else's name. Asserting it from
+      // the branch that was taken would be the same claim with nothing behind
+      // it, and it would send an operator to `core status` against the wrong
+      // Core.
+      current: readCurrentCore(paths),
+      // The path and the mode, never the contents.
+      credentialPath: coreBlobPath(paths, name),
+      color: useColor(deps),
+    })) {
+      deps.out(line);
+    }
+    return EXIT_OK;
+  }
+
+  // stdout, piped: **not one byte of this may move.** It is what every script
+  // that has ever wrapped `core pair` reads, and the block above exists
+  // precisely so that it does not have to change to give an operator more.
   deps.out(`${replacing ? "Replaced" : "Paired"} Core "${name}" → ${blob.endpoint}`);
-  if (current === null) deps.out(`\`current\` now points at "${name}".`);
-  else if (current !== name) {
-    deps.out(`\`current\` is still "${current}" — \`actana core use ${name}\` to switch.`);
+  if (before === null) deps.out(`\`current\` now points at "${name}".`);
+  else if (before !== name) {
+    deps.out(`\`current\` is still "${before}" — \`actana core use ${name}\` to switch.`);
   }
   return EXIT_OK;
 }
@@ -234,14 +296,36 @@ function readTicket(deps: ActanaCliDeps, code: string, session: string | null): 
   const explicit = session?.trim() ?? "";
 
   if (carried === "" && explicit === "") {
-    deps.err("actana core pair: a pairing code names the pairing session it belongs to.");
-    deps.err("Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.");
-    return { ok: false, exit: EXIT_USAGE };
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: a pairing code names the pairing session it belongs to.",
+          "Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.",
+        ],
+        headline: "A pairing code names the pairing session it belongs to.",
+        detail: [
+          "Nothing was dialled: the ticket is read before anything is sent, so no attempt was spent " +
+            "and the code you were given is still good.",
+        ],
+        steps: MISSING_SESSION_STEPS,
+        exit: EXIT_USAGE,
+      }),
+    };
   }
   if (carried !== "" && explicit !== "" && carried !== explicit) {
-    deps.err("actana core pair: the code names one pairing session and `--session` names another.");
-    deps.err("Drop `--session`, or pass the bare code beside it — they have to agree.");
-    return { ok: false, exit: EXIT_USAGE };
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: the code names one pairing session and `--session` names another.",
+          "Drop `--session`, or pass the bare code beside it — they have to agree.",
+        ],
+        headline: "The code names one pairing session and --session names another.",
+        steps: SESSION_DISAGREEMENT_STEPS,
+        exit: EXIT_USAGE,
+      }),
+    };
   }
 
   try {
@@ -267,9 +351,15 @@ function readTicket(deps: ActanaCliDeps, code: string, session: string | null): 
  */
 function badCode(deps: ActanaCliDeps): number {
   const outcome = corePairingOutcome("bad-code");
-  deps.err("actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.");
-  deps.err(outcome.next);
-  return outcome.exit;
+  return refuse(deps, {
+    plain: [
+      "actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.",
+      outcome.next,
+    ],
+    headline: "That was not accepted as a pairing code.",
+    steps: outcome.steps,
+    exit: outcome.exit,
+  });
 }
 
 /** A fingerprint the operator stands behind, or the exit code for the refusal. */
@@ -300,9 +390,19 @@ async function confirmFingerprint(
     return { ok: true, fingerprint: args.fingerprint };
   }
   if (!deps.interactive) {
-    deps.err("actana core pair: no fingerprint was given and there is no terminal to confirm one on.");
-    deps.err(corePairingOutcome("fingerprint-unconfirmed").next);
-    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED };
+    const outcome = corePairingOutcome("fingerprint-unconfirmed");
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: no fingerprint was given and there is no terminal to confirm one on.",
+          outcome.next,
+        ],
+        headline: "No fingerprint was given, and there is no terminal to confirm one on.",
+        steps: outcome.steps,
+        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+      }),
+    };
   }
 
   let identity: CorePairingIdentity;
@@ -323,12 +423,27 @@ async function confirmFingerprint(
     false,
   );
   if (!matches) {
-    deps.err("actana core pair: the fingerprint was not confirmed, so the pairing code was not sent.");
-    deps.err(corePairingOutcome("fingerprint-mismatch").next);
+    const outcome = corePairingOutcome("fingerprint-mismatch");
     // A human comparing two strings and saying they differ is a mismatch, and
-    // it exits as one: the operator has performed exactly the check the SDK
-    // performs when it is given a fingerprint to hold the Core to.
-    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_MISMATCH };
+    // it exits as one — and it gets the same remedy: the operator has just
+    // performed exactly the check the SDK performs when it is handed a
+    // fingerprint to hold the Core to, so there is nothing different to say.
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: the fingerprint was not confirmed, so the pairing code was not sent.",
+          outcome.next,
+        ],
+        headline: "The fingerprint was not confirmed, so the pairing code was not sent.",
+        detail: [
+          "You compared the authority this address presents against the one `actana pair new` " +
+            "printed on the Core, and said they differ. That is the check doing its job.",
+        ],
+        steps: outcome.steps,
+        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
+      }),
+    };
   }
   // The confirmed value is handed back to `pair`, which dials again and
   // re-computes it: what the operator agreed to is enforced on the connection
@@ -346,8 +461,12 @@ async function confirmFingerprint(
 function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
   if (!(err instanceof CorePairingError)) {
     const message = err instanceof Error ? err.message : String(err);
-    deps.err(`actana core pair: pairing failed — ${message}`);
-    return EXIT_FAILURE;
+    return refuse(deps, {
+      plain: [`actana core pair: pairing failed — ${message}`],
+      headline: `Pairing failed — ${message}`,
+      steps: DEFECT_STEPS,
+      exit: EXIT_FAILURE,
+    });
   }
   // `bad-code` is the one failure whose message is not relayed, because the
   // SDK's quotes the code — see {@link badCode}. Reaching it from here means
@@ -358,110 +477,65 @@ function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
   if (err.failure === "bad-code") return badCode(deps);
 
   const outcome = corePairingOutcome(err.failure, err.detail);
-  deps.err(`actana core pair: ${err.message}`);
-  deps.err(outcome.next);
-  return outcome.exit;
+  return refuse(deps, {
+    // The SDK's sentence is the headline. It is written for a caller that
+    // decides where text goes, so the frame wraps it rather than trusting it
+    // to fit — but it is the accurate description of what happened, and
+    // rewording thirteen of them here would be thirteen places for the two
+    // accounts to drift apart.
+    plain: [`actana core pair: ${err.message}`, outcome.next],
+    headline: err.message,
+    steps: outcome.steps,
+    exit: outcome.exit,
+  });
 }
-
-/** What an operator should do next about a failure, and what this process exits with. */
-export type CorePairingOutcome = {
-  /** The code from `exit-codes.ts`. Contract: a script may branch on it. */
-  exit: number;
-  /** One line saying what to do next. Never quotes the code or any credential. */
-  next: string;
-};
 
 /**
- * Every failure the SDK distinguishes, given a number and a next step.
+ * Say no, in whichever of the two shapes stdout is entitled to (#360).
  *
- * One `switch` with no `default`, so a failure added to `CorePairingFailure`
- * stops this file compiling until somebody decides what an operator should do
- * about it — which is the only way a list like this stays honest.
+ * **`plain` is the contract and `headline`/`detail`/`steps` are the frame.**
+ * Two sets of strings rather than one set with the ornaments stripped off,
+ * because the piped lines are what every script that has ever grepped a
+ * pairing failure reads and the only way to keep them from drifting is to
+ * write them out at each site and assert them whole. A refusal that grew a
+ * better explanation this way cannot have moved a byte of the other one.
+ *
+ * The gate is `isatty(stdout)` — not stderr, which is where these lines go.
+ * That looks like the wrong stream to ask about and is deliberately the right
+ * one: `actana core pair … > /dev/null` and `… 2>&1 | tee` are both a program
+ * reading this output, and the promise is that **redirecting stdout gets the
+ * 0.4.2 shape on both streams**. One question, one answer, and no run where
+ * half the output is framed.
  */
-export function corePairingOutcome(
-  failure: CorePairingFailure,
-  detail: CorePairingErrorDetail = {},
-): CorePairingOutcome {
-  switch (failure) {
-    case "bad-address":
-      return {
-        exit: EXIT_USAGE,
-        next: "An address is host:port — the Core's TLS port, the one `actana status` reports on the Core.",
-      };
-    case "bad-code":
-      return {
-        exit: EXIT_USAGE,
-        next: "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
-      };
-    case "bad-fingerprint":
-      return {
-        exit: EXIT_USAGE,
-        next: "A fingerprint is 32 bytes of hex, as AA:BB:… — copy the line `actana pair new` printed.",
-      };
-    case "unreachable":
-      return {
-        exit: EXIT_PAIR_UNREACHABLE,
-        next: "Check the Core is running and that address reaches it — `actana status` on the Core says where it listens.",
-      };
-    case "not-pairable":
-      return {
-        exit: EXIT_PAIR_NOT_PAIRABLE,
-        next: "Something answered there but it has no pairing endpoint — check it is a Core, and update it if it is old.",
-      };
-    case "no-ca-presented":
-      return {
-        exit: EXIT_PAIR_NO_CA,
-        next: "Nothing was presented to compare against the fingerprint — check the address is the Core's own TLS port.",
-      };
-    case "fingerprint-unconfirmed":
-      return {
-        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
-        next: "Pass `--fingerprint <sha256>` — the code is never sent to a certificate authority nobody confirmed.",
-      };
-    case "fingerprint-mismatch":
-      return {
-        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
-        next:
-          "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
-          "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
-      };
-    case "hostname-mismatch":
-      return {
-        exit: EXIT_PAIR_HOSTNAME_MISMATCH,
-        next: "That is the right Core on an address its certificate does not cover — dial the one it was set up for.",
-      };
-    case "certificate-invalid":
-      return {
-        exit: EXIT_PAIR_CERTIFICATE_INVALID,
-        next: "The right Core, with a certificate that cannot be used — check the clock on both machines, then reissue it.",
-      };
-    case "refused":
-      return {
-        exit: EXIT_PAIR_REFUSED,
-        next: "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
-      };
-    case "rate-limited":
-      return {
-        exit: EXIT_PAIR_RATE_LIMITED,
-        next:
-          detail.retryAfterSeconds === undefined
-            ? "Wait, then try again with a fresh code."
-            : `Wait ${detail.retryAfterSeconds} seconds, then try again with a fresh code.`,
-      };
-    case "rejected":
-      return {
-        exit: EXIT_PAIR_REJECTED,
-        next: "The Core would not accept the request itself — that is a bug on this side. Please report it.",
-      };
-    case "core-error":
-      return {
-        exit: EXIT_PAIR_CORE_ERROR,
-        next: "The Core failed while handling this — `actana logs` on the Core has the reason; nothing here does.",
-      };
-    case "malformed-response":
-      return {
-        exit: EXIT_PAIR_MALFORMED_RESPONSE,
-        next: "Something answered that is not a Core, or is not one this build understands. Check the address.",
-      };
+function refuse(
+  deps: ActanaCliDeps,
+  refusal: {
+    /** Exactly what 0.4.2 printed, in order. Never changes. */
+    plain: readonly string[];
+    headline: string;
+    detail?: readonly string[];
+    steps: readonly CorePairStep[];
+    exit: number;
+  },
+): number {
+  if (!deps.stdoutIsTty) {
+    for (const line of refusal.plain) deps.err(line);
+    return refusal.exit;
   }
+  for (const line of corePairRefusalBlock({
+    headline: refusal.headline,
+    detail: refusal.detail ?? [],
+    steps: refusal.steps,
+    color: useColor(deps),
+  })) {
+    deps.err(line);
+  }
+  return refusal.exit;
 }
+
+// The failure table moved to `core-pair-results.ts` with the rest of the
+// result surface (#360): it is what an operator is told, and it now carries
+// the concrete remedy per class as well as the one-line `next`. Re-exported
+// here because this is the module the verb lives in and the table is part of
+// what the verb promises.
+export { corePairingOutcome, type CorePairingOutcome } from "./core-pair-results.ts";

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -245,6 +245,10 @@ export async function runCorePair(
       name,
       endpoint: blob.endpoint,
       replaced: replacing,
+      // What was sent to the Core as this machine's name, which is what the
+      // operator will look for in `actana pair ls` there — not the empty
+      // LABEL this registry stores, which means the Core's own alias.
+      label: args.label ?? deps.hostname,
       // **Read back, not inferred.** The block says which Core is current now,
       // and that is a claim about what is on disk — `writeCurrentCore` above
       // runs only when nothing was selected, so on a machine that already had


### PR DESCRIPTION
Closes #360. The client half of the onboarding pass; #364 did the Core half.

## The problem

An operator on the Core runs `actana pair new`, gets a framed handout (#364),
and carries a code, a fingerprint and a session to the second machine. They
paste the command they were given, and the moment they find out whether it
worked was:

```
Paired Core "prod" → wss://core.test:8443
`current` now points at "prod".
```

…with no hint that there is anything to do next, or, on failure, two lines of
prose where "refused" is the same word for an expired code, a spent one and a
typo.

## The shape

Two shapes, and `isatty(stdout)` is the whole of the switch — no flag, and
deliberately no `--json`, exactly as it is decided one machine over.

**Piped, redirected or captured, both streams are what 0.4.2 printed.** Same
success lines in the same order, same two-line refusals. The suite asserts
those whole against literals rather than trusting them: all three shapes the
pointer note has, and the exact line count of every failure class.

**At a terminal, success is a framed block.**

```
╭────────────────────────────────────────────────────────────────────────╮
│                                                                        │
│   ✓ Paired Core "prod"                                                 │
│                                                                        │
│   Endpoint     wss://core.example.test:8443                            │
│   Sent as      bkp-07 — the name this machine gave                     │
│   Current      "prod" — every later verb talks to this Core            │
│   Credential   /home/ada/.config/actana/cores/prod.txt (mode 0600)     │
│                                                                        │
╰────────────────────────────────────────────────────────────────────────╯

Next steps
  actana core status
    Reach the Core and report what it says. The check that the link works
    end to end.

  actana project ls
    The Projects on this Core. A Session needs one to run in.

  actana harness ls
    Which agents this Core can actually run right now, and which it is
    missing.

  actana session start <project> "<prompt>"
    The first real thing to run on it. Prints the Session id and exits.

  actana core shell
    Or an interactive shell on the Core, to look around it yourself.

  The Panel pairs with this same Core from its Settings -> Cores screen,
  with a code of its own — `actana pair new` on the Core mints that one too.
```

The `Current` row is **read back off disk after the write**, not inferred from
the branch that was taken. `core pair` makes a Core current only when nothing
was, so pairing a second Core changes no pointer — and the block says so and
puts `actana core use <name>` first, rather than congratulating an operator on
a `current` they do not have:

```
│   Current      still "prod" — this pairing did not change it           │
```

The `Sent as` row is a purely local fact: the name this machine put in the
pairing request — `--label`, or its hostname when the flag was not given. It
makes **no** claim about the far end, and the review was right that the earlier
wording did and was wrong to: the Core stores the *session's* label in its
`pair ls`, not the client's. Not called `Label`, because this program already
has two LABEL columns meaning two other things.

The credential row is reassurance, never the blob: the path and the mode, and
the "never logs a blob" sweep still covers this verb.

## Every failure class ends in a command

One remedy per distinguishable failure, because "ask for a fresh code" and
"check the port is open" are answers to different problems — a table that gave
both to both would be the prose it replaced. A test asserts no two classes
share a remedy.

| Class | What it now says |
| --- | --- |
| `refused` — expired, spent, unknown, out of attempts | that the Core deliberately will not say which, `actana pair new --label <name>`, and **re-run with the NEW code *and* the NEW session** |
| `fingerprint-mismatch` | what was compared against what, that the code was not sent, and that there is no flag that skips the comparison and none is coming |
| `unreachable` | a **dial** failure, not a refusal — *if nothing answered*, nothing was sent and the code is still good; a drop part-way through may have spent it — plus `getent hosts`, `nc -vz`, `actana status`, and the proxy/SNI cases |
| `not-pairable` | the other side of that: the dial worked, so update the Core or check the port |
| a bare code | both `--session <id>` **and** the joined `<session>:<code>` form, because an operator has been handed one or the other |
| `rate-limited`, `certificate-invalid`, `hostname-mismatch`, `core-error`, … | their own concrete check — `date -u` on both machines, `actana logs` on the Core, and so on |

Colour follows #364: green tick, red cross, dim headers, `NO_COLOR` honoured,
and no escape ever emitted off the TTY path.

## Reuse, not a second copy

#364's frame primitives — the border width, the padding rule, the colour table,
the display-width measurement — moved from `actana-pair.ts` to a shared
`cli-frame.ts`, and both callers import them. Two copies of a border width is
how the two ends of one handshake start drawing different boxes.

`actana-pair.ts` keeps its handout, its wording and its one `if`, and
`actana-pair.test.ts` is **untouched and still passes whole** — the piped
byte-identity and the framed content it pins are the proof that the lift is a
lift and not a rewrite.

One behaviour change in the shared code: `wrapText` now breaks an over-long
word on its slashes rather than running past the border, the same move
`wrapFingerprint` makes on colons. A credential path under a deep home
directory is ordinary, not pathological — this was caught by the suite running
under a longer temp root. The rule that it may never *shorten* its input still
holds.

## Review round 1 (`b672fcd`)

[The review](https://github.com/actana/control/pull/366#pullrequestreview-5069784593)
found two blocking defects; both are fixed, along with the two should-fix items
and the cheap notes. The detail is in
[this reply](https://github.com/actana/control/pull/366#issuecomment-5482885492).

- **The frame shattered on `fingerprint-mismatch`** — the SDK's sentence carries
  two 95-column colon-hex fingerprints and `wrapText` broke only on `/`.
  `WORD_BREAKS` is now `/`, `:` and `.`; the docstring describes what the
  function actually does; the width test renders the real SDK sentence.
- **The `Label` row named a value the Core does not keep** — reworded to
  `Sent as`, a purely local fact claiming nothing about `pair ls`.
- **`unreachable` promised the code was unspent** — scoped to *if nothing
  answered*, with the post-send case spelled out.
- **`actana core shell` is back** in the next steps.

## What is not here

- `actana pair new`'s output and its handout — #364, landed.
- `packages/panel` — #358, landed.
- The flagless refusal lines in `core-command.ts` and `core-resolution.ts` —
  they belong to #365's sweep.

## Testing

- `pnpm test`: all six stages pass (1169 CLI tests, 3 skipped).
- `pnpm typecheck`, `pnpm lint`: clean — 0 errors, and no finding in any file
  this branch touches.
- 28 new tests in `core-pair.test.ts`, split into the piped contract
  (whole-output assertions) and the framed content per failure class.
- `docs/core-linux-rehearsal.md` gains the checkboxes for the half only two
  machines can check: that the four next steps actually run, that a redirected
  pair is still two plain lines **on both streams**, and that a spent code and
  a dead port give different remedies.

