### PR TITLE
feat: the pairing endpoint in the frame, and a Compose jump to the redeem step

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,7 +5,19 @@
 #
 # then open http://localhost:7420, create the Operator, and give "Add Core" the
 # address core:8443 and that code — checking the fingerprint the Panel shows
-# against the one pair new printed. The Panel dials wss://core:8443 over this
+# against the one pair new printed.
+#
+# A Panel with no Cores opens on the first-run wizard, whose first two steps are
+# about installing a Core on another machine — which the line above has already
+# done, here, on this network. Skip them:
+#
+#   http://localhost:7420/?step=redeem
+#
+# It opens that wizard on its redeem step. The step is a shortcut and nothing
+# more: the address, the fingerprint comparison and the code are still asked
+# for, and a Panel that pairs nothing lands back on the wizard regardless.
+#
+# The Panel dials wss://core:8443 over this
 # network — which is why
 # ACTANA_PUBLIC_HOST below is the compose *service name* and not a real DNS
 # name. Both images are published, so a clean checkout needs nothing built.

--- a/packages/cli/src/__tests__/actana-pair.test.ts
+++ b/packages/cli/src/__tests__/actana-pair.test.ts
@@ -577,6 +577,95 @@ describe("actana pair new, at a terminal", () => {
     expect(screen()).toContain(sessionId);
   });
 
+  // The Panel's form asks for the address *first*, and until now the
+  // frame was the one surface that never said what to put in it — `Endpoint
+  // host` prints only down a pipe and only for `--public-host`. An operator at
+  // a terminal read four values off the box and had to derive the fifth.
+  describe("the endpoint row", () => {
+    /** The framed lines only, stripped of colour. */
+    function box(): string[] {
+      return out
+        .filter((line) => line.includes("│"))
+        .map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+    }
+
+    it("names the address inside the frame, not only under it", () => {
+      expect(runTty(["new", "--label", "laptop"])).toBe(0);
+      expect(box().some((line) => line.includes("Endpoint"))).toBe(true);
+      expect(box().some((line) => line.includes("10.0.0.5:8443"))).toBe(true);
+    });
+
+    it("sits above the fingerprint, the order the Panel's form gates them in", () => {
+      // Address, then fingerprint, then session and code — `PANEL_INSTRUCTION`.
+      // A box that has to be read out of order into the form is a box that
+      // will be read out of order into the form.
+      runTty(["new", "--label", "laptop"]);
+      const at = (needle: string) => box().findIndex((line) => line.includes(needle));
+      expect(at("Endpoint")).toBeGreaterThan(-1);
+      expect(at("CA fingerprint")).toBeGreaterThan(at("Endpoint"));
+      expect(at("Session")).toBeGreaterThan(at("CA fingerprint"));
+    });
+
+    it("is the address the credential names, not whichever one a command dials", async () => {
+      // The endpoint a paired client keeps comes off the stored session, so on
+      // a Core with three addresses there is still exactly one true answer to
+      // "what will this code register" — and it is the primary. Printing the
+      // dialled address here instead would contradict the `# dial …` notes.
+      material = await mintFreshMaterial(["core", "10.0.0.5", "core.example.test"]);
+      persistMaterialToFile(materialPath, material);
+
+      expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+      expect(box().some((line) => line.includes("Endpoint       core:8443"))).toBe(true);
+      // The other two are offered as commands, and only as commands.
+      for (const other of ["10.0.0.5:8443", "core.example.test:8443"]) {
+        expect(box().some((line) => line.includes(other))).toBe(false);
+        expect(commands().some((command) => command.includes(other))).toBe(true);
+      }
+    });
+
+    it("follows --public-host, because that is what the credential will carry", async () => {
+      material = await mintFreshMaterial(["core", "10.0.0.5"]);
+      persistMaterialToFile(materialPath, material);
+
+      expect(runTty(["new", "--label", "laptop", "--public-host", "10.0.0.5"])).toBe(0);
+
+      expect(box().some((line) => line.includes("Endpoint       10.0.0.5:8443"))).toBe(true);
+    });
+
+    it("wraps a long address rather than clipping it, and stays square", async () => {
+      // An address with an ellipsis in it is an address that fails to dial —
+      // the same rule the fingerprint follows, for the same reason.
+      const long = `a-very-long-core-host-name.${"sub.".repeat(8)}example.invalid`;
+      material = await mintFreshMaterial([long]);
+      persistMaterialToFile(materialPath, material);
+
+      expect(runTty(["new", "--label", "laptop"])).toBe(0);
+
+      // Measured on the plain text: an escape sequence has a length and no
+      // width, which is the whole reason `frameRow` pads the way it does.
+      for (const line of box()) expect(displayWidth(line)).toBe(FRAME_WIDTH);
+      for (const elision of ["...", "…"]) expect(screen()).not.toContain(elision);
+
+      // Nothing dropped: the rows under the `Endpoint` heading, in order and
+      // with nothing but the border and the gutter taken off, re-join to
+      // exactly the address — separators included.
+      const content = box().map((line) => line.replace(/^│/, "").replace(/│$/, "").trim());
+      const heading = content.findIndex((line) => line === "Endpoint");
+      expect(heading).toBeGreaterThan(-1);
+      const rest = content.slice(heading + 1);
+      const rejoined = rest.slice(0, rest.indexOf("")).join("");
+      expect(rejoined).toBe(`${long}:8443`);
+    });
+
+    it("changes nothing down a pipe", () => {
+      // The frame is where this row lives. The piped shape is what every script
+      // wrapping `pair new` reads, and it did not grow a field.
+      expect(run(["new", "--label", "laptop"])).toBe(0);
+      expect(out.some((line) => line.startsWith("Endpoint "))).toBe(false);
+    });
+  });
+
   // The wording is pinned to the *form*, not to a paraphrase of it.
   // `AddCoreByPairing.tsx` asks for the address first, gates everything behind
   // a compared CA fingerprint — "the Panel does not send the code until they

--- a/packages/cli/src/actana-pair.ts
+++ b/packages/cli/src/actana-pair.ts
@@ -98,6 +98,7 @@ import {
   frameRow,
   style,
   useColor,
+  wrapText,
 } from "./cli-frame.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
@@ -542,6 +543,44 @@ export function pairingHandout(handout: PairingHandout): string[] {
     ),
   );
   lines.push(frameRow([], color));
+
+  /**
+   * The address, in the box, because the Panel asks for it **first**.
+   *
+   * `PANEL_INSTRUCTION` sends the operator to a form whose first field is this
+   * Core's address, and until this row the frame was the one surface that never
+   * said what to put in it: `Endpoint host` prints only down a pipe and only
+   * for `--public-host`, so an operator at a terminal — the audience this
+   * whole block exists for — read four values off a screen and then had to
+   * work the fifth out for themselves. It sits above the fingerprint for the
+   * same reason: address, then fingerprint, then session and code is the order
+   * the form gates them in, and the frame should be readable top to bottom
+   * into it.
+   *
+   * **It is `credentialHost`, not whichever address a command below dials.**
+   * The endpoint a paired client keeps comes off the stored session — see
+   * {@link PairingHandout.credentialHost} — so on a multi-address Core this row
+   * is the one address that is true of the credential no matter which command
+   * was pasted. The `# dial …` notes under `From a terminal` are what explain
+   * the others; this row does not compete with them.
+   */
+  const credentialEndpoint = endpointAddress(handout.credentialHost, handout.port);
+  const endpointLabel = "Endpoint       ";
+  const endpointRoom = FRAME_CONTENT_WIDTH - displayWidth(endpointLabel);
+  if (displayWidth(credentialEndpoint) <= endpointRoom) {
+    lines.push(
+      frameRow([{ text: endpointLabel, style: ANSI.dim }, { text: credentialEndpoint }], color),
+    );
+  } else {
+    // **Wrapped, never clipped**, on the same rule the fingerprint follows: an
+    // address with an ellipsis in it is an address that fails to dial, and
+    // `wrapText` breaks on the `:` and `.` a long hostname is built out of.
+    lines.push(frameRow([{ text: "Endpoint", style: ANSI.dim }], color));
+    for (const chunk of wrapText(credentialEndpoint, FRAME_CONTENT_WIDTH - 3)) {
+      lines.push(frameRow([{ text: `   ${chunk}` }], color));
+    }
+  }
+  lines.push(frameRow([], color));
   // **Wrapped, never truncated.** The fingerprint is what the client checks the
   // certificate against before it sends the code, so a fingerprint with an
   // ellipsis in it is not a fingerprint — it is an invitation to guess.
@@ -584,7 +623,8 @@ export function pairingHandout(handout: PairingHandout): string[] {
   // {@link PairingHandout.credentialHost}. Saying only "reachable at X" would
   // hand an operator a command that pairs and then leaves their client pointed
   // somewhere it cannot reach, with nothing on the screen explaining why.
-  const credentialEndpoint = endpointAddress(handout.credentialHost, handout.port);
+  // The same value the `Endpoint` row above prints — computed once, so the box
+  // and the notes can never disagree about which address the credential names.
   for (const [index, host] of handout.hosts.entries()) {
     const endpoint = endpointAddress(host, handout.port);
     for (const note of hostNotes(handout, host, endpoint, credentialEndpoint)) {

--- a/packages/panel/src/components/views/FirstRunWizard.tsx
+++ b/packages/panel/src/components/views/FirstRunWizard.tsx
@@ -5,11 +5,15 @@ import { TextField } from "~/components/ui/TextField";
 import { AddCoreByPairing } from "~/components/views/AddCoreByPairing";
 import {
   ADD_CORE_LOCATION,
+  COMPOSE_SHORTCUT_ACTION,
+  COMPOSE_SHORTCUT_NOTICE,
   PAIR_NEW_OUTPUT,
   composePairNewCommand,
   coreInstallPaths,
+  firstRunStepFromSearch,
   labelRefusal,
   pairNewCommand,
+  type FirstRunStepId,
 } from "~/shared/core-onboarding";
 import type { CoreWithDial } from "~/shared/cores";
 import { CURRENT_MC_VERSION } from "~/queries/mission-control-version";
@@ -40,12 +44,19 @@ import { CURRENT_MC_VERSION } from "~/queries/mission-control-version";
  * reaches the Panel's dashboard exactly as often as standing still does: never.
  */
 
-/** The three steps, in the order the machine has to do them. */
+/**
+ * The three steps, in the order the machine has to do them.
+ *
+ * The ids are pinned to `FIRST_RUN_STEP_IDS` rather than spelled out freely:
+ * `?step=` parses against that tuple and `deploy/docker-compose.yml` links one
+ * of them, so a renamed step here has to be a renamed step there, and
+ * `satisfies` is what makes that a compile error instead of a dead link.
+ */
 const STEPS = [
   { id: "install", title: "Install the Core", blurb: "on the machine you want to drive" },
   { id: "mint", title: "Mint a pairing code", blurb: "on that machine, in its terminal" },
   { id: "redeem", title: "Redeem it here", blurb: "in this Panel, with what it printed" },
-] as const;
+] as const satisfies readonly { id: FirstRunStepId; title: string; blurb: string }[];
 
 type StepIndex = 0 | 1 | 2;
 
@@ -69,7 +80,23 @@ export function FirstRunWizard({
    */
   registryError?: string | null;
 }) {
-  const [step, setStep] = useState<StepIndex>(0);
+  /**
+   * Where to open, read from the URL once.
+   *
+   * In the initialiser rather than an effect, so the requested step is the
+   * first thing painted rather than a flash of step 1 that jumps — and read
+   * once rather than subscribed to, because this is a starting position and
+   * not a route. Nothing writes the parameter back as the operator moves, for
+   * the same reason: a wizard that rewrites the address bar mid-pairing makes
+   * the browser's back button look like a way out of a gate that has none.
+   *
+   * `window.location` and not the router, because the gate renders the wizard
+   * in place of the whole shell at whatever route the operator happened to
+   * land on — there is no wizard route to hang a validated search on.
+   */
+  const [step, setStep] = useState<StepIndex>(
+    () => firstRunStepFromSearch(window.location.search) ?? 0,
+  );
   // The name this Panel will be called on the Core, folded live into the mint
   // command. Kept here rather than inside step 2 so stepping away and back
   // does not silently drop what was typed.
@@ -98,6 +125,10 @@ export function FirstRunWizard({
       >
         <Header />
         {registryError && <RegistryErrorBox message={registryError} />}
+        {/* Only where it is an offer. On step 3 the operator is already where
+            it would send them, and a bar advertising the screen you are looking
+            at is noise on the one screen that is asking for a credential. */}
+        {step < 2 && <ComposeShortcutBar label={label} onSkip={() => setStep(2)} />}
         <StepRail step={step} onStep={setStep} />
 
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
@@ -174,6 +205,76 @@ function RegistryErrorBox({ message }: { message: string }) {
       This Panel could not read its own list of Cores, so it cannot tell an empty fleet from an
       unanswered question: {message}
     </div>
+  );
+}
+
+/**
+ * The Compose disclaimer — for the operator whose Core is already up.
+ *
+ * `deploy/docker-compose.yml` starts a Panel *and* a Core, so someone who came
+ * that way has finished step 1 without knowing it was a step, and the two
+ * screens in front of them are install advice for a machine they have already
+ * provisioned. This says so and hands them the one command that is genuinely
+ * still outstanding — the `exec` that mints a code — beside a jump to the
+ * screen that spends it.
+ *
+ * **It asserts nothing.** The Panel cannot tell how it was started
+ * (`COMPOSE_SHORTCUT_NOTICE`), so this is phrased as a question the operator
+ * answers, sits *beside* the rail rather than replacing it, and hides no step:
+ * someone who reads it and is not on Compose has lost one line of screen. That
+ * is the right trade against silently skipping an install step for somebody
+ * who needed it.
+ */
+function ComposeShortcutBar({ label, onSkip }: { label: string; onSkip: () => void }) {
+  return (
+    <div
+      data-compose-shortcut
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: "10px 12px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderLeft: "2px solid var(--accent)",
+        borderRadius: 7,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ flex: 1, minWidth: 220, fontSize: 12.5, lineHeight: 1.5, color: "var(--text-dim)" }}>
+          <Ticked text={COMPOSE_SHORTCUT_NOTICE} />
+        </div>
+        <Btn variant="frame" size="sm" onClick={onSkip}>
+          {COMPOSE_SHORTCUT_ACTION}
+        </Btn>
+      </div>
+      <CommandLine command={composePairNewCommand(label)} />
+    </div>
+  );
+}
+
+/**
+ * Prose with `backticked` runs rendered as code.
+ *
+ * The onboarding strings are written once and read by a person, and the two
+ * values in this one — a command and an address — are things to be typed
+ * exactly. Marking them in the string keeps the copy in
+ * `core-onboarding.ts`, where a test can read it, rather than splitting one
+ * sentence across three JSX children.
+ */
+function Ticked({ text }: { text: string }) {
+  return (
+    <>
+      {text.split("`").map((piece, index) =>
+        index % 2 === 1 ? (
+          <code key={index} style={{ fontFamily: "var(--mono)", color: "var(--text)" }}>
+            {piece}
+          </code>
+        ) : (
+          <span key={index}>{piece}</span>
+        ),
+      )}
+    </>
   );
 }
 

--- a/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
+++ b/packages/panel/src/components/views/__tests__/first-run-gate.test.tsx
@@ -66,7 +66,12 @@ const { FirstRunGate } = await import("../FirstRunGate");
 const { announceCoreRegistryChanged } = await import("~/lib/core-registry-changed");
 const { writeCachedCoreCount } = await import("~/lib/shell-query-cache");
 const { CURRENT_MC_VERSION } = await import("~/queries/mission-control-version");
-const { ADD_CORE_LOCATION, composeUpCoreCommand } = await import("~/shared/core-onboarding");
+const {
+  ADD_CORE_LOCATION,
+  COMPOSE_SHORTCUT_ACTION,
+  composePairNewCommand,
+  composeUpCoreCommand,
+} = await import("~/shared/core-onboarding");
 // Warm the chunk the gate loads lazily. `FirstRunWizard` is imported with
 // `React.lazy` — it has no business in the entry bundle of a Panel that has a
 // fleet — and an unpopulated module registry means React suspends on a promise
@@ -131,6 +136,9 @@ describe("the first-run gate (#358)", () => {
     // The gate seeds its first render from a localStorage count, so a value one
     // test wrote would decide the next test's first paint.
     window.localStorage.clear();
+    // The wizard reads `?step=` once, at mount. A parameter one test set would
+    // silently open the next test's wizard on a different screen.
+    window.history.replaceState({}, "", "/");
     vi.clearAllMocks();
     api.listCores.mockImplementation(async () => ({ cores: CORES }));
     api.inspectCoreForPairing.mockImplementation(async () => ({
@@ -428,6 +436,115 @@ describe("the first-run gate (#358)", () => {
       expect(wizard()).toBeTruthy();
       expect(dashboard()).toBeNull();
       expect(screen.getByRole("alert").textContent).toContain("that code has been used");
+    });
+  });
+
+  /**
+   * The Compose shortcut.
+   *
+   * `docker compose up -d` starts a Panel and a Core together, so the operator
+   * who came that way finished step 1 before the wizard existed for them. Two
+   * halves: a bar that says so, and a `?step=` link the Compose file hands out.
+   *
+   * What these hold is that the shortcut is a *starting position* — it moves
+   * the wizard and touches nothing else. The gate is still a live Core count,
+   * and the redemption is still the same form asking for the same fingerprint.
+   */
+  describe("the Compose shortcut", () => {
+    /** Which rail entry is current, 1-based, as the operator sees it. */
+    function currentStep(): number {
+      const rail = [...document.querySelectorAll("[aria-current='step']")];
+      const label = rail[0]?.textContent ?? "";
+      return Number(/Step (\d)/.exec(label)?.[1] ?? 0);
+    }
+
+    function bar(): HTMLElement | null {
+      return document.querySelector("[data-compose-shortcut]");
+    }
+
+    /** Open the Panel at a URL, the way the Compose file's link does. */
+    async function mountAt(search: string): Promise<void> {
+      window.history.replaceState({}, "", `/${search}`);
+      await mount();
+    }
+
+    it("opens on step 1 when nothing asked otherwise", async () => {
+      await mount();
+      expect(currentStep()).toBe(1);
+    });
+
+    it("opens on the redeem step for the link Compose prints", async () => {
+      await mountAt("?step=redeem");
+      expect(currentStep()).toBe(3);
+      // Not just the rail: the redemption form is the thing on screen.
+      expect(screen.getByLabelText("Core address")).toBeTruthy();
+    });
+
+    it("takes the step number too", async () => {
+      await mountAt("?step=3");
+      expect(currentStep()).toBe(3);
+    });
+
+    it("opens at the beginning on a stale or malformed link", async () => {
+      await mountAt("?step=nowhere");
+      expect(currentStep()).toBe(1);
+      expect(wizard()).toBeTruthy();
+    });
+
+    it("offers the bar on the steps it can skip, and not on the one it lands on", async () => {
+      await mount();
+      expect(bar()).toBeTruthy();
+      await goToStep(2);
+      expect(bar()).toBeTruthy();
+      await goToStep(3);
+      // Advertising the screen you are already reading, on the screen that is
+      // asking for a credential.
+      expect(bar()).toBeNull();
+    });
+
+    it("carries the one command Compose has genuinely not run yet", async () => {
+      // Skipping to step 3 without the mint command would strand the operator
+      // on a form asking for a code nothing has printed.
+      await mount();
+      expect(bar()?.textContent).toContain(composePairNewCommand(""));
+    });
+
+    it("jumps to the redeem step when clicked", async () => {
+      await mount();
+      expect(currentStep()).toBe(1);
+      await click(COMPOSE_SHORTCUT_ACTION);
+      expect(currentStep()).toBe(3);
+      expect(screen.getByLabelText("Core address")).toBeTruthy();
+    });
+
+    it("leaves every step reachable — it skips, it does not remove", async () => {
+      await mountAt("?step=redeem");
+      await goToStep(1);
+      expect(currentStep()).toBe(1);
+      expect(screen.getByText(composeUpCoreCommand(CURRENT_MC_VERSION))).toBeTruthy();
+    });
+
+    it("is not a way past the gate: the dashboard still costs a paired Core", async () => {
+      // The one thing a URL parameter must never buy. The gate reads the Core
+      // registry, and a deep link does not put a Core in it.
+      await mountAt("?step=redeem");
+      expect(wizard()).toBeTruthy();
+      expect(dashboard()).toBeNull();
+
+      await pair();
+
+      expect(dashboard()).toBeTruthy();
+      expect(wizard()).toBeNull();
+    });
+
+    it("still makes the operator compare the fingerprint", async () => {
+      // Skipping the reading does not skip the checking: step 3 is the same
+      // `AddCoreByPairing` Settings mounts, gated the same way.
+      await mountAt("?step=redeem");
+      type("Core address", "prod-vm-1.internal:7777");
+      await click("Check fingerprint");
+      expect(api.pairCore).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("CA fingerprint from `actana pair new`")).toBeTruthy();
     });
   });
 });

--- a/packages/panel/src/shared/__tests__/core-onboarding.test.ts
+++ b/packages/panel/src/shared/__tests__/core-onboarding.test.ts
@@ -4,11 +4,17 @@ import { describe, expect, it } from "vitest";
 import {
   ADD_CORE_FIELD_LABEL,
   ADD_CORE_LOCATION,
+  COMPOSE_SHORTCUT_ACTION,
+  COMPOSE_SHORTCUT_NOTICE,
+  FIRST_RUN_STEP_IDS,
+  FIRST_RUN_STEP_PARAM,
   PAIR_NEW_OUTPUT,
+  REDEEM_STEP_LINK,
   composePairNewCommand,
   composeUpCoreCommand,
   coreImageTag,
   coreInstallPaths,
+  firstRunStepFromSearch,
   labelRefusal,
   pairNewCommand,
 } from "../core-onboarding";
@@ -230,5 +236,98 @@ describe("what the wizard puts on screen", () => {
 
   it("names the canonical Add-a-Core location once", () => {
     expect(ADD_CORE_LOCATION).toBe(`Settings → Cores → ${ADD_CORE_FIELD_LABEL}`);
+  });
+});
+
+/**
+ * The Compose shortcut.
+ *
+ * An operator who came from `deploy/docker-compose.yml` has a Core running
+ * beside this Panel before they ever see the wizard, so its first two screens
+ * are install advice for a machine they already provisioned. The parameter
+ * lets a link skip them; the bar tells them the link exists.
+ */
+describe("opening the wizard on a given step", () => {
+  it("takes the step's own id", () => {
+    expect(firstRunStepFromSearch("?step=install")).toBe(0);
+    expect(firstRunStepFromSearch("?step=mint")).toBe(1);
+    expect(firstRunStepFromSearch("?step=redeem")).toBe(2);
+  });
+
+  it("takes the 1-based number the rail puts on screen", () => {
+    // The rail is labelled "Step 1".."Step 3", and someone told to jump to the
+    // third step will type 3 before they will type `redeem`.
+    expect(firstRunStepFromSearch("?step=1")).toBe(0);
+    expect(firstRunStepFromSearch("?step=3")).toBe(2);
+  });
+
+  it("is forgiving about case and whitespace, and works with other parameters", () => {
+    expect(firstRunStepFromSearch("?step=REDEEM")).toBe(2);
+    expect(firstRunStepFromSearch("?step=%20redeem%20")).toBe(2);
+    expect(firstRunStepFromSearch("?foo=bar&step=redeem&baz=1")).toBe(2);
+    expect(firstRunStepFromSearch("step=redeem")).toBe(2);
+  });
+
+  it("says nothing rather than throwing when it is absent or unrecognised", () => {
+    // A stale bookmark opens the wizard at the beginning. It does not break it.
+    for (const search of ["", "?", "?other=1", "?step=", "?step=0", "?step=4", "?step=redem"]) {
+      expect(firstRunStepFromSearch(search)).toBeNull();
+    }
+  });
+
+  it("covers every step the wizard has, and invents none", () => {
+    expect(FIRST_RUN_STEP_IDS).toEqual(["install", "mint", "redeem"]);
+    for (const [index, id] of FIRST_RUN_STEP_IDS.entries()) {
+      expect(firstRunStepFromSearch(`?${FIRST_RUN_STEP_PARAM}=${id}`)).toBe(index);
+    }
+  });
+
+  it("has a link that opens the last step, and it is relative", () => {
+    // A Panel is reached at whatever address is in front of it; a link with an
+    // origin baked in would be right for exactly one deployment.
+    expect(firstRunStepFromSearch(REDEEM_STEP_LINK)).toBe(FIRST_RUN_STEP_IDS.length - 1);
+    expect(REDEEM_STEP_LINK.startsWith("?")).toBe(true);
+  });
+});
+
+describe("the Compose disclaimer", () => {
+  /** `deploy/docker-compose.yml`, read as text. */
+  const COMPOSE = readFileSync(
+    fileURLToPath(new URL("../../../../../deploy/docker-compose.yml", import.meta.url)),
+    "utf8",
+  );
+
+  it("is offered by the file it is about", () => {
+    // The bar is only half the feature: the operator has to be told the link
+    // exists somewhere they are already reading, and that is the Compose file
+    // whose `up -d` put them in this position.
+    expect(COMPOSE).toContain(REDEEM_STEP_LINK);
+  });
+
+  it("names the address that Compose actually serves the Core on", () => {
+    // `core:8443` is the compose service name, and it is what the redeem step's
+    // first field wants. A disclaimer that skipped two screens without saying
+    // this would strand the operator on the third.
+    expect(COMPOSE_SHORTCUT_NOTICE).toContain("core:8443");
+    expect(COMPOSE).toContain("core:8443");
+  });
+
+  it("asks rather than asserts, because nothing here can detect Compose", () => {
+    // The Panel has no marker for how it was started. The bar is therefore a
+    // question the operator answers about themselves — if it ever starts
+    // claiming, it is claiming something it cannot know.
+    expect(COMPOSE_SHORTCUT_NOTICE).toContain("?");
+  });
+
+  it("is worded as a move between steps, not as a way out of them", () => {
+    // The wizard is a gate, and `first-run-gate.test.tsx` scans every button on
+    // every step for the words an escape hatch gets named. This control lands
+    // on the step that pairs a Core — the gate's only exit — so it must not be
+    // called "Skip", and neither this label nor the notice may carry the words
+    // that guard is looking for.
+    expect(COMPOSE_SHORTCUT_ACTION).toBe("Jump to step 3");
+    for (const copy of [COMPOSE_SHORTCUT_ACTION, COMPOSE_SHORTCUT_NOTICE]) {
+      expect(copy).not.toMatch(/skip|dismiss|later|not now|close|continue anyway|explore/i);
+    }
   });
 });

--- a/packages/panel/src/shared/core-onboarding.ts
+++ b/packages/panel/src/shared/core-onboarding.ts
@@ -103,6 +103,95 @@ export function coreInstallPaths(panelVersion: string): readonly CoreInstallPath
 export const COMPOSE_EXEC_PREFIX = "docker compose -f deploy/docker-compose.yml exec core";
 
 /**
+ * The wizard's three steps, as ids, in the order the machine has to do them.
+ *
+ * Here rather than in the component because {@link firstRunStepFromSearch}
+ * parses them out of a URL and a link in `deploy/docker-compose.yml` writes one
+ * of them by hand. Three places naming the same three strings is how a deep
+ * link starts pointing at a step that no longer exists.
+ */
+export const FIRST_RUN_STEP_IDS = ["install", "mint", "redeem"] as const;
+export type FirstRunStepId = (typeof FIRST_RUN_STEP_IDS)[number];
+
+/** The query parameter that opens the wizard on a given step. */
+export const FIRST_RUN_STEP_PARAM = "step";
+
+/**
+ * Which step a URL asks for, or null for "start at the beginning".
+ *
+ * **This chooses a starting position and can do nothing else.** Every step is
+ * already reachable by clicking the rail, so a link that opens step 3 is a
+ * shortcut past two screens of reading and not a way around anything: the gate
+ * is a live Core count (`FirstRunGate`), the redemption is still a fingerprint
+ * comparison the operator performs, and a Panel with no paired Core lands back
+ * here on the next load whatever the URL said. Nothing downstream may read this
+ * value, and nothing about pairing may become easier because it was set.
+ *
+ * Both spellings are accepted because both are natural to type and neither is
+ * ambiguous: the step's id (`?step=redeem`) reads at a glance in the Compose
+ * file, and its 1-based position (`?step=3`) is what someone who has just been
+ * told "jump to the third step" will try. An unknown value is null rather than
+ * an error — a stale bookmark should open the wizard, not break it.
+ */
+export function firstRunStepFromSearch(search: string): 0 | 1 | 2 | null {
+  const raw = new URLSearchParams(search).get(FIRST_RUN_STEP_PARAM);
+  if (raw === null) return null;
+  const wanted = raw.trim().toLowerCase();
+
+  const byId = FIRST_RUN_STEP_IDS.indexOf(wanted as FirstRunStepId);
+  if (byId >= 0) return byId as 0 | 1 | 2;
+
+  // 1-based, because the rail is labelled "Step 1", "Step 2", "Step 3" and a
+  // person reading a URL off that screen counts from one.
+  if (/^[123]$/.test(wanted)) return (Number(wanted) - 1) as 0 | 1 | 2;
+
+  return null;
+}
+
+/**
+ * The deep link that opens the wizard on the redeem step.
+ *
+ * Relative, and deliberately not built from an origin: a Panel is reached at
+ * whatever address its operator put in front of it — `localhost:7420`, a LAN
+ * name, a reverse proxy — and this module has no business guessing which.
+ */
+export const REDEEM_STEP_LINK = `?${FIRST_RUN_STEP_PARAM}=redeem`;
+
+/**
+ * The disclaimer the wizard shows above the rail, for the operator whose Core
+ * is already running.
+ *
+ * `deploy/docker-compose.yml` brings up a `panel` **and** a `core` on one
+ * network, so an operator who came that way has done step 1 before they ever
+ * saw this screen — the machine is provisioned and the daemon is up. What they
+ * have not done is mint a code, which is one `exec` away, and the wizard's
+ * first two screens are two screens of install advice they do not need.
+ *
+ * **It is a disclaimer, not a detection.** Nothing in the Panel can tell that
+ * it came up under Compose: the container has no marker for it, the
+ * environment carries no flag, and inventing one would be a runtime dependency
+ * on a deployment shape the product does not otherwise care about. So the bar
+ * states the condition and lets the operator recognise themselves in it — which
+ * is also why it never hides a step or preselects one, and why the rail behind
+ * it keeps all three reachable.
+ */
+export const COMPOSE_SHORTCUT_NOTICE =
+  "Came here from `docker compose up -d`? Then the Core is already installed and running beside this Panel at `core:8443` — step 1 is done. Mint a code with the one command below and jump ahead.";
+
+/**
+ * The label on the bar's jump.
+ *
+ * **Worded as a move between steps, never as a way out of them.** The wizard is
+ * a gate — no skip, no dismiss, no later — and `first-run-gate.test.tsx` scans
+ * every button on every step for exactly those words. This control is not an
+ * exception to that rule: it goes *to* the step that pairs a Core, which is the
+ * gate's only exit condition, so naming it "Skip…" would describe the opposite
+ * of what it does and would rightly trip a guard that exists to catch an escape
+ * hatch somebody added later.
+ */
+export const COMPOSE_SHORTCUT_ACTION = "Jump to step 3";
+
+/**
  * What the canonical Add-a-Core surface is called, so the wizard and the
  * settings page name one place with one string (#358 asks for exactly that).
  *


### PR DESCRIPTION
Two things an operator was left to work out for themselves.

## The pairing endpoint, inside the frame

The Panel's "Add a Core" form asks for the Core's address **first**, and the framed block — the shape built for a human at a terminal — was the one surface that never said what to put in it. `Endpoint host` prints only down a pipe, and only for `--public-host`, so at a terminal the address was on screen solely inside the pasteable `actana core pair` commands under the box.

```
╭────────────────────────────────────────────────────────────────────────╮
│                                                                        │
│   Pairing code                                                         │
│                                                                        │
│      4XGW-53B3                                                         │
│                                                                        │
│   Expires        2026-09-01T19:06:32Z (in 5 minutes)                   │
│                                                                        │
│   Endpoint       core:8443                                             │
│                                                                        │
│   CA fingerprint                                                       │
│      5E:1E:26:93:3E:18:97:F5:A3:43:42:D8:F4:C2:E9:D6:                  │
│      EA:78:9C:0A:28:7E:5C:19:93:CC:6B:3D:66:8D:FA:DC                   │
│                                                                        │
│   Session        2e1fb155-d7bb-47e9-a85f-6b6702b27fa1                  │
│   Label          my-panel                                              │
│                                                                        │
╰────────────────────────────────────────────────────────────────────────╯
```

The row sits above the fingerprint so the box reads top to bottom in the order `PANEL_INSTRUCTION` gates the form's fields: address, fingerprint, session, code.

**It prints `credentialHost`** — the address the credential will actually name — not whichever address a given command dials. On a multi-address Core those differ, and the `# dial …` notes under `From a terminal` are what explain the others; this row does not compete with them. Verified live on a three-address Core (`core,192.168.178.40,localhost`): the box says `core:8443` while all three commands are offered, two of them carrying `# dial … — but this code still registers core:8443`. With `--public-host` the row follows the choice.

Long addresses wrap on their own separators rather than clipping, on the same rule the fingerprint follows — an address with an ellipsis in it is an address that fails to dial.

**The piped path did not move a byte.** The row lives in the frame only, so every script wrapping `pair new` reads exactly what it read before. The existing whole-output `toEqual` assertions cover that, plus a new explicit one.

## A Compose disclaimer, and a `?step=` deep link

`docker compose up -d` starts a Panel **and** a Core, so an operator arriving that way has finished the wizard's step 1 without knowing it was a step, and the two screens in front of them are install advice for a machine they already provisioned.

A bar above the rail says so and carries the one command Compose genuinely has not run — the `exec` that mints a code — beside a jump to the step that spends it. `deploy/docker-compose.yml` now prints the link that opens there directly.

**The bar asks rather than asserts.** Nothing in the Panel can detect that it came up under Compose — the container has no marker for it and the environment carries no flag — so it is phrased as a question the operator answers about themselves, sits *beside* the rail rather than replacing it, and hides no step.

**The jump is named "Jump to step 3", not "Skip".** The wizard is a gate, and its suite scans every button on every step for `skip|dismiss|later|not now|close|continue anyway|explore`. That guard is right and is left untouched: this control moves *toward* the gate's only exit — a paired Core — rather than around it, so it is named for what it does. A test pins both the label and the notice against that same pattern.

`?step=` chooses a starting position and nothing else. The gate is still a live Core count, the fingerprint comparison is still performed, and a Panel that pairs nothing lands back on the wizard whatever the URL said — each covered by a test. It accepts the step id (`?step=redeem`) and its 1-based position (`?step=3`); an unrecognised value opens the wizard at the beginning rather than erroring, so a stale bookmark cannot break it.

## Verification

- `packages/cli` — 101/101 in `actana-pair.test.ts`; `tsc --noEmit` clean.
- `packages/panel` — 61/61 across `core-onboarding.test.ts` and `first-run-gate.test.tsx`; `typecheck` clean; eslint clean on all changed files.
- Ran end to end on a clean-volume Compose stack: a real image build of the Panel from this branch, and the Core image with this branch's `actana-cli.cjs` bundle overlaid (a Linux Core tarball cannot be built on an arm64 Mac — `build-core-tarball.mjs` refuses a target its host cannot honestly build).

**Pre-existing failures, not from this change:** `packages/panel`'s full suite is flaky independently of it — three runs produced three different failing files (`terminals-in-browser`, `cores-settings-rename`) — and `actana-machine-cli.test.ts` fails identically on an untouched checkout of this branch's base, which I confirmed by stashing.
