### PR TITLE
fix(panel): the wizard's mint command carries the CLI's NAME placeholder, not a shell redirection

### DIFF
--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -588,7 +588,7 @@ describe("actana pair new, at a terminal", () => {
     expect(screen()).toContain("From the Panel");
     expect(screen()).toContain(PANEL_INSTRUCTION);
     expect(PANEL_INSTRUCTION).toBe(
-      "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+      "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
         "CA fingerprint, then the session and the code",
     );
     // Every field the form requires is named, in the form's order, and the

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -644,13 +644,18 @@ function hostNotes(
  * for. The comparison is the security-relevant step of the whole exchange
  * (#280 step 3, #284); it is the one thing this line must not drop.
  *
+ * The field is called **Add a Core**, not "Add Core": that is the string the
+ * Panel renders it from (`packages/panel/src/shared/core-onboarding.ts`,
+ * `ADD_CORE_FIELD_LABEL`), and this line is worded from the form. #357's issue
+ * text said "Add Core" and was wrong about the field's name.
+ *
  * A constant rather than an inline string because the wording is the spec, and
  * a test asserts this value rather than a regex that would go on passing after
  * somebody paraphrased it. `scripts/e2e-actana-setup-linux.mjs` pins it too:
  * both move with this line.
  */
 export const PANEL_INSTRUCTION =
-  "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+  "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
   "CA fingerprint, then the session and the code";
 
 /**

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -324,7 +324,7 @@ describe("the first-run gate (#358)", () => {
     it("names the mint command on step 2, and what each line it prints is for", async () => {
       await mount();
       await goToStep(2);
-      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText("actana pair new --label NAME")).toBeTruthy();
       expect(screen.getByText(/^Pairing code/)).toBeTruthy();
       expect(screen.getByText(/^CA fingerprint/)).toBeTruthy();
       expect(screen.getByText(/^Session/)).toBeTruthy();
@@ -342,7 +342,7 @@ describe("the first-run gate (#358)", () => {
       });
       // `pair new` reads a value starting with `-` as another option, in both
       // flag forms, and quoting cannot help. So the placeholder is printed.
-      expect(screen.getByText("actana pair new --label <name>")).toBeTruthy();
+      expect(screen.getByText("actana pair new --label NAME")).toBeTruthy();
       expect(screen.queryByText(/--label\s+'?-panel/)).toBeNull();
       expect(document.querySelector("[data-label-refusal]")?.textContent).toMatch(
         /cannot start with/,
@@ -357,14 +357,14 @@ describe("the first-run gate (#358)", () => {
       });
       // Quoted, because it is going to be pasted into a shell.
       expect(screen.getByText("actana pair new --label 'the office'")).toBeTruthy();
-      expect(screen.queryByText("actana pair new --label <name>")).toBeNull();
+      expect(screen.queryByText("actana pair new --label NAME")).toBeNull();
     });
 
     it("keeps every command copyable, since it is pasted on another machine", async () => {
       await mount();
       await goToStep(2);
       const copy = screen.getByRole("button", {
-        name: "Copy: actana pair new --label <name>",
+        name: "Copy: actana pair new --label NAME",
       });
       const writeText = vi.fn(async () => undefined);
       Object.defineProperty(navigator, "clipboard", {
@@ -374,7 +374,7 @@ describe("the first-run gate (#358)", () => {
       await act(async () => {
         fireEvent.click(copy);
       });
-      expect(writeText).toHaveBeenCalledWith("actana pair new --label <name>");
+      expect(writeText).toHaveBeenCalledWith("actana pair new --label NAME");
     });
   });
 

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -65,6 +65,27 @@ function cliPinnedLabels(): string[] {
 }
 
 /**
+ * The placeholder the CLI puts in the name slot, read out of its own export.
+ *
+ * Read rather than repeated, for the same reason the label set above is: the
+ * two surfaces print the same command, and `<name>` — which both of them once
+ * used — is a shell redirection, not a slot. Pinning the Panel's placeholder
+ * to `NAME_PLACEHOLDER` is what keeps them from drifting apart again.
+ */
+function cliNamePlaceholder(): string {
+  const match = /export const NAME_PLACEHOLDER = "([^"]+)";/.exec(CLI_PRINTER);
+  if (!match) {
+    throw new Error(
+      "could not find `NAME_PLACEHOLDER` in actana-pair.ts — if it moved or changed shape, this test has to follow it",
+    );
+  }
+  return match[1];
+}
+
+/** The mint command as the wizard prints it with no usable name typed. */
+const PLACEHOLDER_COMMAND = `actana pair new --label ${cliNamePlaceholder()}`;
+
+/**
  * The order `actana-pair.ts` writes those lines in, read off the `deps.out`
  * calls themselves. `Endpoint host` is dropped: it is printed only for
  * `--public-host`, which this wizard does not teach.
@@ -114,8 +135,8 @@ describe("the mint command", () => {
   it("names `--label` even when no name has been chosen", () => {
     // Dropping the flag would be the easy thing to do and would teach an
     // operator to skip the one field that makes `actana pair ls` readable.
-    expect(pairNewCommand("")).toBe("actana pair new --label <name>");
-    expect(pairNewCommand("   ")).toBe("actana pair new --label <name>");
+    expect(pairNewCommand("")).toBe(PLACEHOLDER_COMMAND);
+    expect(pairNewCommand("   ")).toBe(PLACEHOLDER_COMMAND);
   });
 
   it("folds the chosen name in, untouched when a shell would not mind", () => {
@@ -148,8 +169,8 @@ describe("a name the Core would refuse", () => {
     // in both flag forms, and quoting cannot help because the shell strips the
     // quotes first. Emitting it would hand the operator a command that fails on
     // paste — with the Panel to blame for printing it.
-    expect(pairNewCommand("-panel")).toBe("actana pair new --label <name>");
-    expect(composePairNewCommand("-panel")).toContain("--label <name>");
+    expect(pairNewCommand("-panel")).toBe(PLACEHOLDER_COMMAND);
+    expect(composePairNewCommand("-panel")).toContain(`--label ${cliNamePlaceholder()}`);
   });
 
   it("still refuses it in the CLI's own parser, which is why this exists", () => {

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -230,10 +230,22 @@ export function composePairNewCommand(label: string): string {
  * A name with a space in it silently becomes two arguments, and `pair new`
  * would take the first and reject the second — a failure the operator would
  * blame on the Panel, having pasted exactly what it printed.
+ *
+ * The placeholder is bare `NAME` for the same reason, and it is deliberately
+ * the CLI's own `NAME_PLACEHOLDER` (`packages/cli/src/actana-pair.ts`, #357
+ * review B3): `<name>` is not inert in a shell. Pasted into bash it parses as
+ * redirections — read stdin from a file called `name`, write stdout to the
+ * next word — so the command never runs and what the operator sees is
+ * `bash: name: No such file or directory`, a message that names neither
+ * `actana` nor the actual problem. This is the wizard's *default* state — an
+ * empty name box, behind a one-click copy button — so it is the likeliest
+ * thing of all to be pasted unedited. `NAME` reads as a slot just as clearly,
+ * survives every shell, and pasted unedited it mints a code labelled `NAME`,
+ * recoverable with one `actana core rm NAME`, which a shell error is not.
  */
 function labelArgument(label: string): string {
   const trimmed = label.trim();
-  if (trimmed === "" || labelRefusal(trimmed) !== null) return "<name>";
+  if (trimmed === "" || labelRefusal(trimmed) !== null) return "NAME";
   if (/^[A-Za-z0-9._:@%+,/=-]+$/.test(trimmed)) return trimmed;
   return `'${trimmed.replace(/'/g, `'\\''`)}'`;
 }

--- a/scripts/e2e-actana-setup-linux.mjs
+++ b/scripts/e2e-actana-setup-linux.mjs
@@ -443,7 +443,7 @@ async function main() {
     // Pinned by value: this script is plain node with no path to the CLI's
     // exports. `actana-pair.test.ts` pins the same wording against the
     // constant itself, so a change to it fails there first (#357 review B1).
-    "Settings (gear icon) -> Cores -> Add Core: this Core's address, then compare the " +
+    "Settings (gear icon) -> Cores -> Add a Core: this Core's address, then compare the " +
       "CA fingerprint, then the session and the code",
     "From a terminal",
     "npm i -g @actana/cli",


### PR DESCRIPTION
## Summary

The blocking finding from the second reviewer on the 0.4.3 gate
([PR #367 review](https://github.com/actana/control/pull/367#pullrequestreview-5070357362),
[inline](https://github.com/actana/control/pull/367#discussion_r3897673056)): the first-run wizard's default state — step 2,
empty name box — printed `actana pair new --label <name>` behind a one-click copy button, and `<name>` is the exact shell
hazard this same train removed from the CLI handout. Pasted into bash it parses as redirections and dies with
`bash: name: No such file or directory` — a message naming neither `actana` nor the problem, on the one line whose whole
promise is that it works when pasted.

`labelArgument` now returns the CLI's own bare `NAME` (`NAME_PLACEHOLDER`, `packages/cli/src/actana-pair.ts:712`), and
`pairNewCommand` / `composePairNewCommand` inherit it. Pasted unedited, it mints a code labelled `NAME` — recoverable with one
`actana core rm NAME`, which a shell error is not.

The Panel suite stops repeating the placeholder as a literal: it reads `NAME_PLACEHOLDER` out of the CLI printer, the way it
already reads the pinned label set and the printer's line order, so the two surfaces cannot drift apart again silently.

Also taken, non-blocking from the same review
([inline](https://github.com/actana/control/pull/367#discussion_r3897673080)): `PANEL_INSTRUCTION` said "Add Core" where the
form it points at is labelled "Add a Core" (`ADD_CORE_FIELD_LABEL`, the string #358 canonicalized for wizard and Settings).
That constant's doc says it is worded from the form, so the form's wording wins — one string, its test pin, and the copy
`scripts/e2e-actana-setup-linux.mjs` pins by value. No other behaviour changes.

**Base.** This targets `feat/0.4.3-onboarding`, the gate PR's own branch, so #367 carries the fix into `beta/0.4.3` as one
squash. The `Train rules` check may read that base as not-the-train; that is expected here and not a merge of this branch
into `main`.

## Related issues

Refs #367, #363, #357

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## How was this tested?

- [x] Unit tests added/updated
- [x] Manually verified (describe steps below)

- `pnpm -C packages/panel test` — 146 files, 1535 tests, all passing.
- `pnpm -C packages/cli test` — 50 files, 1179 tests passing (1 file / 3 tests skipped, as on the base).
- `pnpm -C packages/cli typecheck` and `pnpm -C packages/panel typecheck` clean; `pnpm lint` reports 0 errors
  (46 pre-existing warnings, unchanged).
- The three literals the reviewer named (`core-onboarding.test.ts` 117, 118, 151-152) now assert against the placeholder read
  out of `packages/cli`, and `first-run-gate.test.tsx` — which pinned the same broken string five times, including the copy
  button's accessible name and its clipboard payload — moves with them.
- Not run locally: `scripts/e2e-actana-setup-linux.mjs` (needs a Linux VM); its pinned `PANEL_INSTRUCTION` copy was updated
  by value, and `actana-pair.test.ts` fails first on any drift, by that pin's own design.

## Checklist

- [x] My PR title **and every commit in the branch** follow Conventional Commits, and my branch name follows the convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix works, and all tests pass locally
- [x] No secrets, credentials, or personal data are included in this change
