### PR TITLE
docs: drop dead docs/ pointers from source comments

### DIFF
--- a/deploy/core.Dockerfile
+++ b/deploy/core.Dockerfile
@@ -8,9 +8,9 @@
 # update. The metal path — install.sh, `actana setup`, a user service — is
 # untouched and unrelated; this is a second distribution, not a replacement.
 #
-# CVE posture, stated accurately (D6) — measured on this file, on 2026-08-04,
-# from a single build of it scanned with `trivy image`. The write-up of that
-# run has since been deleted, so the numbers below are the surviving record.
+# CVE posture, stated accurately (D6) — measured on 2026-08-04, across this
+# file and cut-down variants of it, scanned with Trivy. The write-up of that
+# run was deleted in 96f7b07 and is readable at 96f7b07^.
 #
 # The base did change, but the base is NOT the mechanism, and anyone
 # summarising it that way will mislead the next reader. The base contributes

--- a/deploy/core.Dockerfile
+++ b/deploy/core.Dockerfile
@@ -9,7 +9,8 @@
 # untouched and unrelated; this is a second distribution, not a replacement.
 #
 # CVE posture, stated accurately (D6) — measured on this file, on 2026-08-04,
-# and written up in docs/research/core-base-measure/core-image-2026-08-04.md.
+# from a single build of it scanned with `trivy image`. The write-up of that
+# run has since been deleted, so the numbers below are the surviving record.
 #
 # The base did change, but the base is NOT the mechanism, and anyone
 # summarising it that way will mislead the next reader. The base contributes

--- a/packages/shared/src/schema-bootstrap.ts
+++ b/packages/shared/src/schema-bootstrap.ts
@@ -464,77 +464,74 @@ export function ensureSchema(sqlite: Database.Database): void {
   // current from here on.
   backfillTokenUsageRollup(sqlite);
 
-  // Actana Control removed the Mission Pet subsystem (docs/specs/02-remove-pet.md).
-  // Every boot idempotently drops the six pet_* rows from app_settings so a
-  // DB carried over from a pre-cutover Mission Control install doesn't keep
-  // dead pet state around. Stays in the tree for one release, then removed.
+  // Actana Control removed the Mission Pet subsystem. Every boot idempotently
+  // drops the six pet_* rows from app_settings so a DB carried over from a
+  // pre-cutover Mission Control install doesn't keep dead pet state around.
+  // Stays in the tree for one release, then removed.
   dropLegacyPetSettings(sqlite);
 
-  // Actana Control removed voice / Whisper (docs/specs/01-remove-whisper.md).
-  // Every boot idempotently drops the voice_command_aliases row from
-  // app_settings and any project_memories rows tagged source='voice', so a
-  // DB carried over from a pre-cutover install doesn't keep dead voice state
-  // around. Stays in the tree for one release, then removed.
+  // Actana Control removed voice / Whisper. Every boot idempotently drops the
+  // voice_command_aliases row from app_settings and any project_memories rows
+  // tagged source='voice', so a DB carried over from a pre-cutover install
+  // doesn't keep dead voice state around. Stays in the tree for one release,
+  // then removed.
   dropLegacyVoiceSettings(sqlite);
 
   // Actana Control removed the Scratch Pad, Custom Scripts / Launch Commands,
-  // and Prompt Search surfaces (docs/specs/07-remove-convenience.md). Every
-  // boot idempotently drops the prompts + scratch_pads tables plus the
-  // projects.launch_commands, projects.custom_scripts, and
-  // user_terminals.start_command columns so a DB carried over from a
-  // pre-cutover Mission Control install doesn't keep the dead schema around.
-  // Stays in the tree for one release, then removed.
+  // and Prompt Search surfaces. Every boot idempotently drops the prompts +
+  // scratch_pads tables plus the projects.launch_commands,
+  // projects.custom_scripts, and user_terminals.start_command columns so a DB
+  // carried over from a pre-cutover Mission Control install doesn't keep the
+  // dead schema around. Stays in the tree for one release, then removed.
   dropLegacyConvenienceSurfaces(sqlite);
 
-  // Actana Control removed Recall / project memory / code graph
-  // (docs/specs/04-remove-recall-and-memory.md). Every boot idempotently drops
-  // the project_memory table (+ its FTS5 shadow tables/triggers), the three
-  // graph_* tables and their indexes, and the ten recall_* rows (plus the
-  // stray code_graph_state legacy blob) from app_settings, so a DB carried
-  // over from a pre-cutover install doesn't keep dead recall state around.
-  // Stays in the tree for one release, then removed.
+  // Actana Control removed Recall / project memory / code graph. Every boot
+  // idempotently drops the project_memory table (+ its FTS5 shadow
+  // tables/triggers), the three graph_* tables and their indexes, and the ten
+  // recall_* rows (plus the stray code_graph_state legacy blob) from
+  // app_settings, so a DB carried over from a pre-cutover install doesn't keep
+  // dead recall state around. Stays in the tree for one release, then removed.
   dropLegacyRecallMemoryGraph(sqlite);
 
   // Actana Control removed bundled agent skills and the diagram HTTP API
-  // (docs/specs/05-remove-bundled-skills.md, ADR 0006). Every boot
-  // idempotently drops the task_diagrams table (+ its indexes and the
-  // 0012-rename dance leftover), and any diagram_* / ship_skill_* /
-  // diagram_skill_* rows from app_settings, so a DB carried over from a
-  // pre-cutover install doesn't keep the dead diagram state around.
-  // Stays in the tree for one release, then removed.
+  // (ADR 0006). Every boot idempotently drops the task_diagrams table (+ its
+  // indexes and the 0012-rename dance leftover), and any diagram_* /
+  // ship_skill_* / diagram_skill_* rows from app_settings, so a DB carried
+  // over from a pre-cutover install doesn't keep the dead diagram state
+  // around. Stays in the tree for one release, then removed.
   dropLegacyBundledSkillsSchema(sqlite);
 
   // Actana Control removed the IDE-adjacent file editor / finder / HTML
-  // preview / markdown annotator surface (docs/specs/06-remove-ide-adjacent.md).
-  // Every boot idempotently drops the two annotation_* rows from app_settings
-  // and scrubs file.finder / file.save entries from every keybindings:* blob,
-  // so a DB carried over from a pre-cutover install doesn't keep dead
-  // annotation settings or orphan hotkey overrides around. Stays in the tree
-  // for one release, then removed.
+  // preview / markdown annotator surface. Every boot idempotently drops the
+  // two annotation_* rows from app_settings and scrubs file.finder /
+  // file.save entries from every keybindings:* blob, so a DB carried over
+  // from a pre-cutover install doesn't keep dead annotation settings or
+  // orphan hotkey overrides around. Stays in the tree for one release, then
+  // removed.
   dropLegacyIdeAdjacentSettings(sqlite);
 
   // Actana Control removed the managed sandbox / remote VM subsystem
-  // (docs/specs/10-remove-sandbox.md, ADR 0009). Every boot idempotently drops
-  // the sandboxes table, the sandbox_id / scope_id columns and their indexes,
-  // and the sandbox.* / multiSandbox.* app_settings rows, so a DB carried over
-  // from a pre-cutover install doesn't keep the dead sandbox schema around.
-  // Stays in the tree for one release, then removed.
+  // (ADR 0009). Every boot idempotently drops the sandboxes table, the
+  // sandbox_id / scope_id columns and their indexes, and the sandbox.* /
+  // multiSandbox.* app_settings rows, so a DB carried over from a pre-cutover
+  // install doesn't keep the dead sandbox schema around. Stays in the tree
+  // for one release, then removed.
   dropLegacySandboxSchema(sqlite);
 
-  // Actana Control removed worktree management and git integration
-  // (docs/specs/11-remove-worktree-and-git.md). Every boot idempotently drops
-  // the worktrees table, the tasks/user_terminals worktree_id columns and
-  // their indexes, the projects branch / worktree_setup_command columns, and
-  // the worktree / git-diff app_settings rows. Sessions previously bound to a
-  // non-default worktree collapse to the project's single implicit path (rows
-  // are kept). Stays in the tree for one release, then removed.
+  // Actana Control removed worktree management and git integration. Every boot
+  // idempotently drops the worktrees table, the tasks/user_terminals
+  // worktree_id columns and their indexes, the projects branch /
+  // worktree_setup_command columns, and the worktree / git-diff app_settings
+  // rows. Sessions previously bound to a non-default worktree collapse to the
+  // project's single implicit path (rows are kept). Stays in the tree for one
+  // release, then removed.
   dropLegacyWorktreeSchema(sqlite);
 
-  // Actana Control adopted the Studio look as the sole Panel look
-  // (docs/specs/12-adopt-studio-look.md). Every boot idempotently drops the
-  // fourteen theming rows from app_settings — every theming setting other
-  // than dark/light (which lives in localStorage as mc:theme) collapsed to a
-  // fixed default. Stays in the tree for one release, then removed.
+  // Actana Control adopted the Studio look as the sole Panel look. Every boot
+  // idempotently drops the fourteen theming rows from app_settings — every
+  // theming setting other than dark/light (which lives in localStorage as
+  // mc:theme) collapsed to a fixed default. Stays in the tree for one release,
+  // then removed.
   dropLegacyThemeSettings(sqlite);
 
   // Actana Control removed the project-root terminal (issue 266). The Panel


### PR DESCRIPTION
#371 deleted `docs/specs/`, `docs/tickets/`, `docs/research/` and `docs/upstream/` and repointed the inbound markdown links. Two reference classes survived, because they are comments in source rather than markdown links, so a link sweep never saw them. A reader following either one gets a 404.

I swept the whole tree for all four directory names rather than trusting the two known spots, and fixed every hit naming a path that no longer exists.

## What changed

**`deploy/core.Dockerfile:12`** — cited `docs/research/core-base-measure/core-image-2026-08-04.md` as the write-up behind the CVE-posture paragraph. The measurement is the valuable part, so the date (2026-08-04), the method (this file and cut-down variants of it, scanned with Trivy) and every count below it — 6 from the base, 1200 of 1227 from `linux-libc-dev`, 15 without it, 1246 raw, 46 surviving suppression — are all kept. The dead path goes, replaced by a live pointer into history: the write-up was deleted in `96f7b07` and is readable at `96f7b07^`.

> The first push of this branch stated the method as "a single build of it scanned with `trivy image`". That was false and was caught in review; `e875f52` corrects it. See the reply on the review thread.

**`packages/shared/src/schema-bootstrap.ts`** — nine comments on the legacy-drop calls cited `docs/specs/01` through `docs/specs/12`:

| Line (before) | Dead path | Call it documents |
| --- | --- | --- |
| 467 | `docs/specs/02-remove-pet.md` | `dropLegacyPetSettings` |
| 473 | `docs/specs/01-remove-whisper.md` | `dropLegacyVoiceSettings` |
| 481 | `docs/specs/07-remove-convenience.md` | `dropLegacyConvenienceSurfaces` |
| 490 | `docs/specs/04-remove-recall-and-memory.md` | `dropLegacyRecallMemoryGraph` |
| 499 | `docs/specs/05-remove-bundled-skills.md` | `dropLegacyBundledSkillsSchema` |
| 508 | `docs/specs/06-remove-ide-adjacent.md` | `dropLegacyIdeAdjacentSettings` |
| 517 | `docs/specs/10-remove-sandbox.md` | `dropLegacySandboxSchema` |
| 525 | `docs/specs/11-remove-worktree-and-git.md` | `dropLegacyWorktreeSchema` |
| 534 | `docs/specs/12-adopt-studio-look.md` | `dropLegacyThemeSettings` |

Each of those comments already states what was removed, what the boot drops and why it stays for one release — the citation was a pointer, not the content. So the reasoning survives word for word and only the parenthetical goes; the lines are re-wrapped to close the gap. The `ADR 0006` and `ADR 0009` citations that shared two of those parentheses are kept, since both ADRs still exist.

## What I deliberately did not change

The sweep's remaining hits for those four names are all inside `docs/adr/` — 0007 (×2), 0013, 0016 and 0031 (×2), which reference `docs/upstream/`, `docs/research/core-base-measure/` and `docs/specs/05-remove-bundled-skills.md`. `docs/adr/README.md:3` calls ADRs "immutable-once-landed" and `CONTRIBUTING.md:166` says to amend by appending a clause, never by rewriting one. Those references are also historically correct: they describe the tree as it stood when each decision was made. Rewriting them would falsify the record, so they are left alone. Happy to append amendment clauses in a follow-up if that is wanted.

Two live hits (`AGENTS.md:17`, `docs/REPO_SETUP.md:25`) name `docs/upstream.md`, which exists. Not touched.

~~Separately, and out of scope here: `AGENTS.md` points at `docs/agents/*.md`, which also does not exist in this tree.~~ **Withdrawn — this was wrong.** On this branch `AGENTS.md` already points at `.agents/`, which exists. The only `docs/agents/` mentions left are historical, inside ADRs 0013 and 0016. No follow-up is needed and none will be opened.

## Scope

Comments only. No behaviour change, no test change, no untouched line reformatted — the diff touches no executable line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Y24BfffhZrMAXxcfTN3kP
