### PR TITLE
fix(shared): stop post-turn subagent helpers healing a finished task back to running

### DIFF
--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -60,8 +60,7 @@ lifecycle POST).
 
 A finished task is healed on **two conditions only**: a subagent tracked from
 that turn is still in flight, or the finish is younger than
-`FINISH_RACE_WINDOW_MS` (one second — both POSTs leave the same harness process
-microseconds apart, so the real race is sub-second). Everything else is one of
+`FINISH_RACE_WINDOW_MS` (one second, inclusive). Everything else is one of
 Claude Code's **post-turn internal helpers**, whose subagent events carry the
 parent session id: refocusing a finished session, or clicking its just-finished
 pin, generates an *away summary* or a title, firing `SubagentStart`/`SubagentStop`
@@ -69,12 +68,45 @@ with no `Stop` to follow. Those are ignored for status, and their starts are not
 tracked either — a lost helper stop would otherwise hold the next turn's `Stop`
 for the whole TTL.
 
-The window was 30 seconds until issue 385, which is 30,000× the race it was
-sized for: every helper firing within half a minute of a finish flipped the card
-back to `running`, and the operator watched a completed Session un-complete
-itself the moment they clicked it. Time is not what tells in-turn work from a
-helper — the tracked active-subagent set is. Widening this window again
-re-opens that bug.
+**Of those two, the clock is what decides the raced-POST case.** Every
+hook-driven finish leaves the tracked set empty by construction — the `finished`
+mapping is downgraded to `running` whenever `hasActiveSubagents` is true, the
+drain's `finishQuietTask` runs only after an idle set, `sessionProcessExited`
+clears the set first, and the Core's session backstop clears before it stamps
+the finish. The active-set condition therefore guards a `finished` written by one
+of the *other* status writers (a core-link task mutation through
+`CoreTaskWriter`, which clears nothing), not the race. Worth keeping — just not
+what protects in-turn work here.
+
+### What the window measures, and what that costs
+
+The window is sized on **emission**: the `Stop` and the turn's own
+`SubagentStart` leave the same harness process microseconds apart. It is
+evaluated on **arrival** — the finish is stamped when the `Stop` POST was
+*handled*, and compared against when the subagent POST is handled. Delivery is
+not microseconds: the hook command is
+`curl -sS -f -m 3 --retry 2 --retry-delay 1` (`packages/core/src/harness-hooks.ts`),
+whose own comment bounds the worst case at *"about eleven seconds"* and names
+the trigger as *"a Core busy serving PTY fan-out and SQLite writes"* — exactly
+what a fan-out turn creates.
+
+So a **retry-delayed in-turn `SubagentStart` is knowingly traded away**. One that
+eats a `-m 3` timeout lands ~4s after a `Stop` that already wrote `finished`,
+finds an empty set and a 4s-old finish, and is dropped *and* never tracked; the
+card reads `finished` through a live fan-out, and no backstop corrects it (every
+backstop below fixes a task stuck on `running`; none fixes one stuck on
+`finished`). That residual is filed as **issue 440**.
+
+The window was 30 seconds until issue 385. That covered the retry tail
+incidentally, at the price of every post-turn helper resurrecting the card for
+half a minute after *every* finish — the operator watched a completed Session
+un-complete itself the moment they clicked it. Widening it back to absorb the
+~11s retry budget puts a pin click at +5s inside it again and re-opens 385. A
+single scalar clock cannot tell a retry-delayed in-turn event from a post-turn
+helper, so one of the two has to lose, and the one visible on every finish is the
+one that was fixed. Telling them apart needs evidence rather than elapsed time —
+a payload discriminator, an emission timestamp, or the W1 status arbiter; issue
+440 sketches those.
 
 Backstops, so a `SubagentStop` that never arrives (lost POST, killed process) —
 or a healed `running` that no `Stop` will ever follow — cannot hold a task on

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -58,14 +58,23 @@ maps to a status on its own, but one arriving **moments after** a task finished
 heals it back to `running` (a `Stop` won the race against the turn's own subagent
 lifecycle POST).
 
-That heal is scoped to a 30-second recent-finish window because Claude Code also
-runs **post-turn internal helpers** whose subagent events carry the parent
-session id: refocusing a finished session generates an *away summary*, firing
-`SubagentStart`/`SubagentStop` minutes after the finish, with no `Stop` to
-follow. Healing on those wedges tasks on `running` forever (the original
-stuck-on-running bug). Beyond the window, helper events are ignored for status
-and their starts are not tracked — a lost helper stop would otherwise hold the
-next turn's `Stop` for the whole TTL.
+A finished task is healed on **two conditions only**: a subagent tracked from
+that turn is still in flight, or the finish is younger than
+`FINISH_RACE_WINDOW_MS` (one second — both POSTs leave the same harness process
+microseconds apart, so the real race is sub-second). Everything else is one of
+Claude Code's **post-turn internal helpers**, whose subagent events carry the
+parent session id: refocusing a finished session, or clicking its just-finished
+pin, generates an *away summary* or a title, firing `SubagentStart`/`SubagentStop`
+with no `Stop` to follow. Those are ignored for status, and their starts are not
+tracked either — a lost helper stop would otherwise hold the next turn's `Stop`
+for the whole TTL.
+
+The window was 30 seconds until issue 385, which is 30,000× the race it was
+sized for: every helper firing within half a minute of a finish flipped the card
+back to `running`, and the operator watched a completed Session un-complete
+itself the moment they clicked it. Time is not what tells in-turn work from a
+helper — the tracked active-subagent set is. Widening this window again
+re-opens that bug.
 
 Backstops, so a `SubagentStop` that never arrives (lost POST, killed process) —
 or a healed `running` that no `Stop` will ever follow — cannot hold a task on
@@ -74,7 +83,7 @@ fourth is armed by nothing, which is the point (issue 243):
 
 - Tracked entries expire after 2 hours (kept long on purpose — a short TTL would
   prematurely finish sessions whose subagents legitimately run long).
-- A held `Stop` (and a recent-finish heal) arms a once-a-minute recheck. Once the
+- A held `Stop` (and a subagent heal) arms a once-a-minute recheck. Once the
   tracked set is idle — drained by real `SubagentStop`s or by expiry — a 3-minute
   drain grace starts: if the re-invoked main harness's own `Stop` lands the finish
   within it (the normal flow), the backstop's promotion is a no-op (it only fires

--- a/packages/panel/src/server/__tests__/harness-hooks-api.test.ts
+++ b/packages/panel/src/server/__tests__/harness-hooks-api.test.ts
@@ -18,7 +18,7 @@ const { TITLE_WAITING } = await import("~/lib/task-sentinels");
 const LOOPBACK_HEADERS = { origin: "http://127.0.0.1:5173" };
 const SESSION_ID = "00000000-0000-4000-8000-000000000000";
 
-// Some cases shift Date.now past the recent-finish heal window; always restore.
+// Some cases pin or shift Date.now around the finish race window; always restore.
 const realNow = Date.now;
 afterEach(() => {
   Date.now = realNow;
@@ -378,10 +378,15 @@ describe("background subagents over the claude hook API", () => {
   it("heals a finished task when a late subagent event loses the race to Stop", async () => {
     await prompt();
     // Stop wins the race against the just-launched subagent's SubagentStart.
+    // Both POSTs leave the same harness process microseconds apart, so the
+    // clock is pinned: the heal window is that race, not the round trip.
+    const raceInstant = realNow();
+    Date.now = () => raceInstant;
     expect((await stop()).status).toBe("finished");
 
     await subagent("SubagentStart", "late-sub");
     expect(getTask(taskId)?.status).toBe("running");
+    Date.now = realNow;
 
     await subagent("SubagentStop", "late-sub");
     expect((await stop()).status).toBe("finished");
@@ -418,10 +423,12 @@ describe("background subagents over the claude hook API", () => {
     await prompt();
     expect((await stop()).status).toBe("finished");
 
-    // Minutes later the user refocuses the pane and Claude Code's internal
-    // away-summary helper fires SubagentStart/Stop — with no Stop to follow.
-    // The finished status must hold (this was the stuck-on-running bug).
-    Date.now = () => realNow() + 31_000;
+    // Seconds later the user refocuses the pane, or clicks the just-finished
+    // pin, and Claude Code's internal away-summary helper fires
+    // SubagentStart/Stop — with no Stop to follow. The finished status must
+    // hold. Five seconds was INSIDE the old 30s heal window (issue 385): the
+    // card flipped back to running and stayed there until the drain backstop.
+    Date.now = () => realNow() + 5_000;
     await subagent("SubagentStart", "away-helper");
     expect(getTask(taskId)?.status).toBe("finished");
     await subagent("SubagentStop", "away-helper");

--- a/packages/panel/src/server/__tests__/subagent-activity.test.ts
+++ b/packages/panel/src/server/__tests__/subagent-activity.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  FINISH_RACE_WINDOW_MS,
   armDeferredFinish,
   clearSubagentActivity,
   disarmDeferredFinish,
@@ -7,13 +8,12 @@ import {
   noteSubagentStart,
   noteSubagentStop,
   noteTaskFinished,
-  taskFinishedRecently,
+  taskFinishedWithinRaceWindow,
 } from "../services/subagent-activity";
 
 const TTL_MS = 2 * 60 * 60 * 1000;
 const RECHECK_MS = 60 * 1000;
 const DRAIN_GRACE_MS = 3 * 60 * 1000;
-const RECENT_FINISH_MS = 30 * 1000;
 
 const realNow = Date.now;
 
@@ -180,17 +180,23 @@ describe("deferred finish backstop", () => {
   });
 });
 
-describe("recent-finish window", () => {
-  it("reports a finish as recent only within the window", () => {
+describe("finish race window", () => {
+  it("reports a finish as raced only within the window", () => {
     const taskId = "task-finish-window";
-    expect(taskFinishedRecently(taskId)).toBe(false);
+    expect(taskFinishedWithinRaceWindow(taskId)).toBe(false);
 
     noteTaskFinished(taskId);
-    expect(taskFinishedRecently(taskId)).toBe(true);
+    expect(taskFinishedWithinRaceWindow(taskId)).toBe(true);
 
     // Beyond the window, a subagent event is a post-turn helper, not a raced
     // lifecycle POST from the finished turn.
-    Date.now = () => realNow() + RECENT_FINISH_MS + 1;
-    expect(taskFinishedRecently(taskId)).toBe(false);
+    Date.now = () => realNow() + FINISH_RACE_WINDOW_MS + 1;
+    expect(taskFinishedWithinRaceWindow(taskId)).toBe(false);
+  });
+
+  it("stays sub-second — the race it models, not a grace period (issue 385)", () => {
+    // The window was 30s, 30,000x the loopback POST race it was sized for,
+    // which let post-turn helper subagents resurrect a finished card.
+    expect(FINISH_RACE_WINDOW_MS).toBeLessThanOrEqual(1_000);
   });
 });

--- a/packages/panel/src/server/__tests__/subagent-activity.test.ts
+++ b/packages/panel/src/server/__tests__/subagent-activity.test.ts
@@ -194,9 +194,11 @@ describe("finish race window", () => {
     expect(taskFinishedWithinRaceWindow(taskId)).toBe(false);
   });
 
-  it("stays sub-second — the race it models, not a grace period (issue 385)", () => {
-    // The window was 30s, 30,000x the loopback POST race it was sized for,
-    // which let post-turn helper subagents resurrect a finished card.
+  it("stays at one second inclusive — a race window, not a grace period (issue 385)", () => {
+    // The window was 30s, which let post-turn helper subagents resurrect a
+    // finished card for half a minute after every finish. Widening it back to
+    // absorb the hook curl's ~11s retry tail re-opens that bug — see
+    // FINISH_RACE_WINDOW_MS and issue 440 for the residual that buys.
     expect(FINISH_RACE_WINDOW_MS).toBeLessThanOrEqual(1_000);
   });
 });

--- a/packages/panel/src/server/services/subagent-activity.ts
+++ b/packages/panel/src/server/services/subagent-activity.ts
@@ -5,8 +5,9 @@
 // process holds its own state; only the code is shared. Re-exported here to
 // preserve existing import paths.
 export {
+  FINISH_RACE_WINDOW_MS,
   noteTaskFinished,
-  taskFinishedRecently,
+  taskFinishedWithinRaceWindow,
   clearTaskFinished,
   noteSubagentStart,
   noteSubagentStop,

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -20,7 +20,13 @@ import type { TaskStatus } from "../domain";
 // clicks the just-finished pin (away-summary generation, the title helper)
 // resurrected a completed card. A heal is legitimate only when the turn can
 // still plausibly be working — a tracked subagent is in flight, or the finish
-// is younger than the sub-second POST race.
+// is younger than FINISH_RACE_WINDOW_MS (one second, inclusive).
+//
+// For the raced-POST case the clock is the whole gate: every hook-driven finish
+// leaves the tracked set empty by construction, so the active-set disjunct only
+// covers a "finished" written by another status writer. What that costs — a
+// retry-delayed in-turn SubagentStart, dropped rather than healed — is filed as
+// issue 440.
 
 const SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
@@ -103,8 +109,9 @@ describe("subagent events on a finished task (issue 385)", () => {
   });
 
   it("stays finished across the whole old 30s heal window", () => {
-    // Every one of these used to write "running": the window was 30s, tuned
-    // 30,000x the sub-second race it was built for.
+    // Every one of these used to write "running": the window was 30s, where
+    // the race it models is the microseconds between two POSTs leaving the
+    // same harness process.
     for (const afterMs of [2_000, 5_000, 15_000, 29_000]) {
       const h = harness();
       h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
@@ -153,8 +160,12 @@ describe("subagent events on a finished task (issue 385)", () => {
     h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
     h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
 
-    // One of the other status writers (structural note W1: three of them, no
-    // arbiter) lands "finished" while sub-1 is demonstrably still working.
+    // Reaching past the pipeline is the point, not a shortcut: no hook-driven
+    // finish can leave the tracked set non-empty, so this branch is only ever
+    // reachable from one of the OTHER status writers (structural note W1:
+    // three of them, no arbiter) landing "finished" over live work — a
+    // core-link task mutation through CoreTaskWriter, say, which clears
+    // nothing.
     h.ports.updateStatus(h.taskId, "finished");
 
     // Long past any POST race, but the turn's own set says work is in flight,

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  handleHarnessHookEvent,
+  type HarnessHookBody,
+  type HookPipelinePorts,
+  type HookTaskFacts,
+} from "../harness-hook-pipeline";
+import {
+  FINISH_RACE_WINDOW_MS,
+  clearSubagentActivity,
+  clearTaskFinished,
+} from "../subagent-activity";
+import type { TaskStatus } from "../domain";
+
+// The subagent branch of the hook pipeline, driven event by event.
+//
+// The bug this pins (issue 385): a subagent event landing on a FINISHED task
+// used to heal it back to "running" for a full 30 seconds afterwards, so the
+// post-turn helpers Claude Code fires when the operator refocuses a pane or
+// clicks the just-finished pin (away-summary generation, the title helper)
+// resurrected a completed card. A heal is legitimate only when the turn can
+// still plausibly be working — a tracked subagent is in flight, or the finish
+// is younger than the sub-second POST race.
+
+const SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const realNow = Date.now;
+let taskIdSeq = 0;
+
+type Harness = {
+  taskId: string;
+  task: HookTaskFacts;
+  ports: HookPipelinePorts;
+  /** Every status the pipeline wrote, oldest first. */
+  writes: TaskStatus[];
+  post(payload: HarnessHookBody): void;
+};
+
+function makeHarness(): Harness {
+  const taskId = `pipeline-task-${++taskIdSeq}`;
+  const task: HookTaskFacts = { status: "ready", claudeSessionId: null };
+  const writes: TaskStatus[] = [];
+  const ports: HookPipelinePorts = {
+    getTask: (id) => (id === taskId ? task : null),
+    updateStatus: (id, status) => {
+      if (id !== taskId) return false;
+      task.status = status;
+      writes.push(status);
+      return true;
+    },
+    setSessionId: (id, sessionId) => {
+      if (id === taskId) task.claudeSessionId = sessionId;
+    },
+  };
+  return {
+    taskId,
+    task,
+    ports,
+    writes,
+    post: (payload) => {
+      handleHarnessHookEvent(taskId, { session_id: SESSION_ID, ...payload }, ports);
+    },
+  };
+}
+
+const harnesses: Harness[] = [];
+
+function harness(): Harness {
+  const next = makeHarness();
+  harnesses.push(next);
+  return next;
+}
+
+beforeEach(() => {
+  taskIdSeq = 0;
+});
+
+afterEach(() => {
+  Date.now = realNow;
+  // Module state in subagent-activity is per process, not per test.
+  for (const used of harnesses.splice(0)) {
+    clearSubagentActivity(used.taskId);
+    clearTaskFinished(used.taskId);
+  }
+});
+
+describe("subagent events on a finished task (issue 385)", () => {
+  it("leaves the task finished when a helper SubagentStart follows the finish", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+
+    // The operator clicks the just-finished pin. Claude Code's away-summary
+    // helper fires SubagentStart/Stop with no Stop to follow, and no subagent
+    // from the finished turn is in flight.
+    Date.now = () => realNow() + FINISH_RACE_WINDOW_MS + 1;
+    h.post({ hook_event_name: "SubagentStart", agent_id: "away-helper" });
+    expect(h.task.status).toBe("finished");
+    h.post({ hook_event_name: "SubagentStop", agent_id: "away-helper" });
+    expect(h.task.status).toBe("finished");
+    expect(h.writes).toEqual(["running", "finished"]);
+  });
+
+  it("stays finished across the whole old 30s heal window", () => {
+    // Every one of these used to write "running": the window was 30s, tuned
+    // 30,000x the sub-second race it was built for.
+    for (const afterMs of [2_000, 5_000, 15_000, 29_000]) {
+      const h = harness();
+      h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
+      h.post({ hook_event_name: "Stop" });
+
+      Date.now = () => realNow() + afterMs;
+      h.post({ hook_event_name: "SubagentStart", agent_id: "title-helper" });
+      expect(h.task.status).toBe("finished");
+      Date.now = realNow;
+    }
+  });
+
+  it("does not record a helper's start, so the next turn's Stop still finishes", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
+    h.post({ hook_event_name: "Stop" });
+
+    // A helper start that was counted as active work would hold the NEXT
+    // turn's Stop on "running" until the 2h TTL if its stop went missing.
+    Date.now = () => realNow() + FINISH_RACE_WINDOW_MS + 1;
+    h.post({ hook_event_name: "SubagentStart", agent_id: "away-helper" });
+    Date.now = realNow;
+
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "next turn" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("still heals a lifecycle POST that genuinely lost the race to Stop", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+
+    // Same-millisecond arrival: the turn's own SubagentStart, reordered.
+    h.post({ hook_event_name: "SubagentStart", agent_id: "raced-sub" });
+    expect(h.task.status).toBe("running");
+
+    h.post({ hook_event_name: "SubagentStop", agent_id: "raced-sub" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("heals past the race window while a tracked subagent is still in flight", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+
+    // One of the other status writers (structural note W1: three of them, no
+    // arbiter) lands "finished" while sub-1 is demonstrably still working.
+    h.ports.updateStatus(h.taskId, "finished");
+
+    // Long past any POST race, but the turn's own set says work is in flight,
+    // so a second in-turn subagent is real work and does un-finish the card.
+    Date.now = () => realNow() + 5 * 60_000;
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-2" });
+    expect(h.task.status).toBe("running");
+  });
+});
+
+describe("in-turn subagents hold the finish", () => {
+  it("holds running until the last background subagent stops", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-2" });
+
+    // The FOREGROUND turn ends while both subagents are still working.
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("running");
+
+    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-1" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("running");
+
+    // Only the Stop that arrives with nothing left active is the real finish.
+    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-2" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("finishes on Stop when the turn's subagents already reported in", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-1" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+  });
+});

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -198,8 +198,24 @@ export function handleHarnessHookEvent(
   //
   //   - a tracked subagent from that turn is still in flight (the set is
   //     non-empty), so the finish landed over live work; or
-  //   - the finish is younger than the sub-second POST race, i.e. this event
-  //     is the turn's own lifecycle POST that lost the race to the Stop.
+  //   - the finish is younger than FINISH_RACE_WINDOW_MS (one second,
+  //     inclusive), i.e. this event is the turn's own lifecycle POST that lost
+  //     the race to the Stop.
+  //
+  // Which of those two actually decides the raced-POST case this exists for?
+  // The clock, alone. Every HOOK-DRIVEN finish leaves the tracked set empty by
+  // construction: the finished mapping below is downgraded to "running"
+  // whenever hasActiveSubagents is true, so the finish write only happens with
+  // an idle set; finishQuietTask runs only after the drain observed an idle
+  // set; the sessionProcessExited branch calls clearSubagentActivity first;
+  // and the Core's session backstop clears before it calls noteTaskFinished.
+  // The active-set disjunct is therefore not the safety net for a raced POST —
+  // it guards a "finished" written by one of the OTHER status writers (a
+  // core-link task mutation through CoreTaskWriter, say, which clears
+  // nothing). That is worth keeping; it is just not what protects in-turn work
+  // here. The clock is, and its cost is documented on FINISH_RACE_WINDOW_MS
+  // and filed as issue 440: a retry-delayed in-turn SubagentStart landing
+  // after the Stop is dropped, not healed.
   //
   // Everything else on a finished task is one of Claude Code's post-turn
   // internal helpers — away-summary generation and the title helper fire

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -29,7 +29,7 @@ import {
   noteSubagentStart,
   noteSubagentStop,
   noteTaskFinished,
-  taskFinishedRecently,
+  taskFinishedWithinRaceWindow,
 } from "./subagent-activity";
 import type { TaskStatus } from "./domain";
 
@@ -190,26 +190,38 @@ export function handleHarnessHookEvent(
   // FOREGROUND turn ends — background subagents keep running, then their
   // completion re-invokes the main harness, whose own Stop follows. Track which
   // subagents are active so the Stop mapping below can hold the session on
-  // "running" until the last one is done. These events carry no status, but a
-  // subagent event arriving MOMENTS after a task finished means the Stop won
-  // the race against the turn's own subagent lifecycle POST — work is still
-  // happening, so heal to running, and arm the drain backstop in case no
-  // further Stop follows.
+  // "running" until the last one is done.
   //
-  // Beyond that window, a subagent event on a finished task is one of Claude
-  // Code's post-turn internal helpers (away-summary generation fires
-  // SubagentStart/Stop when the user refocuses a finished session, with no
-  // Stop after). Healing on those wedges tasks on "running" forever; ignore
-  // them for status, and don't record their starts either — a lost helper
+  // On a task that is ALREADY finished these events carry no status of their
+  // own, and un-finishing the card is only right when the turn can still
+  // plausibly be working. Two things say so, and nothing else does:
+  //
+  //   - a tracked subagent from that turn is still in flight (the set is
+  //     non-empty), so the finish landed over live work; or
+  //   - the finish is younger than the sub-second POST race, i.e. this event
+  //     is the turn's own lifecycle POST that lost the race to the Stop.
+  //
+  // Everything else on a finished task is one of Claude Code's post-turn
+  // internal helpers — away-summary generation and the title helper fire
+  // SubagentStart/Stop when the operator refocuses a finished session or
+  // clicks the just-finished pin, with no Stop to follow. Those must not write
+  // "running" (issue 385): the card would flip back to running seconds after
+  // completing and stay there until the drain backstop noticed. Ignore them
+  // for status, and don't record their starts either — a lost helper
   // SubagentStop would otherwise hold the NEXT turn's Stop for the whole TTL.
   if (isSubagentLifecycleEvent(event)) {
-    const staleFinished = task.status === "finished" && !taskFinishedRecently(taskId);
+    // Read the tracked set BEFORE this event touches it: a helper's own
+    // SubagentStart must not be the evidence that work is in flight.
+    const inTurn =
+      task.status !== "finished" ||
+      hasActiveSubagents(taskId) ||
+      taskFinishedWithinRaceWindow(taskId);
     if (event === HARNESS_HOOK_EVENTS.subagentStart) {
-      if (!staleFinished) noteSubagentStart(taskId, payload.agent_id);
+      if (inTurn) noteSubagentStart(taskId, payload.agent_id);
     } else {
       noteSubagentStop(taskId, payload.agent_id);
     }
-    if (task.status === "finished" && !staleFinished) {
+    if (task.status === "finished" && inTurn) {
       ports.updateStatus(taskId, "running");
       armDeferredFinish(taskId, (id) => finishQuietTask(id, ports));
     }

--- a/packages/shared/src/subagent-activity.ts
+++ b/packages/shared/src/subagent-activity.ts
@@ -9,10 +9,12 @@
 //
 // Claude Code also runs internal helper agents AFTER a session finishes
 // (away-summary generation on refocus, title helpers) whose subagent events
-// carry the parent session id but precede no further Stop. The recent-finish
-// window (taskFinishedRecently) keeps those from healing a finished task back
-// to "running", and the drain grace in armDeferredFinish un-wedges any that
-// slip through.
+// carry the parent session id but precede no further Stop. A finished task is
+// healed back to "running" only for work it can still plausibly be doing —
+// a tracked subagent from the turn is still in flight, or the finish is
+// younger than the sub-second POST race (taskFinishedWithinRaceWindow) — so
+// those helpers cannot resurrect a finished card. The drain grace in
+// armDeferredFinish un-wedges anything that still slips through.
 //
 // In-memory and bounded like the controller's other per-task maps: losing
 // state (app restart) merely restores the legacy finish-on-Stop behavior.
@@ -40,12 +42,18 @@ const DEFERRED_FINISH_RECHECK_MS = 60 * 1000;
 // after) can't leave the task wedged on "running".
 const DRAIN_FINISH_GRACE_MS = 3 * 60 * 1000;
 
-// How long after a task finishes a subagent event can still plausibly belong
-// to the finished turn (a Stop that won the race against the turn's own
-// SubagentStart POST — a sub-second race in practice). Beyond this window a
-// subagent event on a finished task is a post-turn internal helper, not
-// resumed work, and must not heal the task back to "running".
-const RECENT_FINISH_WINDOW_MS = 30 * 1000;
+// How long after a task finishes a subagent event can still be the turn's own
+// lifecycle POST that LOST the race to the Stop POST. Both are loopback POSTs
+// emitted by the same harness process microseconds apart, so the real race is
+// sub-second; one second is its generous outer bound.
+//
+// This is deliberately tiny. The window used to be 30s (issue 385), 30,000x
+// the race it was sized for, which turned every post-turn helper subagent —
+// the away-summary and title helpers Claude Code fires when the operator
+// refocuses or clicks a just-finished pin — into a resurrection of the
+// finished card. Widening it again re-opens that bug: the way to let genuine
+// in-turn work hold a finish is the tracked active-subagent set, not time.
+export const FINISH_RACE_WINDOW_MS = 1_000;
 
 type TaskSubagents = {
   /** agent_id → start time, for payloads that identify the subagent. */
@@ -83,14 +91,15 @@ export function noteTaskFinished(taskId: string): void {
 }
 
 /**
- * True while a subagent event can still mean "the finished Stop raced the
- * turn's own subagent lifecycle POSTs". Unknown tasks report false — after a
- * restart the heal stays off until a real finish is observed again.
+ * True only while a subagent event can still mean "the finished Stop raced the
+ * turn's own subagent lifecycle POSTs" — a sub-second window, not a grace
+ * period. Unknown tasks report false: after a restart the heal stays off until
+ * a real finish is observed again.
  */
-export function taskFinishedRecently(taskId: string): boolean {
+export function taskFinishedWithinRaceWindow(taskId: string): boolean {
   const finishedAt = finishedAtByTask.get(taskId);
   if (finishedAt === undefined) return false;
-  return Date.now() - finishedAt <= RECENT_FINISH_WINDOW_MS;
+  return Date.now() - finishedAt <= FINISH_RACE_WINDOW_MS;
 }
 
 /**

--- a/packages/shared/src/subagent-activity.ts
+++ b/packages/shared/src/subagent-activity.ts
@@ -12,8 +12,8 @@
 // carry the parent session id but precede no further Stop. A finished task is
 // healed back to "running" only for work it can still plausibly be doing —
 // a tracked subagent from the turn is still in flight, or the finish is
-// younger than the sub-second POST race (taskFinishedWithinRaceWindow) — so
-// those helpers cannot resurrect a finished card. The drain grace in
+// younger than FINISH_RACE_WINDOW_MS (taskFinishedWithinRaceWindow) — so those
+// helpers cannot resurrect a finished card. The drain grace in
 // armDeferredFinish un-wedges anything that still slips through.
 //
 // In-memory and bounded like the controller's other per-task maps: losing
@@ -43,16 +43,37 @@ const DEFERRED_FINISH_RECHECK_MS = 60 * 1000;
 const DRAIN_FINISH_GRACE_MS = 3 * 60 * 1000;
 
 // How long after a task finishes a subagent event can still be the turn's own
-// lifecycle POST that LOST the race to the Stop POST. Both are loopback POSTs
-// emitted by the same harness process microseconds apart, so the real race is
-// sub-second; one second is its generous outer bound.
+// lifecycle POST that LOST the race to the Stop POST. One second, inclusive
+// (the comparison below is `<=`).
 //
-// This is deliberately tiny. The window used to be 30s (issue 385), 30,000x
-// the race it was sized for, which turned every post-turn helper subagent —
-// the away-summary and title helpers Claude Code fires when the operator
-// refocuses or clicks a just-finished pin — into a resurrection of the
-// finished card. Widening it again re-opens that bug: the way to let genuine
-// in-turn work hold a finish is the tracked active-subagent set, not time.
+// Be honest about what this measures. It is sized on EMISSION: the Stop and
+// the turn's own SubagentStart leave the same harness process microseconds
+// apart. It is evaluated on ARRIVAL — noteTaskFinished stamps when the Stop
+// POST was HANDLED, and the comparison runs when the subagent POST is handled.
+// Delivery is not microseconds. The hook command in
+// packages/core/src/harness-hooks.ts is
+// `curl -sS -f -m 3 --retry 2 --retry-delay 1`, and its own comment puts the
+// worst case at "about eleven seconds", triggered by "a Core busy serving PTY
+// fan-out and SQLite writes" — precisely the condition a fan-out turn creates.
+//
+// So this window does NOT cover a retry-delayed in-turn SubagentStart. One
+// that eats a `-m 3` timeout lands ~4s after a Stop that already wrote
+// "finished": it finds an empty tracked set and a 4s-old finish, so it is
+// dropped AND never tracked, and the card reads finished through a live
+// fan-out with no backstop (every backstop here corrects a task stuck on
+// "running", none corrects one stuck on "finished"). That is knowingly traded
+// away — see issue 440, filed for the residual.
+//
+// The trade: the window was 30s (issue 385), which meant every post-turn
+// helper subagent — the away-summary and title helpers Claude Code fires when
+// the operator refocuses or clicks a just-finished pin — resurrected the
+// finished card for half a minute after EVERY finish. Widening this back to
+// absorb the ~11s retry budget puts a pin click at +5s inside it again and
+// re-opens 385. A single scalar clock cannot tell a retry-delayed in-turn
+// event from a post-turn helper, so one of the two has to lose; the
+// operator-visible-on-every-finish one is the one that was fixed. Telling them
+// apart needs evidence rather than elapsed time (a payload discriminator, an
+// emission timestamp, or the W1 status arbiter) — issue 440 sketches those.
 export const FINISH_RACE_WINDOW_MS = 1_000;
 
 type TaskSubagents = {
@@ -92,9 +113,10 @@ export function noteTaskFinished(taskId: string): void {
 
 /**
  * True only while a subagent event can still mean "the finished Stop raced the
- * turn's own subagent lifecycle POSTs" — a sub-second window, not a grace
- * period. Unknown tasks report false: after a restart the heal stays off until
- * a real finish is observed again.
+ * turn's own subagent lifecycle POSTs" — one second inclusive, a race window
+ * and not a grace period. It measures ARRIVAL, not emission; see
+ * FINISH_RACE_WINDOW_MS above for what that costs. Unknown tasks report false:
+ * after a restart the heal stays off until a real finish is observed again.
  */
 export function taskFinishedWithinRaceWindow(taskId: string): boolean {
   const finishedAt = finishedAtByTask.get(taskId);


### PR DESCRIPTION
## Summary

The subagent branch of the hook pipeline un-finished a task whenever a `SubagentStart`/`SubagentStop`
arrived within `RECENT_FINISH_WINDOW_MS = 30_000` of the finish. Claude Code fires post-turn internal
helpers — away-summary generation, the title helper — when the operator refocuses a finished pane or
clicks the just-finished pin, and those carry the parent session id, so for a full 30 seconds after
every finish they read as resumed work: the card flipped back to `running` and stayed there until the
drain backstop restored it 3–4 minutes later.

A finished task is now un-finished on two conditions only: a subagent tracked from that turn is still
in flight, or the finish is younger than `FINISH_RACE_WINDOW_MS` — **one second, inclusive**, replacing
the 30s window. Everything else on a finished task is a post-turn helper: ignored for status, and its
start is not tracked either (a lost helper stop would otherwise hold the next turn's `Stop` for the
whole 2h TTL — pre-existing behaviour, kept).

**Which of the two conditions actually decides the raced-POST case? The clock, alone.** Every
hook-driven finish leaves the tracked set empty by construction: the `finished` mapping is downgraded
to `running` whenever `hasActiveSubagents` is true, `finishQuietTask` runs only after the drain
observed an idle set, `sessionProcessExited` calls `clearSubagentActivity` first, and the Core's
session backstop clears before it calls `noteTaskFinished`. The active-set disjunct is therefore not
the safety net here — it guards a `finished` written by one of the *other* W1 status writers (a
core-link task mutation through `CoreTaskWriter`, which clears nothing). Keeping it is right; it just
is not what protects in-turn work in this path.

**What the window costs.** It is sized on *emission* — the `Stop` and the turn's own `SubagentStart`
leave the same harness process microseconds apart — but evaluated on *arrival*: the finish is stamped
when the `Stop` POST was handled, and compared against when the subagent POST is handled. Delivery is
not microseconds. The hook command is `curl -sS -f -m 3 --retry 2 --retry-delay 1`
(`packages/core/src/harness-hooks.ts`), whose own comment bounds the worst case at *"about eleven
seconds"* under *"a Core busy serving PTY fan-out and SQLite writes"* — exactly what a fan-out turn
creates. So a retry-delayed in-turn `SubagentStart` landing after the `Stop` is dropped and never
tracked, leaving the card `finished` through a live fan-out with no backstop. **That is knowingly
traded away**, because a window wide enough for the ~11s retry tail puts a pin click at +5s back inside
it and re-opens #385. A single scalar clock cannot separate the two cases — that is the W1 structural
note this ticket defers. The residual is filed as **#440**.

The genuine in-turn hold path is untouched: an in-turn subagent is tracked before the foreground `Stop`
arrives, so that `Stop` is still downgraded to `running`, and only the `Stop` arriving with an idle set
lands the real finish.

### ⚠️ Deploy note — a Panel-only deploy will look like this fix failed

This is a `packages/shared` change, and for Core-owned Sessions the hook pipeline runs on **the Core**
(issue #84), not the Panel. `packages/core` depends on `@actana/shared` and bundles it into the Core
release tarball that `deploy/core.Dockerfile` installs. A refreshed Panel image carries none of this
for Sessions whose hooks POST to a Core. **Ship the Core image the Panel talks to.**

### Deliberately not in this PR

- **No event-bus rewrite and no status arbiter** — structural note W1, deferred by the ticket.
- **The 60s recheck × 3min drain grace is unchanged.** The issue's "speed the visible correction"
  would mean shortening the grace that lets a re-invoked main agent compose its follow-up turn;
  shrinking it risks prematurely finishing a live turn. With the heal gated, nothing spurious reaches
  the backstop.
- **F1 (#387) and F4 (#390)** also touch `harness-hook-pipeline.ts` and are later waves — untouched.

## Related issues

Closes #385
Refs #440 (the residual this trade creates), #292 (the older status-versus-turn seam)

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation (`docs/harness-status-detection.md` rewritten around the two heal conditions)
- [ ] 🔧 Build / CI / tooling

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/E2E tests added/updated
- [ ] Manually verified — **no**, and stated plainly: no live Panel was clicked for this change.
      AC1 is proven by test at the pipeline and HTTP layers, not by driving pairdemo.

New `packages/shared/src/__tests__/harness-hook-pipeline.test.ts` (7 tests) drives
`handleHarnessHookEvent` event by event:

1. a helper `SubagentStart`/`SubagentStop` after a finish leaves the task `finished`, with the recorded
   status writes exactly `["running", "finished"]`;
2. the regression pinned across the whole old window — 2s, 5s, 15s, 29s all stay `finished`;
3. a helper's start is not tracked, so the next turn's `Stop` still finishes;
4. a genuinely raced lifecycle POST still heals;
5. the active-set disjunct — reachable only by reaching past the pipeline, which is the point;
6. an in-turn subagent still holds the finish until the last one stops;
7. `Stop` finishes when the turn's subagents already reported in.

Panel: `harness-hooks-api.test.ts`'s race case pins `Date.now` so the window measures the race and not
the HTTP round trip, and its helper case fires at +5s — inside the old window — instead of +31s.
`subagent-activity.test.ts` asserts the window stays at one second inclusive.

`pnpm test` green (6/6 stages: root 23 files, sdk 22, shared 31, cli 50, core 57 / 903 tests, panel
146 / 1556 tests). `pnpm typecheck` clean. `pnpm lint` 0 errors. Existing Stop and OpenCode
idle-finish suites pass unchanged.

## Checklist

- [x] This PR targets the open pin/session/CLI/drop feature branch
      `fix/operator-pins-sessions-drop-cli`, not `main` and not `beta/0.4.5` — `Train rules` green
- [x] My PR title **and every commit in the branch** follow Conventional Commits, and the branch name
      follows the branching convention
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix works, and all tests pass locally
- [x] I updated documentation (`docs/harness-status-detection.md`)
- [x] No secrets, credentials, or personal data are included in this change
- [x] This PR is marked as **draft** and stacked on the feature branch

### Boundaries

Files owned by the tickets running in parallel on this branch are untouched: `ProjectFilesPanel.tsx`
and `pending-file-drop.ts` (#400), `events-command.ts` (#402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pa35nN54tKU2AbVX9Neg7o
