### PR TITLE
fix(panel): stop nested Files-drawer drops uploading twice

### DIFF
--- a/packages/panel/src/components/views/ProjectFilesPanel.tsx
+++ b/packages/panel/src/components/views/ProjectFilesPanel.tsx
@@ -29,6 +29,11 @@
 // and the row stops the event so the panel behind it does not take the same
 // drop a second time as a write to the root.
 //
+// **The panel root stops the drop too** (#400). The board behind the drawer is
+// a drop target in its own right, so a drop that reached both wrote the file
+// twice. The rule is the same one the rows follow: the innermost target that
+// understands the drop is the one that answers for it.
+//
 // **A drag held on a folder opens it** (#228). With the first two in place a
 // drop could still only reach a folder that happened to be open before the drag
 // began, because a drag cannot click a chevron. The timing lives in
@@ -172,9 +177,19 @@ export function ProjectFilesPanel({
       data-testid="project-files-panel"
       // The Project root, which is where a drop lands unless a folder row
       // claimed it first — those stop the event before it reaches here (#227).
+      //
+      // And this root stops it in turn (#400). The board underneath is a drop
+      // target too, and its handler re-reads the same `DataTransfer` into a
+      // fresh array of `File` handles — a new array identity, so the consume
+      // effect's guard above sees a drop it has never taken and sends it. One
+      // gesture, two uploads, the second reported as an overwrite of the first.
+      // The drawer is on top and it is the more specific target, so it is the
+      // one that answers: exactly the reasoning the folder rows already apply
+      // to this panel, applied one level out.
       onDragOver={(e) => {
         if (!dragCarriesFiles(e)) return;
         e.preventDefault();
+        e.stopPropagation();
         e.dataTransfer.dropEffect = "copy";
         setDragging(true);
         setDropTarget(null);
@@ -190,6 +205,8 @@ export function ProjectFilesPanel({
       onDrop={(e) => {
         if (!dragCarriesFiles(e)) return;
         e.preventDefault();
+        // The upload for this gesture happens here and only here (#400).
+        e.stopPropagation();
         setDragging(false);
         setDropTarget(null);
         spring.cancel();

--- a/packages/panel/src/components/views/__tests__/project-files-panel.test.tsx
+++ b/packages/panel/src/components/views/__tests__/project-files-panel.test.tsx
@@ -391,3 +391,102 @@ describe("a drag held over a collapsed folder", () => {
     expect(writes()[0]![0]).toContain("path=incoming%2Fbye.txt");
   });
 });
+
+// #400. The drawer floats over the Project board, and the board is a drop
+// target too — it reads the drop into its own fresh array of `File` handles and
+// hands that to this panel as a `pendingDrop`. A new array is a new identity, so
+// the consume effect's guard cannot tell it from a drop it has never seen, and
+// the one gesture becomes two uploads. Nothing downstream can catch that: by the
+// time the second write reaches the Core it is a well-formed request for the
+// same bytes, and the Core reports it as an overwrite. The event has to stop at
+// the innermost target that understood it, which is this panel.
+describe("a drop on the drawer, with the board behind it", () => {
+  const FOLDERED = [
+    { type: "entry", path: "incoming", size: 0, mtime: 1, mode: 0o040755, sha256: null, kind: "directory" },
+    { type: "entry", path: "readme.md", size: 4, mtime: 1, mode: 0o100644, sha256: null, kind: "file" },
+  ];
+
+  /** A listing re-served on every read, with every upload answered as written. */
+  function serving(entries: unknown[]): void {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        const path = new URL(url, "http://panel.test").searchParams.get("path") ?? "";
+        return ndjsonResponse([
+          { type: "entry", path, size: 2, mtime: 1, mode: 0o100644, sha256: null, result: "written" },
+          { type: "done", entries: 1, bytes: 2 },
+        ]);
+      }
+      return ndjsonResponse([...entries, { type: "done" }]);
+    });
+  }
+
+  /** The panel as an operator meets it: inside the board that also takes drops. */
+  function onBoard(): { drop: ReturnType<typeof vi.fn>; dragOver: ReturnType<typeof vi.fn> } {
+    const drop = vi.fn();
+    const dragOver = vi.fn();
+    render(
+      <div data-testid="board" onDragOver={dragOver} onDrop={drop}>
+        <ProjectFilesPanel coreId="core_a" projectId="p1" projectName="acme" />
+      </div>,
+    );
+    return { drop, dragOver };
+  }
+
+  it.each([
+    ["the drawer background", FOLDERED, () => screen.getByTestId("project-files-panel")],
+    ["the drawer header", FOLDERED, () => screen.getByText("acme")],
+    ["the empty state", [], () => screen.getByText("Nothing here yet")],
+    ["a row that is not a folder", FOLDERED, () => row("readme.md")],
+  ])("uploads once to the Project root when the file lands on %s", async (_where, entries, target) => {
+    serving(entries);
+    const board = onBoard();
+    const at = await waitFor(target);
+
+    const dataTransfer = fileDrag([new File(["hi"], "hello.txt")]);
+    fireEvent.dragOver(at, { dataTransfer });
+    fireEvent.drop(at, { dataTransfer });
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(writes()[0]![0]).toContain("path=hello.txt");
+    // The board never hears either half of the gesture, which is the whole of
+    // the fix: a board that heard the drop would upload these same bytes again.
+    expect(board.drop).not.toHaveBeenCalled();
+    expect(board.dragOver).not.toHaveBeenCalled();
+
+    // And it stays at one after everything the upload set in motion has settled
+    // — the re-read of the listing, and the render that re-read causes.
+    await waitFor(() => expect(screen.getByText("written")).toBeTruthy());
+    expect(writes()).toHaveLength(1);
+  });
+
+  it("still writes once, under the folder, when the file lands on a folder row", async () => {
+    serving(FOLDERED);
+    const board = onBoard();
+    await waitFor(() => expect(renderedPaths()).toEqual(["incoming", "readme.md"]));
+
+    const dataTransfer = fileDrag([new File(["hi"], "hello.txt")]);
+    fireEvent.dragOver(row("incoming"), { dataTransfer });
+    fireEvent.drop(row("incoming"), { dataTransfer });
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(writes()[0]![0]).toContain("path=incoming%2Fhello.txt");
+    expect(board.drop).not.toHaveBeenCalled();
+  });
+
+  it("leaves a drop on the board outside the drawer to the board", async () => {
+    serving(FOLDERED);
+    const board = onBoard();
+    await waitFor(() => expect(renderedPaths()).toEqual(["incoming", "readme.md"]));
+
+    const dataTransfer = fileDrag([new File(["hi"], "hello.txt")]);
+    fireEvent.dragOver(screen.getByTestId("board"), { dataTransfer });
+    fireEvent.drop(screen.getByTestId("board"), { dataTransfer });
+
+    expect(board.dragOver).toHaveBeenCalledTimes(1);
+    expect(board.drop).toHaveBeenCalledTimes(1);
+    // The panel took nothing: outside the drawer the board owns the drop, and
+    // stopping propagation inside the drawer must not have narrowed that.
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(0));
+    expect(writes()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #400.

## What the operator saw

Drop a file on the Files drawer's background, header, uploads list or a row that is not a folder, and the same file
uploaded twice — the second pass reported as `overwritten`, or as a 409 while the first was still in flight.

## Why

`ProjectFilesPanel.tsx`'s root `onDrop` called `preventDefault` but not `stopPropagation`, so the event carried on to the
Project board behind the drawer. The board's `onDrop` in `projects.$id.tsx` reads the same `DataTransfer` into a **fresh**
array of `File` handles and hands it back to the panel as `pendingDrop`. A fresh array is a fresh identity, so the
panel's consume effect — whose guard is `takenDrop.current === pendingDrop` — saw a drop it had never taken, and sent it.
One gesture, two writes.

Nothing downstream could catch it: by the time the second `PUT` reaches the Core it is a well-formed request for the same
bytes at the same path, and the Core correctly reports it as an overwrite.

## The fix

`e.stopPropagation()` on the panel root's `onDrop` and `onDragOver`, mirroring what the folder rows have done since #227
— where the comment already names this exact hazard for the panel behind them. The rule applied one level out: the
innermost target that understands the drop is the one that answers for it.

`onDragLeave` deliberately keeps propagating, so the board can still clear its own drag highlight.

## Scope

**`projects.$id.tsx` is untouched.** The panel-root fix is sufficient on its own — the board handler needed no change —
so #397, #398, #399 and #401 can own that file in their own waves. `packages/shared` (#385) and the CLI's
`events-command.ts` (#402) are untouched too.

#222 is folder-as-tar and the executable bit, not this double-fire; left alone.

## Tests

`project-files-panel.test.tsx` gains a describe that renders the panel inside a board stand-in with counting
`onDragOver`/`onDrop` spies:

- background, header, empty state and a non-folder row each upload **exactly once** to the Project root, and the board
  hears neither event;
- a folder row still writes once, under that folder;
- a drop on the board *outside* the drawer still reaches the board, and the panel writes nothing.

All four `it.each` cases fail when the two `stopPropagation` calls are removed, and pass with them.

`pnpm -C packages/panel run test` — 146 files, 1561 tests, green. `pnpm typecheck` clean; `pnpm lint` 0 errors.

Draft on purpose, and based on `fix/operator-pins-sessions-drop-cli` — the shared feature branch for the
pin/session/CLI/drop wave, not `main` and not `beta/0.4.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgW1Pt4d2kXNPymoSq6okh
