### PR TITLE
feat: onboarding — framed pairing output at a TTY, a Panel first-run wizard, and a token-scope docs fix

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -699,9 +699,13 @@ jobs:
   # every delete call, it refuses to run when empty, and it is unit-tested
   # against a release repository being handed to it by name.
   #
-  # The credential is a *second* token, not the one the image push uses. That
-  # is the point: the push credential never gains delete, and the delete
-  # credential never appears in a job that touches a release repository.
+  # The credential is a *second* token, not the one the image push uses. Both
+  # carry delete now — the description PATCH in `descriptions` is a delete-scope
+  # call, so `DOCKERHUB_TOKEN` is `Read, Write, Delete` too (#359) — and the
+  # second token therefore buys separation rather than a narrower scope: it is
+  # the only credential pointed at a delete endpoint, it never appears in a job
+  # that touches a release repository, and it can be revoked or rotated without
+  # taking the publishing path down with it.
   dev-tag-sweep:
     name: Sweep the -dev image tags
     if: >-
@@ -797,7 +801,9 @@ jobs:
           DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
           OWNER: ${{ github.repository_owner }}
           # The same one PAT the image push uses — *not* the cleanup token.
-          # Descriptions are a write to a page, not a delete.
+          # It needs `Read, Write, Delete`: the PATCH below is a delete-scope
+          # call on the Hub API, and a `Read & Write` token 403s on it while
+          # image pushes keep working (#359). See docs/REPO_SETUP.md section 2.
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
@@ -819,7 +825,7 @@ jobs:
             | jq -r '.token // empty')"
 
           if [[ -z "$jwt" ]]; then
-            echo "::error title=Docker Hub auth failed::Could not exchange DOCKERHUB_USERNAME/DOCKERHUB_TOKEN for a JWT. This endpoint rejects organization access tokens ('Cannot log into an organization account') — use a PERSONAL access token with Read & Write scope, from an account with Admin on the org. That one token serves the image push as well."
+            echo "::error title=Docker Hub auth failed::Could not exchange DOCKERHUB_USERNAME/DOCKERHUB_TOKEN for a JWT. This endpoint rejects organization access tokens ('Cannot log into an organization account') — use a PERSONAL access token with Read, Write, Delete scope, from an account with Admin on the org. That one token serves the image push as well."
             exit 1
           fi
 
@@ -857,7 +863,7 @@ jobs:
                   "https://hub.docker.com/v2/repositories/${namespace}/${repo}/")"
 
             if [[ "$status" != "200" ]]; then
-              echo "::error title=Failed to update $repo::HTTP $status — $(cat /tmp/resp.json)"
+              echo "::error title=Failed to update $repo::HTTP $status — $(cat /tmp/resp.json). A 403 'insufficient scope' here means DOCKERHUB_TOKEN is scoped Read & Write: this PATCH is a delete-scope call, so the token needs Read, Write, Delete (#359). Image pushes succeed on the narrower scope, which is why they stay green. See docs/REPO_SETUP.md section 2."
               return 1
             fi
             echo "✅ ${namespace}/${repo} — $bytes bytes of README, short description set"

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -40,8 +40,8 @@ section is what each one is.
 | Name | Kind | Needed for |
 | --- | --- | --- |
 | `DOCKERHUB_USERNAME` | Secret | Publishing `panel` and `core` to Docker Hub, and syncing each image's README |
-| `DOCKERHUB_TOKEN` | Secret | Same — one **personal** access token, `Read & Write`, not the account password |
-| `DOCKERHUB_CLEANUP_TOKEN` | Secret | The weekly `-dev` tag sweep, and nothing else — a **second**, delete-capable PAT |
+| `DOCKERHUB_TOKEN` | Secret | Same — one **personal** access token, `Read, Write, Delete`, not the account password |
+| `DOCKERHUB_CLEANUP_TOKEN` | Secret | The weekly `-dev` tag sweep, and nothing else — a **second** PAT, the only one pointed at a delete endpoint |
 | `NPM_TOKEN` | Secret | Publishing `@actana/sdk` and `@actana/cli` to npm from `release.yml` |
 | `APP_ID` | Secret | The GitHub App's numeric id. Every job in `promote.yml` that pushes |
 | `APP_PRIVATE_KEY` | Secret | That App's private key, the whole PEM. Same jobs — **both or neither** |
@@ -99,7 +99,7 @@ The scope itself must exist and the account must own it before the first
 release. `npm access list packages @actana` answers that, and an npm 404 on
 `@actana/sdk` before the first publish is expected rather than a problem.
 
-### It must be a *personal* access token, and one token does both jobs
+### It must be a *personal* access token, `Read, Write, Delete`, and one token does both jobs
 
 Pushing an image and editing a repository's description go through different
 systems: the image push authenticates to the **registry**, where an
@@ -110,10 +110,13 @@ API**, whose `/v2/users/login` endpoint refuses organization accounts outright �
 {"detail":"Cannot log into an organization account"}
 ```
 
-So an OAT would mean paying for a Docker Team or Business subscription **and
-still** provisioning a PAT. One PAT does both instead: create it under your
-**Account settings → Personal access tokens** with **Read & Write** scope, from
-an account with **Admin** on the org, and set `DOCKERHUB_USERNAME` to that
+So a Docker Hub **organization access token is not an option here** — it is
+rejected by the `/v2/users/login` JWT exchange no matter how it is scoped, and
+using one would mean paying for a Docker Team or Business subscription **and
+still** provisioning a PAT. Do not let anyone talk you into an OAT for this
+secret. One classic PAT does both jobs instead: create it under your **Account
+settings → Personal access tokens** with **Read, Write, Delete** scope, from an
+account with **Admin** on the org, and set `DOCKERHUB_USERNAME` to that
 account's own username (not the org — the org goes in `DOCKERHUB_NAMESPACE`).
 
 ```bash
@@ -124,6 +127,36 @@ gh variable set DOCKERHUB_NAMESPACE --repo actana/control --body actana
 
 A wrong pairing is the single most common way to get
 `unauthorized: incorrect username or password` from an otherwise correct setup.
+
+**`Read, Write, Delete` is the scope, and `Read & Write` is not enough.** The
+image pushes are satisfied by `Read & Write`, so a token scoped that way looks
+correct right up to the weekly `descriptions` chore, which fails every one of
+its four `PATCH /v2/repositories/…` calls with `HTTP 403 — access denied:
+insufficient scope` while the pushes keep working
+([#359](https://github.com/actana/control/issues/359)). Writing a repository's
+description is a delete-scope call on the Hub API. This was proved on the token
+itself rather than reasoned about: on 2026-08-31 the scope of the existing
+`DOCKERHUB_TOKEN` was widened to `Read, Write, Delete` in Docker Hub with **the
+secret value unchanged**, and the next dispatched run
+([33396982252](https://github.com/actana/control/actions/runs/33396982252)) went
+green on the first try and filled all four pages.
+
+Two consequences worth stating plainly:
+
+- **Never swap this secret for a narrower token.** It is the same credential
+  that pushes `panel`, `core`, `panel-dev` and `core-dev`. Narrowing it back to
+  `Read & Write` does not blank the pages — the `PATCH` 403s and writes nothing,
+  so the last text written stays up while the weekly chore goes red and the four
+  pages quietly stop tracking `docs/images/`. That is harder to notice than a
+  blank page, not easier. Narrowing it below that breaks every image push too.
+- **There is no repository-scoped alternative to reach for.** A Docker Hub PAT
+  carries an account-wide permission level rather than a repository list, and
+  per-repository scoping needs an organization access token — the one credential
+  the `/v2/users/login` exchange rejects outright, above
+  ([ADR 0023](adr/0023-release-trains-and-digest-promotion.md) D38, *the
+  delete-capable credential*; [ADR 0016](adr/0016-the-0-1-0-shape.md) D31). So
+  this token can delete anywhere the account can reach. That is a property to
+  manage — one owner, recorded and rotated — not one to scope away.
 
 ### Rotating it — the token belongs to a person
 
@@ -138,8 +171,10 @@ the push, which is the worst moment to find out.
       an account that leaves as a compromised credential: revoke first,
       re-provision second
 
-To rotate, create the new token first — overwriting the secret is atomic, so
-nothing is unpublishable in between:
+To rotate, create the new token first — with the same **Read, Write, Delete**
+scope, because a rotation that quietly narrows it reintroduces
+[#359](https://github.com/actana/control/issues/359) — and overwrite second;
+overwriting the secret is atomic, so nothing is unpublishable in between:
 
 ```bash
 gh secret set DOCKERHUB_USERNAME --repo actana/control
@@ -178,16 +213,27 @@ what bounds the blast radius of the delete credential below.
       [`core-dev.md`](images/core-dev.md); typing something now only creates a
       thing to disagree with
 
-### `DOCKERHUB_CLEANUP_TOKEN` — the second, delete-capable token
+### `DOCKERHUB_CLEANUP_TOKEN` — the second token, the one aimed at deletes
 
 The weekly `dev-tag-sweep` chore deletes stale `pr-*` and `sha-*` tags from
-`panel-dev` and `core-dev`, and delete is a permission the push token must never
-have. It is therefore a **second** PAT, and it is the more dangerous of the two:
-Docker Hub personal access tokens carry an account-wide permission level rather
-than a repository list, so this one can delete from `actana/panel` and
-`actana/core` as well, and Docker Hub has no undelete.
+`panel-dev` and `core-dev`, and it runs on its own credential rather than on the
+push token. Both tokens carry delete — the descriptions `PATCH` above is why the
+push token does — so the second PAT does not buy a narrower scope. It buys two
+things that survive that:
 
-The only thing preventing that is the hard-coded, exact-match repository
+- **Blast radius.** It appears in exactly one job, the weekly sweep, and never
+  in a job that pushes or promotes. The push token is on every PR build, train
+  build, release and promotion; keeping the one credential that is aimed at a
+  delete endpoint out of all of those is the point.
+- **Independent rotation.** It can be revoked the moment the sweep misbehaves,
+  without taking the publishing path down with it.
+
+What it does *not* buy is containment by scope: Docker Hub personal access
+tokens carry an account-wide permission level rather than a repository list, so
+either token could delete from `actana/panel` and `actana/core`, and Docker Hub
+has no undelete.
+
+The only thing bounding the sweep is the hard-coded, exact-match repository
 allowlist in `scripts/lib/dev-tag-sweep.mjs` — re-asserted before every delete
 call, refusing to run when empty, and unit-tested against a release repository
 handed to it by name ([ADR

--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -168,6 +168,39 @@ actana core status
       --public-host <addr>` re-mint that would register the one you dialled.
       Pair on a non-primary address and confirm `core status` behaves the way
       the warning said it would.
+- [ ] Because you are at a terminal on that machine too, the pairing **result**
+      comes framed (#360): a green `✓`, the endpoint, an honest `Current` row,
+      where the credential landed at mode 0600 — and under it `actana core
+      status`, `actana project ls`, `actana harness ls`, `actana session
+      start` and `actana core shell`. Run all five. They are the checkbox: a
+      next step that does not work is worse than no next step.
+- [ ] The `Sent as` row names what this machine put in the request — the
+      `--label` you passed, or its hostname. It claims nothing about the Core,
+      and it should not: `actana pair ls` **on the Core** lists the label the
+      *code* was minted with, which is a different string. Check both screens
+      and confirm the client never told you to look for a name that is not
+      there (#366 review 2).
+- [ ] Pair a **second** Core on that machine. The block says `current` is still
+      the first one and offers `actana core use <name>` — it does not claim a
+      `current` the pairing did not take.
+- [ ] `actana core pair … > /tmp/paired.txt 2>&1` instead gives the two plain
+      lines and nothing else — no frame, no next steps, on either stream. That
+      is the contract every script wrapping this command depends on.
+      (`rm /tmp/paired.txt` after.)
+- [ ] Run it once more with the **same, now spent** code. The refusal is framed,
+      red, and ends in `actana pair new --label <name>` plus the reminder to
+      re-run with the NEW code *and* the NEW session — not prose alone.
+- [ ] Run it against a port nothing listens on. That refusal says **dial**
+      failure rather than refusal, scopes the "your code is still good"
+      promise to *if nothing answered*, and offers `getent hosts` / `nc -vz` —
+      a different remedy from the one above, which is the whole point of the
+      table.
+- [ ] Run it with a `--fingerprint` that is wrong by one byte. The refusal is
+      framed and **the box holds**: the real SDK sentence carries two full
+      95-column fingerprints, both wrapped on their own colons and neither
+      shortened, and every border lands in the same column (#366 review 1).
+      This is the one screen an operator compares character by character.
+- [ ] `NO_COLOR=1` on any of the above: same words, same box, no escapes.
 
 ---
 

--- a/docs/core-linux-rehearsal.md
+++ b/docs/core-linux-rehearsal.md
@@ -131,6 +131,43 @@ actana pair new --label my-panel
       fingerprint**, and when the code expires.
 - [ ] The code is short enough to read out loud over a phone without spelling
       anything — no `0`, `O`, `1`, `I` or `L` in it.
+- [ ] Because you are at a terminal, it comes **framed** (#357): the code, the
+      whole fingerprint wrapped rather than shortened, the session — and under
+      it both ways to spend them, the Panel path and a pasteable
+      `actana core pair …` command per address this Core answers on.
+- [ ] `actana pair new > /tmp/code.txt` instead gives the plain labelled lines
+      and nothing else — no frame, no instructions. That is the contract every
+      script wrapping this command depends on. (`rm /tmp/code.txt` after.)
+
+### The pasteable line, on a second machine
+
+**This is the one thing nothing automated can check**, and the reason it is a
+checkbox: the command below is generated from real minted values, and whether
+it works is a question about two machines. Take the `actana core pair …` line
+the block printed to a second machine — another VM, a laptop, a container with
+`npm i -g @actana/cli` on it — and paste it **unedited**.
+
+```bash
+# on the second machine, pasted exactly as printed
+actana core pair <as-printed>
+actana core status
+```
+
+- [ ] It pastes and runs. No `bash: …: No such file or directory`, no shell
+      error naming a file instead of `actana` — the line survives a shell as
+      printed, placeholder and all.
+- [ ] If `pair new` was run with no `--label`, the name slot is `NAME` and the
+      line still runs. Rename or remove it afterwards with `actana core rm`.
+- [ ] It pairs: the Core is registered, and no fingerprint had to be retyped.
+- [ ] `actana core status` **reaches the Core** from that second machine. A
+      pairing that succeeds and then cannot be reached is the failure this
+      checkbox exists for.
+- [ ] On a Core with several `--public-host` addresses: the block warns, on
+      every address but the one the credential will carry, that the code still
+      registers the other endpoint — and names the `actana pair new
+      --public-host <addr>` re-mint that would register the one you dialled.
+      Pair on a non-primary address and confirm `core status` behaves the way
+      the warning said it would.
 
 ---
 

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { X509Certificate } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import {
   loadMaterialFromFile,
   materialFilePath,
@@ -25,6 +26,7 @@ import {
   persistMaterialToFile,
   type PersistedMaterial,
 } from "@actana/shared/core-material-store";
+import { coreNameError } from "@actana/shared/blob-registry";
 import { normalisePairingCode, PAIRING_CODE_ALPHABET } from "@actana/shared/pairing-code";
 import { createPairingSession, PAIRING_SESSION_TTL_MS } from "@actana/shared/pairing-session";
 import {
@@ -37,9 +39,14 @@ import {
 } from "@actana/shared/pairing-store";
 import {
   describeDuration,
+  displayWidth,
+  FRAME_WIDTH,
   MAX_PAIRING_TTL_MS,
+  NAME_PLACEHOLDER,
+  PANEL_INSTRUCTION,
   parseDuration,
   runPairCommand,
+  wrapFingerprint,
 } from "../actana-pair.ts";
 import type { ActanaCliDeps } from "../cli-deps.ts";
 import { stubClientHalf, stubMachineHalf } from "./machine-fixture.ts";
@@ -53,8 +60,19 @@ let out: string[];
 let err: string[];
 let audited: Record<string, unknown>[];
 
-/** One run of `actana pair <argv>`, with its two streams captured. */
-function run(argv: string[], now = NOW, env: Record<string, string> = {}): number {
+/**
+ * One run of `actana pair <argv>`, with its two streams captured.
+ *
+ * **stdout is a pipe unless a test says otherwise**, which is the shape the
+ * stdout contract is about and the shape everything written before #357
+ * asserts against. {@link runTty} is the other one.
+ */
+function run(
+  argv: string[],
+  now = NOW,
+  env: Record<string, string> = {},
+  stdoutIsTty = false,
+): number {
   out = [];
   err = [];
   const deps: ActanaCliDeps = {
@@ -65,11 +83,17 @@ function run(argv: string[], now = NOW, env: Record<string, string> = {}): numbe
     home: dir,
     out: (line: string) => out.push(line),
     err: (line: string) => err.push(line),
+    stdoutIsTty,
   };
   return runPairCommand(deps, argv, {
     materialPath: () => materialPath,
     audit: (record) => audited.push(record),
   });
+}
+
+/** The same run with a terminal on stdout — the framed shape (#357). */
+function runTty(argv: string[], now = NOW, env: Record<string, string> = {}): number {
+  return run(argv, now, env, true);
 }
 
 function store(): PairingStore {
@@ -419,6 +443,461 @@ describe("actana pair new --public-host", () => {
     expect(help).toMatch(/certificate already covers/);
   });
 });
+
+// ─── pair new, the two shapes (#357) ────────────────────────────────────────
+//
+// One command, two audiences. Down a pipe it is the labelled lines a script
+// cuts fields out of; at a terminal it is a framed handout that says what the
+// code is for and what to type on the other machine. The switch is
+// `isatty(stdout)` and nothing else — there is deliberately no `--json` and no
+// flag — so the two things this suite has to hold are that the piped shape did
+// not move a byte, and that the framed one carries everything an operator needs
+// to finish the job without retyping a fingerprint.
+
+describe("actana pair new, piped", () => {
+  /** The 0.4.2 shape, written out rather than derived from the code under test. */
+  function expectedLines(over: { label?: string; endpointHost?: string } = {}): string[] {
+    const lines = [
+      `Pairing code   ${field("Pairing code")}`,
+      `CA fingerprint ${new X509Certificate(material.caCert).fingerprint256}`,
+      "Expires        2026-08-20T12:05:00Z (in 5 minutes)",
+    ];
+    if (over.label) lines.push(`Label          ${over.label}`);
+    if (over.endpointHost) lines.push(`Endpoint host  ${over.endpointHost}`);
+    lines.push(`Session        ${field("Session")}`);
+    return lines;
+  }
+
+  it("prints the labelled lines byte for byte, in the order 0.4.2 printed them", () => {
+    expect(run(["new", "--label", "laptop"])).toBe(0);
+    // Every line, whole, in order — not `toContain`. A framed block that leaked
+    // into the piped path, an extra blank line, a changed column width or a
+    // reordered field would each fail here, and each of them breaks a script.
+    expect(out).toEqual(expectedLines({ label: "laptop" }));
+  });
+
+  it("keeps the unlabelled shape, which has no Label line at all", () => {
+    expect(run(["new"])).toBe(0);
+    expect(out).toEqual(expectedLines());
+  });
+
+  it("keeps `Endpoint host` where it was, between Label and Session", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(run(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    expect(out).toEqual(expectedLines({ label: "laptop", endpointHost: "10.0.0.5" }));
+  });
+
+  it("writes no escape sequence, no box drawing and no instructions", () => {
+    run(["new", "--label", "laptop"]);
+    const printed = out.join("\n");
+    expect(printed).not.toMatch(/\x1b\[/);
+    for (const ornament of ["╭", "│", "─"]) expect(printed).not.toContain(ornament);
+    expect(printed).not.toContain("From the Panel");
+    expect(printed).not.toContain("From a terminal");
+    expect(printed).not.toContain("npm i -g");
+  });
+
+  it("is the shape a Core with several addresses prints too", async () => {
+    // The framed path prints one command per address. Down a pipe the several
+    // addresses change nothing at all: same five lines.
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(run(["new", "--label", "laptop"])).toBe(0);
+
+    expect(out).toEqual(expectedLines({ label: "laptop" }));
+  });
+});
+
+describe("actana pair new, at a terminal", () => {
+  /** Everything stdout saw, as one string. */
+  function screen(): string {
+    return out.join("\n");
+  }
+
+  /** The pasteable command lines — the ones that start the client verb. */
+  function commands(): string[] {
+    return out.map((line) => line.trim()).filter((line) => line.startsWith("actana core pair "));
+  }
+
+  it("frames the code, and the code is what was minted", () => {
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const session = store().listSessions()[0]!;
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(screen())?.[1];
+    expect(code).toBeDefined();
+    // The digest in the store is the digest of the code on the screen, which is
+    // the only thing that makes the framed shape the same shape.
+    expect(
+      pairingCodeMatches(
+        session.codeHash,
+        hashPairingCode({
+          key: derivePairingCodeKey(material.bearerSecret),
+          sessionId: session.id,
+          code: code!,
+        }),
+      ),
+    ).toBe(true);
+    expect(screen()).toContain("╭");
+    expect(screen()).toContain("Pairing code");
+  });
+
+  it("prints the expiry beside the code, absolute and relative", () => {
+    runTty(["new", "--ttl", "2h"]);
+    expect(screen()).toContain("2026-08-20T14:00:00Z (in 2 hours)");
+  });
+
+  it("prints the WHOLE fingerprint, wrapped rather than shortened", () => {
+    runTty(["new", "--label", "laptop"]);
+
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    expect(fingerprint.split(":")).toHaveLength(32);
+
+    // Inside the frame it is wrapped: no framed line holds the whole of it,
+    // and the framed lines that hold pieces of it re-join to exactly the value
+    // — nothing dropped, nothing elided, nothing rewritten.
+    const framed = out.filter((line) => line.includes("│"));
+    expect(framed.some((line) => line.includes(fingerprint))).toBe(false);
+    const rejoined = framed
+      .map((line) => /([0-9A-F]{2}(?::[0-9A-F]{2}){7,}:?)/.exec(line)?.[1] ?? "")
+      .join("");
+    expect(rejoined).toBe(fingerprint);
+    for (const elision of ["...", "…"]) expect(screen()).not.toContain(elision);
+    // And the pasteable command carries it whole, on one line, because that is
+    // the copy a client actually checks the certificate against.
+    expect(commands()[0]).toContain(`--fingerprint ${fingerprint}`);
+  });
+
+  it("prints the session id", () => {
+    runTty(["new"]);
+    const sessionId = store().listSessions()[0]!.id;
+    expect(screen()).toContain(sessionId);
+  });
+
+  // The wording is pinned to the *form*, not to a paraphrase of it.
+  // `AddCoreByPairing.tsx` asks for the address first, gates everything behind
+  // a compared CA fingerprint — "the Panel does not send the code until they
+  // match" — and only then shows Session and Pairing code. An instruction that
+  // named only the code sent an operator to a form that wanted two things
+  // first, one of them the security-relevant one (#357 review B1).
+  it("gives the Panel path in the order the Panel's own form asks for it", () => {
+    runTty(["new", "--label", "laptop"]);
+    expect(screen()).toContain("From the Panel");
+    expect(screen()).toContain(PANEL_INSTRUCTION);
+    expect(PANEL_INSTRUCTION).toBe(
+      "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+        "CA fingerprint, then the session and the code",
+    );
+    // Every field the form requires is named, in the form's order, and the
+    // fingerprint comparison is not dropped — it is what makes the first dial
+    // verifiable, and the frame above prints the fingerprint without this
+    // sentence saying what it is for.
+    const address = PANEL_INSTRUCTION.indexOf("address");
+    const fingerprint = PANEL_INSTRUCTION.indexOf("fingerprint");
+    const session = PANEL_INSTRUCTION.indexOf("session");
+    const code = PANEL_INSTRUCTION.indexOf("code");
+    expect(address).toBeGreaterThan(-1);
+    expect(fingerprint).toBeGreaterThan(address);
+    expect(session).toBeGreaterThan(fingerprint);
+    expect(code).toBeGreaterThan(session);
+    expect(PANEL_INSTRUCTION).toContain("compare");
+  });
+
+  it("gives the terminal path: the install, then a command with real values", () => {
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    expect(screen()).toContain("From a terminal");
+    expect(screen()).toContain("npm i -g @actana/cli");
+
+    const session = store().listSessions()[0]!;
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(screen())![1]!;
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    expect(commands()).toEqual([
+      `actana core pair laptop 10.0.0.5:8443 ${code} --session ${session.id} --fingerprint ${fingerprint}`,
+    ]);
+    // One address, and it is the one the credential will name, so there is
+    // nothing to warn about.
+    expect(screen()).toContain("# dial 10.0.0.5:8443 — and that is the endpoint this code registers");
+    expect(screen()).not.toContain("still registers");
+    // The install line comes before the command it installs the binary for.
+    expect(screen().indexOf("npm i -g @actana/cli")).toBeLessThan(screen().indexOf("actana core pair "));
+  });
+
+  // The other half of the ticket: `readTicket` refuses a bare code, so a
+  // pasteable line without `--session` is a line that fails on arrival.
+  it("carries --session, with the id of the session it just minted", () => {
+    runTty(["new", "--label", "laptop"]);
+    const session = store().listSessions()[0]!;
+    for (const command of commands()) {
+      expect(command).toContain(`--session ${session.id}`);
+      expect(command).toContain("--fingerprint ");
+    }
+  });
+
+  it("offers one command per configured address, the primary first", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const addresses = commands().map((command) => command.split(" ")[4]);
+    expect(addresses).toEqual(["core:8443", "10.0.0.5:8443", "core.example.test:8443"]);
+  });
+
+  // #357 review B2. The endpoint a paired client keeps comes off the stored
+  // session, never off the address it dialled — so a code minted without
+  // `--public-host` registers the primary for *every* command in the block.
+  // A comment that said only "reachable at 10.0.0.5" was true about the dial
+  // and false about the result: pair from a machine that cannot resolve
+  // `core`, and `actana core status` fails right after a successful pairing
+  // with nothing on screen explaining it.
+  it("says which endpoint the credential will carry, per address", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+    const printed = screen();
+    // The primary dials and registers the same address: nothing to warn about.
+    expect(printed).toContain("# dial core:8443 — and that is the endpoint this code registers");
+    // Every other address says what it really leaves behind, and how to get a
+    // code that does register it — the `--public-host` workflow #347 designed.
+    for (const host of ["10.0.0.5", "core.example.test"]) {
+      expect(printed).toContain(`# dial ${host}:8443 — but this code still registers core:8443`);
+      expect(printed).toContain(
+        `#   to register ${host}:8443: actana pair new --label laptop --public-host ${host}`,
+      );
+    }
+    // And the untruth is gone: no address is described as one you keep unless
+    // it is one you keep.
+    expect(printed).not.toContain("reachable at 10.0.0.5");
+  });
+
+  it("drops --label from the re-mint hint when there is no usable label", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5"]);
+    persistMaterialToFile(materialPath, material);
+
+    runTty(["new"]);
+
+    expect(screen()).toContain("#   to register 10.0.0.5:8443: actana pair new --public-host 10.0.0.5");
+  });
+
+  it("warns about nothing when --public-host made dial and endpoint agree", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    // The session records the choice, so redemption hands back 10.0.0.5 — the
+    // address the one command dials.
+    expect(store().listSessions()[0]!.endpointHost).toBe("10.0.0.5");
+    expect(screen()).toContain("# dial 10.0.0.5:8443 — and that is the endpoint this code registers");
+    expect(screen()).not.toContain("still registers");
+    expect(screen()).not.toContain("to register");
+  });
+
+  it("offers only the chosen address when --public-host chose one", async () => {
+    material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+    persistMaterialToFile(materialPath, material);
+
+    expect(runTty(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+    // That is the endpoint redemption will hand this client, so a command
+    // pointing anywhere else would pair it to an address the code did not pick.
+    expect(commands().map((command) => command.split(" ")[4])).toEqual(["10.0.0.5:8443"]);
+  });
+
+  it("dials the port this install recorded, not a guess", () => {
+    fs.writeFileSync(
+      path.join(dir, "actana.json"),
+      JSON.stringify({
+        version: "0.4.3",
+        port: 9443,
+        host: "0.0.0.0",
+        publicHost: "10.0.0.5",
+        label: "core-1",
+        installDir: dir,
+        dataDir: dir,
+      }),
+    );
+
+    runTty(["new", "--label", "laptop"]);
+
+    expect(commands()[0]).toContain(" 10.0.0.5:9443 ");
+  });
+
+  it("dials the container's port when it is running in one", () => {
+    runTty(["new", "--label", "laptop"], NOW, { ACTANA_CONTAINER: "1", ACTANA_PORT: "7443" });
+    expect(commands()[0]).toContain(" 10.0.0.5:7443 ");
+  });
+
+  it("falls back to 8443 rather than printing no command at all", () => {
+    // No `actana.json` beside the material: an operator with a wrong port can
+    // fix one character, and an operator with no command has to build it.
+    runTty(["new", "--label", "laptop"]);
+    expect(commands()[0]).toContain(" 10.0.0.5:8443 ");
+  });
+
+  it("uses a placeholder name when there is no label to use", () => {
+    runTty(["new"]);
+    expect(commands()[0]).toContain("actana core pair NAME ");
+  });
+
+  it("uses a placeholder when the label is not a name the client registry takes", () => {
+    // `--label` takes anything an operator wants to call a machine; a Core name
+    // does not. Pasting `my laptop` would fail on the far machine with a
+    // message about a registry nobody mentioned.
+    runTty(["new", "--label", "my laptop"]);
+    expect(commands()[0]).toContain("actana core pair NAME ");
+    // The label is still the label — it is on the frame and in the store.
+    expect(screen()).toContain("my laptop");
+    expect(store().listSessions()[0]!.label).toBe("my laptop");
+  });
+
+  // #357 review B3. `<name>` is not inert in a shell: pasted into bash it is
+  // "read stdin from a file called `name`, write stdout to a file called
+  // `10.0.0.5:8443`", and the command never runs. This is the assertion that
+  // was missing — not that a placeholder is *present*, but that the line the
+  // block promises is pasteable actually survives being pasted.
+  it("emits a line a real shell parses into the words it printed", () => {
+    for (const argv of [["new"], ["new", "--label", "my laptop"], ["new", "--label", "laptop"]]) {
+      runTty(argv);
+      const command = commands()[0]!;
+      // `sh -c 'printf %s\n <the line>'` is the whole test: a shell reads the
+      // line as a command with arguments and hands them back. A redirection,
+      // a glob or a quote would consume a word, redirect the output or fail
+      // outright — and each of those is a paste that does not work.
+      const echoed = execFileSync("/bin/sh", ["-c", `printf '%s\n' ${command}`], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      expect(echoed.split("\n").filter(Boolean)).toEqual(command.split(" "));
+    }
+  });
+
+  it("never puts a shell metacharacter in the pasteable line", () => {
+    // The belt to the braces above: the line is built from a label, an address,
+    // a code, a uuid and colon-hex, and none of those may bring a character a
+    // shell would act on.
+    for (const argv of [["new"], ["new", "--label", "my laptop"], ["new", "--label", "laptop"]]) {
+      runTty(argv);
+      expect(commands()[0]).not.toMatch(/[<>|&;$`()'"*?[\]{}\\]/);
+    }
+  });
+
+  it("names the placeholder in one place, and it is shell-safe there", () => {
+    expect(NAME_PLACEHOLDER).toBe("NAME");
+    // A slot an operator forgets to edit registers a Core called NAME, which
+    // one `actana core rm NAME` undoes. A shell error undoes nothing.
+    expect(coreNameError(NAME_PLACEHOLDER)).toBeNull();
+  });
+
+  it("colours at a terminal, and the frame stays square anyway", () => {
+    runTty(["new", "--label", "laptop"]);
+    const printed = out.join("\n");
+    expect(printed).toMatch(/\x1b\[1;36m/);
+    // Padding measured on the plain text, so every framed row is the same
+    // *display* width despite the escapes having a length and no width.
+    const framed = out.filter((line) => line.includes("│")).map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+    expect(framed.length).toBeGreaterThan(5);
+    expect(new Set(framed.map((line) => [...line].length))).toEqual(new Set([74]));
+  });
+
+  // #357 review N1. `String.length` is UTF-16 code units, and `--label` takes
+  // anything: a CJK label measured that way lands the right border early, and
+  // an over-long one pushes it out. The label is the row that gives — never
+  // the fingerprint, which wraps instead.
+  it("keeps the frame square for a wide label, measured in columns", () => {
+    runTty(["new", "--label", "笔记本"], NOW, { NO_COLOR: "1" });
+    const framed = out.filter((line) => line.includes("│"));
+    expect(framed.length).toBeGreaterThan(5);
+    for (const line of framed) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    expect(screen()).toContain("笔记本");
+  });
+
+  it("clips an over-long label rather than bending the frame", () => {
+    const long = "l".repeat(200);
+    runTty(["new", "--label", long], NOW, { NO_COLOR: "1" });
+
+    const framed = out.filter((line) => line.includes("│"));
+    for (const line of framed) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    // Clipped, and marked as clipped.
+    expect(screen()).toContain("…");
+    expect(screen()).not.toContain(long);
+    // The label the operator gave is untouched everywhere it matters: in the
+    // store, and in the piped shape.
+    expect(store().listSessions()[0]!.label).toBe(long);
+    expect(run(["new", "--label", long])).toBe(0);
+    expect(out).toContain(`Label          ${long}`);
+  });
+
+  it("clips the label and never the fingerprint", () => {
+    runTty(["new", "--label", "l".repeat(200)], NOW, { NO_COLOR: "1" });
+    const fingerprint = new X509Certificate(material.caCert).fingerprint256;
+    const framed = out.filter((line) => line.includes("│"));
+    const rejoined = framed
+      .map((line) => /([0-9A-F]{2}(?::[0-9A-F]{2}){7,}:?)/.exec(line)?.[1] ?? "")
+      .join("");
+    expect(rejoined).toBe(fingerprint);
+  });
+
+  it("degrades to no escapes under NO_COLOR, keeping every instruction", () => {
+    runTty(["new", "--label", "laptop"], NOW, { NO_COLOR: "1" });
+    const printed = out.join("\n");
+    expect(printed).not.toMatch(/\x1b\[/);
+    expect(printed).toContain("From the Panel");
+    expect(printed).toContain("From a terminal");
+    expect(commands()).toHaveLength(1);
+  });
+
+  it("mints exactly what the piped shape mints — only the printing differs", () => {
+    expect(runTty(["new", "--label", "laptop", "--ttl", "30s"])).toBe(0);
+    const session = store().listSessions()[0]!;
+    expect(session.expiresAt - session.createdAt).toBe(30_000);
+    expect(session.label).toBe("laptop");
+    // The prose on stderr is the same prose, terminal or not: it is not what a
+    // scraper reads, and it is what a human is told either way.
+    expect(err.join("\n")).toMatch(/Read the code AND the fingerprint/);
+    expect(err.join("\n")).toContain(`actana pair revoke ${session.id}`);
+  });
+
+  it("still stores a digest and never the code, framed or not", () => {
+    runTty(["new", "--label", "laptop"]);
+    const code = /([A-Z2-9]{4}-[A-Z2-9]{4})/.exec(out.join("\n"))![1]!;
+    const session = store().listSessions()[0]!;
+    expect(JSON.stringify(session)).not.toContain(code);
+    expect(JSON.stringify(session)).not.toContain(code.replace("-", ""));
+  });
+
+  it("refuses the same things it refuses down a pipe, and frames nothing", () => {
+    expect(runTty(["new", "--ttl", "5"])).toBe(2);
+    expect(out).toEqual([]);
+    expect(store().listSessions()).toEqual([]);
+  });
+});
+
+describe("wrapFingerprint", () => {
+  it("keeps every group, and marks the break with the separator", () => {
+    const fingerprint = Array.from({ length: 32 }, (_, i) => i.toString(16).padStart(2, "0").toUpperCase()).join(":");
+    const lines = wrapFingerprint(fingerprint);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.endsWith(":")).toBe(true);
+    expect(lines[1]!.endsWith(":")).toBe(false);
+    // Rejoinable, exactly: a wrapped fingerprint is the same value with a line
+    // break in it, and never a shortened one.
+    expect(lines.join("")).toBe(fingerprint);
+  });
+
+  it("cannot shorten its input, whatever it is asked for", () => {
+    for (const perLine of [0, 1, 5, 999]) {
+      expect(wrapFingerprint("AA:BB:CC:DD", perLine).join("")).toBe("AA:BB:CC:DD");
+    }
+  });
+});
+
 
 // ─── pair ls ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -588,7 +588,7 @@ describe("actana pair new, at a terminal", () => {
     expect(screen()).toContain("From the Panel");
     expect(screen()).toContain(PANEL_INSTRUCTION);
     expect(PANEL_INSTRUCTION).toBe(
-      "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+      "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
         "CA fingerprint, then the session and the code",
     );
     // Every field the form requires is named, in the form's order, and the

--- a/packages/cli/src/__tests__/cli-harness.ts
+++ b/packages/cli/src/__tests__/cli-harness.ts
@@ -85,6 +85,13 @@ export type RunOptions = {
   stdin?: string;
   /** Force the TTY answer. Defaults to false when `stdin` is set, true otherwise. */
   stdinIsTty?: boolean;
+  /**
+   * Whether stdout is a terminal. Defaults to **false** — a run captured into
+   * an array is a piped run, and the commands that render differently at a
+   * terminal must render their scrapeable shape here unless a suite says
+   * otherwise.
+   */
+  stdoutIsTty?: boolean;
   /** What `core status` gets back, or a throw. */
   probe?: CoreProbeFn;
   /** What every other noun gets when it dials, or a throw. */
@@ -320,6 +327,7 @@ export function makeCliFixture(): CliFixture {
           : () => {},
         readStdin: async () => opts.stdin ?? "",
         stdinIsTty: opts.stdinIsTty ?? opts.stdin === undefined,
+        stdoutIsTty: opts.stdoutIsTty ?? false,
         probe:
           opts.probe ??
           (async () => {

--- a/packages/cli/src/__tests__/core-command.test.ts
+++ b/packages/cli/src/__tests__/core-command.test.ts
@@ -58,6 +58,17 @@ describe("actana core add", () => {
     expect(help).toContain("actana core pair");
   });
 
+  // #357. The usage line in this help showed three positionals and no flags,
+  // while `readTicket` refuses a code that does not name its pairing session.
+  // A help that omits a required flag is a help that hands out a command line
+  // the program then rejects.
+  it("shows the flags `pair` actually requires", async () => {
+    const run = await cli().run(["core", "--help"]);
+    expect(run.out.join("\n")).toContain(
+      "actana core pair <name> <address> <code> --session <id> --fingerprint <sha256>",
+    );
+  });
+
   it("leaves the registry it wrote readable by exactly its owner", async () => {
     haveCore("prod");
     expect(statSync(coreBlobPath(cli().paths, "prod")).mode & 0o777).toBe(0o600);

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -314,6 +314,17 @@ describe("actana core pair — the command line", () => {
     }
   });
 
+  // #357. `readTicket` refuses a bare code without `--session <id>` or the
+  // joined `<session>:<code>` form, and this usage line used to show neither —
+  // so an operator who followed it exactly landed on a second refusal for a
+  // flag they had never been told about.
+  it("shows both required flags in the usage line it prints", async () => {
+    const run = await cli().run(["core", "pair", "prod"], { pairing: fakePairing() });
+    expect(run.err.join("\n")).toContain(
+      "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+    );
+  });
+
   it("refuses a fourth argument without echoing it", async () => {
     const run = await cli().run(
       ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],

--- a/packages/cli/src/__tests__/core-pair.test.ts
+++ b/packages/cli/src/__tests__/core-pair.test.ts
@@ -17,6 +17,9 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { existsSync, statSync } from "node:fs";
 import { coreBlobPath, readCurrentCore } from "../blob-registry.ts";
+import { displayWidth, FRAME_WIDTH } from "../cli-frame.ts";
+import { corePairingOutcome, corePairSuccessBlock } from "../core-pair-results.ts";
+import { wrapText } from "../cli-frame.ts";
 import { resolveCore } from "../core-resolution.ts";
 import { CorePairingError, type CorePairingFailure } from "@actana/sdk/core-pairing.ts";
 import {
@@ -508,5 +511,689 @@ describe("actana core pair — what it says", () => {
     const run = await cli().run(["core", "wat"]);
     expect(run.code).toBe(EXIT_USAGE);
     expect(run.err.join("\n")).toContain("Verbs: pair, ls");
+  });
+});
+
+// ─── the two shapes (#360) ──────────────────────────────────────────────────
+//
+// One command, two audiences — the client half of the split #357 made on the
+// Core. Down a pipe `core pair` is the lines 0.4.2 printed and nothing else; at
+// a terminal it is a framed result that says what just happened and what to
+// type next. The switch is `isatty(stdout)` and nothing else, so the two things
+// this suite has to hold are that the piped shape did not move a byte, and that
+// the framed one carries a concrete remedy for every class of failure rather
+// than the prose that sent an operator to the help.
+
+/** The escape byte, built rather than typed, so no raw control byte is in this file. */
+const ESC = String.fromCharCode(0x1b);
+const GREEN = `${ESC}[32m`;
+const RED = `${ESC}[31m`;
+
+/** The three arguments for a second Core, so the pointer has something to keep. */
+function sparePairArgv(): string[] {
+  return [
+    "core",
+    "pair",
+    "spare",
+    "core.test:8443",
+    CODE,
+    "--session",
+    SESSION,
+    "--fingerprint",
+    PAIRED_FINGERPRINT,
+  ];
+}
+
+/** Every failure the SDK distinguishes and that a fake Core can be told to raise. */
+const SDK_FAILURES: CorePairingFailure[] = [
+  "bad-address",
+  // Both added after #366 review 8. `fingerprint-unconfirmed` the fake has
+  // always been able to raise — the older table below proves it — and
+  // `bad-fingerprint` had never been covered by any list at all, so neither
+  // sat inside the byte-identity loop, the something-to-type loop or the
+  // distinct-remedy check. `bad-code` stays out on purpose: it is intercepted
+  // before the SDK's message can quote the code, so its first line is this
+  // package's own and the loop's literal would not describe it.
+  "bad-fingerprint",
+  "fingerprint-unconfirmed",
+  "unreachable",
+  "not-pairable",
+  "no-ca-presented",
+  "fingerprint-mismatch",
+  "hostname-mismatch",
+  "certificate-invalid",
+  "refused",
+  "rate-limited",
+  "rejected",
+  "core-error",
+  "malformed-response",
+];
+
+describe("actana core pair, piped", () => {
+  it("prints the two success lines byte for byte, in the order 0.4.2 printed them", async () => {
+    const run = await cli().run(pairArgv(), { pairing: fakePairing() });
+
+    expect(run.code).toBe(EXIT_OK);
+    // Whole, in order — not `toContain`. A framed block that leaked into the
+    // piped path, an extra blank line, a reworded pointer note or a fourth line
+    // would each fail here, and each of them breaks a script.
+    expect(run.out).toEqual([
+      'Paired Core "prod" → wss://core.test:8443',
+      '`current` now points at "prod".',
+    ]);
+    expect(run.err).toEqual([]);
+  });
+
+  it("keeps the second-Core shape, which names the pointer it did not move", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    const second = await cli().run(sparePairArgv(), { pairing: fakePairing() });
+
+    expect(second.out).toEqual([
+      'Paired Core "spare" → wss://core.test:8443',
+      '`current` is still "prod" — `actana core use spare` to switch.',
+    ]);
+  });
+
+  it("keeps the re-pair shape, which is one line and no pointer note at all", async () => {
+    await cli().run(pairArgv(), { pairing: fakePairing() });
+    const again = await cli().run(pairArgv(), { pairing: fakePairing() });
+
+    // `current` already names this Core, so 0.4.2 said nothing about it. The
+    // framed block *does* have a row for it, and this is the assertion that
+    // keeps that row from leaking down here.
+    expect(again.out).toEqual(['Replaced Core "prod" → wss://core.test:8443']);
+  });
+
+  it("writes no escape sequence, no box drawing and no next steps", async () => {
+    const run = await cli().run(pairArgv(), { pairing: fakePairing() });
+    const printed = [...run.out, ...run.err].join("\n");
+
+    expect(printed).not.toMatch(/\x1b\[/);
+    for (const ornament of ["╭", "╰", "│", "─", "✓", "✗"]) expect(printed).not.toContain(ornament);
+    expect(printed).not.toContain("Next steps");
+    expect(printed).not.toContain("actana core status");
+  });
+
+  it("gives every SDK failure exactly the two lines it gave in 0.4.2", async () => {
+    for (const failure of SDK_FAILURES) {
+      const run = await cli().run(pairArgv(), { pairing: fakePairing({ fails: failure }) });
+      // Two lines: the SDK's sentence, then the one-line next step. Exactly two
+      // — the remedy the frame adds is three or four more, and none of them may
+      // appear here.
+      expect(run.err, `${failure} did not print the 0.4.2 pair of lines`).toEqual([
+        `actana core pair: the fake Core answered ${failure}`,
+        corePairingOutcome(failure).next,
+      ]);
+      expect(run.out).toEqual([]);
+    }
+  });
+
+  it("pins two of those next-step lines by value, not by the table that writes them", async () => {
+    // The table is the code under test, so a suite that only compared against
+    // it would pass on a rewrite of every line in it. Two spelled out: the
+    // class an operator hits most, and the one that matters most.
+    const refused = await cli().run(pairArgv(), { pairing: fakePairing({ fails: "refused" }) });
+    expect(refused.err[1]).toBe(
+      "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
+    );
+
+    const mismatch = await cli().run(pairArgv(), { pairing: fakePairing({ fails: "fingerprint-mismatch" }) });
+    expect(mismatch.err[1]).toBe(
+      "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
+        "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
+    );
+  });
+
+  it("gives every refusal this file words itself exactly the lines it gave in 0.4.2", async () => {
+    const missing = await cli().run(["core", "pair", "prod"], { pairing: fakePairing() });
+    expect(missing.err).toEqual([
+      "actana core pair: a name, an address and a code are required.",
+      "  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+      "`actana pair new` on the Core prints the code, the fingerprint and the session.",
+    ]);
+
+    const extra = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(extra.err).toEqual([
+      "actana core pair: too many arguments — expected <name> <address> <code>.",
+    ]);
+
+    const badName = await cli().run(
+      ["core", "pair", "bad name", "core.test:8443", CODE, "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(badName.err).toEqual([
+      "actana core pair: a Core name starts with a letter or digit and holds only letters, digits, dot, dash and underscore.",
+    ]);
+
+    const noSession = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(noSession.err).toEqual([
+      "actana core pair: a pairing code names the pairing session it belongs to.",
+      "Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.",
+    ]);
+
+    const disagree = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION],
+      { pairing: fakePairing() },
+    );
+    expect(disagree.err).toEqual([
+      "actana core pair: the code names one pairing session and `--session` names another.",
+      "Drop `--session`, or pass the bare code beside it — they have to agree.",
+    ]);
+
+    const shape = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", "no", "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { pairing: fakePairing() },
+    );
+    expect(shape.err).toEqual([
+      "actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.",
+      "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
+    ]);
+  });
+
+  it("is the same piped shape with NO_COLOR set as without it", async () => {
+    const plain = await cli().run(pairArgv(), { pairing: fakePairing() });
+    cli().cleanup();
+    fixture = null;
+    const noColor = await cli().run(pairArgv(), { pairing: fakePairing(), env: { NO_COLOR: "1" } });
+    expect(noColor.out).toEqual(plain.out);
+  });
+});
+
+describe("actana core pair, at a terminal", () => {
+  /** The framed lines of a run — the ones the border is drawn on. */
+  function framed(lines: string[]): string[] {
+    return lines.filter((line) => /^[╭│╰]/.test(line));
+  }
+
+  /**
+   * Everything a run said, as one line of prose.
+   *
+   * The escapes come off and every run of whitespace becomes one space, so a
+   * sentence can be asserted as the sentence it is rather than as the shape a
+   * 74-column wrap happened to give it. Asserting the wrap instead would make
+   * every one of these tests fail on a reworded neighbour.
+   */
+  function prose(lines: string[]): string {
+    return lines
+      .join(" ")
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      // The border too: a sentence wrapped across two framed rows has a bar,
+      // two runs of padding and a gutter in the middle of it.
+      .replace(/[│╭╮╰╯─]/g, " ")
+      .replace(/\s+/g, " ");
+  }
+
+  it("frames the success, marks it green, and names the Core and its endpoint", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = run.out.join("\n");
+
+    expect(run.code).toBe(EXIT_OK);
+    expect(screen).toContain("╭");
+    expect(screen).toContain("╰");
+    expect(screen).toContain('Paired Core "prod"');
+    expect(screen).toContain("wss://core.test:8443");
+    // Green, and only on the marker — nothing on a success is red.
+    expect(screen).toContain(`${GREEN}✓`);
+    expect(screen).not.toContain(RED);
+  });
+
+  it("claims `current` only for a Core that actually became current", async () => {
+    const first = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    expect(first.out.join("\n")).toContain('"prod" — every later verb talks to this Core');
+
+    // The second pairing does not move the pointer, and the block has to say so
+    // rather than congratulating an operator on a `current` they do not have.
+    const second = await cli().run(sparePairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = second.out.join("\n");
+    expect(readCurrentCore(cli().paths)).toBe("prod");
+    expect(screen).toContain('still "prod" — this pairing did not change it');
+    expect(screen).not.toContain("every later verb talks to this Core");
+    // And the first thing it offers is the command that fixes it.
+    expect(screen).toContain("actana core use spare");
+  });
+
+  it("offers `core use` only when there is a pointer to move", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    expect(run.out.join("\n")).not.toContain("actana core use prod");
+  });
+
+  it("ends in the four verbs a freshly paired Core exists for", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    const screen = run.out.join("\n");
+
+    expect(screen).toContain("Next steps");
+    for (const verb of [
+      "actana core status",
+      "actana project ls",
+      "actana harness ls",
+      "actana session start <project>",
+      // #360 names this beside `session start`, and #366 review 4 caught it
+      // missing.
+      "actana core shell",
+    ]) {
+      expect(screen, `the success block does not teach ${verb}`).toContain(verb);
+    }
+    // In that order: verify, then look around, then do something.
+    expect(screen.indexOf("actana core status")).toBeLessThan(screen.indexOf("actana project ls"));
+    expect(screen.indexOf("actana project ls")).toBeLessThan(screen.indexOf("actana harness ls"));
+    expect(screen.indexOf("actana harness ls")).toBeLessThan(screen.indexOf("actana session start"));
+    expect(screen.indexOf("actana session start")).toBeLessThan(screen.indexOf("actana core shell"));
+    // And the Panel, which is the other thing to pair with the same Core.
+    expect(screen).toContain("Settings -> Cores");
+  });
+
+  it("reports the name it sent as a local fact, claiming nothing about the Core", async () => {
+    // #366 review 2. The row used to say this name was "this machine, in the
+    // Core's `pair ls`", and that is false — the Core stores the *session*
+    // label there. So the row now states only what is true on this side, and
+    // this test pins the absence of the claim as hard as the presence of the
+    // value: a reworded row that quietly grew the claim back would fail here.
+    const labelled = await cli().run(pairArgv(["--label", "ada-laptop"]), {
+      stdoutIsTty: true,
+      pairing: fakePairing(),
+    });
+    const said = prose(labelled.out);
+    expect(said).toContain("Sent as ada-laptop — the name this machine gave");
+    expect(said).not.toContain("pair ls");
+    expect(said).not.toContain("revoke");
+
+    // The value is the one that actually crossed the seam, not one this block
+    // made up to fill a row — asserted against what the SDK was handed.
+    const pairing = fakePairing();
+    const bare = await cli().run(pairArgv(), { stdoutIsTty: true, pairing });
+    expect(pairing.paired[0]?.label).toBeTruthy();
+    expect(prose(bare.out)).toContain(`Sent as ${pairing.paired[0]?.label} —`);
+
+    // And nothing about it reaches the piped shape.
+    const piped = await cli().run(pairArgv(["--label", "ada-laptop"]), { pairing: fakePairing() });
+    expect(piped.out.join("\n")).not.toContain("ada-laptop");
+  });
+
+  it("says where the credential landed and at what mode, and never what is in it", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+
+    const inFrame = run.out
+      .map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""))
+      .filter((line) => line.startsWith("│"))
+      .map((line) => line.replace(/^│\s*/, "").replace(/\s*│$/, ""))
+      .join("");
+    expect(inFrame).toContain(coreBlobPath(cli().paths, "prod"));
+    expect(prose(run.out)).toContain("(mode 0600)");
+    for (const secret of SENTINELS) expect(run.all).not.toContain(secret);
+  });
+
+  it("frames every failure class, each with a marker and something to type", async () => {
+    for (const failure of SDK_FAILURES) {
+      const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing({ fails: failure }) });
+      const screen = run.err.join("\n");
+
+      expect(run.code, `${failure} exited ${run.code}`).toBe(corePairingOutcome(failure).exit);
+      expect(screen, `${failure} was not framed`).toContain("╭");
+      expect(screen, `${failure} carried no red marker`).toContain(`${RED}✗`);
+      expect(screen, `${failure} offered no remedy section`).toContain("What to do");
+      // The acceptance criterion in full: every class ends with a copyable
+      // command, not only an explanation. A command line is the one that is
+      // indented two and carries no escape — the notes under it are dim.
+      const commands = run.err.filter((line) => /^ {2}\S/.test(line) && !line.startsWith(ESC));
+      expect(commands.length, `${failure} ended with an explanation and nothing to type`).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives no two failure classes the same remedy", async () => {
+    // The point of the table: "ask for a fresh code" and "check the port is
+    // open" are answers to different problems, and a surface that gave both to
+    // both would be the prose it replaced.
+    const seen = new Map<string, string>();
+    for (const failure of SDK_FAILURES) {
+      const remedy = corePairingOutcome(failure)
+        .steps.map((step) => `${step.command ?? ""}|${step.note}`)
+        .join("\n");
+      expect(seen.has(remedy), `${failure} repeats ${seen.get(remedy)}'s remedy`).toBe(false);
+      seen.set(remedy, failure);
+    }
+  });
+
+  it("tells an expired or unknown code how to mint a fresh one, and to re-run with it", async () => {
+    const run = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing({ fails: "refused" }) });
+    const screen = run.err.join("\n");
+
+    expect(screen).toContain("actana pair new --label <name>");
+    const said = prose(run.err);
+    expect(said).toContain("expired, already spent, never issued, or out of attempts");
+    // The mistake this exists to stop: a new code with yesterday's session.
+    expect(said).toContain("NEW code");
+    expect(said).toContain("NEW --session");
+    expect(said).toContain("the old session will not redeem the new code");
+  });
+
+  it("explains the fingerprint comparison and warns against going round it", async () => {
+    const run = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "fingerprint-mismatch" }),
+    });
+    const screen = run.err.join("\n");
+
+    const said = prose(run.err);
+    expect(said).toContain("compared against the one you gave, and the two differ");
+    expect(said).toContain("The code was not sent");
+    expect(said).toContain("no flag that skips the comparison");
+    expect(said).toContain("somebody sitting between you and the right one");
+    expect(screen).toContain("actana pair new --label <name>");
+  });
+
+  it("separates a dial failure from a refusal, and says what to check", async () => {
+    const unreachable = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "unreachable" }),
+    });
+    const dial = prose(unreachable.err);
+    expect(dial).toContain("a dial failure, not a refusal");
+    // #366 review 3: the guarantee is conditional, because this class also
+    // covers a drop *after* the code went out — one timer spans the whole
+    // exchange, the Core's signing included. An unconditional "your code is
+    // still good" here costs the operator a second trip.
+    expect(dial).toContain("If nothing answered, nothing was sent");
+    expect(dial).toContain("the connection dropped part-way through");
+    expect(dial).toContain("mint a fresh one");
+    expect(dial).not.toContain("the code was never sent, no attempt was spent");
+    expect(dial).toContain("getent hosts <host>");
+    expect(dial).toContain("nc -vz <host> <port>");
+    expect(dial).toContain("HTTPS_PROXY");
+    // Nothing about minting a fresh code: the code in the operator's hand is
+    // still good, and sending them back to the Core would waste the trip.
+    expect(dial).not.toContain("actana pair new");
+
+    const answered = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ fails: "not-pairable" }),
+    });
+    const stillWrong = prose(answered.err);
+    expect(stillWrong).toContain("The dial worked");
+    expect(stillWrong).toContain("actana update");
+    expect(stillWrong).not.toContain("getent hosts");
+  });
+
+  it("points a bare code at both the flag and the joined form the usage line shows", async () => {
+    const run = await cli().run(
+      ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+      { stdoutIsTty: true, pairing: fakePairing() },
+    );
+    const screen = run.err.join("\n");
+
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(screen).toContain(
+      "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+    );
+    expect(screen).toContain(
+      "actana core pair <name> <host:port> <session>:<code> --fingerprint <sha256>",
+    );
+    expect(prose(run.err)).toContain("prints the session id on its own line");
+  });
+
+  it("wraps a credential path too long for the frame instead of overflowing it", async () => {
+    // A deep home directory is ordinary, and the row that reassures an
+    // operator their credential exists is the row most likely to be long.
+    const deep = "d".repeat(30);
+    const run = await cli().run(
+      ["core", "pair", deep, "core.test:8443", CODE, "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+      { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } },
+    );
+
+    for (const line of framed(run.out)) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    const inFrame = framed(run.out)
+      .map((line) => line.replace(/^│\s*/, "").replace(/\s*│$/, ""))
+      .join("");
+    // Wrapped, never shortened: the whole path is still there.
+    expect(inFrame).toContain(coreBlobPath(cli().paths, deep));
+  });
+
+  // #366 review 1. The old width test only ever rendered `the fake Core
+  // answered <failure>` — a headline far too short to break anything — so it
+  // looked like it covered the frame and did not. The SDK's real
+  // `fingerprint-mismatch` sentence carries **two** 95-column colon-hex
+  // fingerprints with no space and no slash in them, and that is the one class
+  // on this screen whose whole subject is a value compared character by
+  // character. Built here to the SDK's own format rather than imported, so a
+  // change to that format shows up as a diff a reader has to look at.
+  function sdkFingerprintMismatch(): CorePairingError {
+    const presented = PAIRED_FINGERPRINT;
+    const expected = PAIRED_FINGERPRINT.split(":").reverse().join(":");
+    return new CorePairingError(
+      "fingerprint-mismatch",
+      `https://core.test:8443 presented a certificate authority with fingerprint ${presented}, ` +
+        `but ${expected} was expected — the pairing code was not sent`,
+    );
+  }
+
+  it("holds the frame around the SDK's real fingerprint-mismatch sentence", async () => {
+    const err = sdkFingerprintMismatch();
+    const run = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing({ failsWith: err }),
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(run.code).toBe(EXIT_PAIR_FINGERPRINT_MISMATCH);
+    const lines = framed(run.err);
+    expect(lines.length).toBeGreaterThan(3);
+    for (const line of lines) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+
+    // Wrapped, never shortened — and this is the class where that matters most:
+    // an operator is being asked to compare these two values by eye, and a
+    // fingerprint with an ellipsis in it is an invitation to guess.
+    const said = prose(run.err).replace(/ /g, "");
+    expect(said).toContain(PAIRED_FINGERPRINT.replace(/ /g, ""));
+    expect(said).toContain(PAIRED_FINGERPRINT.split(":").reverse().join(":"));
+    expect(said).not.toContain("…");
+  });
+
+  it("holds the frame around every refusal this file words itself", async () => {
+    // #366 review 9: five of these were never rendered by any test, so the
+    // width invariant was unproven for exactly the blocks whose step lists this
+    // PR wrote from scratch.
+    const tty = { stdoutIsTty: true, env: { NO_COLOR: "1" } } as const;
+    const runs = [
+      await cli().run(["core", "pair", "prod"], { ...tty, pairing: fakePairing() }),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", CODE, "WXYZ-6789", "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "bad name", "core.test:8443", CODE, "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", `other-session:${CODE}`, "--session", SESSION],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", "no", "--session", SESSION, "--fingerprint", PAIRED_FINGERPRINT],
+        { ...tty, pairing: fakePairing() },
+      ),
+      await cli().run(pairArgv(), {
+        ...tty,
+        pairing: fakePairing({ failsWith: new TypeError("cannot read properties of undefined") }),
+      }),
+    ];
+
+    for (const [index, run] of runs.entries()) {
+      const lines = framed(run.err);
+      expect(lines.length, `refusal ${index} was not framed`).toBeGreaterThan(3);
+      for (const line of lines) {
+        expect(displayWidth(line), `refusal ${index}: "${line}"`).toBe(FRAME_WIDTH);
+      }
+      // And each still ends in something to type.
+      const commands = run.err.filter((line) => /^ {2}\S/.test(line));
+      expect(commands.length, `refusal ${index} had nothing to type`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps every framed line exactly the frame's width", async () => {
+    // Measured under NO_COLOR, because `displayWidth` counts columns and an
+    // escape sequence has none — the padding is computed on the plain text and
+    // this is the assertion that says so.
+    const runs = [
+      await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } }),
+      await cli().run(pairArgv(), {
+        stdoutIsTty: true,
+        pairing: fakePairing({ fails: "refused" }),
+        env: { NO_COLOR: "1" },
+      }),
+      await cli().run(
+        ["core", "pair", "prod", "core.test:8443", CODE, "--fingerprint", PAIRED_FINGERPRINT],
+        { stdoutIsTty: true, pairing: fakePairing(), env: { NO_COLOR: "1" } },
+      ),
+    ];
+    for (const run of runs) {
+      const lines = framed([...run.out, ...run.err]);
+      expect(lines.length).toBeGreaterThan(3);
+      for (const line of lines) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+    }
+  });
+
+  it("degrades to no escapes under NO_COLOR, keeping every instruction", async () => {
+    const coloured = await cli().run(pairArgv(), { stdoutIsTty: true, pairing: fakePairing() });
+    // Back to nothing registered, so the second run is the same first pairing
+    // in the same fixture — same credential path, same `current` sentence, and
+    // a comparison that is about the escapes and nothing else.
+    await cli().run(["core", "rm", "prod"]);
+    const plain = await cli().run(pairArgv(), {
+      stdoutIsTty: true,
+      pairing: fakePairing(),
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(coloured.out.join("\n")).toMatch(/\x1b\[/);
+    expect(plain.out.join("\n")).not.toMatch(/\x1b\[/);
+    // Same block, same words, same commands — only the escapes are gone.
+    expect(plain.out).toEqual(coloured.out.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "")));
+    // And the padding was computed on the plain text: strip the escapes off
+    // the coloured run and its borders still land in the same column. That is
+    // the property a frame padded by `String.length` would fail.
+    for (const line of framed(coloured.out)) {
+      expect(displayWidth(line.replace(/\x1b\[[0-9;]*m/g, ""))).toBe(FRAME_WIDTH);
+    }
+  });
+
+  it("never prints the pairing code, framed or not", async () => {
+    for (const stdoutIsTty of [true, false]) {
+      cli().cleanup();
+      fixture = null;
+      const run = await cli().run(pairArgv(), { stdoutIsTty, pairing: fakePairing() });
+      expect(run.all, "the pairing code reached an output sink").not.toContain(CODE);
+      expect(run.all.toUpperCase(), "the pairing code reached an output sink").not.toContain("ABCD");
+    }
+  });
+});
+
+// ─── the pure renderers, called directly (#366 review 7) ───────────────────
+//
+// Two properties that `runCorePair` cannot reach. Both modules are pure —
+// values in, lines out — so calling them is the whole of the setup, and a
+// branch nothing exercises is a branch nobody knows the shape of.
+
+describe("corePairSuccessBlock, directly", () => {
+  /** A block with every field filled, so a test can vary exactly one. */
+  function block(over: Partial<Parameters<typeof corePairSuccessBlock>[0]> = {}): string[] {
+    return corePairSuccessBlock({
+      name: "prod",
+      endpoint: "wss://core.test:8443",
+      replaced: false,
+      label: "bkp-07",
+      current: "prod",
+      credentialPath: "/home/ada/.config/actana/cores/prod.txt",
+      color: false,
+      ...over,
+    });
+  }
+
+  it("says nothing is selected when the pointer is gone, rather than naming one", () => {
+    // Unreachable through the verb: `runCorePair` writes the pointer when
+    // nothing holds it and then reads it back. It is reachable in the world —
+    // a concurrent `actana core rm` between those two lines — and the honest
+    // answer is that nothing is selected, not a name that is not there.
+    const said = block({ current: null }).join("\n");
+
+    expect(said).toContain("nothing is selected yet");
+    expect(said).not.toContain("every later verb talks to this Core");
+    // And it offers the command that fixes it, because it is not current.
+    expect(said).toContain("actana core use prod");
+  });
+
+  it("keeps the frame at width for all three pointer states", () => {
+    for (const current of ["prod", "other", null]) {
+      for (const line of block({ current }).filter((one) => /^[╭│╰]/.test(one))) {
+        expect(displayWidth(line), `current=${current}: "${line}"`).toBe(FRAME_WIDTH);
+      }
+    }
+  });
+});
+
+describe("wrapText, on the values a frame actually holds", () => {
+  /** Every wrap is lossless: the pieces put back together are the input. */
+  function rejoined(text: string, columns: number): string {
+    return wrapText(text, columns).join("").replace(/ /g, "");
+  }
+
+  it("breaks colon-hex on its colons, and loses nothing", () => {
+    const fingerprint = PAIRED_FINGERPRINT;
+    const lines = wrapText(fingerprint, 40);
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(40);
+    // Every line but the last ends on the separator, which is what tells a
+    // reader the value continues.
+    for (const line of lines.slice(0, -1)) expect(line.endsWith(":")).toBe(true);
+    expect(lines.join("")).toBe(fingerprint);
+  });
+
+  it("breaks a path on its slashes, and loses nothing", () => {
+    const path = "/home/ada.mcdonald/.config/actana/cores/a-rather-long-core-name.txt";
+    const lines = wrapText(path, 30);
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(30);
+    expect(lines.join("")).toBe(path);
+  });
+
+  it("breaks a URL on either separator", () => {
+    const url = "https://a-very-long-host-name.example.invalid:8443/v1/pairing/redeem";
+    expect(rejoined(url, 24)).toBe(url);
+    for (const line of wrapText(url, 24)) expect(displayWidth(line)).toBeLessThanOrEqual(24);
+  });
+
+  it("leaves a word with neither separator whole and over-long, never cut", () => {
+    // The residual, pinned so it stays a decision rather than a surprise: there
+    // is nowhere left to break that would not put a line ending inside a name,
+    // and a ragged border is a cheaper failure than a value that cannot be
+    // trusted. Documented on `wrapText` in exactly these terms.
+    const unbreakable = "z".repeat(90);
+    const lines = wrapText(`before ${unbreakable} after`, 40);
+
+    expect(lines).toContain(unbreakable);
+    expect(lines.join(" ")).toContain(unbreakable);
+    expect(lines.join("")).not.toContain("…");
+  });
+
+  it("never drops a character, whatever it is handed", () => {
+    for (const text of [
+      PAIRED_FINGERPRINT,
+      "/a/b/c/d/e/f/g/h",
+      "wss://core.test:8443",
+      "a b c",
+      "",
+      "::::",
+      "////",
+    ]) {
+      expect(rejoined(text, 8), `wrapText dropped part of ${JSON.stringify(text)}`).toBe(
+        text.replace(/ /g, ""),
+      );
+    }
   });
 });

--- a/packages/cli/src/__tests__/machine-fixture.ts
+++ b/packages/cli/src/__tests__/machine-fixture.ts
@@ -165,6 +165,7 @@ export type ClientHalf = Pick<
   | "verbose"
   | "readStdin"
   | "stdinIsTty"
+  | "stdoutIsTty"
   | "probe"
   | "connect"
   | "pairing"
@@ -189,6 +190,9 @@ export function stubClientHalf(
     verbose: () => {},
     readStdin: async () => "",
     stdinIsTty: false,
+    // Piped, so every suite that does not ask otherwise sees the shape a script
+    // sees — which is the shape the stdout contract is about.
+    stdoutIsTty: false,
     probe: refuse("dial a Core"),
     connect: refuse("dial a Core"),
     pairing: { identify: refuse("identify a Core"), pair: refuse("pair with a Core") },

--- a/packages/cli/src/actana-cli-entry.ts
+++ b/packages/cli/src/actana-cli-entry.ts
@@ -144,6 +144,7 @@ async function main(): Promise<void> {
       : () => {},
     readStdin,
     stdinIsTty: Boolean(process.stdin.isTTY),
+    stdoutIsTty: Boolean(process.stdout.isTTY),
     probe: probeCore,
     connect: connectCore,
     // The one dial that starts with nothing trusted: `core pair` enrolls this

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -28,6 +28,14 @@
 // design working, not an omission, and `pair-command.test.ts` asserts it rather
 // than trusting it.
 //
+// **`pair new` has two shapes, and `isatty(stdout)` is the whole of the
+// switch** (#357). Down a pipe it is the labelled lines below, byte for byte
+// what 0.4.2 printed, because they are a screen-scraping contract. At a
+// terminal it is a framed handout that also says what to click in the Panel and
+// what to paste on the other machine. There is deliberately no `--json` and no
+// flag: a second way to ask is a second thing to keep true. See "the operator's
+// shape" further down for what is drawn and why.
+//
 // **What the fingerprint is for.** `pair new` prints the CA fingerprint beside
 // the code because the client's first dial is the one dial it cannot verify any
 // other way: it holds no certificate, so it has nothing pinned. A human reads
@@ -42,10 +50,14 @@
 // redeems them and enforces the revocations. Neither imports the other.
 
 import { randomUUID } from "node:crypto";
+import * as path from "node:path";
 import {
+  CONTAINER_PORT_ENV,
   CONTAINER_PUBLIC_HOST_ENV,
+  DEFAULT_CONTAINER_PORT,
   inContainer,
 } from "@actana/shared/actana-container-contract";
+import { coreNameError } from "@actana/shared/blob-registry";
 import { certFingerprintSha256 } from "@actana/shared/core-cert-material";
 import {
   formatPublicHosts,
@@ -75,6 +87,7 @@ import {
   pairingAuditor,
   type PairingAuditSink,
 } from "@actana/shared/pairing-audit";
+import { readActanaConfig } from "./actana-config.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -113,6 +126,16 @@ Minting a code
   The code is printed once and never stored. This Core keeps only a keyed
   digest of it, so nothing — including \`pair ls\` — can print it again. A lost
   code is re-minted, not recovered.
+
+  **At a terminal it prints more than that.** Those facts come framed, with
+  both ways to spend them under it: what to click in the Panel, and a command
+  to paste on the machine being paired — \`actana core pair\` with this code,
+  this session and this fingerprint already in it, one per address this Core
+  answers on.
+
+  Redirect stdout and you get the labelled lines and nothing else, which is
+  what a script reads. That is the whole of the switch: there is no flag for
+  it, and \`pair new > code.txt\` or \`pair new | …\` gives the plain shape.
 
 Choosing an address
   A Core can be reachable more than one way at once — \`ACTANA_PUBLIC_HOST\` takes
@@ -263,20 +286,50 @@ function pairNew(deps: ActanaCliDeps, rest: string[], ctx: PairCommandContext): 
 
   store.createSession(session, now);
 
-  // stdout: the three facts a human reads out. stderr: everything explaining
-  // them, so a `pair new` that is being piped or screen-scraped stays three
-  // labelled lines and nothing else.
+  const fingerprint = certFingerprintSha256(material.caCert);
+
+  // stderr is the same in both shapes below. It is the prose, and prose is not
+  // what a scraper reads — so the two sentences that explain the code are here
+  // whether the frame was drawn or not.
   deps.err("Read the code AND the fingerprint out to the machine you are pairing.");
   deps.err("The code is printed once — this Core keeps only a digest of it.");
-  deps.out(`Pairing code   ${code}`);
-  deps.out(`CA fingerprint ${certFingerprintSha256(material.caCert)}`);
-  deps.out(`Expires        ${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`);
-  if (label) deps.out(`Label          ${label}`);
-  // Only when it was chosen. A Core with one configured address has nothing to
-  // say here, and a line that appeared on every `pair new` would be noise on
-  // the terminal an operator is reading a credential off.
-  if (endpointHost) deps.out(`Endpoint host  ${endpointHost}`);
-  deps.out(`Session        ${sessionId}`);
+
+  if (deps.stdoutIsTty) {
+    // The operator's shape (#357). Everything about it is cosmetic: it carries
+    // the same facts the labelled lines do, plus the two ways to spend them,
+    // and it is reachable only when there is a human at the other end.
+    for (const line of pairingHandout({
+      code,
+      fingerprint,
+      expiresAt: session.expiresAt,
+      now,
+      sessionId,
+      label,
+      hosts: handoutHosts(material.serverHosts, endpointHost),
+      // What redemption will name, which is the chosen host when there is one
+      // and this Core's primary when there is not — the same resolution
+      // `core-pairing-wiring.ts` does, stated here so the block can say it.
+      credentialHost: endpointHost ?? primaryPublicHost(material.serverHosts),
+      port: corePort(deps, materialPath),
+      color: useColor(deps),
+    })) {
+      deps.out(line);
+    }
+  } else {
+    // stdout: the facts a human reads out, one labelled line each. **Not one
+    // byte of this may move** — it is what every script that has ever wrapped
+    // `pair new` reads, and the frame above exists precisely so that this does
+    // not have to change to give an operator something better to look at.
+    deps.out(`Pairing code   ${code}`);
+    deps.out(`CA fingerprint ${fingerprint}`);
+    deps.out(`Expires        ${absoluteTime(session.expiresAt)} (${relativeTime(session.expiresAt, now)})`);
+    if (label) deps.out(`Label          ${label}`);
+    // Only when it was chosen. A Core with one configured address has nothing to
+    // say here, and a line that appeared on every `pair new` would be noise on
+    // the terminal an operator is reading a credential off.
+    if (endpointHost) deps.out(`Endpoint host  ${endpointHost}`);
+    deps.out(`Session        ${sessionId}`);
+  }
   deps.err(`Cancel it before it is used with \`actana pair revoke ${sessionId}\`.`);
   return EXIT_OK;
 }
@@ -386,6 +439,463 @@ function chooseEndpointHost(
     return REFUSED;
   }
   return wanted;
+}
+
+// ─── the operator's shape (#357) ────────────────────────────────────────────
+//
+// `pair new` has two audiences and they want opposite things. A script wants
+// labelled lines it can cut a field out of and nothing else; the person
+// standing at the Core wants to know what the code is *for* and what to type
+// next, on the other machine, without reassembling `actana core pair` out of
+// four separate lines by hand.
+//
+// **The switch is `isatty(stdout)` and nothing else.** No flag, no environment
+// variable, and deliberately no `--json` (#357). A pipe, a file, a `$( )` and a
+// CI log all get the labelled lines, byte for byte what 0.4.2 printed, and
+// `actana-pair.test.ts` asserts that against a literal rather than trusting it.
+// A terminal gets the frame below. Nothing else in this command reads the
+// answer — the session that was minted, the digest that was stored and the
+// exit code are identical either way, because a command that *did* something
+// different at a terminal is a command no script can trust.
+//
+// Everything here is pure: values in, lines out. That is what lets the suite
+// assert on the frame without a terminal, and what keeps the decision to draw
+// one in exactly one `if`.
+
+/** The escape sequences the frame uses, and the only ANSI in this file. */
+const ANSI = {
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  /** The pairing code itself, which is the one thing on the screen that matters. */
+  boldCyan: "\u001b[1;36m",
+} as const;
+
+/**
+ * Whether to colour, given a terminal.
+ *
+ * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
+ * (https://no-color.org). Honouring it costs one clause and means an operator
+ * whose terminal renders escapes badly still gets the instructions, rather than
+ * having to choose between colour and a pipe.
+ */
+function useColor(deps: ActanaCliDeps): boolean {
+  const noColor = deps.env.NO_COLOR;
+  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
+}
+
+/** The frame's total width, borders included. Fixed, so the output is one shape. */
+export const FRAME_WIDTH = 74;
+
+/** How far in from the left border the content starts. */
+const FRAME_GUTTER = 3;
+
+/** One run of styled text inside a framed line. */
+type Span = { text: string; style?: string };
+
+/**
+ * Every fact the handout renders. Times arrive as epoch ms and the clock does
+ * not: `now` is passed in, because this file reads the clock in exactly one
+ * place and it is not here.
+ */
+export type PairingHandout = {
+  code: string;
+  /** The full colon-separated hex. Wrapped below, and never shortened. */
+  fingerprint: string;
+  expiresAt: number;
+  now: number;
+  sessionId: string;
+  /** `""` when the code was minted without one. */
+  label: string;
+  /** The addresses to offer a pasteable command for, primary first. */
+  hosts: readonly string[];
+  /**
+   * The address the **credential** will name, whichever of {@link hosts} was
+   * dialled (#357 review B2).
+   *
+   * Not the same question as "which address do I dial", and conflating the two
+   * is the bug this field exists to spell out. The endpoint a paired client
+   * keeps comes off the stored session, never off the address it dialled:
+   * `core-pairing-wiring.ts` reads `session.endpointHost` and falls back to the
+   * Core's primary. So a code minted with `--public-host` carries that host,
+   * and a code minted without one carries the primary for *every* command in
+   * the block — including the ones that dial something else.
+   */
+  credentialHost: string;
+  port: number;
+  color: boolean;
+};
+
+/**
+ * The framed block, the Panel path and the terminal path, as lines.
+ *
+ * The order is the order of the questions an operator asks: what is the code,
+ * how long have I got, what do I compare the certificate against, which session
+ * is it — and then, under the frame, what do I actually do with it.
+ */
+export function pairingHandout(handout: PairingHandout): string[] {
+  const { code, fingerprint, sessionId, label, color } = handout;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  lines.push(frameRow([{ text: "Pairing code", style: ANSI.dim }], color));
+  lines.push(frameRow([], color));
+  // The one line the whole command exists for, and the only one in bold cyan.
+  lines.push(frameRow([{ text: `   ${code}`, style: ANSI.boldCyan }], color));
+  lines.push(frameRow([], color));
+  lines.push(
+    frameRow(
+      [
+        { text: "Expires        ", style: ANSI.dim },
+        {
+          text: `${absoluteTime(handout.expiresAt)} (${relativeTime(handout.expiresAt, handout.now)})`,
+        },
+      ],
+      color,
+    ),
+  );
+  lines.push(frameRow([], color));
+  // **Wrapped, never truncated.** The fingerprint is what the client checks the
+  // certificate against before it sends the code, so a fingerprint with an
+  // ellipsis in it is not a fingerprint — it is an invitation to guess.
+  lines.push(frameRow([{ text: "CA fingerprint", style: ANSI.dim }], color));
+  for (const chunk of wrapFingerprint(fingerprint)) {
+    lines.push(frameRow([{ text: `   ${chunk}` }], color));
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameRow([{ text: "Session        ", style: ANSI.dim }, { text: sessionId }], color));
+  if (label) {
+    // The one row whose content has no bound: `--label` takes whatever an
+    // operator wants to call a machine. Clipped to what the frame holds, and
+    // it is *this* row that gives — a label is a name the operator already
+    // knows and can read off `pair ls`, where the fingerprint is a value they
+    // have to compare character by character (#357 review N1).
+    const room = FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth("Label          ") - 1;
+    lines.push(
+      frameRow([{ text: "Label          ", style: ANSI.dim }, { text: clip(label, room) }], color),
+    );
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  // The canonical path first: most people pairing a Core are sitting in front
+  // of a Panel, and the code goes straight into it.
+  lines.push(style("From the Panel", ANSI.bold, color));
+  lines.push(`  ${PANEL_INSTRUCTION}`);
+  lines.push("");
+
+  lines.push(style("From a terminal", ANSI.bold, color));
+  lines.push("  npm i -g @actana/cli");
+  lines.push("");
+  // One command per address, **with the minted values already in it**. A
+  // placeholder here would put the operator back where they started: reading
+  // four fields off a screen and retyping them into a fifth thing.
+  //
+  // Each one says which endpoint the *credential* ends up naming, because for
+  // every address but one that is not the address the command dials — see
+  // {@link PairingHandout.credentialHost}. Saying only "reachable at X" would
+  // hand an operator a command that pairs and then leaves their client pointed
+  // somewhere it cannot reach, with nothing on the screen explaining why.
+  const credentialEndpoint = endpointAddress(handout.credentialHost, handout.port);
+  for (const [index, host] of handout.hosts.entries()) {
+    const endpoint = endpointAddress(host, handout.port);
+    for (const note of hostNotes(handout, host, endpoint, credentialEndpoint)) {
+      lines.push(style(`  ${note}`, ANSI.dim, color));
+    }
+    lines.push(`  ${corePairCommand(handout, host)}`);
+    if (index < handout.hosts.length - 1) lines.push("");
+  }
+  return lines;
+}
+
+/**
+ * The comment lines above one pasteable command.
+ *
+ * Two shapes, and which one an address gets is the whole of #357 review B2:
+ *
+ *   - the address the credential will name — dial it, keep it, nothing to say;
+ *   - any other configured address — dial it and the pairing works, but the
+ *     client is left registered at `credentialEndpoint`, which on a machine
+ *     that cannot reach that name is a successful pairing followed by an
+ *     `actana core status` that fails for no visible reason.
+ *
+ * The second shape carries the fix rather than only the warning: one `pair new
+ * --public-host <addr>` mints a code whose redemption hands back *that*
+ * address, which is the workflow #347 and ADR 0038 designed and the one this
+ * block should be teaching.
+ */
+function hostNotes(
+  handout: PairingHandout,
+  host: string,
+  endpoint: string,
+  credentialEndpoint: string,
+): string[] {
+  if (endpoint === credentialEndpoint) {
+    return [`# dial ${endpoint} — and that is the endpoint this code registers`];
+  }
+  const label = handout.label && coreNameError(handout.label) === null ? ` --label ${handout.label}` : "";
+  return [
+    `# dial ${endpoint} — but this code still registers ${credentialEndpoint}`,
+    `#   to register ${endpoint}: actana pair new${label} --public-host ${host}`,
+  ];
+}
+
+/**
+ * The Panel path, worded once, and worded from the form rather than from
+ * memory (#357 review B1).
+ *
+ * `AddCoreByPairing.tsx` asks for things in a fixed order and gates them:
+ * the **Core address** first, with a "Check fingerprint" button beside it;
+ * then the **CA fingerprint**, typed and compared, and *"the Panel does not
+ * send the code until they match"*; and only past a verified fingerprint does
+ * step 3 exist at all — **Session**, then **Pairing code**, then an optional
+ * name. An instruction that said "then enter the code" sent an operator to a
+ * form that first wants an address this block never called a field, and then
+ * wants the fingerprint they had just been told they did not need — while the
+ * frame above prints that fingerprint prominently and never says what it is
+ * for. The comparison is the security-relevant step of the whole exchange
+ * (#280 step 3, #284); it is the one thing this line must not drop.
+ *
+ * A constant rather than an inline string because the wording is the spec, and
+ * a test asserts this value rather than a regex that would go on passing after
+ * somebody paraphrased it. `scripts/e2e-actana-setup-linux.mjs` pins it too:
+ * both move with this line.
+ */
+export const PANEL_INSTRUCTION =
+  "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+  "CA fingerprint, then the session and the code";
+
+/**
+ * The line the operator pastes on the other machine.
+ *
+ * Every value is real: the label, the address, the code, the session and the
+ * whole fingerprint. `--session` is not optional — `readTicket` on the client
+ * refuses a bare code without it — and its absence from two usage strings is
+ * the other half of #357.
+ *
+ * One line, not a backslash continuation. A continuation is one keystroke away
+ * from being pasted into something that does not join it, and the whole promise
+ * of this line is that it works when pasted.
+ */
+function corePairCommand(handout: PairingHandout, host: string): string {
+  return [
+    "actana core pair",
+    handoutName(handout.label),
+    endpointAddress(host, handout.port),
+    handout.code,
+    "--session",
+    handout.sessionId,
+    "--fingerprint",
+    handout.fingerprint,
+  ].join(" ");
+}
+
+/**
+ * What the pasted command calls the Core.
+ *
+ * The `--label` when there is one and the client's registry would accept it,
+ * and {@link NAME_PLACEHOLDER} otherwise. The check is `coreNameError` — the
+ * client's own rule — rather than a second opinion about names written here: a
+ * label with a space in it is a fine label and not a Core name, and pasting it
+ * would fail on the far machine with a message about a registry nobody
+ * mentioned.
+ */
+function handoutName(label: string): string {
+  if (!label || coreNameError(label) !== null) return NAME_PLACEHOLDER;
+  return label;
+}
+
+/**
+ * The name slot, when there is no usable label — and it is bare `NAME` rather
+ * than `<name>` for one reason (#357 review B3).
+ *
+ * `<name>` is not inert in a shell. Pasted into bash it is a redirection: read
+ * stdin from a file called `name`, and send stdout to a file named after the
+ * next word. The command never runs, and what the operator sees is
+ * `bash: name: No such file or directory` — a message that names neither
+ * `actana` nor the actual problem, on the one line whose whole promise is that
+ * it works when pasted. It fires on `actana pair new` with no `--label`, which
+ * is the documented default.
+ *
+ * `NAME` reads as a slot just as clearly, survives every shell, and if it is
+ * pasted unedited it registers a Core called `NAME` — recoverable with one
+ * `actana core rm NAME`, which a shell error is not.
+ */
+export const NAME_PLACEHOLDER = "NAME";
+
+/**
+ * `host:port`, with an IPv6 literal bracketed.
+ *
+ * The same rule `endpointFor` applies in `actana-config.ts`, for the same
+ * reason: `fe80::1:8443` is not an address anything can parse.
+ */
+function endpointAddress(host: string, port: number): string {
+  const bracketed = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `${bracketed}:${port}`;
+}
+
+/**
+ * The fingerprint, broken across lines on its own separators.
+ *
+ * Split on the colons that are already in it and re-joined, so a wrapped
+ * fingerprint reads as the same value with a line break in it: every line but
+ * the last ends with the separator, which is what tells a reader there is more.
+ * Nothing is dropped — this function cannot shorten its input, which is the
+ * property that matters.
+ */
+export function wrapFingerprint(fingerprint: string, groupsPerLine = 16): string[] {
+  const groups = fingerprint.split(":");
+  const perLine = Math.max(1, groupsPerLine);
+  const lines: string[] = [];
+  for (let i = 0; i < groups.length; i += perLine) {
+    const last = i + perLine >= groups.length;
+    lines.push(groups.slice(i, i + perLine).join(":") + (last ? "" : ":"));
+  }
+  return lines;
+}
+
+/** The top or bottom rule. */
+function frameEdge(which: "top" | "bottom", color: boolean): string {
+  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
+  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
+}
+
+/**
+ * One line between the two borders.
+ *
+ * The padding is measured on the **plain** text and the styling applied
+ * afterwards, because an escape sequence has a length and no width — pad a
+ * coloured string by `String.length` and the right border walks off by however
+ * many bytes the colour cost.
+ */
+function frameRow(spans: Span[], color: boolean): string {
+  const plain = spans.map((span) => span.text).join("");
+  const body = spans.map((span) => style(span.text, span.style, color)).join("");
+  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
+  const bar = style("│", ANSI.dim, color);
+  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
+}
+
+/**
+ * How many terminal columns `text` occupies.
+ *
+ * `String.length` is UTF-16 code units and a frame padded by it is crooked for
+ * anybody whose label is not Latin: `笔记本` is three code units and six
+ * columns, so the right border lands three early (#357 review N1). Counted per
+ * code point — a surrogate pair is one character, not two — with the wide
+ * ranges at two and the zero-width ones at nothing.
+ *
+ * Deliberately not a full `wcwidth`. This measures the four things that reach
+ * a frame row: ASCII, an operator's label, a UUID and colon-hex. Emoji with
+ * joiners and skin tones can still measure a column off, and the cost of that
+ * is a ragged border on one line — not a truncated fingerprint, which is the
+ * thing this file may never do.
+ */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const character of text) {
+    const point = character.codePointAt(0) ?? 0;
+    if (isZeroWidth(point)) continue;
+    width += isWide(point) ? 2 : 1;
+  }
+  return width;
+}
+
+/** Combining marks and variation selectors: they attach, they take no column. */
+function isZeroWidth(point: number): boolean {
+  return (
+    (point >= 0x0300 && point <= 0x036f) ||
+    (point >= 0x200b && point <= 0x200f) ||
+    (point >= 0xfe00 && point <= 0xfe0f) ||
+    point === 0x2060 ||
+    point === 0xfeff
+  );
+}
+
+/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
+function isWide(point: number): boolean {
+  return (
+    (point >= 0x1100 && point <= 0x115f) ||
+    (point >= 0x2e80 && point <= 0xa4cf) ||
+    (point >= 0xac00 && point <= 0xd7a3) ||
+    (point >= 0xf900 && point <= 0xfaff) ||
+    (point >= 0xfe30 && point <= 0xfe6f) ||
+    (point >= 0xff00 && point <= 0xff60) ||
+    (point >= 0xffe0 && point <= 0xffe6) ||
+    (point >= 0x1f300 && point <= 0x1f64f) ||
+    (point >= 0x1f900 && point <= 0x1f9ff) ||
+    (point >= 0x20000 && point <= 0x3fffd)
+  );
+}
+
+/**
+ * `text` shortened to `columns` display columns, marked when it was shortened.
+ *
+ * **Only ever called on the label.** Truncation is a lie about a value, and
+ * there is exactly one value in this block cheap enough to tell it about: a
+ * label is a name the operator chose and can read back off `pair ls`. The
+ * fingerprint wraps instead — see {@link wrapFingerprint} — and nothing routes
+ * it through here.
+ */
+function clip(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text;
+  let kept = "";
+  let width = 0;
+  for (const character of text) {
+    const next = width + displayWidth(character);
+    // One column held back for the marker, which is one column wide.
+    if (next > columns - 1) break;
+    kept += character;
+    width = next;
+  }
+  return `${kept}…`;
+}
+
+/** Wrap `text` in an escape sequence, or hand it back untouched. */
+function style(text: string, code: string | undefined, color: boolean): string {
+  return color && code ? `${code}${text}${ANSI.reset}` : text;
+}
+
+/**
+ * The addresses the handout offers a command for, primary first.
+ *
+ * When `--public-host` chose one, it is the only one: the credential redemption
+ * hands back carries *that* endpoint, and offering the others would be offering
+ * commands whose paired client then dials an address this code did not choose.
+ * Otherwise it is the whole configured list in the operator's order, which is
+ * the order the primary is first in (#347).
+ *
+ * A Core whose material predates the SAN list having been recorded has no list
+ * to offer, and falls back to what `primaryPublicHost` falls back to rather
+ * than printing a command with an empty address in it.
+ */
+function handoutHosts(configured: readonly string[], chosen: string | undefined): string[] {
+  if (chosen) return [chosen];
+  return configured.length > 0 ? [...configured] : [primaryPublicHost(configured)];
+}
+
+/**
+ * The port the pasteable command dials.
+ *
+ * In a container it is the one the contract names — `ACTANA_PORT`, or 8443
+ * when it is unset — because there is no `actana.json` there. On metal it is
+ * what `actana setup` recorded beside the material, which is the directory
+ * `materialPath` points into. A config that cannot be read falls back to the
+ * documented default rather than refusing to print the command: an operator
+ * with a wrong port in front of them can fix it, and one with no command at all
+ * cannot.
+ */
+function corePort(deps: ActanaCliDeps, materialPath: string): number {
+  if (inContainer(deps.env)) {
+    const raw = deps.env[CONTAINER_PORT_ENV]?.trim();
+    const parsed = raw ? Number(raw) : Number.NaN;
+    return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535
+      ? parsed
+      : DEFAULT_CONTAINER_PORT;
+  }
+  return readActanaConfig(path.dirname(materialPath))?.port ?? DEFAULT_CONTAINER_PORT;
 }
 
 // ─── ls ─────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -88,9 +88,26 @@ import {
   type PairingAuditSink,
 } from "@actana/shared/pairing-audit";
 import { readActanaConfig } from "./actana-config.ts";
+import {
+  ANSI,
+  clip,
+  displayWidth,
+  frameEdge,
+  FRAME_CONTENT_WIDTH,
+  FRAME_HEADING,
+  frameRow,
+  style,
+  useColor,
+} from "./cli-frame.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
+
+// The frame's own vocabulary, re-exported because it is part of what this
+// module prints and `actana-pair.test.ts` measures the handout with it. The
+// definitions moved to `cli-frame.ts` when `actana core pair` grew a frame of
+// its own (#360) — there is one border width in this program, not two.
+export { displayWidth, FRAME_WIDTH } from "./cli-frame.ts";
 
 export const PAIR_HELP = `actana pair — enroll a client on THIS machine's Core
 
@@ -462,37 +479,6 @@ function chooseEndpointHost(
 // assert on the frame without a terminal, and what keeps the decision to draw
 // one in exactly one `if`.
 
-/** The escape sequences the frame uses, and the only ANSI in this file. */
-const ANSI = {
-  reset: "\u001b[0m",
-  bold: "\u001b[1m",
-  dim: "\u001b[2m",
-  /** The pairing code itself, which is the one thing on the screen that matters. */
-  boldCyan: "\u001b[1;36m",
-} as const;
-
-/**
- * Whether to colour, given a terminal.
- *
- * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
- * (https://no-color.org). Honouring it costs one clause and means an operator
- * whose terminal renders escapes badly still gets the instructions, rather than
- * having to choose between colour and a pipe.
- */
-function useColor(deps: ActanaCliDeps): boolean {
-  const noColor = deps.env.NO_COLOR;
-  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
-}
-
-/** The frame's total width, borders included. Fixed, so the output is one shape. */
-export const FRAME_WIDTH = 74;
-
-/** How far in from the left border the content starts. */
-const FRAME_GUTTER = 3;
-
-/** One run of styled text inside a framed line. */
-type Span = { text: string; style?: string };
-
 /**
  * Every fact the handout renders. Times arrive as epoch ms and the clock does
  * not: `now` is passed in, because this file reads the clock in exactly one
@@ -571,7 +557,7 @@ export function pairingHandout(handout: PairingHandout): string[] {
     // it is *this* row that gives — a label is a name the operator already
     // knows and can read off `pair ls`, where the fingerprint is a value they
     // have to compare character by character (#357 review N1).
-    const room = FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth("Label          ") - 1;
+    const room = FRAME_CONTENT_WIDTH - displayWidth("Label          ");
     lines.push(
       frameRow([{ text: "Label          ", style: ANSI.dim }, { text: clip(label, room) }], color),
     );
@@ -582,11 +568,11 @@ export function pairingHandout(handout: PairingHandout): string[] {
 
   // The canonical path first: most people pairing a Core are sitting in front
   // of a Panel, and the code goes straight into it.
-  lines.push(style("From the Panel", ANSI.bold, color));
+  lines.push(style("From the Panel", FRAME_HEADING, color));
   lines.push(`  ${PANEL_INSTRUCTION}`);
   lines.push("");
 
-  lines.push(style("From a terminal", ANSI.bold, color));
+  lines.push(style("From a terminal", FRAME_HEADING, color));
   lines.push("  npm i -g @actana/cli");
   lines.push("");
   // One command per address, **with the minted values already in it**. A
@@ -754,108 +740,6 @@ export function wrapFingerprint(fingerprint: string, groupsPerLine = 16): string
     lines.push(groups.slice(i, i + perLine).join(":") + (last ? "" : ":"));
   }
   return lines;
-}
-
-/** The top or bottom rule. */
-function frameEdge(which: "top" | "bottom", color: boolean): string {
-  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
-  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
-}
-
-/**
- * One line between the two borders.
- *
- * The padding is measured on the **plain** text and the styling applied
- * afterwards, because an escape sequence has a length and no width — pad a
- * coloured string by `String.length` and the right border walks off by however
- * many bytes the colour cost.
- */
-function frameRow(spans: Span[], color: boolean): string {
-  const plain = spans.map((span) => span.text).join("");
-  const body = spans.map((span) => style(span.text, span.style, color)).join("");
-  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
-  const bar = style("│", ANSI.dim, color);
-  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
-}
-
-/**
- * How many terminal columns `text` occupies.
- *
- * `String.length` is UTF-16 code units and a frame padded by it is crooked for
- * anybody whose label is not Latin: `笔记本` is three code units and six
- * columns, so the right border lands three early (#357 review N1). Counted per
- * code point — a surrogate pair is one character, not two — with the wide
- * ranges at two and the zero-width ones at nothing.
- *
- * Deliberately not a full `wcwidth`. This measures the four things that reach
- * a frame row: ASCII, an operator's label, a UUID and colon-hex. Emoji with
- * joiners and skin tones can still measure a column off, and the cost of that
- * is a ragged border on one line — not a truncated fingerprint, which is the
- * thing this file may never do.
- */
-export function displayWidth(text: string): number {
-  let width = 0;
-  for (const character of text) {
-    const point = character.codePointAt(0) ?? 0;
-    if (isZeroWidth(point)) continue;
-    width += isWide(point) ? 2 : 1;
-  }
-  return width;
-}
-
-/** Combining marks and variation selectors: they attach, they take no column. */
-function isZeroWidth(point: number): boolean {
-  return (
-    (point >= 0x0300 && point <= 0x036f) ||
-    (point >= 0x200b && point <= 0x200f) ||
-    (point >= 0xfe00 && point <= 0xfe0f) ||
-    point === 0x2060 ||
-    point === 0xfeff
-  );
-}
-
-/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
-function isWide(point: number): boolean {
-  return (
-    (point >= 0x1100 && point <= 0x115f) ||
-    (point >= 0x2e80 && point <= 0xa4cf) ||
-    (point >= 0xac00 && point <= 0xd7a3) ||
-    (point >= 0xf900 && point <= 0xfaff) ||
-    (point >= 0xfe30 && point <= 0xfe6f) ||
-    (point >= 0xff00 && point <= 0xff60) ||
-    (point >= 0xffe0 && point <= 0xffe6) ||
-    (point >= 0x1f300 && point <= 0x1f64f) ||
-    (point >= 0x1f900 && point <= 0x1f9ff) ||
-    (point >= 0x20000 && point <= 0x3fffd)
-  );
-}
-
-/**
- * `text` shortened to `columns` display columns, marked when it was shortened.
- *
- * **Only ever called on the label.** Truncation is a lie about a value, and
- * there is exactly one value in this block cheap enough to tell it about: a
- * label is a name the operator chose and can read back off `pair ls`. The
- * fingerprint wraps instead — see {@link wrapFingerprint} — and nothing routes
- * it through here.
- */
-function clip(text: string, columns: number): string {
-  if (displayWidth(text) <= columns) return text;
-  let kept = "";
-  let width = 0;
-  for (const character of text) {
-    const next = width + displayWidth(character);
-    // One column held back for the marker, which is one column wide.
-    if (next > columns - 1) break;
-    kept += character;
-    width = next;
-  }
-  return `${kept}…`;
-}
-
-/** Wrap `text` in an escape sequence, or hand it back untouched. */
-function style(text: string, code: string | undefined, color: boolean): string {
-  return color && code ? `${code}${text}${ANSI.reset}` : text;
 }
 
 /**

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -644,13 +644,18 @@ function hostNotes(
  * for. The comparison is the security-relevant step of the whole exchange
  * (#280 step 3, #284); it is the one thing this line must not drop.
  *
+ * The field is called **Add a Core**, not "Add Core": that is the string the
+ * Panel renders it from (`packages/panel/src/shared/core-onboarding.ts`,
+ * `ADD_CORE_FIELD_LABEL`), and this line is worded from the form. #357's issue
+ * text said "Add Core" and was wrong about the field's name.
+ *
  * A constant rather than an inline string because the wording is the spec, and
  * a test asserts this value rather than a regex that would go on passing after
  * somebody paraphrased it. `scripts/e2e-actana-setup-linux.mjs` pins it too:
  * both move with this line.
  */
 export const PANEL_INSTRUCTION =
-  "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+  "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
   "CA fingerprint, then the session and the code";
 
 /**

--- a/packages/cli/src/cli-deps.ts
+++ b/packages/cli/src/cli-deps.ts
@@ -72,6 +72,21 @@ export type ActanaCliDeps = {
    * a hang.
    */
   stdinIsTty: boolean;
+  /**
+   * Whether **stdout** is a terminal — the whole of the switch between the two
+   * shapes `actana pair new` prints (#357).
+   *
+   * Its own field rather than {@link interactive}, which is the *pair* of them
+   * and answers a different question: whether there is somewhere to prompt.
+   * `actana pair new > code.txt` at a terminal has an interactive stdin and a
+   * redirected stdout, and it is the second half that decides whether what
+   * lands in that file is the scrapeable labelled lines or a box drawing.
+   *
+   * A cosmetic frame is only ever built off this. Nothing about *what* the CLI
+   * does may read it — a command that behaved differently down a pipe than it
+   * does at a terminal is a command no script can trust.
+   */
+  stdoutIsTty: boolean;
   // ─── the client half: Cores this machine can reach ────────────────────────
 
   /** How `core status` reaches a Core. See `core-probe.ts`. */

--- a/packages/cli/src/cli-frame.ts
+++ b/packages/cli/src/cli-frame.ts
@@ -1,0 +1,290 @@
+// The framed, coloured shapes this CLI draws **only when stdout is a terminal**.
+//
+// These primitives arrived with `actana pair new` (#357) and lived inside
+// `actana-pair.ts` because there was one framed block in the program. #360 adds
+// the second one — `actana core pair`, the other end of the same exchange — and
+// two copies of a border width, a padding rule and a colour table is how the two
+// ends of one handshake start drawing different boxes. So they are here, and
+// both callers import them.
+//
+// **The gate is `isatty(stdout)` and nothing else.** No flag, no environment
+// variable beyond `NO_COLOR`, and deliberately no `--json`. A pipe, a file, a
+// `$( )` and a CI log get exactly the lines the command printed before any of
+// this existed; a terminal gets the frame. Nothing about *what* a command does
+// may read that answer — a command that behaved differently down a pipe than it
+// does at a terminal is a command no script can trust — and nothing here can
+// help it to, because everything in this file is pure: values in, lines out.
+// That is also what lets the suites assert on a frame without a terminal.
+
+import type { ActanaCliDeps } from "./cli-deps.ts";
+
+/** The escape sequences the frames use, and the only ANSI in this package. */
+export const ANSI = {
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  /** A value that is the whole point of the screen — a pairing code. */
+  boldCyan: "\u001b[1;36m",
+  /** The marker on a block that says something worked. */
+  green: "\u001b[32m",
+  /** The marker on a block that says something did not. */
+  red: "\u001b[31m",
+} as const;
+
+/**
+ * Whether to colour, given a terminal.
+ *
+ * `stdoutIsTty` is the gate; `NO_COLOR` is the standard opt-out on top of it
+ * (https://no-color.org). Honouring it costs one clause and means an operator
+ * whose terminal renders escapes badly still gets the instructions, rather than
+ * having to choose between colour and a pipe.
+ */
+export function useColor(deps: ActanaCliDeps): boolean {
+  const noColor = deps.env.NO_COLOR;
+  return deps.stdoutIsTty && (noColor === undefined || noColor === "");
+}
+
+/** The frame's total width, borders included. Fixed, so the output is one shape. */
+export const FRAME_WIDTH = 74;
+
+/** How far in from the left border the content starts. */
+export const FRAME_GUTTER = 3;
+
+/**
+ * How many columns a framed row's content may occupy.
+ *
+ * The two borders, the gutter, and one column held back on the right so the
+ * closing bar is never flush against a word.
+ */
+export const FRAME_CONTENT_WIDTH = FRAME_WIDTH - 2 - FRAME_GUTTER - 1;
+
+/**
+ * The style a section heading **under** a frame carries.
+ *
+ * `From the Panel` on the Core's handout and `Next steps` on the client's
+ * result are the same element doing the same job, and #366's review caught them
+ * rendering differently — one bold, one dim — which is the exact drift this
+ * module exists to stop. Bold, because that is what #364 shipped and `pair new`
+ * has an operator reading it in the wild today; a heading that is dimmer than
+ * the prose beneath it is also the wrong way round.
+ *
+ * Field labels *inside* a frame stay {@link ANSI.dim}. They are a column, not a
+ * heading — the eye finds them by position.
+ */
+export const FRAME_HEADING = ANSI.bold;
+
+/** One run of styled text inside a framed line. */
+export type Span = { text: string; style?: string };
+
+/** The top or bottom rule. */
+export function frameEdge(which: "top" | "bottom", color: boolean): string {
+  const [left, right] = which === "top" ? ["╭", "╮"] : ["╰", "╯"];
+  return style(`${left}${"─".repeat(FRAME_WIDTH - 2)}${right}`, ANSI.dim, color);
+}
+
+/**
+ * One line between the two borders.
+ *
+ * The padding is measured on the **plain** text and the styling applied
+ * afterwards, because an escape sequence has a length and no width — pad a
+ * coloured string by `String.length` and the right border walks off by however
+ * many bytes the colour cost.
+ */
+export function frameRow(spans: Span[], color: boolean): string {
+  const plain = spans.map((span) => span.text).join("");
+  const body = spans.map((span) => style(span.text, span.style, color)).join("");
+  const fill = Math.max(1, FRAME_WIDTH - 2 - FRAME_GUTTER - displayWidth(plain));
+  const bar = style("│", ANSI.dim, color);
+  return `${bar}${" ".repeat(FRAME_GUTTER)}${body}${" ".repeat(fill)}${bar}`;
+}
+
+/**
+ * How many terminal columns `text` occupies.
+ *
+ * `String.length` is UTF-16 code units and a frame padded by it is crooked for
+ * anybody whose label is not Latin: three CJK characters are three code units
+ * and six columns, so the right border lands three early (#357 review N1).
+ * Counted per code point — a surrogate pair is one character, not two — with
+ * the wide ranges at two and the zero-width ones at nothing.
+ *
+ * Deliberately not a full `wcwidth`. This measures the handful of things that
+ * reach a frame row: ASCII, an operator's label, a UUID, colon-hex and a tick.
+ * Emoji with joiners and skin tones can still measure a column off, and the
+ * cost of that is a ragged border on one line — not a truncated fingerprint,
+ * which is the thing these callers may never do.
+ */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const character of text) {
+    const point = character.codePointAt(0) ?? 0;
+    if (isZeroWidth(point)) continue;
+    width += isWide(point) ? 2 : 1;
+  }
+  return width;
+}
+
+/** Combining marks and variation selectors: they attach, they take no column. */
+function isZeroWidth(point: number): boolean {
+  return (
+    (point >= 0x0300 && point <= 0x036f) ||
+    (point >= 0x200b && point <= 0x200f) ||
+    (point >= 0xfe00 && point <= 0xfe0f) ||
+    point === 0x2060 ||
+    point === 0xfeff
+  );
+}
+
+/** The double-width blocks: CJK, Hangul, kana, fullwidth forms, and emoji. */
+function isWide(point: number): boolean {
+  return (
+    (point >= 0x1100 && point <= 0x115f) ||
+    (point >= 0x2e80 && point <= 0xa4cf) ||
+    (point >= 0xac00 && point <= 0xd7a3) ||
+    (point >= 0xf900 && point <= 0xfaff) ||
+    (point >= 0xfe30 && point <= 0xfe6f) ||
+    (point >= 0xff00 && point <= 0xff60) ||
+    (point >= 0xffe0 && point <= 0xffe6) ||
+    (point >= 0x1f300 && point <= 0x1f64f) ||
+    (point >= 0x1f900 && point <= 0x1f9ff) ||
+    (point >= 0x20000 && point <= 0x3fffd)
+  );
+}
+
+/**
+ * `text` shortened to `columns` display columns, marked when it was shortened.
+ *
+ * **Only ever called on something the operator can read back somewhere else.**
+ * Truncation is a lie about a value, and the values worth telling it about are
+ * names — a label is a name the operator chose and can read back from where
+ * they chose it. A fingerprint wraps instead, and nothing routes one through
+ * here.
+ */
+export function clip(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text;
+  let kept = "";
+  let width = 0;
+  for (const character of text) {
+    const next = width + displayWidth(character);
+    // One column held back for the marker, which is one column wide.
+    if (next > columns - 1) break;
+    kept += character;
+    width = next;
+  }
+  return `${kept}…`;
+}
+
+/** Wrap `text` in an escape sequence, or hand it back untouched. */
+export function style(text: string, code: string | undefined, color: boolean): string {
+  return color && code ? `${code}${text}${ANSI.reset}` : text;
+}
+
+/**
+ * `text` broken across lines at spaces, measured in display columns.
+ *
+ * Prose is the one thing a frame holds that has no natural break in it: a label
+ * is short, and a diagnostic relayed from the SDK is a sentence of whatever
+ * length that sentence is — with, sometimes, an unbreakable value sitting in
+ * the middle of it.
+ *
+ * **This function may not shorten its input.** Every caller is printing
+ * something an operator has to read exactly — a path to their own credential,
+ * an address, a fingerprint they are being asked to *compare* — and a wrap that
+ * drops characters is a truncation wearing a different name.
+ *
+ * So a word too long for a line of its own is broken on {@link WORD_BREAKS} —
+ * `/`, `:` and `.`, the separators the values reaching a frame are built out
+ * of: a path, an origin, a `host:port`, colon-hex, a domain name. The
+ * separator stays at the end of the line it breaks after, which is what tells a
+ * reader the value continues — the same move `wrapFingerprint` makes on the
+ * Core's side.
+ *
+ * Neither is an edge case. A credential lands under the operator's home
+ * directory, and a home deep enough to overflow a 74-column box is an ordinary
+ * machine; the SDK's `fingerprint-mismatch` sentence carries **two** 95-column
+ * colon-hex fingerprints, and that is the one class on this screen whose whole
+ * subject is a value being compared character by character (#366 review 1).
+ *
+ * **The residual, stated rather than hidden:** a word with neither separator in
+ * it and no room to fit is left whole and over-long, and the border beside it
+ * runs one column past the rest. That is deliberate. There is nowhere left to
+ * break that would not put a line ending in the middle of a name, and a ragged
+ * border is a cheaper failure than a value an operator cannot trust. It is
+ * pinned by a test so it stays a decision.
+ */
+export function wrapText(text: string, columns: number): string[] {
+  const width = Math.max(1, columns);
+  const lines: string[] = [];
+  let line = "";
+  for (const word of text.split(/\s+/).filter((piece) => piece !== "")) {
+    const candidate = line === "" ? word : `${line} ${word}`;
+    if (displayWidth(candidate) <= width) {
+      line = candidate;
+      continue;
+    }
+    if (line !== "") lines.push(line);
+    line = "";
+    if (displayWidth(word) <= width) {
+      line = word;
+      continue;
+    }
+    // Too long for any line. Break it where it has a break, and leave the last
+    // chunk open so anything after it — `(mode 0600)`, `was expected — the
+    // pairing code was not sent` — can share that line rather than starting
+    // another.
+    const chunks = breakLongWord(word, width);
+    lines.push(...chunks.slice(0, -1));
+    line = chunks.at(-1) ?? "";
+  }
+  if (line !== "") lines.push(line);
+  return lines.length > 0 ? lines : [""];
+}
+
+/**
+ * The separators an over-long word may be broken after.
+ *
+ * Three, because between them they are what every unbreakable value this
+ * program prints is built out of:
+ *
+ *   - `/` — a filesystem path, and the path half of a URL;
+ *   - `:` — `host:port`, an `https://` scheme, and colon-hex: a SHA-256
+ *     fingerprint is 95 columns and is the reason this list is not just `/`
+ *     (#366 review 1);
+ *   - `.` — a domain name, which is the long slash-free value an endpoint row
+ *     is made of and the one the review asked about by name. Found by a test:
+ *     `https://a-very-long-host-name.example.invalid:8443/…` has 38 columns
+ *     between its `//` and its port, and neither of the first two separators
+ *     is anywhere in them.
+ *
+ * A sentence-ending full stop is a break point too, in principle. In practice
+ * it never is: a word is only broken here when it is longer on its own than
+ * the whole line, and the last word of a sentence is not.
+ */
+const WORD_BREAKS = /(?<=[/:.])/;
+
+/**
+ * One over-long word, split after its separators, each line keeping its own.
+ *
+ * The separator stays at the end of the line it breaks after, which is what
+ * tells a reader that the value continues — the same reason `wrapFingerprint`
+ * keeps its colons on the Core's side.
+ *
+ * **Lossless by construction.** The split is a zero-width lookbehind, so the
+ * pieces are the input partitioned rather than tokenised: nothing is consumed
+ * as a delimiter and `chunks.join("")` is the word it was handed. A word with
+ * no separator in it comes back as one over-long chunk — see the residual in
+ * {@link wrapText}.
+ */
+function breakLongWord(word: string, width: number): string[] {
+  const chunks: string[] = [];
+  let chunk = "";
+  for (const piece of word.split(WORD_BREAKS)) {
+    if (piece === "") continue;
+    if (chunk !== "" && displayWidth(chunk + piece) > width) {
+      chunks.push(chunk);
+      chunk = "";
+    }
+    chunk += piece;
+  }
+  if (chunk !== "") chunks.push(chunk);
+  return chunks.length > 0 ? chunks : [word];
+}

--- a/packages/cli/src/core-command.ts
+++ b/packages/cli/src/core-command.ts
@@ -65,7 +65,7 @@ const STATUS_TIMEOUT_MS = 15_000;
 export const CORE_HELP = `actana core — the Cores this machine can reach
 
 Usage
-  actana core pair <name> <address> <code>
+  actana core pair <name> <address> <code> --session <id> --fingerprint <sha256>
                                   enroll THIS machine on a Core
   actana core ls                  list the Cores this machine knows
   actana core use <name>          point \`current\` at a Core

--- a/packages/cli/src/core-pair-results.ts
+++ b/packages/cli/src/core-pair-results.ts
@@ -1,0 +1,833 @@
+// What `actana core pair` says when it is done — the success block, and every
+// class of refusal (#360).
+//
+// **The client end of #357.** `actana pair new` grew two shapes on the Core:
+// labelled lines down a pipe, a framed handout at a terminal, with `isatty`
+// as the whole of the switch. This is the same command one machine over. The
+// operator has just carried a code, a fingerprint and a session across the
+// room, and the moment they find out whether it worked is the moment that most
+// needs to say what to do next — on success because there is a Core to use now
+// and nothing on the screen saying how, and on failure because "refused" is
+// the same word for an expired code, a spent one and a typo.
+//
+// **Everything here is pure: values in, lines out.** No `deps`, no clock, no
+// filesystem, no decision about whether to draw. `core-pair.ts` owns the one
+// `if` that reads `stdoutIsTty`, and this module cannot see it — which is what
+// lets the suite assert on a frame without a terminal, and what keeps the
+// piped path provably a different set of strings rather than the same strings
+// with the ornaments stripped off.
+//
+// **The piped contract lives in `core-pair.ts`, not here.** Nothing in this
+// file is ever printed when stdout is not a terminal: down a pipe the command
+// emits exactly the lines 0.4.2 emitted, and `core-pair.test.ts` asserts them
+// whole against a literal. Adding a line here cannot move a byte of that.
+//
+// **Nothing secret reaches these strings.** Not the credential, not the private
+// key, and not the pairing code — the code is a bearer secret for as long as
+// its session is open, so it is not echoed in a confirmation and not quoted in
+// a diagnostic. That is why every "mint a fresh one" step below names the
+// command rather than the value, and why the success block says where the
+// credential landed and never what is in it.
+
+import {
+  ANSI,
+  clip,
+  frameEdge,
+  FRAME_CONTENT_WIDTH,
+  FRAME_HEADING,
+  frameRow,
+  style,
+  wrapText,
+  type Span,
+} from "./cli-frame.ts";
+import type { CorePairingErrorDetail, CorePairingFailure } from "@actana/sdk/core-pairing.ts";
+import {
+  EXIT_PAIR_CERTIFICATE_INVALID,
+  EXIT_PAIR_CORE_ERROR,
+  EXIT_PAIR_FINGERPRINT_MISMATCH,
+  EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+  EXIT_PAIR_HOSTNAME_MISMATCH,
+  EXIT_PAIR_MALFORMED_RESPONSE,
+  EXIT_PAIR_NO_CA,
+  EXIT_PAIR_NOT_PAIRABLE,
+  EXIT_PAIR_RATE_LIMITED,
+  EXIT_PAIR_REFUSED,
+  EXIT_PAIR_REJECTED,
+  EXIT_PAIR_UNREACHABLE,
+  EXIT_USAGE,
+} from "./exit-codes.ts";
+
+/**
+ * One thing to do next: the line to type, and why.
+ *
+ * The command comes first and unstyled, because it is the thing that gets
+ * selected with a mouse — dimming a line an operator is about to copy is how a
+ * terminal theme turns an instruction into something unreadable. The note is
+ * indented under it and dim, because it is read once.
+ *
+ * A step with no command is prose that earns its place: a warning, or a fact
+ * that changes what the operator should type rather than being typed itself.
+ */
+export type CorePairStep = {
+  /** The line to type, exactly as it should be typed. Never styled. */
+  command?: string;
+  /** What it is for. Wrapped, dim. */
+  note: string;
+};
+
+/** How wide the prose under a frame may run. No border to keep it inside. */
+const PROSE_WIDTH = 76;
+
+/** The column the success block's values start in. */
+const FIELD_WIDTH = 13;
+
+/**
+ * The command that mints a replacement, which is the answer to half the
+ * failures below.
+ *
+ * One constant because it is one instruction: an expired code, a spent code, a
+ * code the Core has never heard of and a fingerprint that has moved on all end
+ * the same way — somebody walks back to the Core and mints a new one. The
+ * three values that come back travel together, which is the part an operator
+ * gets wrong: re-running with a new code and yesterday's `--session` fails in
+ * exactly the way that sent them here.
+ */
+const REMINT = "actana pair new --label <name>";
+
+/** The usage line, as `core-pair.ts` and `CORE_HELP` both print it. */
+const PAIR_USAGE = "actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>";
+
+/** The same call with the session carried inside the code instead. */
+const PAIR_USAGE_JOINED = "actana core pair <name> <host:port> <session>:<code> --fingerprint <sha256>";
+
+/** The step every re-mint ends with. Stated once; it is the same mistake each time. */
+const REMINT_RERUN: CorePairStep = {
+  note:
+    "Re-run with the NEW code, the NEW --session and the fingerprint printed beside them. A code and " +
+    "its session are one credential — the old session will not redeem the new code.",
+};
+
+// ─── the success block ──────────────────────────────────────────────────────
+
+/**
+ * Everything the success block renders.
+ *
+ * `current` is the pointer **read back after the write**, not the name that was
+ * just paired and not a guess about what the write did. `core pair` makes a
+ * Core current only when nothing was, so on any machine with a Core already
+ * registered the honest answer is "no" — and a block that congratulated an
+ * operator on a `current` they do not have would send them to `core status`
+ * against the wrong Core, which is the confusion this whole ticket is about.
+ */
+export type CorePairSuccess = {
+  name: string;
+  endpoint: string;
+  /** Whether a Core of this name was already registered. Chooses one word. */
+  replaced: boolean;
+  /**
+   * The name this machine put in the pairing request — `--label`, or its
+   * hostname when the flag was not given.
+   *
+   * **A purely local fact, and the row is worded to claim nothing else**
+   * (#366 review 2). The first version of this row said it was "this machine,
+   * in the Core's `pair ls`", and that is false: `core-pairing-routes.ts`
+   * builds `PairedClient.label` from **`session.label`** — the name the *Core*
+   * operator typed at `actana pair new --label <name>` — and this value
+   * reaches the Core only as the certificate CN, and only in the sub-case
+   * where the session carried no label at all. `actana pair revoke` matches on
+   * `client.label` and on a `CN=`-prefixed subject, so it would not have found
+   * this name either. A row whose stated purpose was revocation and which
+   * could not be revoked by is worse than no row.
+   *
+   * What it is good for is the case an operator did not choose: no `--label`,
+   * so this machine sent its hostname and nothing on the screen said so. That
+   * is a fact about **this** side, it is checkable here, and it is all this
+   * row now says.
+   */
+  label: string;
+  /** What `current` names now. `null` when nothing does. */
+  current: string | null;
+  /** Where the credential landed. The path, at mode 0600 — never the contents. */
+  credentialPath: string;
+  color: boolean;
+};
+
+/**
+ * The framed confirmation, and the next steps under it.
+ *
+ * The frame answers "what just happened" and the section under it answers "what
+ * do I do now", which is the same division `pair new`'s handout uses: facts
+ * inside the border, commands outside it where they are long enough to need the
+ * room and must survive being copied.
+ */
+export function corePairSuccessBlock(result: CorePairSuccess): string[] {
+  const { color } = result;
+  const isCurrent = result.current === result.name;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  lines.push(
+    frameRow(
+      [
+        { text: "✓ ", style: ANSI.green },
+        { text: `${result.replaced ? "Replaced" : "Paired"} Core "${result.name}"` },
+      ],
+      color,
+    ),
+  );
+  lines.push(frameRow([], color));
+  lines.push(...field("Endpoint", result.endpoint, color));
+  // "Sent as", not "Label", because there are two LABEL columns in this
+  // program already — `core ls`'s, which means the *Core's* own alias, and
+  // `pair ls`'s on the Core, which means the *session's*. This is neither. It
+  // is what left this machine, and the row says only that.
+  //
+  // Clipped, and it is this row that gives: it is a name the operator either
+  // typed or can read off `hostname`, where every other value here is one they
+  // have to be able to copy.
+  lines.push(...field("Sent as", `${clip(result.label, 30)} — the name this machine gave`, color));
+  lines.push(...field("Current", currentSentence(result, isCurrent), color));
+  // Reassurance, not a secret: the operator has just been told a credential
+  // exists and has no way to see that it does. The path and the mode are the
+  // whole of what can be said about it — the blob itself never reaches an
+  // output sink, `--verbose` included.
+  lines.push(...field("Credential", `${result.credentialPath} (mode 0600)`, color));
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  lines.push(style("Next steps", FRAME_HEADING, color));
+  lines.push(...stepLines(nextSteps(result, isCurrent), color));
+  return lines;
+}
+
+/**
+ * What the `Current` row says, which is a claim this block has to have earned.
+ *
+ * Three answers, and the middle one is the reason the field exists: pairing a
+ * second Core on a machine that already has one changes nothing about
+ * `current`, and the operator's very next command will talk to the other Core
+ * unless this line tells them so.
+ *
+ * **The third is defensive and says so** (#366 review 7). `runCorePair` writes
+ * the pointer when nothing holds it and then reads it back, so a `null` here
+ * means the pointer was cleared between those two lines — a concurrent
+ * `actana core rm`, or a registry that has gone missing underneath the write.
+ * Rare, not impossible, and the honest thing to print is that nothing is
+ * selected rather than a name that is not. It is unreachable through the verb,
+ * so the suite renders it by calling this block directly: a branch nothing
+ * exercises is a branch nobody knows the shape of.
+ */
+function currentSentence(result: CorePairSuccess, isCurrent: boolean): string {
+  if (isCurrent) return `"${result.name}" — every later verb talks to this Core`;
+  if (result.current === null) return "nothing is selected yet";
+  return `still "${result.current}" — this pairing did not change it`;
+}
+
+/**
+ * The four verbs a freshly paired Core exists for, in the order they are useful.
+ *
+ * Verify, then look around, then do something: `core status` is the one that
+ * says the link works at all, `project ls` and `harness ls` are the two things
+ * a Session needs to name, and `session start` is the first real action. An
+ * operator who has just carried a code across a room has earned a screen that
+ * does not make them go and read the help.
+ */
+function nextSteps(result: CorePairSuccess, isCurrent: boolean): CorePairStep[] {
+  const steps: CorePairStep[] = [];
+  if (!isCurrent) {
+    // First, because every verb below it reads `current`, and running them
+    // now would report on a Core the operator did not just pair.
+    steps.push({
+      command: `actana core use ${result.name}`,
+      note: "Point `current` at it. Everything below talks to `current` until you do, or pass --core each time.",
+    });
+  }
+  steps.push({
+    command: "actana core status",
+    note: "Reach the Core and report what it says. The check that the link works end to end.",
+  });
+  steps.push({
+    command: "actana project ls",
+    note: "The Projects on this Core. A Session needs one to run in.",
+  });
+  steps.push({
+    command: "actana harness ls",
+    note: "Which agents this Core can actually run right now, and which it is missing.",
+  });
+  steps.push({
+    command: 'actana session start <project> "<prompt>"',
+    note: "The first real thing to run on it. Prints the Session id and exits.",
+  });
+  // Named in #360 beside `session start` as the other first real action, and
+  // dropped from the first cut of this list — silently, which is the part the
+  // review was right about (#366 review 4). It is the interactive half of the
+  // same idea: `session start` hands work to an agent, `core shell` puts the
+  // operator on the machine themselves.
+  steps.push({
+    command: "actana core shell",
+    note: "Or an interactive shell on the Core, to look around it yourself.",
+  });
+  steps.push({
+    note:
+      "The Panel pairs with this same Core from its Settings -> Cores screen, with a code of its own — " +
+      "`actana pair new` on the Core mints that one too.",
+  });
+  return steps;
+}
+
+// ─── the refusals ───────────────────────────────────────────────────────────
+
+/** A framed refusal: what happened, and what to do about it. */
+export type CorePairRefusal = {
+  /**
+   * What went wrong, beside the marker.
+   *
+   * Wrapped rather than assumed to fit, because for most classes this is the
+   * SDK's own sentence and the SDK writes for a library's caller, not for a
+   * 74-column box. A headline that ran off the border would be the one line on
+   * the screen an operator cannot read.
+   */
+  headline: string;
+  /** Anything further, as paragraphs, wrapped inside the frame. May be empty. */
+  detail: readonly string[];
+  /** What to do next. Never empty — a refusal with no remedy is the bug #360 fixes. */
+  steps: readonly CorePairStep[];
+  color: boolean;
+};
+
+/**
+ * The framed refusal, and the steps under it.
+ *
+ * The same shape as the success block on purpose. An operator who has seen one
+ * has seen the other, and the marker is the only thing they have to read to
+ * know which of the two they are looking at.
+ */
+export function corePairRefusalBlock(refusal: CorePairRefusal): string[] {
+  const { color } = refusal;
+  const lines: string[] = [];
+
+  lines.push(frameEdge("top", color));
+  lines.push(frameRow([], color));
+  // The marker takes two columns, so the wrap is measured against what is left
+  // and the continuations line up under the first word rather than under the ✗.
+  const headline = wrapText(refusal.headline, FRAME_CONTENT_WIDTH - 2);
+  for (const [index, line] of headline.entries()) {
+    const spans: Span[] =
+      index === 0 ? [{ text: "✗ ", style: ANSI.red }, { text: line }] : [{ text: `  ${line}` }];
+    lines.push(frameRow(spans, color));
+  }
+  for (const paragraph of refusal.detail) {
+    lines.push(frameRow([], color));
+    for (const line of wrapText(paragraph, FRAME_CONTENT_WIDTH)) {
+      lines.push(frameRow([{ text: line }], color));
+    }
+  }
+  lines.push(frameRow([], color));
+  lines.push(frameEdge("bottom", color));
+  lines.push("");
+
+  lines.push(style("What to do", FRAME_HEADING, color));
+  lines.push(...stepLines(refusal.steps, color));
+  return lines;
+}
+
+// ─── the failure table ──────────────────────────────────────────────────────
+
+/** What an operator should do next about a failure, and what this process exits with. */
+export type CorePairingOutcome = {
+  /** The code from `exit-codes.ts`. Contract: a script may branch on it. */
+  exit: number;
+  /**
+   * One line saying what to do next. Never quotes the code or any credential.
+   *
+   * **This is the piped shape and it may not move.** It is the second of the two
+   * lines a redirected `core pair` writes to stderr, it is what every script
+   * that has ever grepped a pairing failure reads, and the framed block exists
+   * precisely so that it does not have to change to give an operator more.
+   */
+  next: string;
+  /**
+   * The same advice as commands, for the framed shape only.
+   *
+   * Every entry is reachable — a step that names a flag nobody has or a verb
+   * that does not exist is worse than the prose it replaced, because prose does
+   * not look like something to paste.
+   */
+  steps: readonly CorePairStep[];
+};
+
+/**
+ * Every failure the SDK distinguishes, given a number, a next step and a remedy.
+ *
+ * One `switch` with no `default`, so a failure added to `CorePairingFailure`
+ * stops this file compiling until somebody decides what an operator should do
+ * about it — which is the only way a list like this stays honest.
+ *
+ * The `steps` are the #360 half. The rule they follow: **each distinguishable
+ * failure gets its own concrete remedy**, not a shared one. "Ask for a fresh
+ * code" and "check the port is open" are the correct answers to two different
+ * problems, and a table that gave both answers to both would be back where the
+ * prose started.
+ */
+export function corePairingOutcome(
+  failure: CorePairingFailure,
+  detail: CorePairingErrorDetail = {},
+): CorePairingOutcome {
+  switch (failure) {
+    case "bad-address":
+      return {
+        exit: EXIT_USAGE,
+        next: "An address is host:port — the Core's TLS port, the one `actana status` reports on the Core.",
+        steps: [
+          {
+            note:
+              "An address is host:port and nothing else — not a URL, not a bare hostname, and not the " +
+              "Panel's port.",
+          },
+          {
+            command: "actana status",
+            note: "On the Core: it reports the address and the TLS port that Core actually listens on.",
+          },
+        ],
+      };
+    case "bad-code":
+      return {
+        exit: EXIT_USAGE,
+        next: "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
+        steps: [
+          {
+            note:
+              "A pairing code is eight characters, written XXXX-XXXX. Hyphen and case are yours to get " +
+              "wrong; the shape is not. Nothing was dialled and no attempt was spent.",
+          },
+          {
+            command: REMINT,
+            note: "On the Core: mints a fresh code and prints the session and fingerprint that belong to it.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "bad-fingerprint":
+      return {
+        exit: EXIT_USAGE,
+        next: "A fingerprint is 32 bytes of hex, as AA:BB:… — copy the line `actana pair new` printed.",
+        steps: [
+          {
+            note:
+              "A fingerprint is 32 bytes of hex written AA:BB:… — copy the whole line, colons included, " +
+              "with nothing elided. `pair new` wraps it and never shortens it, so what is on that screen " +
+              "is the whole value.",
+          },
+          { command: REMINT, note: "On the Core: prints the current fingerprint again if the line was lost." },
+        ],
+      };
+    case "unreachable":
+      return {
+        exit: EXIT_PAIR_UNREACHABLE,
+        next: "Check the Core is running and that address reaches it — `actana status` on the Core says where it listens.",
+        steps: [
+          {
+            // The distinction the whole class turns on: a dial that never
+            // landed has spent nothing, so the code in the operator's hand is
+            // still good and re-minting one would be wasted effort.
+            //
+            // **Scoped, because this class is not only the dial** (#366 review
+            // 3). `postRedemption` reports `transport` — and so `unreachable` —
+            // from its error handler, which is armed across `req.end(body)` as
+            // well as before it: one 15s timer covers the whole exchange
+            // including the Core signing the certificate, so a slow Core or a
+            // reset mid-flight lands here with the session already spent. A
+            // block that promised the code was good would send that operator
+            // back for a `refused` and a second trip.
+            note:
+              "Nothing answered at that address — a dial failure, not a refusal. If nothing answered, " +
+              "nothing was sent: no attempt was spent and the code you were given is still good.",
+          },
+          {
+            note:
+              "If instead the connection dropped part-way through, the Core may have redeemed the code " +
+              "before the answer was lost. A retry that comes back refused means exactly that — mint a " +
+              "fresh one rather than reading it as a second network fault.",
+          },
+          { command: "getent hosts <host>", note: "Does the name resolve, and to the machine you mean?" },
+          {
+            command: "nc -vz <host> <port>",
+            note:
+              "Is the TLS port open from here? A firewall, a NAT, or a container port that was never " +
+              "published all look exactly like this.",
+          },
+          {
+            command: "actana status",
+            note: "On the Core: whether it is running, and which address and port it is listening on.",
+          },
+          {
+            note:
+              "A proxy named in HTTPS_PROXY, or SNI rewritten by something in front of the Core, lands " +
+              "here too — the dial reaches a machine, just not that one.",
+          },
+        ],
+      };
+    case "not-pairable":
+      return {
+        exit: EXIT_PAIR_NOT_PAIRABLE,
+        next: "Something answered there but it has no pairing endpoint — check it is a Core, and update it if it is old.",
+        steps: [
+          {
+            // The other side of `unreachable`: the dial worked. Something is
+            // listening and it refused to be a Core, which is a different fix.
+            note:
+              "Something answered and it has no pairing endpoint. The dial worked — so this is not a " +
+              "network problem: either that is not a Core, or it is one too old to pair.",
+          },
+          { command: "actana status", note: "On the Core: which version it is running." },
+          { command: "actana update", note: "On the Core: brings it onto a build that pairs." },
+          {
+            note:
+              "If it is not a Core, check the port. A reverse proxy or another service sitting on that " +
+              "port answers in exactly this way.",
+          },
+        ],
+      };
+    case "no-ca-presented":
+      return {
+        exit: EXIT_PAIR_NO_CA,
+        next: "Nothing was presented to compare against the fingerprint — check the address is the Core's own TLS port.",
+        steps: [
+          {
+            note:
+              "Nothing was presented to compare the fingerprint against, so there was nothing to pin and " +
+              "the code was not sent.",
+          },
+          {
+            note:
+              "Check the address is the Core's own TLS port — a plain-HTTP port, or a proxy terminating " +
+              "TLS in front of the Core with its own certificate, both end here.",
+          },
+          { command: "actana status", note: "On the Core: the TLS port it presents its own authority on." },
+        ],
+      };
+    case "fingerprint-unconfirmed":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+        next: "Pass `--fingerprint <sha256>` — the code is never sent to a certificate authority nobody confirmed.",
+        steps: [
+          {
+            note:
+              "The code is never sent to a certificate authority nobody confirmed, and there is no flag " +
+              "that waives that. Absent is not waived.",
+          },
+          {
+            command: PAIR_USAGE,
+            note: "Pass the fingerprint `actana pair new` printed on the Core, whole and unedited.",
+          },
+          {
+            note:
+              "Or run this where there is a terminal: without --fingerprint it prints the authority the " +
+              "Core presents and asks you to compare it yourself.",
+          },
+        ],
+      };
+    case "fingerprint-mismatch":
+      return {
+        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
+        next:
+          "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
+          "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
+        steps: [
+          {
+            note:
+              "The SHA-256 fingerprint of the certificate authority that address presents was compared " +
+              "against the one you gave, and the two differ. The code was not sent.",
+          },
+          {
+            // The warning is the point of the class. Everything else in this
+            // command is a convenience; this comparison is the security
+            // argument, and the failure mode is an operator looking for a way
+            // past it.
+            note:
+              "Do not look for a way around this. There is no flag that skips the comparison and none " +
+              "will be added: an unverified authority is the exact thing pairing exists to rule out, and " +
+              "a mismatch is either the wrong machine answering or somebody sitting between you and the " +
+              "right one.",
+          },
+          {
+            command: REMINT,
+            note:
+              "On the Core: prints the fingerprint that Core is presenting today. Compare it against " +
+              "yours by eye before you retry — material reissued since you wrote yours down is " +
+              "indistinguishable from an impostor at this end.",
+          },
+        ],
+      };
+    case "hostname-mismatch":
+      return {
+        exit: EXIT_PAIR_HOSTNAME_MISMATCH,
+        next: "That is the right Core on an address its certificate does not cover — dial the one it was set up for.",
+        steps: [
+          {
+            note:
+              "The right Core, reached at an address its certificate does not cover. The authority " +
+              "matched; the name did not.",
+          },
+          { command: "actana status", note: "On the Core: the addresses its certificate was issued for. Dial one of those." },
+          {
+            note:
+              "If the address you need is genuinely missing, it has to be added to the certificate on " +
+              "the Core — re-running `actana setup` with it is what does that.",
+          },
+        ],
+      };
+    case "certificate-invalid":
+      return {
+        exit: EXIT_PAIR_CERTIFICATE_INVALID,
+        next: "The right Core, with a certificate that cannot be used — check the clock on both machines, then reissue it.",
+        steps: [
+          {
+            note:
+              "The right Core, with a certificate that cannot be used. Most often a clock: a certificate " +
+              "is not yet valid, or has expired, according to whichever of the two machines is wrong.",
+          },
+          { command: "date -u", note: "On both machines. They should agree to within a minute." },
+          {
+            note:
+              "If the clocks agree, the Core's material has genuinely expired and needs reissuing on the " +
+              "Core before anything can pair with it.",
+          },
+        ],
+      };
+    case "refused":
+      return {
+        exit: EXIT_PAIR_REFUSED,
+        next: "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
+        steps: [
+          {
+            // The Core deliberately will not say which of the four. Saying so
+            // here is what stops an operator re-typing a code they think is
+            // merely mistyped when it has in fact expired.
+            note:
+              "The Core would not redeem that code: expired, already spent, never issued, or out of " +
+              "attempts. It does not say which — telling an unauthenticated caller apart from a guesser " +
+              "is how codes get guessed. The Core's audit log says.",
+          },
+          {
+            command: REMINT,
+            note: "On the Core: mints a fresh code and prints the session and fingerprint beside it.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "rate-limited":
+      return {
+        exit: EXIT_PAIR_RATE_LIMITED,
+        next:
+          detail.retryAfterSeconds === undefined
+            ? "Wait, then try again with a fresh code."
+            : `Wait ${detail.retryAfterSeconds} seconds, then try again with a fresh code.`,
+        steps: [
+          {
+            note:
+              detail.retryAfterSeconds === undefined
+                ? "The Core is refusing redemptions from here for now. Wait before trying again."
+                : `The Core is refusing redemptions from here for now. Wait ${detail.retryAfterSeconds} ` +
+                  "seconds before trying again.",
+          },
+          {
+            command: REMINT,
+            note:
+              "On the Core, after the wait: every failed redemption spends one of the session's five " +
+              "attempts, so a fresh code is the retry that reliably works.",
+          },
+          REMINT_RERUN,
+        ],
+      };
+    case "rejected":
+      return {
+        exit: EXIT_PAIR_REJECTED,
+        next: "The Core would not accept the request itself — that is a bug on this side. Please report it.",
+        steps: [
+          {
+            note:
+              "The Core would not accept the request this build sent. That is a defect here, not " +
+              "something to work around: no code, address or fingerprint changes it.",
+          },
+          {
+            command: `${PAIR_USAGE} --verbose`,
+            note:
+              "Re-run with --verbose and report what it prints, with the exit code. It names the steps " +
+              "and never prints the code, the key or the credential.",
+          },
+        ],
+      };
+    case "core-error":
+      return {
+        exit: EXIT_PAIR_CORE_ERROR,
+        next: "The Core failed while handling this — `actana logs` on the Core has the reason; nothing here does.",
+        steps: [
+          {
+            note:
+              "The Core failed while handling this. Nothing on this side knows why, and nothing on this " +
+              "side can be changed to fix it.",
+          },
+          { command: "actana logs", note: "On the Core: the reason will be there." },
+        ],
+      };
+    case "malformed-response":
+      return {
+        exit: EXIT_PAIR_MALFORMED_RESPONSE,
+        next: "Something answered that is not a Core, or is not one this build understands. Check the address.",
+        steps: [
+          {
+            note:
+              "Something answered and what came back was not a pairing response this build understands. " +
+              "Either it is not a Core, or the two ends are too far apart in version.",
+          },
+          { command: "actana status", note: "On the Core: its version." },
+          { command: "actana --version", note: "Here: this build's. Update whichever of the two is older." },
+        ],
+      };
+  }
+}
+
+// ─── the refusals this file words itself ────────────────────────────────────
+//
+// Four shapes that never reach the SDK, because they are caught before anything
+// is dialled. They are worded here rather than relayed for the reason the module
+// header gives: the SDK's own messages quote what they were handed, which is
+// correct for a library and wrong for a CLI whose stderr is a terminal, a CI
+// log and a shell history at once.
+
+/** The three positionals are missing, or one of them is. */
+export const MISSING_ARGUMENTS_STEPS: readonly CorePairStep[] = [
+  {
+    command: PAIR_USAGE,
+    note:
+      "The order is the order they are read out: what this machine will call the Core, where the Core " +
+      "is, and the code.",
+  },
+  {
+    command: REMINT,
+    note: "On the Core: prints the code, the session and the fingerprint — all three of the values this needs.",
+  },
+];
+
+/** A fourth positional turned up. Never echoed — it may be the code. */
+export const TOO_MANY_ARGUMENTS_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "Three positionals, then flags. A code pasted twice, or an address repeated after the code, lands " +
+      "here. The extra word is not echoed back — it may be the code, and a code in a shell history is a " +
+      "code that leaked.",
+  },
+  { command: PAIR_USAGE, note: "The shape it wants." },
+];
+
+/**
+ * A bare code that does not name its pairing session.
+ *
+ * Both spellings, because both work and an operator has been handed one of
+ * them: `pair new` prints the session on its own line, and the joined form is
+ * what the framed handout pastes. Showing only the flag sends somebody holding
+ * a joined string back to the Core for nothing.
+ */
+export const MISSING_SESSION_STEPS: readonly CorePairStep[] = [
+  {
+    command: PAIR_USAGE,
+    note: "`actana pair new` prints the session id on its own line, beside the code. This is the form the usage line shows.",
+  },
+  {
+    command: PAIR_USAGE_JOINED,
+    note:
+      "Or the joined <session>:<code> form, which carries the session inside the code — that is what the " +
+      "pasteable command in `pair new`'s framed handout uses. Either works; both are the same two values.",
+  },
+];
+
+/** The code names one session and `--session` names another. */
+export const SESSION_DISAGREEMENT_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "The code carries one pairing session and --session names another. They have to agree, and this " +
+      "will not guess which of the two you meant.",
+  },
+  { command: PAIR_USAGE, note: "The bare code, with the session beside it." },
+  { command: PAIR_USAGE_JOINED, note: "Or the joined form on its own, with no --session at all." },
+];
+
+/** A name the registry will not take. */
+export function badNameSteps(nameError: string): readonly CorePairStep[] {
+  return [
+    { note: `${nameError[0]?.toUpperCase() ?? ""}${nameError.slice(1)}.` },
+    {
+      note:
+        "A name this registry will not take is a name `core ls`, `core use`, `core rm`, `core status`, " +
+        "`core shell` and `core exec` could not reach afterwards, so it is refused before anything is " +
+        "dialled.",
+    },
+    { command: PAIR_USAGE, note: "Pick another name. Nothing else about the pairing changes." },
+  ];
+}
+
+/** Anything that is not a `CorePairingError` — a defect, not an operator error. */
+export const DEFECT_STEPS: readonly CorePairStep[] = [
+  {
+    note:
+      "That is not an operator error: it is a fault in this build, and no code, address or fingerprint " +
+      "changes it.",
+  },
+  {
+    command: `${PAIR_USAGE} --verbose`,
+    note:
+      "Re-run with --verbose and report what it prints, with the exit code. It never prints the code, " +
+      "the key or the credential.",
+  },
+];
+
+// ─── rendering ──────────────────────────────────────────────────────────────
+
+/**
+ * One framed field: a dim label in its column, the value beside it, wrapped.
+ *
+ * Continuations line up under the value rather than under the label, so a
+ * wrapped endpoint still reads as one field. A value with no space in it — a
+ * long path — runs past the border rather than being cut: `wrapText` cannot
+ * shorten its input, and a ragged border is cheaper than a path an operator
+ * cannot copy.
+ */
+function field(label: string, value: string, color: boolean): string[] {
+  const room = FRAME_CONTENT_WIDTH - FIELD_WIDTH;
+  const wrapped = wrapText(value, room);
+  return wrapped.map((line, index) => {
+    const spans: Span[] =
+      index === 0
+        ? [{ text: label.padEnd(FIELD_WIDTH), style: ANSI.dim }, { text: line }]
+        : [{ text: " ".repeat(FIELD_WIDTH) }, { text: line }];
+    return frameRow(spans, color);
+  });
+}
+
+/**
+ * The steps under a frame: the command flush and unstyled, the note under it.
+ *
+ * Unstyled because the command is what gets selected with a mouse, and a dim
+ * escape around it is how a low-contrast terminal theme turns an instruction
+ * into something that cannot be read. The note is dim because it is read once.
+ */
+function stepLines(steps: readonly CorePairStep[], color: boolean): string[] {
+  const lines: string[] = [];
+  for (const [index, step] of steps.entries()) {
+    if (index > 0) lines.push("");
+    if (step.command !== undefined) {
+      lines.push(`  ${step.command}`);
+      for (const line of wrapText(step.note, PROSE_WIDTH - 4)) {
+        lines.push(style(`    ${line}`, ANSI.dim, color));
+      }
+    } else {
+      for (const line of wrapText(step.note, PROSE_WIDTH - 2)) {
+        lines.push(style(`  ${line}`, ANSI.dim, color));
+      }
+    }
+  }
+  return lines;
+}

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -127,8 +127,12 @@ export async function runCorePair(
   const [name, address, code, ...extra] = rest;
   if (name === undefined || address === undefined || code === undefined) {
     deps.err("actana core pair: a name, an address and a code are required.");
-    deps.err("  actana core pair <name> <host:port> <code> --fingerprint <sha256>");
-    deps.err("`actana pair new` on the Core prints the code and the fingerprint.");
+    // Both required flags, because both are (#357). `readTicket` below refuses
+    // a bare code without `--session`, and a usage line that omitted it sent the
+    // operator straight back here with the same three positionals and a fourth
+    // refusal.
+    deps.err("  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>");
+    deps.err("`actana pair new` on the Core prints the code, the fingerprint and the session.");
     return EXIT_USAGE;
   }
   if (extra.length > 0) {

--- a/packages/cli/src/core-pair.ts
+++ b/packages/cli/src/core-pair.ts
@@ -46,19 +46,33 @@
 // whose `bad-code` message quotes what it was handed — correct for a library
 // whose caller decides where text goes, wrong for a CLI whose stderr is a
 // terminal, a CI log and a shell history at once.
+//
+// **Two shapes, and `isatty(stdout)` is the whole of the switch (#360).** Down
+// a pipe this is what 0.4.2 printed and nothing else: one or two lines on a
+// success, one or two on a refusal, in the same words and the same order. At a
+// terminal both come framed — a green tick over the endpoint, an honest
+// `current` row and the four verbs a paired Core exists for; a red cross over
+// the reason and, for every class of failure, the command that fixes *that*
+// class. No flag chooses between them and deliberately no `--json`, exactly as
+// `actana pair new` decides it one machine over. `core-pair-results.ts` builds
+// both blocks and can see none of this; the one `if` per site is here.
+//
+// **What the command does is identical either way.** The credential that lands,
+// the `current` pointer, the exit code and what crosses the seam are the same
+// bytes at a terminal and down a pipe, because a command that *did* something
+// different at a terminal is a command no script can trust.
 
 import {
   CorePairingError,
   fetchCorePairingIdentity,
   pairWithCore,
   parsePairingTicket,
-  type CorePairingErrorDetail,
-  type CorePairingFailure,
   type CorePairingIdentity,
   type PairWithCoreOptions,
 } from "@actana/sdk/core-pairing.ts";
 import type { CoreRegistrationBlob } from "@actana/sdk/core-registration-blob.ts";
 import {
+  coreBlobPath,
   coreExists,
   coreNameError,
   readCurrentCore,
@@ -66,22 +80,25 @@ import {
   writeCurrentCore,
   type RegistryPaths,
 } from "./blob-registry.ts";
+import { useColor } from "./cli-frame.ts";
+import {
+  badNameSteps,
+  corePairingOutcome,
+  corePairRefusalBlock,
+  corePairSuccessBlock,
+  DEFECT_STEPS,
+  MISSING_ARGUMENTS_STEPS,
+  MISSING_SESSION_STEPS,
+  SESSION_DISAGREEMENT_STEPS,
+  TOO_MANY_ARGUMENTS_STEPS,
+  type CorePairStep,
+} from "./core-pair-results.ts";
 import { encodeRegistrationBlobText } from "./registration-blob-file.ts";
 import {
   EXIT_FAILURE,
   EXIT_OK,
-  EXIT_PAIR_CERTIFICATE_INVALID,
-  EXIT_PAIR_CORE_ERROR,
   EXIT_PAIR_FINGERPRINT_MISMATCH,
   EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
-  EXIT_PAIR_HOSTNAME_MISMATCH,
-  EXIT_PAIR_MALFORMED_RESPONSE,
-  EXIT_PAIR_NO_CA,
-  EXIT_PAIR_NOT_PAIRABLE,
-  EXIT_PAIR_RATE_LIMITED,
-  EXIT_PAIR_REFUSED,
-  EXIT_PAIR_REJECTED,
-  EXIT_PAIR_UNREACHABLE,
   EXIT_USAGE,
 } from "./exit-codes.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -126,20 +143,34 @@ export async function runCorePair(
 ): Promise<number> {
   const [name, address, code, ...extra] = rest;
   if (name === undefined || address === undefined || code === undefined) {
-    deps.err("actana core pair: a name, an address and a code are required.");
-    // Both required flags, because both are (#357). `readTicket` below refuses
-    // a bare code without `--session`, and a usage line that omitted it sent the
-    // operator straight back here with the same three positionals and a fourth
-    // refusal.
-    deps.err("  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>");
-    deps.err("`actana pair new` on the Core prints the code, the fingerprint and the session.");
-    return EXIT_USAGE;
+    return refuse(deps, {
+      // Both required flags, because both are (#357). `readTicket` below
+      // refuses a bare code without `--session`, and a usage line that omitted
+      // it sent the operator straight back here with the same three
+      // positionals and a fourth refusal.
+      plain: [
+        "actana core pair: a name, an address and a code are required.",
+        "  actana core pair <name> <host:port> <code> --session <id> --fingerprint <sha256>",
+        "`actana pair new` on the Core prints the code, the fingerprint and the session.",
+      ],
+      headline: "A name, an address and a code are required.",
+      detail: [
+        "Nothing was dialled. These are the three values `actana pair new` reads out on the Core, " +
+          "in the order it reads them.",
+      ],
+      steps: MISSING_ARGUMENTS_STEPS,
+      exit: EXIT_USAGE,
+    });
   }
   if (extra.length > 0) {
-    // Never the value: an operator who typed the code twice, or put it after
-    // the address a second time, would have it echoed back at them.
-    deps.err("actana core pair: too many arguments — expected <name> <address> <code>.");
-    return EXIT_USAGE;
+    return refuse(deps, {
+      // Never the value: an operator who typed the code twice, or put it after
+      // the address a second time, would have it echoed back at them.
+      plain: ["actana core pair: too many arguments — expected <name> <address> <code>."],
+      headline: "Too many arguments — expected <name> <address> <code>.",
+      steps: TOO_MANY_ARGUMENTS_STEPS,
+      exit: EXIT_USAGE,
+    });
   }
 
   // The registry's own name validation, first and with its own wording: a name
@@ -147,8 +178,12 @@ export async function runCorePair(
   // `rm`, `status`, `shell` or `exec` could reach afterwards.
   const nameError = coreNameError(name);
   if (nameError) {
-    deps.err(`actana core pair: ${nameError}.`);
-    return EXIT_USAGE;
+    return refuse(deps, {
+      plain: [`actana core pair: ${nameError}.`],
+      headline: `That is not a name this registry will take — ${nameError}.`,
+      steps: badNameSteps(nameError),
+      exit: EXIT_USAGE,
+    });
   }
 
   // The ticket first, before anything is dialled and before an operator is
@@ -200,13 +235,44 @@ export async function runCorePair(
   writeCoreBlob(paths, name, encodeRegistrationBlobText({ ...blob, label: "" }));
   deps.verbose(`stored at ${paths.coresDir}/${name}.txt, mode 0600`);
 
-  const current = readCurrentCore(paths);
-  if (current === null) writeCurrentCore(paths, name);
+  const before = readCurrentCore(paths);
+  if (before === null) writeCurrentCore(paths, name);
 
+  if (deps.stdoutIsTty) {
+    // The operator's shape (#360). Cosmetic, and reachable only when there is
+    // a human at the other end: same credential, same pointer, same exit code.
+    for (const line of corePairSuccessBlock({
+      name,
+      endpoint: blob.endpoint,
+      replaced: replacing,
+      // What this machine put in the request, and nothing more is claimed of
+      // it (#366 review 2). The Core keeps the *session* label in its
+      // `pair ls`, not this one — see `CorePairSuccess.label`.
+      label: args.label ?? deps.hostname,
+      // **Read back, not inferred.** The block says which Core is current now,
+      // and that is a claim about what is on disk — `writeCurrentCore` above
+      // runs only when nothing was selected, so on a machine that already had
+      // a Core the honest answer is somebody else's name. Asserting it from
+      // the branch that was taken would be the same claim with nothing behind
+      // it, and it would send an operator to `core status` against the wrong
+      // Core.
+      current: readCurrentCore(paths),
+      // The path and the mode, never the contents.
+      credentialPath: coreBlobPath(paths, name),
+      color: useColor(deps),
+    })) {
+      deps.out(line);
+    }
+    return EXIT_OK;
+  }
+
+  // stdout, piped: **not one byte of this may move.** It is what every script
+  // that has ever wrapped `core pair` reads, and the block above exists
+  // precisely so that it does not have to change to give an operator more.
   deps.out(`${replacing ? "Replaced" : "Paired"} Core "${name}" → ${blob.endpoint}`);
-  if (current === null) deps.out(`\`current\` now points at "${name}".`);
-  else if (current !== name) {
-    deps.out(`\`current\` is still "${current}" — \`actana core use ${name}\` to switch.`);
+  if (before === null) deps.out(`\`current\` now points at "${name}".`);
+  else if (before !== name) {
+    deps.out(`\`current\` is still "${before}" — \`actana core use ${name}\` to switch.`);
   }
   return EXIT_OK;
 }
@@ -234,14 +300,36 @@ function readTicket(deps: ActanaCliDeps, code: string, session: string | null): 
   const explicit = session?.trim() ?? "";
 
   if (carried === "" && explicit === "") {
-    deps.err("actana core pair: a pairing code names the pairing session it belongs to.");
-    deps.err("Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.");
-    return { ok: false, exit: EXIT_USAGE };
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: a pairing code names the pairing session it belongs to.",
+          "Pass `--session <id>` — `actana pair new` prints it beside the code — or the <session>:<code> form.",
+        ],
+        headline: "A pairing code names the pairing session it belongs to.",
+        detail: [
+          "Nothing was dialled: the ticket is read before anything is sent, so no attempt was spent " +
+            "and the code you were given is still good.",
+        ],
+        steps: MISSING_SESSION_STEPS,
+        exit: EXIT_USAGE,
+      }),
+    };
   }
   if (carried !== "" && explicit !== "" && carried !== explicit) {
-    deps.err("actana core pair: the code names one pairing session and `--session` names another.");
-    deps.err("Drop `--session`, or pass the bare code beside it — they have to agree.");
-    return { ok: false, exit: EXIT_USAGE };
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: the code names one pairing session and `--session` names another.",
+          "Drop `--session`, or pass the bare code beside it — they have to agree.",
+        ],
+        headline: "The code names one pairing session and --session names another.",
+        steps: SESSION_DISAGREEMENT_STEPS,
+        exit: EXIT_USAGE,
+      }),
+    };
   }
 
   try {
@@ -267,9 +355,15 @@ function readTicket(deps: ActanaCliDeps, code: string, session: string | null): 
  */
 function badCode(deps: ActanaCliDeps): number {
   const outcome = corePairingOutcome("bad-code");
-  deps.err("actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.");
-  deps.err(outcome.next);
-  return outcome.exit;
+  return refuse(deps, {
+    plain: [
+      "actana core pair: that was not accepted as a pairing code — hyphen and case do not matter, its shape does.",
+      outcome.next,
+    ],
+    headline: "That was not accepted as a pairing code.",
+    steps: outcome.steps,
+    exit: outcome.exit,
+  });
 }
 
 /** A fingerprint the operator stands behind, or the exit code for the refusal. */
@@ -300,9 +394,19 @@ async function confirmFingerprint(
     return { ok: true, fingerprint: args.fingerprint };
   }
   if (!deps.interactive) {
-    deps.err("actana core pair: no fingerprint was given and there is no terminal to confirm one on.");
-    deps.err(corePairingOutcome("fingerprint-unconfirmed").next);
-    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED };
+    const outcome = corePairingOutcome("fingerprint-unconfirmed");
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: no fingerprint was given and there is no terminal to confirm one on.",
+          outcome.next,
+        ],
+        headline: "No fingerprint was given, and there is no terminal to confirm one on.",
+        steps: outcome.steps,
+        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
+      }),
+    };
   }
 
   let identity: CorePairingIdentity;
@@ -323,12 +427,27 @@ async function confirmFingerprint(
     false,
   );
   if (!matches) {
-    deps.err("actana core pair: the fingerprint was not confirmed, so the pairing code was not sent.");
-    deps.err(corePairingOutcome("fingerprint-mismatch").next);
+    const outcome = corePairingOutcome("fingerprint-mismatch");
     // A human comparing two strings and saying they differ is a mismatch, and
-    // it exits as one: the operator has performed exactly the check the SDK
-    // performs when it is given a fingerprint to hold the Core to.
-    return { ok: false, exit: EXIT_PAIR_FINGERPRINT_MISMATCH };
+    // it exits as one — and it gets the same remedy: the operator has just
+    // performed exactly the check the SDK performs when it is handed a
+    // fingerprint to hold the Core to, so there is nothing different to say.
+    return {
+      ok: false,
+      exit: refuse(deps, {
+        plain: [
+          "actana core pair: the fingerprint was not confirmed, so the pairing code was not sent.",
+          outcome.next,
+        ],
+        headline: "The fingerprint was not confirmed, so the pairing code was not sent.",
+        detail: [
+          "You compared the authority this address presents against the one `actana pair new` " +
+            "printed on the Core, and said they differ. That is the check doing its job.",
+        ],
+        steps: outcome.steps,
+        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
+      }),
+    };
   }
   // The confirmed value is handed back to `pair`, which dials again and
   // re-computes it: what the operator agreed to is enforced on the connection
@@ -346,8 +465,12 @@ async function confirmFingerprint(
 function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
   if (!(err instanceof CorePairingError)) {
     const message = err instanceof Error ? err.message : String(err);
-    deps.err(`actana core pair: pairing failed — ${message}`);
-    return EXIT_FAILURE;
+    return refuse(deps, {
+      plain: [`actana core pair: pairing failed — ${message}`],
+      headline: `Pairing failed — ${message}`,
+      steps: DEFECT_STEPS,
+      exit: EXIT_FAILURE,
+    });
   }
   // `bad-code` is the one failure whose message is not relayed, because the
   // SDK's quotes the code — see {@link badCode}. Reaching it from here means
@@ -358,110 +481,65 @@ function reportPairingFailure(deps: ActanaCliDeps, err: unknown): number {
   if (err.failure === "bad-code") return badCode(deps);
 
   const outcome = corePairingOutcome(err.failure, err.detail);
-  deps.err(`actana core pair: ${err.message}`);
-  deps.err(outcome.next);
-  return outcome.exit;
+  return refuse(deps, {
+    // The SDK's sentence is the headline. It is written for a caller that
+    // decides where text goes, so the frame wraps it rather than trusting it
+    // to fit — but it is the accurate description of what happened, and
+    // rewording thirteen of them here would be thirteen places for the two
+    // accounts to drift apart.
+    plain: [`actana core pair: ${err.message}`, outcome.next],
+    headline: err.message,
+    steps: outcome.steps,
+    exit: outcome.exit,
+  });
 }
-
-/** What an operator should do next about a failure, and what this process exits with. */
-export type CorePairingOutcome = {
-  /** The code from `exit-codes.ts`. Contract: a script may branch on it. */
-  exit: number;
-  /** One line saying what to do next. Never quotes the code or any credential. */
-  next: string;
-};
 
 /**
- * Every failure the SDK distinguishes, given a number and a next step.
+ * Say no, in whichever of the two shapes stdout is entitled to (#360).
  *
- * One `switch` with no `default`, so a failure added to `CorePairingFailure`
- * stops this file compiling until somebody decides what an operator should do
- * about it — which is the only way a list like this stays honest.
+ * **`plain` is the contract and `headline`/`detail`/`steps` are the frame.**
+ * Two sets of strings rather than one set with the ornaments stripped off,
+ * because the piped lines are what every script that has ever grepped a
+ * pairing failure reads and the only way to keep them from drifting is to
+ * write them out at each site and assert them whole. A refusal that grew a
+ * better explanation this way cannot have moved a byte of the other one.
+ *
+ * The gate is `isatty(stdout)` — not stderr, which is where these lines go.
+ * That looks like the wrong stream to ask about and is deliberately the right
+ * one: `actana core pair … > /dev/null` and `… 2>&1 | tee` are both a program
+ * reading this output, and the promise is that **redirecting stdout gets the
+ * 0.4.2 shape on both streams**. One question, one answer, and no run where
+ * half the output is framed.
  */
-export function corePairingOutcome(
-  failure: CorePairingFailure,
-  detail: CorePairingErrorDetail = {},
-): CorePairingOutcome {
-  switch (failure) {
-    case "bad-address":
-      return {
-        exit: EXIT_USAGE,
-        next: "An address is host:port — the Core's TLS port, the one `actana status` reports on the Core.",
-      };
-    case "bad-code":
-      return {
-        exit: EXIT_USAGE,
-        next: "A pairing code is eight characters, written XXXX-XXXX. `actana pair new` prints a fresh one.",
-      };
-    case "bad-fingerprint":
-      return {
-        exit: EXIT_USAGE,
-        next: "A fingerprint is 32 bytes of hex, as AA:BB:… — copy the line `actana pair new` printed.",
-      };
-    case "unreachable":
-      return {
-        exit: EXIT_PAIR_UNREACHABLE,
-        next: "Check the Core is running and that address reaches it — `actana status` on the Core says where it listens.",
-      };
-    case "not-pairable":
-      return {
-        exit: EXIT_PAIR_NOT_PAIRABLE,
-        next: "Something answered there but it has no pairing endpoint — check it is a Core, and update it if it is old.",
-      };
-    case "no-ca-presented":
-      return {
-        exit: EXIT_PAIR_NO_CA,
-        next: "Nothing was presented to compare against the fingerprint — check the address is the Core's own TLS port.",
-      };
-    case "fingerprint-unconfirmed":
-      return {
-        exit: EXIT_PAIR_FINGERPRINT_UNCONFIRMED,
-        next: "Pass `--fingerprint <sha256>` — the code is never sent to a certificate authority nobody confirmed.",
-      };
-    case "fingerprint-mismatch":
-      return {
-        exit: EXIT_PAIR_FINGERPRINT_MISMATCH,
-        next:
-          "Do not retry until you know why: either that is not the Core you were told about, or its credentials " +
-          "were reissued and the fingerprint you have is stale. `actana pair new` prints the current one.",
-      };
-    case "hostname-mismatch":
-      return {
-        exit: EXIT_PAIR_HOSTNAME_MISMATCH,
-        next: "That is the right Core on an address its certificate does not cover — dial the one it was set up for.",
-      };
-    case "certificate-invalid":
-      return {
-        exit: EXIT_PAIR_CERTIFICATE_INVALID,
-        next: "The right Core, with a certificate that cannot be used — check the clock on both machines, then reissue it.",
-      };
-    case "refused":
-      return {
-        exit: EXIT_PAIR_REFUSED,
-        next: "Ask for a fresh code — `actana pair new` on the Core. Its audit log says which of the four this was.",
-      };
-    case "rate-limited":
-      return {
-        exit: EXIT_PAIR_RATE_LIMITED,
-        next:
-          detail.retryAfterSeconds === undefined
-            ? "Wait, then try again with a fresh code."
-            : `Wait ${detail.retryAfterSeconds} seconds, then try again with a fresh code.`,
-      };
-    case "rejected":
-      return {
-        exit: EXIT_PAIR_REJECTED,
-        next: "The Core would not accept the request itself — that is a bug on this side. Please report it.",
-      };
-    case "core-error":
-      return {
-        exit: EXIT_PAIR_CORE_ERROR,
-        next: "The Core failed while handling this — `actana logs` on the Core has the reason; nothing here does.",
-      };
-    case "malformed-response":
-      return {
-        exit: EXIT_PAIR_MALFORMED_RESPONSE,
-        next: "Something answered that is not a Core, or is not one this build understands. Check the address.",
-      };
+function refuse(
+  deps: ActanaCliDeps,
+  refusal: {
+    /** Exactly what 0.4.2 printed, in order. Never changes. */
+    plain: readonly string[];
+    headline: string;
+    detail?: readonly string[];
+    steps: readonly CorePairStep[];
+    exit: number;
+  },
+): number {
+  if (!deps.stdoutIsTty) {
+    for (const line of refusal.plain) deps.err(line);
+    return refusal.exit;
   }
+  for (const line of corePairRefusalBlock({
+    headline: refusal.headline,
+    detail: refusal.detail ?? [],
+    steps: refusal.steps,
+    color: useColor(deps),
+  })) {
+    deps.err(line);
+  }
+  return refusal.exit;
 }
+
+// The failure table moved to `core-pair-results.ts` with the rest of the
+// result surface (#360): it is what an operator is told, and it now carries
+// the concrete remedy per class as well as the one-line `next`. Re-exported
+// here because this is the module the verb lives in and the table is part of
+// what the verb promises.
+export { corePairingOutcome, type CorePairingOutcome } from "./core-pair-results.ts";

--- a/packages/panel/src/components/views/CoresSettingsPage.tsx
+++ b/packages/panel/src/components/views/CoresSettingsPage.tsx
@@ -6,6 +6,8 @@ import { Field, SettingsSection } from "~/components/views/SettingsParts";
 import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import { CoreNeedsUpdateNotice } from "~/components/views/CoreNeedsUpdate";
 import { api } from "~/lib/api";
+import { announceCoreRegistryChanged } from "~/lib/core-registry-changed";
+import { ADD_CORE_FIELD_LABEL } from "~/shared/core-onboarding";
 import { formatRelativeTime } from "~/lib/format-relative-time";
 import { coreOrder, type CoreDialStatus, type CoreWithDial } from "~/shared/cores";
 
@@ -74,6 +76,10 @@ export function CoresSettingsPage() {
    */
   const handlePaired = async (core: CoreWithDial) => {
     await refresh();
+    // The fleet just went from N to N+1. Anything else in this tab watching the
+    // registry — the first-run gate above all — re-reads now rather than at its
+    // next poll (#358).
+    announceCoreRegistryChanged();
     toast.success(`Core "${core.label}" paired.`);
   };
 
@@ -110,6 +116,10 @@ export function CoresSettingsPage() {
       await api.removeCore(core.id);
       setPendingRemoval(null);
       await refresh();
+      // And N to N-1. When that leaves zero, the first-run gate is what puts
+      // the pairing wizard back up — the gate is on the count, not on whether
+      // this Panel has ever been paired (#358).
+      announceCoreRegistryChanged();
       toast.success(`Core "${core.label}" removed.`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to remove Core.");
@@ -164,7 +174,9 @@ export function CoresSettingsPage() {
             )}
           </Field>
 
-          <Field label="Add a Core">
+          {/* Named from the same constant the first-run wizard points at, so
+              the two paths name one place with one string (#358). */}
+          <Field label={ADD_CORE_FIELD_LABEL}>
             <AddCoreByPairing onPaired={handlePaired} />
           </Field>
         </>

--- a/packages/panel/src/components/views/FirstRunGate.tsx
+++ b/packages/panel/src/components/views/FirstRunGate.tsx
@@ -1,0 +1,221 @@
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { api } from "~/lib/api";
+import { onCoreRegistryChanged } from "~/lib/core-registry-changed";
+import { readCachedCoreCount, writeCachedCoreCount } from "~/lib/shell-query-cache";
+import { CORES_POLL_MS } from "~/lib/use-fleet";
+
+// Lazy, for the same reason the settings overlay is: on every load of a Panel
+// that *has* a fleet — which is every load after the first — the wizard and the
+// pairing form it mounts are bytes nobody will render. The gate itself has to
+// stay eager, because deciding is its whole job and it decides before anything
+// paints; it is a `listCores()` and a branch, and costs the entry chunk nothing.
+const FirstRunWizard = lazy(() =>
+  import("~/components/views/FirstRunWizard").then((m) => ({ default: m.FirstRunWizard })),
+);
+
+/**
+ * The gate (#358): a Panel that knows no Cores shows the pairing wizard, and
+ * a Panel that knows one shows the app.
+ *
+ * **The condition is the count, not the calendar.** This is not a first-run
+ * flag, not a "seen it" preference, and not something the operator can be past.
+ * It is a live read of the Core registry, so a fresh Panel lands in the wizard
+ * and a Panel whose last Core was forgotten goes back to it — the same rule
+ * answering both, because they are the same state. There is nothing to reset
+ * and nothing to migrate.
+ *
+ * **It replaces the shell rather than covering it.** `children` here is the
+ * entire app — top bar, project rail, router outlet, settings overlay — and at
+ * zero Cores none of it mounts. That is what makes this a gate rather than a
+ * modal: there is no route to type, no escape key, no click-outside, and no
+ * dead dashboard behind the wizard to glimpse. The only exit is a paired Core.
+ *
+ * The one screen this does *not* stand in front of is `/login` and `/setup`:
+ * `__root.tsx` renders those outside the shell entirely, so an operator still
+ * creates their account first and meets the wizard immediately after.
+ */
+
+export function FirstRunGate({ children }: { children: ReactNode }) {
+  const { count, error, refresh } = useCoreRegistry();
+
+  /**
+   * The pairing form's `onPaired`, and the reason it is awaited.
+   *
+   * `AddCoreByPairing` holds its busy state until this resolves, so re-reading
+   * the registry here — rather than optimistically counting the Core it just
+   * handed us — means the form stays visibly mid-pairing right up to the moment
+   * the dashboard is genuinely unlocked. The alternative flashes an empty
+   * wizard between the pairing landing and the count catching up, which reads
+   * as a failure of the thing that just succeeded.
+   *
+   * Counting the returned Core instead would also be the gate believing
+   * something other than the registry, which is the one thing it must not do.
+   */
+  const handlePaired = useCallback(async () => {
+    await refresh();
+  }, [refresh]);
+
+  // Genuinely unknown: no live answer yet *and* nothing cached to stand in for
+  // one, which is the first load in this browser and no other. Drawing the
+  // wizard here would flash it at every operator with a fleet, and drawing the
+  // shell would flash a dashboard at operators with none — the two mistakes
+  // this component exists to prevent. Every other load paints on the seed.
+  if (count === null && error === null) return null;
+
+  // A registry we could not read is not a registry with no Cores in it, but it
+  // is certainly not one we can unlock a dashboard on. The wizard is the honest
+  // screen for it, and it says which of the two happened.
+  if (count === null || count === 0) {
+    return (
+      <Suspense fallback={null}>
+        <FirstRunWizard onPaired={handlePaired} registryError={error} />
+      </Suspense>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+/**
+ * How many Cores this Panel is paired with, kept fresh.
+ *
+ * Deliberately not `useCores`. That hook is built for the Cores list: it holds
+ * the rows, folds live dial pushes into them, and refreshes on a nonce. This
+ * needs none of the rows and cannot use a nonce, because the gate has to be
+ * able to *wait* for a re-read — `onPaired` is a promise the pairing form is
+ * holding its busy state on, and a nonce cannot be awaited. What is shared is
+ * the thing that matters: both ask `api.listCores()` and both pace themselves
+ * off `CORES_POLL_MS`, so there is one answer about the fleet, one cadence, and
+ * no second source of truth for either.
+ *
+ * `count` starts at whatever this browser was last told (`readCachedCoreCount`)
+ * so a paired Panel paints its shell on the first client render, the same
+ * bargain `installShellQueryCache` makes for projects, groups and settings. The
+ * seed is never an answer: the live read lands on the same tick and corrects
+ * it, and a *stale* seed can only cost one frame in either direction.
+ *
+ * After that it never returns to null: a poll that fails leaves the last known
+ * count standing, so a Panel with a fleet is not thrown into the wizard by one
+ * bad request.
+ */
+function useCoreRegistry(): {
+  count: number | null;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const [count, setCount] = useState<number | null>(() => readCachedCoreCount() ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  const mounted = useRef(true);
+  // What the last settled read said, readable from inside `refresh` without
+  // making it depend on — and be rebuilt by — the state it sets.
+  const known = useRef<number | null>(count);
+  // Monotonic, so a slow poll that lands after a fast explicit refresh cannot
+  // overwrite the newer answer with its older one — which, on this component,
+  // would mean re-locking a dashboard that had just been unlocked.
+  const issued = useRef(0);
+  const settled = useRef(0);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    issued.current += 1;
+    const seq = issued.current;
+    try {
+      let next = (await api.listCores()).cores.length;
+      /**
+       * Tearing down a live session takes two answers, not one.
+       *
+       * Locking the gate unmounts the whole shell: every open terminal panel,
+       * every websocket, whatever the operator was mid-way through. The gate
+       * already refuses to do that on a *failed* read; an empty successful one
+       * deserves the same suspicion, because a Panel server that restarts
+       * against an empty or unmigrated data directory answers 200 with nothing
+       * in it and would take the session down with no prompt and no undo.
+       *
+       * So an empty answer that would close the gate is re-asked, and only two
+       * consecutive empty successes lock it. This buys exactly what it says: a
+       * single anomalous 200 cannot end a session. It does not defend against a
+       * registry that is genuinely and persistently empty — nothing short of
+       * asking the operator could, and a Panel whose Cores are really gone
+       * belongs in the wizard.
+       */
+      if (next === 0 && (known.current ?? 0) > 0) {
+        next = (await api.listCores()).cores.length;
+      }
+      if (!mounted.current || seq < settled.current) return;
+      settled.current = seq;
+      known.current = next;
+      setCount(next);
+      setError(null);
+      writeCachedCoreCount(next);
+    } catch (err) {
+      if (!mounted.current || seq < settled.current) return;
+      settled.current = seq;
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  // Gated means "the wizard is what is on screen": no fleet known, or none at
+  // all. It decides how hard this hook works — see the two effects below.
+  const gated = count === null || count === 0;
+
+  useEffect(() => {
+    void refresh();
+    // Pairing or forgetting a Core anywhere in this tab is the whole reason
+    // this number changes. Waiting out a poll for it would leave the gate
+    // visibly wrong for up to fifteen seconds.
+    return onCoreRegistryChanged(() => void refresh());
+  }, [refresh]);
+
+  /**
+   * The poll runs **only while the gate is up**.
+   *
+   * Once unlocked there is nothing here worth a standing timer: every registry
+   * change this tab makes arrives on the event above, and the shell that is now
+   * mounted is already reading the same endpoint through `useCores`. A third
+   * recurring `listCores()` for the life of the tab bought nothing but load.
+   */
+  useEffect(() => {
+    if (!gated) return;
+    const timer = setInterval(() => void refresh(), CORES_POLL_MS);
+    return () => clearInterval(timer);
+  }, [gated, refresh]);
+
+  /**
+   * What the dropped poll would have caught: a Core forgotten in *another* tab.
+   *
+   * The event is window-scoped, so it does not cross tabs, and the requirement
+   * is about the count rather than about which tab did the forgetting. Re-asking
+   * when this tab comes back to the front covers it at the only moment it
+   * matters — when someone is looking at this Panel — and costs nothing while
+   * they are not.
+   */
+  useEffect(() => {
+    if (gated) return;
+    const recheck = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    window.addEventListener("focus", recheck);
+    document.addEventListener("visibilitychange", recheck);
+    return () => {
+      window.removeEventListener("focus", recheck);
+      document.removeEventListener("visibilitychange", recheck);
+    };
+  }, [gated, refresh]);
+
+  return { count, error, refresh };
+}

--- a/packages/panel/src/components/views/FirstRunWizard.tsx
+++ b/packages/panel/src/components/views/FirstRunWizard.tsx
@@ -1,0 +1,534 @@
+import { useEffect, useRef, useState } from "react";
+import { Btn } from "~/components/ui/Btn";
+import { Icon } from "~/components/ui/Icon";
+import { TextField } from "~/components/ui/TextField";
+import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
+import {
+  ADD_CORE_LOCATION,
+  PAIR_NEW_OUTPUT,
+  composePairNewCommand,
+  coreInstallPaths,
+  labelRefusal,
+  pairNewCommand,
+} from "~/shared/core-onboarding";
+import type { CoreWithDial } from "~/shared/cores";
+import { CURRENT_MC_VERSION } from "~/queries/mission-control-version";
+
+/**
+ * The first-run pairing wizard (#358) — what a Panel with no Cores shows
+ * instead of a dashboard.
+ *
+ * **This is composition, not a second pairing implementation.** Step 3 mounts
+ * the very `AddCoreByPairing` that Settings → Cores → Add Core mounts, with the
+ * same props and the same `onPaired` contract, so the fingerprint-before-code
+ * ordering, the mismatch refusal, and every failure sentence are that
+ * component's, once. Nothing about redeeming a code is decided here. What this
+ * file adds is the two things a fresh operator is missing and a settings page
+ * cannot give them: the order to do things in, and the commands to run on the
+ * *other* machine.
+ *
+ * **There is no way out of it that is not a paired Core.** No skip, no "later",
+ * no dismiss, and no route past it — see `FirstRunGate`, which renders this
+ * instead of the app shell rather than over it. That is not a stance about
+ * onboarding; it is what the product is. A Panel is a window onto machines it
+ * is paired with, and paired with none it has nothing to draw. An empty
+ * dashboard would be a screen whose every affordance is dead.
+ *
+ * Moving between steps 1, 2 and 3 is free, in both directions. Steps 1 and 2
+ * are reference — an operator who already installed the Core last week should
+ * not have to scroll past its install command — and moving between them
+ * reaches the Panel's dashboard exactly as often as standing still does: never.
+ */
+
+/** The three steps, in the order the machine has to do them. */
+const STEPS = [
+  { id: "install", title: "Install the Core", blurb: "on the machine you want to drive" },
+  { id: "mint", title: "Mint a pairing code", blurb: "on that machine, in its terminal" },
+  { id: "redeem", title: "Redeem it here", blurb: "in this Panel, with what it printed" },
+] as const;
+
+type StepIndex = 0 | 1 | 2;
+
+export function FirstRunWizard({
+  onPaired,
+  registryError = null,
+}: {
+  /**
+   * The same contract `CoresSettingsPage` fulfils: the Core the redemption
+   * produced, and a promise the pairing form waits on before it lets go of its
+   * busy state. The gate resolves it once it has re-read the registry, so the
+   * form stays visibly mid-pairing until the dashboard is genuinely unlocked
+   * rather than blinking through an empty wizard on the way.
+   */
+  onPaired: (core: CoreWithDial) => Promise<void>;
+  /**
+   * Why the Core registry could not be read, if it could not be. Shown rather
+   * than swallowed: "no Cores" and "could not ask" look identical from here,
+   * and an operator who is about to be told to install a Core deserves to know
+   * which of the two they are looking at.
+   */
+  registryError?: string | null;
+}) {
+  const [step, setStep] = useState<StepIndex>(0);
+  // The name this Panel will be called on the Core, folded live into the mint
+  // command. Kept here rather than inside step 2 so stepping away and back
+  // does not silently drop what was typed.
+  const [label, setLabel] = useState("");
+
+  return (
+    <div
+      data-first-run-wizard
+      style={{
+        position: "fixed",
+        inset: 0,
+        overflowY: "auto",
+        background: "var(--surface-1)",
+        color: "var(--text)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 780,
+          margin: "0 auto",
+          padding: "48px 24px 64px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 22,
+        }}
+      >
+        <Header />
+        {registryError && <RegistryErrorBox message={registryError} />}
+        <StepRail step={step} onStep={setStep} />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {step === 0 && <InstallStep />}
+          {step === 1 && <MintStep label={label} onLabel={setLabel} />}
+          {step === 2 && <RedeemStep onPaired={onPaired} />}
+        </div>
+
+        <Footer step={step} onStep={setStep} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What this screen is and why it is the whole screen.
+ *
+ * The second sentence is the one that matters: an operator who thinks the Panel
+ * is broken will go looking for the way past it, and there isn't one. Saying so
+ * plainly is cheaper than letting them find out.
+ */
+function Header() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--text-dim)",
+        }}
+      >
+        Actana Control
+      </div>
+      <h1 style={{ fontSize: 24, fontWeight: 650, margin: 0, letterSpacing: "-0.01em" }}>
+        Pair your first Core
+      </h1>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 13.5,
+          lineHeight: 1.55,
+          color: "var(--text-dim)",
+          maxWidth: 620,
+        }}
+      >
+        A Panel drives machines called Cores — this one is paired with none, so there is nothing
+        for it to show yet. Three steps, run on the machine you want to drive and finished here.
+        The Panel opens on the first Core that pairs.
+      </p>
+    </div>
+  );
+}
+
+/** The registry read that failed, said out loud rather than read as emptiness. */
+function RegistryErrorBox({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      data-first-run-registry-error
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: "var(--danger, #e5484d)",
+        padding: "10px 12px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--danger, #e5484d)",
+        borderRadius: 7,
+      }}
+    >
+      This Panel could not read its own list of Cores, so it cannot tell an empty fleet from an
+      unanswered question: {message}
+    </div>
+  );
+}
+
+/** The three steps as a rail — where you are, and what is still ahead. */
+function StepRail({ step, onStep }: { step: StepIndex; onStep: (next: StepIndex) => void }) {
+  return (
+    <ol
+      style={{
+        listStyle: "none",
+        display: "flex",
+        gap: 8,
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {STEPS.map((entry, index) => {
+        const active = index === step;
+        return (
+          <li key={entry.id} style={{ flex: 1, minWidth: 0 }}>
+            <button
+              type="button"
+              onClick={() => onStep(index as StepIndex)}
+              aria-current={active ? "step" : undefined}
+              style={{
+                width: "100%",
+                textAlign: "left",
+                display: "flex",
+                flexDirection: "column",
+                gap: 3,
+                padding: "10px 12px",
+                cursor: "pointer",
+                background: active ? "var(--surface-0)" : "transparent",
+                border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 7,
+                color: "inherit",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: 10,
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                  color: active ? "var(--accent-ink)" : "var(--text-dim)",
+                }}
+              >
+                Step {index + 1}
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>{entry.title}</span>
+              <span style={{ fontSize: 11.5, color: "var(--text-dim)" }}>{entry.blurb}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+/**
+ * Step 1 — put a Core on a machine.
+ *
+ * Both documented paths, side by side, because the Panel cannot see the machine
+ * and so cannot choose. The commands come from `~/shared/core-onboarding`,
+ * which is the same place any other surface would read them from.
+ */
+function InstallStep() {
+  // The Compose line is pinned to this Panel's own line, so the Core it brings
+  // up is built from the same train — see `coreInstallPaths`.
+  const paths = coreInstallPaths(CURRENT_MC_VERSION);
+  return (
+    <StepBody
+      title="Install the Core on the machine you want to drive"
+      lede="A Core is the daemon that owns the repository and runs the Harnesses. It goes on the machine with your code — a laptop, a workstation, a build box — not on this Panel. Pick whichever path fits that machine."
+    >
+      {paths.map((path) => (
+        <div key={path.id} data-install-path={path.id} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ fontSize: 13, fontWeight: 600 }}>{path.title}</div>
+          <Prose>{path.blurb}</Prose>
+          {path.commands.map((command) => (
+            <CommandLine key={command} command={command} />
+          ))}
+          {path.note && <Aside>{path.note}</Aside>}
+        </div>
+      ))}
+    </StepBody>
+  );
+}
+
+/**
+ * Step 2 — mint a code on that machine.
+ *
+ * The command is built from what the operator types, so `--label` is a thing
+ * they have chosen rather than a flag they were shown and skipped. Under it,
+ * every line `pair new` prints and what each one is for — including `Label`,
+ * which that command always produces because it always carries `--label`. An
+ * operator who knows which lines matter reads the terminal once instead of
+ * three times.
+ */
+function MintStep({ label, onLabel }: { label: string; onLabel: (next: string) => void }) {
+  const refusal = labelRefusal(label);
+  return (
+    <StepBody
+      title="Mint a pairing code on that machine"
+      lede="Back on the Core's terminal. This prints a one-time code that this Panel redeems — it is single-use, it expires in five minutes by default, and the Core keeps only a digest of it, so it is printed exactly once."
+    >
+      <TextField
+        label="Name this Panel will have on that Core"
+        value={label}
+        onChange={onLabel}
+        placeholder="my-panel"
+        hint="Optional, and worth setting: it is what `actana pair ls` calls this Panel on the Core later."
+        autoComplete="off"
+        spellCheck={false}
+        ariaInvalid={refusal !== null}
+      />
+      {/* A name the Core would refuse never reaches the command block: the
+          placeholder is printed instead, and the reason is said here. Printing
+          the refused form would be the Panel handing over a command that fails
+          on paste — the one failure `labelRefusal` exists to prevent. */}
+      {refusal && (
+        <div
+          role="alert"
+          data-label-refusal
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 11.5,
+            lineHeight: 1.5,
+            color: "var(--danger, #e5484d)",
+          }}
+        >
+          {refusal}
+        </div>
+      )}
+      <CommandLine command={pairNewCommand(label)} />
+      <Prose>Or, if that Core came up under Docker Compose:</Prose>
+      <CommandLine command={composePairNewCommand(label)} />
+
+      <div style={{ fontSize: 13, fontWeight: 600, marginTop: 4 }}>What it prints, and why</div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          padding: "12px 14px",
+          background: "var(--surface-0)",
+          border: "1px solid var(--border)",
+          borderRadius: 7,
+        }}
+      >
+        {PAIR_NEW_OUTPUT.map((line) => (
+          <div key={line.label} style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            <div
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: 11.5,
+                color: "var(--text)",
+                wordBreak: "break-all",
+              }}
+            >
+              {line.label} <span style={{ color: "var(--accent-ink)" }}>{line.sample}</span>
+            </div>
+            <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--text-dim)" }}>
+              {line.meaning}
+            </div>
+          </div>
+        ))}
+      </div>
+      <Aside>
+        Those values are stand-ins — nothing has been minted for you. Read the real ones off that
+        machine&apos;s terminal.
+      </Aside>
+    </StepBody>
+  );
+}
+
+/**
+ * Step 3 — the redemption, which is `AddCoreByPairing` and nothing else.
+ *
+ * The one thing this step adds is naming where the same form lives once the
+ * wizard is gone. An operator who pairs a second Core next month should look
+ * for Settings → Cores → Add Core and not for this screen, which they will
+ * never see again unless they forget every Core they have.
+ */
+function RedeemStep({ onPaired }: { onPaired: (core: CoreWithDial) => Promise<void> }) {
+  return (
+    <StepBody
+      title="Redeem the code here"
+      lede="Give the Panel the Core's address, compare the fingerprint it is presented against the one on that terminal, and only then enter the code. The Panel does not send the code until the two match."
+    >
+      <AddCoreByPairing onPaired={onPaired} />
+      <Aside>
+        This is the same form as <strong>{ADD_CORE_LOCATION}</strong>, which is where every Core
+        after this one is paired. The gear icon in the top bar is waiting for you on the other side
+        of this step.
+      </Aside>
+    </StepBody>
+  );
+}
+
+/** Back / forward. There is no third button, and there never will be. */
+function Footer({ step, onStep }: { step: StepIndex; onStep: (next: StepIndex) => void }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+      <Btn
+        variant="frame"
+        size="sm"
+        onClick={() => onStep((step - 1) as StepIndex)}
+        disabled={step === 0}
+      >
+        Back
+      </Btn>
+      {step < 2 ? (
+        <Btn variant="primary" size="sm" onClick={() => onStep((step + 1) as StepIndex)}>
+          Next
+        </Btn>
+      ) : (
+        <span style={{ fontFamily: "var(--mono)", fontSize: 11.5, color: "var(--text-dim)" }}>
+          The Panel opens as soon as a Core pairs.
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** One step's frame: a heading, a sentence, and whatever the step is made of. */
+function StepBody({
+  title,
+  lede,
+  children,
+}: {
+  title: string;
+  lede: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        padding: "18px 20px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: 9,
+      }}
+    >
+      <h2 style={{ fontSize: 15.5, fontWeight: 650, margin: 0 }}>{title}</h2>
+      <Prose>{lede}</Prose>
+      {children}
+    </section>
+  );
+}
+
+function Prose({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: "var(--text-dim)" }}>
+      {children}
+    </p>
+  );
+}
+
+function Aside({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 11.5,
+        lineHeight: 1.5,
+        color: "var(--text-dim)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One pasteable command.
+ *
+ * A copy button rather than prose for the same reason `CoreNeedsUpdateNotice`
+ * has one: the command is going to be pasted into a terminal on a *different*
+ * machine, often read off a phone, and retyping a `curl … | bash` one-liner by
+ * eye is how an operator ends up debugging their own typo.
+ */
+function CommandLine({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  // The "copied" flash outlives the step it was clicked on: copy on step 1,
+  // press Next inside a second and a half, and the timer would fire into an
+  // unmounted tree. Held so it can be cancelled.
+  const flash = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (flash.current !== null) clearTimeout(flash.current);
+    },
+    [],
+  );
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(command).then(
+      () => {
+        setCopied(true);
+        if (flash.current !== null) clearTimeout(flash.current);
+        flash.current = setTimeout(() => setCopied(false), 1500);
+      },
+      () => undefined,
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "7px 9px",
+        background: "var(--surface-1)",
+        border: "1px solid var(--border)",
+        borderRadius: 5,
+      }}
+    >
+      <code
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: "var(--mono)",
+          fontSize: 11.5,
+          color: "var(--text)",
+          overflowX: "auto",
+          whiteSpace: "pre",
+        }}
+      >
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={`Copy: ${command}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "3px 7px",
+          background: "transparent",
+          border: "1px solid var(--border)",
+          borderRadius: 4,
+          color: "var(--text-dim)",
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          cursor: "pointer",
+          flexShrink: 0,
+        }}
+      >
+        <Icon name={copied ? "check" : "copy"} size={11} />
+        {copied ? "copied" : "copy"}
+      </button>
+    </div>
+  );
+}

--- a/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
+++ b/packages/panel/src/components/views/__tests__/cores-settings-pairing.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CoreWithDial } from "~/shared/cores";
 import type { CorePairingFailureCode, CorePairingRefusal } from "~/shared/core-pairing";
@@ -52,6 +52,10 @@ const api = {
   renameCore: vi.fn(),
   removeCore: vi.fn(async () => undefined),
   getKeybindings: vi.fn(async () => ({ bindings: {} })),
+  // Not this suite's subject: `ConfirmDialog` renders a `CardFrame`, whose glow
+  // reads settings through react-query. Stubbed so opening the removal dialog
+  // is about the removal.
+  getSettings: vi.fn(async () => ({})),
 };
 
 const toasts = { success: vi.fn(), error: vi.fn() };
@@ -59,17 +63,24 @@ const toasts = { success: vi.fn(), error: vi.fn() };
 vi.mock("~/lib/api", () => ({ api, ApiError }));
 vi.mock("sonner", () => ({ toast: toasts }));
 
+const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
 const { CoresSettingsPage } = await import("../CoresSettingsPage");
 const { KeybindingsProvider } = await import("~/lib/keybindings/store");
 const { pairingFailureMessage } = await import("~/shared/core-pairing");
+const { CORE_REGISTRY_CHANGED_EVENT } = await import("~/lib/design-meta");
 
 let CORES: CoreWithDial[] = [];
 
 async function openPage(): Promise<void> {
+  // A query client because the removal dialog's `CardFrame` reads settings
+  // through one; retries off so a stubbed failure is a failure now.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
-    <KeybindingsProvider>
-      <CoresSettingsPage />
-    </KeybindingsProvider>,
+    <QueryClientProvider client={client}>
+      <KeybindingsProvider>
+        <CoresSettingsPage />
+      </KeybindingsProvider>
+    </QueryClientProvider>,
   );
   await act(async () => {});
 }
@@ -453,5 +464,82 @@ describe("adding a Core by short code (#286)", () => {
       expect(state()).toBe("unchecked");
       expect(screen.queryByLabelText("Pairing code")).toBeNull();
     });
+  });
+});
+
+/**
+ * The registry announcements (#358).
+ *
+ * Pairing and forgetting are the only two things in this tree that change how
+ * many Cores this Panel has, and the first-run gate decides whether there is a
+ * dashboard at all on exactly that number. The gate's own suite drives the
+ * event directly; without these, the two halves of `remove → announce → wizard`
+ * are each proven and never meet, and dropping either call here would go
+ * unnoticed — degrading silently to "the wizard comes back within fifteen
+ * seconds" rather than at once.
+ */
+describe("telling the rest of the tab that the registry moved (#358)", () => {
+  let announced: Mock<() => void>;
+  // The listener is its own binding rather than the spy itself: a `vi.fn()` is
+  // not typed as an `EventListener`, and both add and remove need one identity.
+  let onAnnounce: () => void;
+
+  beforeEach(() => {
+    CORES = [];
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    api.inspectCoreForPairing.mockImplementation(async () => ({
+      identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+    }));
+    api.pairCore.mockImplementation(async () => ({ core: paired() }));
+    api.removeCore.mockImplementation(async () => undefined);
+    announced = vi.fn<() => void>();
+    onAnnounce = () => {
+      announced();
+    };
+    window.addEventListener(CORE_REGISTRY_CHANGED_EVENT, onAnnounce);
+  });
+
+  afterEach(() => {
+    window.removeEventListener(CORE_REGISTRY_CHANGED_EVENT, onAnnounce);
+    cleanup();
+  });
+
+  it("announces when a pairing lands", async () => {
+    await openPage();
+    await verify();
+    type("Session", "ps_abc");
+    type("Pairing code", "k7rp-9x4t");
+    await click("Pair Core");
+
+    expect(api.pairCore).toHaveBeenCalled();
+    expect(announced).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces when a Core is forgotten — the last one is what puts the wizard back", async () => {
+    CORES = [paired("prod-vm-1")];
+    await openPage();
+
+    await click("Remove Core prod-vm-1");
+    CORES = [];
+    // The dialog's own button. The row's is named "Remove Core prod-vm-1", so
+    // this exact name reaches only the confirmation.
+    await click("Remove Core");
+
+    expect(api.removeCore).toHaveBeenCalledWith("core_new");
+    expect(announced).toHaveBeenCalledTimes(1);
+  });
+
+  it("says nothing when the removal failed", async () => {
+    // The count did not move, so nothing should be told that it did — a gate
+    // that re-read here would spend a request to learn what it already knew.
+    CORES = [paired("prod-vm-1")];
+    await openPage();
+    api.removeCore.mockRejectedValueOnce(new Error("core is busy"));
+
+    await click("Remove Core prod-vm-1");
+    await click("Remove Core");
+
+    expect(announced).not.toHaveBeenCalled();
   });
 });

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -1,0 +1,433 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CoreWithDial } from "~/shared/cores";
+
+/**
+ * The first-run gate (#358) — the Panel shows the pairing wizard, and nothing
+ * else, until it knows a Core.
+ *
+ * What these tests hold it to is the gate itself, because that is the part that
+ * can be wrong in a way nobody notices: that zero Cores means the wizard *and
+ * not the dashboard*, that a successful pairing is the only thing that opens
+ * the app, that the condition is the live count rather than a first-run flag —
+ * so forgetting the last Core puts the wizard back — and that the redemption
+ * step is the same `AddCoreByPairing` Settings mounts rather than a second
+ * implementation of the most safety-critical flow in the product.
+ */
+
+const PRESENTED =
+  "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+const ORIGIN = "https://prod-vm-1.internal:7777";
+
+/** The client's error type, as `~/lib/api` declares it. */
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+function core(label = "prod-vm-1"): CoreWithDial {
+  return {
+    id: "core_new",
+    endpoint: "wss://prod-vm-1.internal:7777",
+    label,
+    lastEventId: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    dial: { coreId: "core_new", state: "connecting", lastSeenAt: null },
+  };
+}
+
+let CORES: CoreWithDial[] = [];
+
+const api = {
+  listCores: vi.fn(async (): Promise<{ cores: CoreWithDial[] }> => ({ cores: CORES })),
+  inspectCoreForPairing: vi.fn(async (_address: string) => ({
+    identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+  })),
+  pairCore: vi.fn(async (_body: unknown): Promise<{ core: CoreWithDial }> => {
+    // The registry is what the gate reads, so a pairing that "succeeds" has to
+    // land in it — anything else would let the gate pass on a promise rather
+    // than on a Core.
+    CORES = [core()];
+    return { core: core() };
+  }),
+};
+
+vi.mock("~/lib/api", () => ({ api, ApiError }));
+
+const { FirstRunGate } = await import("../FirstRunGate");
+const { announceCoreRegistryChanged } = await import("~/lib/core-registry-changed");
+const { writeCachedCoreCount } = await import("~/lib/shell-query-cache");
+const { CURRENT_MC_VERSION } = await import("~/queries/mission-control-version");
+const { ADD_CORE_LOCATION, composeUpCoreCommand } = await import("~/shared/core-onboarding");
+// Warm the chunk the gate loads lazily. `FirstRunWizard` is imported with
+// `React.lazy` — it has no business in the entry bundle of a Panel that has a
+// fleet — and an unpopulated module registry means React suspends on a promise
+// the loader resolves on its own schedule rather than on this tick.
+await import("../FirstRunWizard");
+
+const DASHBOARD = "the-dashboard";
+
+/** Settle the registry read, and the lazy wizard behind it. */
+async function flush(): Promise<void> {
+  await act(async () => {});
+}
+
+async function mount(): Promise<void> {
+  render(
+    <FirstRunGate>
+      <div data-testid={DASHBOARD}>Fleet</div>
+    </FirstRunGate>,
+  );
+  await flush();
+}
+
+function wizard(): HTMLElement | null {
+  return document.querySelector("[data-first-run-wizard]");
+}
+
+function dashboard(): HTMLElement | null {
+  return screen.queryByTestId(DASHBOARD);
+}
+
+function type(label: string | RegExp, value: string): void {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+async function click(name: string | RegExp): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+/** Walk the wizard to a given step. Steps are reference; step 3 is the act. */
+async function goToStep(n: 1 | 2 | 3): Promise<void> {
+  await click(new RegExp(`Step ${n}`));
+}
+
+/** The whole redemption, exactly as an operator does it in Settings. */
+async function pair(): Promise<void> {
+  await goToStep(3);
+  type("Core address", "prod-vm-1.internal:7777");
+  await click("Check fingerprint");
+  await act(async () => {
+    type("CA fingerprint from `actana pair new`", PRESENTED);
+  });
+  type("Session", "ps_abc");
+  type("Pairing code", "k7rp-9x4t");
+  await click("Pair Core");
+}
+
+describe("the first-run gate (#358)", () => {
+  beforeEach(() => {
+    CORES = [];
+    // The gate seeds its first render from a localStorage count, so a value one
+    // test wrote would decide the next test's first paint.
+    window.localStorage.clear();
+    vi.clearAllMocks();
+    api.listCores.mockImplementation(async () => ({ cores: CORES }));
+    api.inspectCoreForPairing.mockImplementation(async () => ({
+      identity: { fingerprint: PRESENTED, httpsOrigin: ORIGIN },
+    }));
+    api.pairCore.mockImplementation(async () => {
+      CORES = [core()];
+      return { core: core() };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("what a Panel shows for a given fleet", () => {
+    it("shows the wizard, and no dashboard at all, when it knows zero Cores", async () => {
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+      expect(screen.getByRole("heading", { name: "Pair your first Core" })).toBeTruthy();
+    });
+
+    it("shows the app, and no wizard, once it knows one", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("shows neither until the registry has answered", async () => {
+      // A wizard flashed at an operator with a fleet, or a dashboard flashed at
+      // one without, are the two mistakes this component exists to prevent.
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      await mount();
+      expect(wizard()).toBeNull();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("paints the shell on the first render when this browser has seen a fleet", async () => {
+      // The seed is the whole point: without it every load of every Panel
+      // blanks until `listCores()` answers, which is a network round-trip in
+      // front of the shell to protect a state only a first-ever load is in.
+      writeCachedCoreCount(2);
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      render(
+        <FirstRunGate>
+          <div data-testid={DASHBOARD}>Fleet</div>
+        </FirstRunGate>,
+      );
+      // No flush: this has to be true of the first client render, not of the
+      // render after a promise settles.
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("paints the wizard on the first render when this browser has seen none", async () => {
+      writeCachedCoreCount(0);
+      api.listCores.mockImplementation(() => new Promise(() => {}));
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("keeps the seed honest — the live read corrects it", async () => {
+      // A cached count is a memory, not an answer. An operator who forgot their
+      // last Core from another browser must not be handed a dashboard.
+      writeCachedCoreCount(3);
+      CORES = [];
+      await mount();
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("never unlocks on a registry read it could not make", async () => {
+      api.listCores.mockRejectedValue(new Error("panel unreachable"));
+      await mount();
+      expect(dashboard()).toBeNull();
+      expect(wizard()).toBeTruthy();
+      // "No Cores" and "could not ask" are different things, and the operator
+      // about to be told to install a Core is owed the difference.
+      const box = document.querySelector("[data-first-run-registry-error]");
+      expect(box?.textContent).toContain("panel unreachable");
+    });
+  });
+
+  describe("it is a gate, not a suggestion", () => {
+    it("offers nothing that skips, dismisses or defers it, on any step", async () => {
+      // A keyword scan cannot prove absence on its own — "Go to Panel" would
+      // pass it — which is why the structural test below is the one doing the
+      // work. What this catches is an escape hatch added later by someone who
+      // named it the obvious thing, and it now looks at all three steps rather
+      // than only at the one that happens to be open on mount.
+      await mount();
+      for (const step of [1, 2, 3] as const) {
+        await goToStep(step);
+        const escapes = screen
+          .getAllByRole("button")
+          .map((button) => `${button.textContent ?? ""} ${button.getAttribute("aria-label") ?? ""}`)
+          .filter((name) => /skip|dismiss|later|not now|close|continue anyway|explore/i.test(name));
+        expect(escapes).toEqual([]);
+      }
+    });
+
+    it("keeps the dashboard away on every step of the way through it", async () => {
+      await mount();
+      for (const step of [1, 2, 3, 2, 1] as const) {
+        await goToStep(step);
+        expect(dashboard()).toBeNull();
+        expect(wizard()).toBeTruthy();
+      }
+    });
+
+    it("comes back when the last Core is forgotten, because the gate is the count", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      // Settings → Cores → Remove, as far as this component can see it.
+      CORES = [];
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+      await flush();
+
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+    });
+
+    it("does not tear down a live session on a single empty answer", async () => {
+      // Locking the gate unmounts the shell — every terminal, every socket. A
+      // Panel server that restarts against an empty or unmigrated data
+      // directory answers 200 with nothing in it, and one such answer must not
+      // end a session with no prompt and no undo.
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      api.listCores.mockResolvedValueOnce({ cores: [] });
+      const before = api.listCores.mock.calls.length;
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+      await flush();
+
+      expect(api.listCores.mock.calls.length).toBe(before + 2);
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("does not throw a paired Panel into the wizard over one failed poll", async () => {
+      CORES = [core()];
+      await mount();
+      expect(dashboard()).toBeTruthy();
+
+      api.listCores.mockRejectedValueOnce(new Error("socket hang up"));
+      await act(async () => {
+        announceCoreRegistryChanged();
+      });
+
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+  });
+
+  describe("what the operator is told to run on the Core", () => {
+    it("hands over both install paths on step 1", async () => {
+      await mount();
+      await goToStep(1);
+      expect(
+        screen.getByText(
+          "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+        ),
+      ).toBeTruthy();
+      expect(screen.getByText("actana setup")).toBeTruthy();
+      expect(screen.getByText(composeUpCoreCommand(CURRENT_MC_VERSION))).toBeTruthy();
+    });
+
+    it("brings up the Core alone, at a tag that resolves", async () => {
+      // The reader of this screen already has a Panel. A bare `up -d` would
+      // start the file's `panel` service too — clashing with theirs on 7420 or
+      // shadowing it — and `:latest` does not resolve until a release exists.
+      await mount();
+      await goToStep(1);
+      const compose = screen.getByText(/docker compose .* up -d/);
+      expect(compose.textContent?.endsWith("up -d core")).toBe(true);
+      expect(compose.textContent).toContain(`ACTANA_TAG=beta-${CURRENT_MC_VERSION}`);
+      expect(screen.queryByText("docker compose -f deploy/docker-compose.yml up -d")).toBeNull();
+    });
+
+    it("names the mint command on step 2, and what each line it prints is for", async () => {
+      await mount();
+      await goToStep(2);
+      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText(/^Pairing code/)).toBeTruthy();
+      expect(screen.getByText(/^CA fingerprint/)).toBeTruthy();
+      expect(screen.getByText(/^Session/)).toBeTruthy();
+      // The command taught here always carries `--label`, so `pair new` always
+      // prints a `Label` line. Leaving it out left one line on the operator's
+      // terminal that this screen did not account for.
+      expect(screen.getByText(/^Label/)).toBeTruthy();
+    });
+
+    it("refuses to print a command the Core would reject, and says why", async () => {
+      await mount();
+      await goToStep(2);
+      await act(async () => {
+        type("Name this Panel will have on that Core", "-panel");
+      });
+      // `pair new` reads a value starting with `-` as another option, in both
+      // flag forms, and quoting cannot help. So the placeholder is printed.
+      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.queryByText(/--label\s+'?-panel/)).toBeNull();
+      expect(document.querySelector("[data-label-refusal]")?.textContent).toMatch(
+        /cannot start with/,
+      );
+    });
+
+    it("rewrites the mint command as the operator names this Panel", async () => {
+      await mount();
+      await goToStep(2);
+      await act(async () => {
+        type("Name this Panel will have on that Core", "the office");
+      });
+      // Quoted, because it is going to be pasted into a shell.
+      expect(screen.getByText("actana pair new --label 'the office'")).toBeTruthy();
+      expect(screen.queryByText("actana pair new --label <name>")).toBeNull();
+    });
+
+    it("keeps every command copyable, since it is pasted on another machine", async () => {
+      await mount();
+      await goToStep(2);
+      const copy = screen.getByRole("button", {
+        name: "Copy: actana pair new --label <name>",
+      });
+      const writeText = vi.fn(async () => undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+      await act(async () => {
+        fireEvent.click(copy);
+      });
+      expect(writeText).toHaveBeenCalledWith("actana pair new --label <name>");
+    });
+  });
+
+  describe("redeeming the code", () => {
+    it("is the Settings pairing form, not a second one", async () => {
+      await mount();
+      await goToStep(3);
+      // The ordering `AddCoreByPairing` owns: an address, a fingerprint that
+      // has been looked at, and only then a code. If this step had forked the
+      // flow, this is where the fork would show.
+      expect(screen.getByLabelText("Core address")).toBeTruthy();
+      expect(screen.queryByLabelText("Pairing code")).toBeNull();
+      expect(document.querySelector("[data-fingerprint-state]")?.getAttribute("data-fingerprint-state")).toBe(
+        "unchecked",
+      );
+      expect(screen.getByText(ADD_CORE_LOCATION)).toBeTruthy();
+    });
+
+    it("posts the same body Settings posts", async () => {
+      await mount();
+      await pair();
+      expect(api.pairCore).toHaveBeenCalledWith({
+        address: "prod-vm-1.internal:7777",
+        code: "k7rp-9x4t",
+        sessionId: "ps_abc",
+        expectedFingerprint: PRESENTED,
+        label: "",
+      });
+    });
+
+    it("unlocks the dashboard on the first Core that pairs", async () => {
+      await mount();
+      expect(dashboard()).toBeNull();
+
+      await pair();
+
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("stays put when the code is refused", async () => {
+      await mount();
+      api.pairCore.mockRejectedValueOnce(
+        new ApiError("that code has been used", 400, {
+          failure: "refused",
+          error: "that code has been used",
+        }),
+      );
+      await pair();
+
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+      expect(screen.getByRole("alert").textContent).toContain("that code has been used");
+    });
+  });
+});

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -324,7 +324,7 @@ describe("the first-run gate (#358)", () => {
     it("names the mint command on step 2, and what each line it prints is for", async () => {
       await mount();
       await goToStep(2);
-      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText("actana pair new --label NAME")).toBeTruthy();
       expect(screen.getByText(/^Pairing code/)).toBeTruthy();
       expect(screen.getByText(/^CA fingerprint/)).toBeTruthy();
       expect(screen.getByText(/^Session/)).toBeTruthy();
@@ -342,7 +342,7 @@ describe("the first-run gate (#358)", () => {
       });
       // `pair new` reads a value starting with `-` as another option, in both
       // flag forms, and quoting cannot help. So the placeholder is printed.
-      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText("actana pair new --label NAME")).toBeTruthy();
       expect(screen.queryByText(/--label\s+'?-panel/)).toBeNull();
       expect(document.querySelector("[data-label-refusal]")?.textContent).toMatch(
         /cannot start with/,
@@ -357,14 +357,14 @@ describe("the first-run gate (#358)", () => {
       });
       // Quoted, because it is going to be pasted into a shell.
       expect(screen.getByText("actana pair new --label 'the office'")).toBeTruthy();
-      expect(screen.queryByText("actana pair new --label <name>")).toBeNull();
+      expect(screen.queryByText("actana pair new --label NAME")).toBeNull();
     });
 
     it("keeps every command copyable, since it is pasted on another machine", async () => {
       await mount();
       await goToStep(2);
       const copy = screen.getByRole("button", {
-        name: "Copy: actana pair new --label <name>",
+        name: "Copy: actana pair new --label NAME",
       });
       const writeText = vi.fn(async () => undefined);
       Object.defineProperty(navigator, "clipboard", {
@@ -374,7 +374,7 @@ describe("the first-run gate (#358)", () => {
       await act(async () => {
         fireEvent.click(copy);
       });
-      expect(writeText).toHaveBeenCalledWith("actana pair new --label <name>");
+      expect(writeText).toHaveBeenCalledWith("actana pair new --label NAME");
     });
   });
 

--- a/packages/panel/src/lib/core-registry-changed.ts
+++ b/packages/panel/src/lib/core-registry-changed.ts
@@ -1,0 +1,32 @@
+import { CORE_REGISTRY_CHANGED_EVENT } from "~/lib/design-meta";
+
+/**
+ * "The Core registry just changed — ask again."
+ *
+ * The registry only ever changes because an operator paired a Core or forgot
+ * one, so the read paths that watch it poll slowly (`useCores`, fifteen
+ * seconds), which is right for a list and wrong for a gate. The first-run gate
+ * decides whether this Panel shows a dashboard at all; up to fifteen seconds of
+ * wizard after a pairing landed, or of dashboard after the last Core was
+ * forgotten, is the gate being wrong about the only thing it decides.
+ *
+ * So the two gestures that change the registry say so, and whoever is watching
+ * re-reads. This is a nudge, not a channel: nothing is carried and nothing is
+ * cached, because the answer to "how many Cores are there" belongs to the
+ * server and a count riding an event would be a second source of truth for the
+ * one number the gate must not be wrong about. The event says *ask again*.
+ *
+ * Window-scoped, so it reaches every component in this tab and no further.
+ * Another tab's pairing is picked up by the poll, as it always was.
+ */
+export function announceCoreRegistryChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(CORE_REGISTRY_CHANGED_EVENT));
+}
+
+/** Listen for {@link announceCoreRegistryChanged}. Returns the unsubscribe. */
+export function onCoreRegistryChanged(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  window.addEventListener(CORE_REGISTRY_CHANGED_EVENT, listener);
+  return () => window.removeEventListener(CORE_REGISTRY_CHANGED_EVENT, listener);
+}

--- a/packages/panel/src/lib/design-meta.ts
+++ b/packages/panel/src/lib/design-meta.ts
@@ -63,6 +63,19 @@ export type OpenSettingsEventDetail = { panel?: string };
  * before navigating away. Listened to by SettingsPanel. */
 export const CLOSE_SETTINGS_EVENT = "mc:close-settings";
 
+/**
+ * Dispatched whenever the Core registry gained or lost a row — a pairing that
+ * landed, a Core that was forgotten. Listened to by `~/lib/core-registry-changed`,
+ * which is what makes the first-run gate turn over at once rather than at the
+ * next registry poll.
+ *
+ * It carries no payload deliberately: the answer to "how many Cores are there"
+ * belongs to the server, and a count riding an event would be a second source
+ * of truth for the one number the gate is not allowed to be wrong about. The
+ * event says *ask again*, nothing more.
+ */
+export const CORE_REGISTRY_CHANGED_EVENT = "mc:core-registry-changed";
+
 export const ICON_COLORS = ["#ff5a1f", "#8ab4ff", "#c792ea", "#ff9466", "#f472b6", "#34d399", "#fb923c"];
 export const GROUP_COLORS = ["#ff5a1f", "#8ab4ff", "#c792ea", "#ff9466", "#f472b6", "#34d399", "#fb923c"];
 

--- a/packages/panel/src/lib/shell-query-cache.ts
+++ b/packages/panel/src/lib/shell-query-cache.ts
@@ -9,6 +9,16 @@ export const SHELL_QUERY_CACHE_KEYS = {
   projects: "mc:shell-cache:projects:v1",
   groups: "mc:shell-cache:groups:v1",
   settings: "mc:shell-cache:settings:v1",
+  /**
+   * How many Cores this Panel was paired with, last time anyone asked.
+   *
+   * Read by the first-run gate (#358) so a Panel with a fleet paints its shell
+   * on the first client render instead of blanking for a round trip — the same
+   * bargain the three keys above make, for the one number that decides whether
+   * there is a shell to paint at all. It is a seed and never an answer: the
+   * live `listCores()` corrects it on the same tick it lands.
+   */
+  coreCount: "mc:shell-cache:core-count:v1",
 } as const;
 
 type CacheEnvelope<T> = {
@@ -79,6 +89,16 @@ export function readCachedGroups(): Group[] | undefined {
 export function readCachedSettings(): AppSettings | undefined {
   const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.settings);
   return isObject(data) ? (data as AppSettings) : undefined;
+}
+
+/** The seeded Core count, or undefined when this browser has never been told. */
+export function readCachedCoreCount(): number | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.coreCount);
+  return typeof data === "number" && Number.isInteger(data) && data >= 0 ? data : undefined;
+}
+
+export function writeCachedCoreCount(count: number): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.coreCount, count);
 }
 
 export function writeCachedProjects(projects: ProjectWithCounts[]): void {

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -25,7 +25,14 @@ import type { ProjectPresentation } from "~/db/schema";
 // is for Core-side content the event stream doesn't cover.
 
 const FLEET_POLL_MS = 15_000;
-const CORES_POLL_MS = 15_000;
+/**
+ * How often the registry is re-read, absent something saying it changed.
+ *
+ * Exported because the first-run gate polls the same registry for the same
+ * reason and had hand-copied the number (#358 review): one cadence, one place
+ * to change it, and no comment claiming two constants agree.
+ */
+export const CORES_POLL_MS = 15_000;
 
 /** Event kinds that change what a `tasksList` would return. */
 const TASK_EVENT_KINDS = /^(task:|session:|pty:)/;

--- a/packages/panel/src/routes/__root.tsx
+++ b/packages/panel/src/routes/__root.tsx
@@ -47,6 +47,7 @@ import {
 import { useSettings, useProjects } from "~/queries";
 import { ProviderUsageIndicator } from "~/components/views/ProviderUsageIndicator";
 import { UpdateBanner } from "~/components/views/UpdateBanner";
+import { FirstRunGate } from "~/components/views/FirstRunGate";
 import {
   normalizeSettingsPanelId,
   type SettingsPanelId,
@@ -149,7 +150,19 @@ function RootComponent() {
                      * slot for an app-wide skeleton if we want one later.
                      */}
                     <ClientOnly fallback={null}>
-                      <Shell />
+                      {/*
+                       * The pairing gate (#358). A Panel that knows no Cores
+                       * has nothing to draw, so it draws the wizard *instead
+                       * of* the shell rather than over it: no top bar, no
+                       * rail, no outlet, and so no route or keystroke that
+                       * reaches a dead dashboard. It sits inside ClientOnly
+                       * because the registry read is a client read like every
+                       * other, and inside the providers because the pairing
+                       * form it mounts is the same one Settings mounts.
+                       */}
+                      <FirstRunGate>
+                        <Shell />
+                      </FirstRunGate>
                     </ClientOnly>
                   </HeaderActionsProvider>
                 </GroupsDialogProvider>

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -1,0 +1,213 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ADD_CORE_FIELD_LABEL,
+  ADD_CORE_LOCATION,
+  PAIR_NEW_OUTPUT,
+  composePairNewCommand,
+  composeUpCoreCommand,
+  coreImageTag,
+  coreInstallPaths,
+  labelRefusal,
+  pairNewCommand,
+} from "../core-onboarding";
+
+/**
+ * The Core-side commands the first-run wizard teaches (#358).
+ *
+ * These are pasted into a terminal on a machine this Panel cannot see, so the
+ * only thing standing between a wrong string here and an operator debugging
+ * their own install is this file.
+ *
+ * **The `pair new` block is checked against the CLI, not against itself.** The
+ * first version of this suite asserted `PAIR_NEW_OUTPUT`'s labels against a
+ * literal copy of `PAIR_NEW_OUTPUT`'s own contents — a tautology that pinned
+ * the module to itself, said nothing about what `actana pair new` prints, and
+ * is exactly why a missing `Label` line survived review. So the expectations
+ * below are *read out of `packages/cli`*: the label set from the contract the
+ * CLI's own suite pins for this invocation, and the order from the printer.
+ * Neither can be satisfied by editing this package. #357 is about to reframe
+ * that output; when it does, this suite is what goes red.
+ */
+
+const VERSION = "0.4.3";
+
+/** `packages/cli/src/__tests__/actana-pair.test.ts`, read as text. */
+const CLI_TEST = readCli("__tests__/actana-pair.test.ts");
+/** `packages/cli/src/actana-pair.ts`, read as text. */
+const CLI_PRINTER = readCli("actana-pair.ts");
+
+function readCli(relative: string): string {
+  const path = fileURLToPath(new URL(`../../../../cli/src/${relative}`, import.meta.url));
+  const source = readFileSync(path, "utf8");
+  // A file that moved must fail loudly here rather than quietly stop covering
+  // anything — a check that silently no longer checks is worse than none.
+  if (source.trim() === "") throw new Error(`${relative} is empty`);
+  return source;
+}
+
+/**
+ * The stdout contract the CLI's suite pins for `pair new --label <name>` — the
+ * exact invocation this wizard teaches.
+ *
+ * Lifted from its assertion that every stdout line matches
+ * `/^(Pairing code|CA fingerprint|Expires|Label|Session) /`.
+ */
+function cliPinnedLabels(): string[] {
+  const match = /\/\^\(([^)]+)\)\s\//.exec(CLI_TEST);
+  if (!match) {
+    throw new Error(
+      "could not find the pinned stdout contract in actana-pair.test.ts — if that assertion moved or changed shape, this test has to follow it",
+    );
+  }
+  return match[1].split("|");
+}
+
+/**
+ * The order `actana-pair.ts` writes those lines in, read off the `deps.out`
+ * calls themselves. `Endpoint host` is dropped: it is printed only for
+ * `--public-host`, which this wizard does not teach.
+ */
+function printerOrder(pinned: string[]): string[] {
+  const emitted = [...CLI_PRINTER.matchAll(/deps\.out\(`([A-Za-z][A-Za-z ]*?) +\$\{/g)].map(
+    (m) => m[1],
+  );
+  if (emitted.length === 0) throw new Error("found no `deps.out` label lines in actana-pair.ts");
+  return emitted.filter((label) => pinned.includes(label));
+}
+
+describe("the `pair new` output block, against the CLI itself", () => {
+  it("explains every line that invocation prints, and invents none", () => {
+    expect(new Set(PAIR_NEW_OUTPUT.map((line) => line.label))).toEqual(new Set(cliPinnedLabels()));
+  });
+
+  it("lists them in the order the terminal shows them", () => {
+    // The wizard is a recognition aid; a set in the wrong order is a worse one.
+    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toEqual(printerOrder(cliPinnedLabels()));
+  });
+
+  it("includes `Label`, because the command it teaches always carries `--label`", () => {
+    // Named on its own: it is the line the first version of this block missed,
+    // and the one an operator sees only when they follow the wizard's command.
+    expect(cliPinnedLabels()).toContain("Label");
+    expect(PAIR_NEW_OUTPUT.map((line) => line.label)).toContain("Label");
+  });
+
+  it("samples the shapes an operator has to recognise", () => {
+    const sample = (label: string) =>
+      PAIR_NEW_OUTPUT.find((line) => line.label === label)?.sample ?? "";
+    // `absoluteTime` emits ISO-8601 in UTC, with the milliseconds stripped.
+    expect(sample("Expires")).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \(.+\)$/);
+    // `randomUUID()` — 36 characters, no prefix. A short stand-in invites
+    // truncating the real one into the redeem step's Session box.
+    expect(sample("Session")).toHaveLength(36);
+    expect(sample("Session")).toMatch(/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/);
+  });
+
+  it("says something about every line", () => {
+    for (const line of PAIR_NEW_OUTPUT) expect(line.meaning.trim()).not.toBe("");
+  });
+});
+
+describe("the mint command", () => {
+  it("names `--label` even when no name has been chosen", () => {
+    // Dropping the flag would be the easy thing to do and would teach an
+    // operator to skip the one field that makes `actana pair ls` readable.
+    expect(pairNewCommand("")).toBe("actana pair new --label <name>");
+    expect(pairNewCommand("   ")).toBe("actana pair new --label <name>");
+  });
+
+  it("folds the chosen name in, untouched when a shell would not mind", () => {
+    expect(pairNewCommand("my-panel")).toBe("actana pair new --label my-panel");
+    expect(pairNewCommand("  home_panel.2  ")).toBe("actana pair new --label home_panel.2");
+  });
+
+  it("quotes a name a shell would otherwise split or eat", () => {
+    // Pasted unquoted, `pair new` would take "the" and refuse "office".
+    expect(pairNewCommand("the office")).toBe("actana pair new --label 'the office'");
+    expect(pairNewCommand("mehdi's mac")).toBe(`actana pair new --label 'mehdi'\\''s mac'`);
+    expect(pairNewCommand("a;rm -rf b")).toBe("actana pair new --label 'a;rm -rf b'");
+  });
+
+  it("has a Compose form that runs the same command inside the Core container", () => {
+    expect(composePairNewCommand("my-panel")).toBe(
+      "docker compose -f deploy/docker-compose.yml exec core actana pair new --label my-panel",
+    );
+  });
+});
+
+describe("a name the Core would refuse", () => {
+  it("is refused here, with the reason", () => {
+    expect(labelRefusal("-panel")).toMatch(/cannot start with/);
+    expect(labelRefusal("  -panel")).toMatch(/cannot start with/);
+  });
+
+  it("never reaches the printed command", () => {
+    // The CLI's option parser refuses any `--label` value starting with `-`,
+    // in both flag forms, and quoting cannot help because the shell strips the
+    // quotes first. Emitting it would hand the operator a command that fails on
+    // paste — with the Panel to blame for printing it.
+    expect(pairNewCommand("-panel")).toBe("actana pair new --label <name>");
+    expect(composePairNewCommand("-panel")).toContain("--label <name>");
+  });
+
+  it("still refuses it in the CLI's own parser, which is why this exists", () => {
+    // Read from the CLI rather than asserted from memory: if that guard is ever
+    // relaxed, this stops being a rule the Panel has to enforce.
+    expect(CLI_PRINTER).toContain('value.startsWith("-")');
+  });
+
+  it("lets every ordinary name through", () => {
+    for (const name of ["my-panel", "panel-1", "the office", "a_b.c"]) {
+      expect(labelRefusal(name)).toBeNull();
+    }
+  });
+});
+
+describe("what the wizard puts on screen", () => {
+  it("offers both documented install paths, each with something to paste", () => {
+    const paths = coreInstallPaths(VERSION);
+    expect(paths.map((path) => path.id)).toEqual(["installer", "compose"]);
+    for (const path of paths) expect(path.commands.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the installer's two commands, in the order that works", () => {
+    const installer = coreInstallPaths(VERSION).find((path) => path.id === "installer");
+    expect(installer?.commands).toEqual([
+      "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+      "actana setup",
+    ]);
+  });
+
+  it("brings up the Core service alone, never a second Panel", () => {
+    // `docker compose … up -d` starts the whole file, `panel` included. That is
+    // the README's command, for a reader who has no Panel; here the reader is
+    // looking at one, and a bare `up -d` would clash with it on 7420 or shadow
+    // it — with this screen having told them to do it.
+    const compose = coreInstallPaths(VERSION).find((path) => path.id === "compose");
+    const up = compose?.commands.find((command) => command.includes("up -d"));
+    expect(up).toBe(composeUpCoreCommand(VERSION));
+    expect(up?.endsWith("up -d core")).toBe(true);
+    expect(compose?.commands.join("\n")).not.toMatch(/up -d(\s|$)(?!core)/);
+  });
+
+  it("pins an image tag rather than falling through to a `:latest` that 404s", () => {
+    const up = composeUpCoreCommand(VERSION);
+    expect(up.startsWith(`ACTANA_TAG=${coreImageTag(VERSION)} `)).toBe(true);
+    expect(coreImageTag("0.4.3")).toBe("beta-0.4.3");
+    // And the note has to explain the tag, or the operator cannot correct it
+    // once a release exists.
+    const compose = coreInstallPaths(VERSION).find((path) => path.id === "compose");
+    expect(compose?.note).toContain("ACTANA_TAG");
+    expect(compose?.note).toContain(VERSION);
+  });
+
+  it("tracks the Panel's own line rather than a hard-coded version", () => {
+    expect(composeUpCoreCommand("9.9.9")).toContain("ACTANA_TAG=beta-9.9.9");
+  });
+
+  it("names the canonical Add-a-Core location once", () => {
+    expect(ADD_CORE_LOCATION).toBe(`Settings → Cores → ${ADD_CORE_FIELD_LABEL}`);
+  });
+});

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -65,6 +65,27 @@ function cliPinnedLabels(): string[] {
 }
 
 /**
+ * The placeholder the CLI puts in the name slot, read out of its own export.
+ *
+ * Read rather than repeated, for the same reason the label set above is: the
+ * two surfaces print the same command, and `<name>` — which both of them once
+ * used — is a shell redirection, not a slot. Pinning the Panel's placeholder
+ * to `NAME_PLACEHOLDER` is what keeps them from drifting apart again.
+ */
+function cliNamePlaceholder(): string {
+  const match = /export const NAME_PLACEHOLDER = "([^"]+)";/.exec(CLI_PRINTER);
+  if (!match) {
+    throw new Error(
+      "could not find `NAME_PLACEHOLDER` in actana-pair.ts — if it moved or changed shape, this test has to follow it",
+    );
+  }
+  return match[1];
+}
+
+/** The mint command as the wizard prints it with no usable name typed. */
+const PLACEHOLDER_COMMAND = `actana pair new --label ${cliNamePlaceholder()}`;
+
+/**
  * The order `actana-pair.ts` writes those lines in, read off the `deps.out`
  * calls themselves. `Endpoint host` is dropped: it is printed only for
  * `--public-host`, which this wizard does not teach.
@@ -114,8 +135,8 @@ describe("the mint command", () => {
   it("names `--label` even when no name has been chosen", () => {
     // Dropping the flag would be the easy thing to do and would teach an
     // operator to skip the one field that makes `actana pair ls` readable.
-    expect(pairNewCommand("")).toBe("actana pair new --label <name>");
-    expect(pairNewCommand("   ")).toBe("actana pair new --label <name>");
+    expect(pairNewCommand("")).toBe(PLACEHOLDER_COMMAND);
+    expect(pairNewCommand("   ")).toBe(PLACEHOLDER_COMMAND);
   });
 
   it("folds the chosen name in, untouched when a shell would not mind", () => {
@@ -148,8 +169,8 @@ describe("a name the Core would refuse", () => {
     // in both flag forms, and quoting cannot help because the shell strips the
     // quotes first. Emitting it would hand the operator a command that fails on
     // paste — with the Panel to blame for printing it.
-    expect(pairNewCommand("-panel")).toBe("actana pair new --label <name>");
-    expect(composePairNewCommand("-panel")).toContain("--label <name>");
+    expect(pairNewCommand("-panel")).toBe(PLACEHOLDER_COMMAND);
+    expect(composePairNewCommand("-panel")).toContain(`--label ${cliNamePlaceholder()}`);
   });
 
   it("still refuses it in the CLI's own parser, which is why this exists", () => {

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -230,10 +230,22 @@ export function composePairNewCommand(label: string): string {
  * A name with a space in it silently becomes two arguments, and `pair new`
  * would take the first and reject the second — a failure the operator would
  * blame on the Panel, having pasted exactly what it printed.
+ *
+ * The placeholder is bare `NAME` for the same reason, and it is deliberately
+ * the CLI's own `NAME_PLACEHOLDER` (`packages/cli/src/actana-pair.ts`, #357
+ * review B3): `<name>` is not inert in a shell. Pasted into bash it parses as
+ * redirections — read stdin from a file called `name`, write stdout to the
+ * next word — so the command never runs and what the operator sees is
+ * `bash: name: No such file or directory`, a message that names neither
+ * `actana` nor the actual problem. This is the wizard's *default* state — an
+ * empty name box, behind a one-click copy button — so it is the likeliest
+ * thing of all to be pasted unedited. `NAME` reads as a slot just as clearly,
+ * survives every shell, and pasted unedited it mints a code labelled `NAME`,
+ * recoverable with one `actana core rm NAME`, which a shell error is not.
  */
 function labelArgument(label: string): string {
   const trimmed = label.trim();
-  if (trimmed === "" || labelRefusal(trimmed) !== null) return "<name>";
+  if (trimmed === "" || labelRefusal(trimmed) !== null) return "NAME";
   if (/^[A-Za-z0-9._:@%+,/=-]+$/.test(trimmed)) return trimmed;
   return `'${trimmed.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -1,0 +1,239 @@
+// What an operator has to do on the *other* machine before this Panel is
+// worth anything — as data, so the first-run wizard and any future surface
+// print the same commands.
+//
+// The Panel's whole shape is that the machine doing the work is somewhere
+// else. Every string in this file is therefore a **Core-side** command: it is
+// pasted into a terminal on the machine being paired, never run by the Panel
+// and never run by the browser. That is why they live beside `cores.ts`'s
+// `CORE_UPDATE_COMMAND` rather than in a component — a command an operator
+// pastes on another machine is a fact about the product, and it belongs
+// somewhere a test can read it.
+//
+// Their source of truth is the repository's own install documentation
+// (`README.md` §Quickstart, `INSTALL.md` §Step 1–3) and, for the `pair new`
+// output block, `packages/cli/src/actana-pair.ts` itself. When those change,
+// these change with them; a wizard that teaches a command the docs no longer
+// print, or describes output the CLI no longer emits, is worse than no wizard
+// at all. `__tests__/core-onboarding.test.ts` reads the CLI's own pinned
+// contract rather than a copy of this file, so that drift is a red suite.
+
+/** One documented way to put a Core on a machine. */
+export type CoreInstallPath = {
+  /** Stable handle, used as a React key and as a test's grip on the block. */
+  id: "installer" | "compose";
+  /** What this path is, in the operator's terms. */
+  title: string;
+  /** Which machine it suits — the choice, not the mechanics. */
+  blurb: string;
+  /** The lines to paste, in order. Each is copyable on its own. */
+  commands: readonly string[];
+  /** The one thing that trips people up on this path, or null. */
+  note: string | null;
+};
+
+/**
+ * The image tag the Compose file should be pinned to, for a Panel on this
+ * version.
+ *
+ * `deploy/docker-compose.yml` defaults both services to `:latest`, and
+ * `README.md` §Quickstart is explicit that `:latest` 404s until the first
+ * release is published — the images publish as `beta-x.y.z` off the open train
+ * and are retagged `x.y.z` plus `latest` only when that train is released. So
+ * the wizard prints a tag rather than the bare default, and it prints *this
+ * Panel's own line*: pairing a Core built from a different line than the Panel
+ * driving it is the one thing `ACTANA_TAG` exists to prevent
+ * (`deploy/docker-compose.yml`, "one variable, both services").
+ *
+ * Derived rather than hard-coded, so the wizard cannot go stale against the
+ * train it ships on.
+ */
+export function coreImageTag(panelVersion: string): string {
+  return `beta-${panelVersion}`;
+}
+
+/** The Compose line that brings up **only the Core**, pinned to that tag. */
+export function composeUpCoreCommand(panelVersion: string): string {
+  return `ACTANA_TAG=${coreImageTag(panelVersion)} docker compose -f deploy/docker-compose.yml up -d core`;
+}
+
+/**
+ * The two install paths, in the order the README offers them.
+ *
+ * Both are here rather than one being chosen for the operator, because the
+ * choice is about their machine and the Panel cannot see their machine. The
+ * blurbs are the README's own "Which one?" paragraph, split in two.
+ *
+ * **The Compose path brings up `core` and nothing else.** `README.md`'s
+ * `docker compose … up -d` starts the whole file — a Panel *and* a Core — which
+ * is the right command in the README, where the reader has no Panel yet, and
+ * the wrong one here, where by definition they are already looking at one. Left
+ * bare it would either clash with their Panel on 7420 or shadow it, and the
+ * screen would have told them to do it. Naming the `core` service is the whole
+ * difference (`deploy/docker-compose.yml`, the `core:` service).
+ */
+export function coreInstallPaths(panelVersion: string): readonly CoreInstallPath[] {
+  return [
+    {
+      id: "installer",
+      title: "Installer — a machine that already has your code",
+      blurb:
+        "Linux, or macOS on arm64, as your own user and without sudo. Two commands, because installing is not activating: the first places the Core bundle and the `actana` CLI, the second turns the machine into a Core.",
+      commands: [
+        "curl -fsSL https://raw.githubusercontent.com/actana/control/main/install.sh | bash",
+        "actana setup",
+      ],
+      note: "The installer prints the exact `actana setup` line to run — run the line it printed, not this one, if the two differ.",
+    },
+    {
+      id: "compose",
+      title: "Docker Compose — a Core beside this Panel",
+      blurb:
+        "A Core on the same Compose file as this Panel, and only the Core: the file also defines a `panel` service, and you are already looking at a Panel. Quickest way to see a Session run if this Panel is itself a container.",
+      commands: [
+        "git clone https://github.com/actana/control && cd control",
+        composeUpCoreCommand(panelVersion),
+      ],
+      note: `\`ACTANA_TAG\` pins both services to one line, and it is set here because the file's default is \`:latest\`, which does not resolve until a release is published. \`${coreImageTag(panelVersion)}\` is the line this Panel is on. Once a release exists, that line's tag is \`${panelVersion}\`.`,
+    },
+  ];
+}
+
+/** The Compose prefix that runs a Core-side command inside the Core container. */
+export const COMPOSE_EXEC_PREFIX = "docker compose -f deploy/docker-compose.yml exec core";
+
+/**
+ * What the canonical Add-a-Core surface is called, so the wizard and the
+ * settings page name one place with one string (#358 asks for exactly that).
+ *
+ * `CoresSettingsPage` renders the field, and the wizard's redeem step points at
+ * it; both read these rather than each spelling it out.
+ */
+export const ADD_CORE_FIELD_LABEL = "Add a Core";
+export const ADD_CORE_LOCATION = `Settings → Cores → ${ADD_CORE_FIELD_LABEL}`;
+
+/**
+ * What `actana pair new --label <name>` writes to stdout, as an operator will
+ * see it, and what each line is for.
+ *
+ * A sample rather than live values, because the Panel is on the wrong machine
+ * to have any: nothing here has been minted, and the point of showing it is
+ * that the person watching the Panel recognises these lines when they scroll
+ * past on the Core's terminal. Four of them are typed back into the redeem
+ * step or checked against it; one is a deadline.
+ *
+ * **The set is the set that command prints, not a shorter one.** `pair new`
+ * emits `Label` whenever `--label` is given, and the wizard always teaches
+ * `--label` — so `Label` belongs here, between `Expires` and `Session`, in the
+ * order `packages/cli/src/actana-pair.ts` writes them. (`Endpoint host` is the
+ * sixth line and is not here: it appears only for `--public-host`, which this
+ * wizard does not teach.) The CLI's own suite pins that set for this exact
+ * invocation, and `__tests__/core-onboarding.test.ts` reads it from there.
+ *
+ * **The shapes are what recognition runs on**, so they match the real printer
+ * even though the values do not: an ISO-8601 expiry (`absoluteTime`), and a
+ * 36-character UUID session (`randomUUID`). A short prefixed stand-in would
+ * invite an operator to truncate a UUID into the Session box and fail a
+ * redemption for a reason nothing on screen explains.
+ *
+ * The values are obvious fakes on purpose. An operator who pastes `K7RP-9X4T`
+ * gets a refusal, which is the correct outcome and a cheaper one than a sample
+ * that could be mistaken for a real code.
+ */
+export type PairNewOutputLine = {
+  /** The label as `pair new` prints it, left-aligned in a fixed column. */
+  label: string;
+  /** A stand-in value — never a real credential. */
+  sample: string;
+  /** What the operator does with it. */
+  meaning: string;
+};
+
+export const PAIR_NEW_OUTPUT: readonly PairNewOutputLine[] = [
+  {
+    label: "Pairing code",
+    sample: "K7RP-9X4T",
+    meaning:
+      "The one-time code. Single-use, expires, and dies after five wrong guesses. It is printed once — the Core keeps only a digest — so a lost code is re-minted by running the command again.",
+  },
+  {
+    label: "CA fingerprint",
+    sample: "AA:BB:CC:…:99",
+    meaning:
+      "That Core's certificate authority, as 32 colon-separated bytes. You compare it against the fingerprint this Panel shows you *before* the code is sent, which is what makes the pairing safe over a network you do not trust.",
+  },
+  {
+    label: "Expires",
+    sample: "2026-08-31T14:32:07Z (in 5 minutes)",
+    meaning:
+      "The deadline, in UTC. Five minutes by default; `--ttl` moves it. Past it, mint another.",
+  },
+  {
+    label: "Label",
+    sample: "my-panel",
+    meaning:
+      "The name you passed to `--label`, echoed back. It is what that Core calls this Panel in `actana pair ls`, and it is the Core's record — not the name this Panel will show you, which you choose in the last box below.",
+  },
+  {
+    label: "Session",
+    sample: "7f2c1a9e-4b60-4c3d-9f21-8e5a7c0d1b34",
+    meaning:
+      "The pairing session the code belongs to — a full 36-character UUID. It goes in the Session box below, whole.",
+  },
+];
+
+/**
+ * Why a typed name cannot go into `--label`, or null if it can.
+ *
+ * There is exactly one such reason and it is not a style rule: `actana pair
+ * new`'s option parser refuses any value that starts with `-`, in **both** flag
+ * forms — `--label -panel` and `--label=-panel` hit the same guard
+ * (`actana-pair.ts`, "needs a value"). Quoting does not help either, because
+ * the shell strips the quotes before the CLI ever sees the token.
+ *
+ * So it has to be caught here, on the Panel side. Emitting the command anyway
+ * would produce precisely the failure {@link pairNewCommand} exists to prevent:
+ * an operator pasting exactly what the Panel printed and being refused by the
+ * Core for it.
+ */
+export function labelRefusal(label: string): string | null {
+  if (label.trim().startsWith("-")) {
+    return "A name cannot start with “-”. `actana pair new` reads it as another option and refuses the command — in both `--label -x` and `--label=-x` form, and quoting does not help because the shell strips the quotes first.";
+  }
+  return null;
+}
+
+/**
+ * The mint command, with the operator's chosen name folded in.
+ *
+ * `--label` is what the Core will call this Panel in `actana pair ls`, so the
+ * name is worth choosing rather than defaulting; an empty box therefore prints
+ * the placeholder rather than dropping the flag, because a wizard that teaches
+ * `actana pair new` teaches an operator to skip the one thing that makes their
+ * pairing list readable later. A name the Core would refuse
+ * ({@link labelRefusal}) prints the placeholder too — never the refused form.
+ */
+export function pairNewCommand(label: string): string {
+  return `actana pair new --label ${labelArgument(label)}`;
+}
+
+/** The same command, for a Core that came up under Compose. */
+export function composePairNewCommand(label: string): string {
+  return `${COMPOSE_EXEC_PREFIX} ${pairNewCommand(label)}`;
+}
+
+/**
+ * The `--label` argument: a placeholder when nothing usable is typed, and
+ * otherwise the name, quoted only when a shell would need it.
+ *
+ * Quoting matters because this string is going to be pasted into a terminal.
+ * A name with a space in it silently becomes two arguments, and `pair new`
+ * would take the first and reject the second — a failure the operator would
+ * blame on the Panel, having pasted exactly what it printed.
+ */
+function labelArgument(label: string): string {
+  const trimmed = label.trim();
+  if (trimmed === "" || labelRefusal(trimmed) !== null) return "<name>";
+  if (/^[A-Za-z0-9._:@%+,/=-]+$/.test(trimmed)) return trimmed;
+  return `'${trimmed.replace(/'/g, `'\\''`)}'`;
+}

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -443,7 +443,7 @@ async function main() {
     // Pinned by value: this script is plain node with no path to the CLI's
     // exports. `actana-pair.test.ts` pins the same wording against the
     // constant itself, so a change to it fails there first (#357 review B1).
-    "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+    "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
       "CA fingerprint, then the session and the code",
     "From a terminal",
     "npm i -g @actana/cli",

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -18,7 +18,9 @@
 //     own** (#287);
 //   • `--version` installs that exact release; with no flag, the latest;
 //   • `status` / `start` / `stop` / `restart` / `logs` control and report the
-//     daemon, and `pair new` mints a code on it;
+//     daemon, and `pair new` mints a code on it — in **both** its shapes:
+//     the labelled lines when its stdout is redirected, and the framed
+//     handout with both redemption paths when it has a terminal (#357);
 //   • re-running the two commands upgrades in place — one unit, same pairing
 //     credentials, and a pre-rename `actana-harness.service` is taken out on
 //     the way;
@@ -393,16 +395,112 @@ async function main() {
   // The verb that replaced the reprint. It has to work on the machine the
   // one-liner produced, and it must not put the code on stdout twice or leak a
   // credential while doing it.
-  const minted = mustAsOperator("actana pair new --label e2e-panel");
+  //
+  // **Redirected, deliberately.** Since #357 `pair new` renders a framed
+  // handout when stdout is a terminal, and `machinectl shell` gives it one —
+  // so a scrape run here without the redirect would be reading the cosmetic
+  // shape. The contract this asserts is the *other* one: what a script sees.
+  // Both shapes are checked, this one first, because it is the one anything
+  // downstream depends on.
+  const redirected = mustAsOperator("actana pair new --label e2e-panel > /tmp/pair-new.out");
+  const minted = mustAsOperator("cat /tmp/pair-new.out");
+  // The file held a redeemable code. This whole file's discipline is about not
+  // leaving credentials lying around, and an ephemeral container is a reason
+  // nobody notices rather than a reason it is fine (#357 review N2).
+  mustAsOperator("rm -f /tmp/pair-new.out");
   if (!/Pairing code\s+[A-Z2-9]{4}-[A-Z2-9]{4}/.test(minted.stdout)) {
     die("`actana pair new` printed no pairing code", minted.stdout.split("\n"));
   }
   if (!/CA fingerprint\s+[0-9A-F]{2}(:[0-9A-F]{2}){31}/.test(minted.stdout)) {
     die("`actana pair new` printed no CA fingerprint", minted.stdout.split("\n"));
   }
-  if (/BEGIN (CERTIFICATE|PRIVATE KEY)/.test(minted.stdout)) {
-    die("`actana pair new` printed certificate material", minted.stdout.split("\n"));
+  // **Both streams, and both shapes.** Before the redirect, `minted.stdout` was
+  // the folded stdout+stderr `machinectl shell` produces, so this check covered
+  // stderr too; scraping a file narrowed it to one stream of one run. The
+  // framed run below is swept by the same list (#357 review N2).
+  const leakChecked = [
+    ["redirected stdout", minted.stdout],
+    ["the redirected run's own streams", `${redirected.stdout}${redirected.stderr}`],
+  ];
+  // Nothing cosmetic reached a redirected stdout: no frame, no instructions,
+  // no escape sequence. This is the half of #357 that scripts depend on, and
+  // the only place it is checked against a real installed Core.
+  for (const cosmetic of ["\u256d", "\u2502", "From the Panel", "From a terminal", "npm i -g"]) {
+    if (minted.stdout.includes(cosmetic)) {
+      die(`redirected \`actana pair new\` printed ${cosmetic}`, minted.stdout.split("\n"));
+    }
   }
+  log("`actana pair new` keeps its labelled lines when stdout is not a terminal (#357)");
+
+  // And the other shape, on the same machine: `machinectl shell` is a
+  // terminal, so this run frames the code and says what to do with it. The
+  // pasteable line has to carry `--session` — without it the client's
+  // `readTicket` refuses the code it was just handed.
+  const framed = mustAsOperator("actana pair new --label e2e-tty");
+  for (const wanted of [
+    "\u256d",
+    "From the Panel",
+    // Pinned by value: this script is plain node with no path to the CLI's
+    // exports. `actana-pair.test.ts` pins the same wording against the
+    // constant itself, so a change to it fails there first (#357 review B1).
+    "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+      "CA fingerprint, then the session and the code",
+    "From a terminal",
+    "npm i -g @actana/cli",
+  ]) {
+    if (!framed.stdout.includes(wanted)) {
+      die(`framed \`actana pair new\` printed no ${JSON.stringify(wanted)}`, framed.stdout.split("\n"));
+    }
+  }
+  const pasteable = framed.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("actana core pair "));
+  if (!pasteable) die("framed `actana pair new` printed no pasteable command", framed.stdout.split("\n"));
+  if (!/--session [0-9a-f-]{36}\b/.test(pasteable)) {
+    die("the pasteable command carries no --session", [pasteable]);
+  }
+  if (!/--fingerprint [0-9A-F]{2}(:[0-9A-F]{2}){31}/.test(pasteable)) {
+    die("the pasteable command carries no whole fingerprint", [pasteable]);
+  }
+  // #357 review B3: the line's whole promise is that it works when pasted, and
+  // `<name>` was a shell redirection. Handing it to the machine's own shell is
+  // the only check that means anything — `printf` hands back the words a shell
+  // actually parsed, so a redirection or a glob shows up as a missing word.
+  const echoed = mustAsOperator(`printf '%s\\n' ${pasteable}`);
+  const words = echoed.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (words.join(" ") !== pasteable) {
+    die("the pasteable command did not survive a shell", [pasteable, ...words]);
+  }
+  // And the default invocation, which is the one #357 review B3 was about: no
+  // `--label`, so the name is the placeholder, and the placeholder is the thing
+  // a shell used to eat. Checked on the real machine rather than only in the
+  // unit suite, because "survives a shell" is a claim about a shell.
+  const unlabelled = mustAsOperator("actana pair new");
+  const defaultLine = unlabelled.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("actana core pair "));
+  if (!defaultLine) die("unlabelled `actana pair new` printed no pasteable command", unlabelled.stdout.split("\n"));
+  if (!/^actana core pair NAME /.test(defaultLine)) {
+    die("the unlabelled command does not use the shell-safe name placeholder", [defaultLine]);
+  }
+  const defaultEchoed = mustAsOperator(`printf '%s\\n' ${defaultLine}`);
+  const defaultWords = defaultEchoed.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (defaultWords.join(" ") !== defaultLine) {
+    die("the unlabelled pasteable command did not survive a shell", [defaultLine, ...defaultWords]);
+  }
+  log("both pasteable commands survive the machine's own shell, placeholder included (#357)");
+
+  leakChecked.push(["the framed run", `${framed.stdout}${framed.stderr}`]);
+  leakChecked.push(["the unlabelled framed run", `${unlabelled.stdout}${unlabelled.stderr}`]);
+  for (const [what, output] of leakChecked) {
+    if (/BEGIN (CERTIFICATE|PRIVATE KEY)/.test(output)) {
+      die(`\`actana pair new\` printed certificate material on ${what}`, output.split("\n"));
+    }
+  }
+  log("`actana pair new` frames the code and both redemption paths at a terminal (#357)");
+  log("neither shape of `actana pair new` leaked certificate material on either stream");
   const reprint = asOperator("actana token");
   if (reprint.status === 0) die("`actana token` still reprints something — #287 removed it");
   // Both streams: `machinectl shell` folds the session's stderr into the


### PR DESCRIPTION
The gate pull request for the **0.4.3 train**. Four tickets, all merged into `feat/0.4.3-onboarding` and squashing into
one commit on `beta/0.4.3`.

Closes #357. Closes #358. Closes #359. Closes #360.

The theme is the one the train is named for: the first hour with this product. Three of the four tickets are the pairing
handshake — what the Core prints when it mints a code, what the client prints when it redeems one, and what a Panel that
knows no Core shows instead of an empty dashboard. The fourth corrects a token scope our own documentation had wrong.

| Ticket | Pull request | Commit |
| --- | --- | --- |
| #359 — `DOCKERHUB_TOKEN` scope: the descriptions PATCH needs Read, Write, Delete | #362 | `c06155d` |
| #357 — `actana pair new`: instructional, framed output when stdout is a TTY | #364 | `ca7e085` |
| #358 — Panel: first-run pairing wizard, no dashboard until a Core is paired | #363 | `4af3b92` |
| #360 — `actana core pair`: framed success and failure output with next steps | #366 | `7ec41e0` |

## Piped output is byte-identical, throughout

**No CLI output changes for anything that is not a terminal.** `isatty(stdout)` is the whole of the switch in both
commands — no flag, no `--json`, no environment variable. Piped, redirected or captured, `actana pair new` and
`actana core pair` print exactly what 0.4.2 printed: the same lines, in the same order, at the same column. The suites
assert the piped arrays against literals rather than trusting them, so a drift in the byte stream is a red check and not
a discovery made by whatever script was parsing it. Exit codes, the session minted, the digest stored and every error
condition are identical in both shapes; only the drawing reads the TTY bit.

At a terminal, `pair new` becomes a framed handout — the code and its expiry, the full CA fingerprint never truncated,
the session id, and under the frame both redemption paths, including a pasteable one-liner per configured public host
carrying the real minted values. `core pair` gains the matching result block at the other end of the same exchange, with
one remedy per failure. Colour is terminal-only and `NO_COLOR` removes it without taking the instructions with it. The
frame primitives both ends draw with live in one shared `cli-frame.ts`, so the two halves of one handshake cannot start
drawing different boxes.

## The Panel wizard (#358)

A Panel that knows no Cores draws a three-step wizard instead of the app: install the Core on the machine you want to
drive, mint a code there, redeem it here. The gate is the live Core count, not a first-run flag — a new Operator lands
in the wizard, and a Panel whose last Core is forgotten goes back to it, one rule for what is one state. It replaces the
shell rather than covering it: at zero Cores the top bar, the rail, the outlet and the settings overlay do not mount, so
there is no route to type and no dead dashboard behind it. Redemption mounts `AddCoreByPairing`, the same component
Settings uses, so the fingerprint-before-code ordering and every failure sentence stay written once. Settings is
untouched.

## The token scope (#359)

A PAT scoped `Read & Write` pushes images happily and then 403s every `PATCH /v2/repositories/…`, which is why all four
Docker Hub pages were blank since launch. The scope was widened on the live token on 2026-08-31 and the chore went green
and filled the pages; this ticket is the documentation catching up — `docs/REPO_SETUP.md` §2, one error string in
`housekeeping.yml`, and the retired "descriptions are a write, not a delete" premise wherever it still stood. Docs only,
and no operator action is left outstanding.

---

## Review

**Two reviews are required before this merges:**

- **moderator** — `opencode`
- **pr** — `claude`

## Notes for the reviewer

- **Base is `beta/0.4.3`, the open train — not `main`.** Nothing here targets `main`, and no tag or workflow dispatch is
  part of this pull request.
- **Squash is this repository's only merge method**, so the four ticket subjects collapse into the single train commit
  this title describes.
- **`Promotion gate` is red on the train → `main` pull request by design, not on this one.** This is a ticket-side gate
  into the train.
- All seven version stamps on the branch read `0.4.3` — the six workspace manifests and the `LINE=` stamp in
  `install.sh` — which is what `Train rules` asserts.
- The branch is four commits ahead of `beta/0.4.3` and zero behind, so no merge from the train was needed.
