### PR TITLE
fix(cli): events tail --limit must exit from history

### DIFF
--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -271,11 +271,16 @@ describe("actana events tail", () => {
     await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS);
 
     const result = await run;
-    expect(result.code).toBe(EXIT_OK);
+    // Every event it got is on stdout and stays there — but the run was cut
+    // off, not finished, and the status says so. A short file with a zero
+    // status is the one shape a scripted consumer cannot tell from a complete
+    // read (#402 review, finding 4).
+    expect(result.code).toBe(EXIT_FAILURE);
     expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([
       14, 15, 16, 17, 18, 19, 20, 21, 22,
     ]);
     expect(result.err.join("\n")).toContain("stopped answering");
+    expect(result.err.join("\n")).toContain("did not finish");
     expect(core.closed).toBe(true);
   });
 
@@ -296,6 +301,108 @@ describe("actana events tail", () => {
     expect(result.out).toHaveLength(0);
     expect(result.err.join("\n")).toContain("stopped answering");
     expect(core.closed).toBe(true);
+  });
+
+  it("does not wedge a --limit run that has no cursor and no --since either", async () => {
+    // #402 review, finding 1. `actana events tail --limit 30` is the invocation
+    // an operator is most likely to type, and it takes the *other* side of the
+    // printing switch: no cursor, so the run is walking the log to find its tip
+    // before it prints anything. A Core that never answers `subscribe` wedges
+    // that walk exactly as it wedges a read — the deadline covers both sides,
+    // or it does not cover the reported symptom.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--limit", "30"], {
+      connect: core.connect,
+    });
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(result.out).toHaveLength(0);
+    expect(result.err.join("\n")).toContain("stopped answering");
+    expect(core.closed).toBe(true);
+  });
+
+  it("keeps timing a tip hunt the Core is still answering, and stops at the tip", async () => {
+    // The same side, behaving. Each frame re-arms the clock, so a Core walking
+    // a long log slowly is a Core answering — and once it says where the log
+    // ends the clock comes off for good, because from there the run is a follow
+    // and a follow waits through any amount of quiet.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--limit", "1"], { connect: core.connect });
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (const round of [1, 2, 3]) {
+      // Most of a deadline's worth of silence, then an answer. Three times.
+      await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS - 1_000);
+      core.emitEvent({ eventId: round, kind: "task:updated" });
+      core.emitReplayed(round);
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    core.emitReplayed(3);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The tip is known and printing is on. Now an hour of quiet, which a follow
+    // is entitled to sit through.
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS * 120);
+    core.emitEvent({ eventId: 4, kind: "session:finished" });
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([4]);
+  });
+
+  it("stops the clock while the link is down, and restarts it on the reconnect", async () => {
+    // #402 review, finding 2. A dropped socket is not a Core refusing to answer:
+    // nothing can arrive to re-arm the deadline until the link is back, and the
+    // durable client re-dials for as long as it takes and replays the whole tail
+    // from the cursor. A deadline left running would fire through a Core restart
+    // and truncate a read the reconnect was about to complete — and this file
+    // promises an operator that a restart costs neither a repeat nor a gap.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--since", "13", "--limit", "30", "--json"], {
+      connect: core.connect,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    core.emitEvent({ eventId: 14, kind: "task:updated" });
+    core.emitDisconnected("socket hang up");
+
+    // A Core restart, taking far longer than the deadline it is not subject to.
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS * 4);
+
+    let ended = false;
+    void run.then(() => {
+      ended = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ended, "the deadline fired through a reconnect").toBe(false);
+
+    // …and the link comes back, replays the rest from the cursor, and the read
+    // finishes at the end of the log the way it would have without the drop.
+    core.emitReplayed(14);
+    for (let eventId = 15; eventId <= 22; eventId += 1) {
+      core.emitEvent({ eventId, kind: eventId === 22 ? "session:finished" : "task:updated" });
+    }
+    core.emitReplayed(22);
+    await vi.advanceTimersByTimeAsync(0);
+    core.emitReplayed(22);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([
+      14, 15, 16, 17, 18, 19, 20, 21, 22,
+    ]);
+    expect(result.err.join("\n")).toContain("reconnecting");
   });
 
   it("still follows when the log had nothing past where the run started", async () => {
@@ -322,6 +429,43 @@ describe("actana events tail", () => {
     const result = await run;
     expect(result.code).toBe(EXIT_OK);
     expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([1, 2]);
+  });
+
+  it("does not report a read finished when the walk settled for an approximation", async () => {
+    // #402 review, finding 5. `event-tip.ts` gives up after MAX_TIP_ROUNDS
+    // against a Core appending faster than this side can drain it, writes
+    // "carrying on from #N" and hands back a number that may be behind the
+    // log's end. That sentence was written for a first run, which really does
+    // carry on. A read takes the number as the end of the history and stops —
+    // so it must say so itself, and must not call a knowingly incomplete read a
+    // finished one.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--since", "start", "--limit", "100000"], {
+      connect: core.connect,
+    });
+    await settle();
+
+    // MAX_TIP_ROUNDS is 200 and lives in `event-tip.ts`; the round after the
+    // last one it will take is where the hunt gives up. Every tail here is
+    // non-empty, which is what keeps it asking.
+    for (let round = 1; round <= 201; round += 1) {
+      core.emitEvent({ eventId: round, kind: "task:updated" });
+      core.emitReplayed(round);
+    }
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_FAILURE);
+    // Everything it did read is still on stdout — the status is what says the
+    // read is short, not a missing line.
+    expect(result.out).toHaveLength(201);
+    const said = result.err.join("\n");
+    expect(said).toContain("faster than they could be read");
+    expect(said).toContain("did not finish");
+    // The other caller's sentence, which would be a lie here.
+    expect(said).not.toContain("carrying on");
+    expect(core.closed).toBe(true);
   });
 
   it("ends a read whose history matched no --kind, rather than following", async () => {

--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -11,14 +11,14 @@
 // be the replay storm the ticket names, produced deliberately on the first
 // command an operator types.
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   fakeCore,
   makeCliFixture,
   registerCore,
   type CliFixture,
 } from "./cli-harness.ts";
-import { EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 
 let fixture: CliFixture | null = null;
 function cli(): CliFixture {
@@ -28,7 +28,15 @@ function cli(): CliFixture {
 afterEach(() => {
   fixture?.cleanup();
   fixture = null;
+  vi.useRealTimers();
 });
+
+/**
+ * The 30s a bounded run gives a Core that has gone quiet, jumped rather than
+ * waited out. `events-command.ts` holds the constant; a test that hard-coded a
+ * shorter one would be testing a different command.
+ */
+const SUBSCRIBE_ANSWER_MS = 30_000;
 
 async function withRegisteredCore(): Promise<void> {
   registerCore(cli().paths, "prod");
@@ -195,6 +203,155 @@ describe("actana events tail", () => {
     // A consumer parsing stdout must never have to recognise a status line.
     expect(result.out).toHaveLength(1);
     JSON.parse(result.out[0]!);
+  });
+
+  // ─── #402: --limit reads history and exits ────────────────────────────────
+  //
+  // On live pairdemo, `events tail --since 13 --limit 30 --json` sat until it
+  // was killed. The nine events past #13 were already in SQLite — the
+  // `session:finished` the operator was waiting for among them — and the
+  // command printed them and then waited for twenty-one more that no one was
+  // ever going to append. `--limit` is a ceiling on a read of the log, not a
+  // quota the command blocks on.
+
+  it("exits from history when the log holds fewer events than --limit", async () => {
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    // The pairdemo run, frame for frame: a cursor at #13, a ceiling of 30, and
+    // a Core whose log ends at #22 with the finish already in it.
+    const run = cli().run(["events", "tail", "--since", "13", "--limit", "30", "--json"], {
+      connect: core.connect,
+    });
+    await settle();
+
+    for (let eventId = 14; eventId <= 21; eventId += 1) {
+      core.emitEvent({ eventId, kind: "task:updated" });
+    }
+    core.emitEvent({ eventId: 22, kind: "session:finished", taskId: "t-1" });
+    core.emitReplayed(22);
+    await settle();
+
+    // One marker is a receipt for what was sent, not a statement that the log
+    // has ended, so the run asks again from where it got to — the same
+    // discipline a first run's tip hunt uses (`event-tip.ts`).
+    expect(core.subscribes).toContain(22);
+    core.emitReplayed(22);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    // Nine events, not thirty, and the command is back at the prompt.
+    expect(result.out).toHaveLength(9);
+    const rows = result.out.map((line) => JSON.parse(line));
+    expect(rows[0].eventId).toBe(14);
+    expect(rows[8]).toMatchObject({ eventId: 22, kind: "session:finished" });
+    expect(core.closed).toBe(true);
+  });
+
+  it("prints the history it was given when the subscribe never replays or pushes", async () => {
+    // The other half of #402: the Core is contended, the subscribe answers with
+    // a tail and then goes silent — no `eventsReplayed`, no live push, nothing
+    // to close the loop on. The events are already here; a command that holds
+    // them hostage to a marker that is not coming is the hang, reported.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--since", "13", "--limit", "30", "--json"], {
+      connect: core.connect,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (let eventId = 14; eventId <= 22; eventId += 1) {
+      core.emitEvent({ eventId, kind: eventId === 22 ? "session:finished" : "task:updated" });
+    }
+    // And now the Core says nothing at all, for as long as anyone is willing to
+    // wait. Nobody is: the deadline is re-armed on every frame, so it runs from
+    // the last thing the Core actually said.
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([
+      14, 15, 16, 17, 18, 19, 20, 21, 22,
+    ]);
+    expect(result.err.join("\n")).toContain("stopped answering");
+    expect(core.closed).toBe(true);
+  });
+
+  it("does not wedge on a subscribe that answers nothing at all", async () => {
+    // Nothing printed and nothing to print: the run still ends, and it ends
+    // saying why rather than exiting 0 on a Core it never heard from.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--since", "13", "--limit", "30", "--json"], {
+      connect: core.connect,
+    });
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(result.out).toHaveLength(0);
+    expect(result.err.join("\n")).toContain("stopped answering");
+    expect(core.closed).toBe(true);
+  });
+
+  it("still follows when the log had nothing past where the run started", async () => {
+    // The case #402 deliberately leaves alone, and the one `events-tail-cursor`
+    // is built on: a cursor with an empty log past it is what a follow looks
+    // like at the moment it starts, so there is no read to finish and `--limit`
+    // keeps the meaning it has always had. Ending here would end the run before
+    // its first line.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--since", "start", "--limit", "2"], {
+      connect: core.connect,
+    });
+    await settle();
+
+    // Caught up, with nothing to have caught up on.
+    core.emitReplayed(0);
+    await settle();
+
+    core.emitEvent({ eventId: 1, kind: "task:created" });
+    core.emitEvent({ eventId: 2, kind: "session:finished" });
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([1, 2]);
+  });
+
+  it("stops timing the Core once it has said where its log ends", async () => {
+    // The deadline covers a subscribe that never answers, not a Core with
+    // nothing to say. Once the end of the log is known the run is following,
+    // and a follow that gave up after thirty quiet seconds would be a worse
+    // hang than the one #402 fixed — silent, and on a Core behaving perfectly.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--since", "start", "--limit", "1"], {
+      connect: core.connect,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    core.emitReplayed(0);
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS * 3);
+
+    // Still here, an hour of quiet later.
+    let ended = false;
+    void run.then(() => {
+      ended = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ended).toBe(false);
+
+    core.emitEvent({ eventId: 1, kind: "session:finished" });
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(JSON.parse(result.out[0]!).eventId).toBe(1);
   });
 
   it("rejects a --since or --limit that is not a number", async () => {

--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -324,6 +324,35 @@ describe("actana events tail", () => {
     expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([1, 2]);
   });
 
+  it("ends a read whose history matched no --kind, rather than following", async () => {
+    // What decides whether there was history to read is what the Core had, not
+    // what the filter let through. A read of a log that held nothing this
+    // operator asked for still finished, and has nothing left to wait for —
+    // reading `printed` here would hang exactly where #402 hung, one flag over.
+    //
+    // The first-run half of the kind filter — history skipped while the cursor
+    // advances past it — is #403 and is not touched here.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(
+      ["events", "tail", "--json", "--since", "13", "--limit", "30", "--kind", "session:finished"],
+      { connect: core.connect },
+    );
+    await settle();
+
+    core.emitEvent({ eventId: 14, kind: "task:updated" });
+    core.emitEvent({ eventId: 15, kind: "task:updated" });
+    core.emitReplayed(15);
+    await settle();
+    core.emitReplayed(15);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out).toEqual([]);
+    expect(core.closed).toBe(true);
+  });
+
   it("stops timing the Core once it has said where its log ends", async () => {
     // The deadline covers a subscribe that never answers, not a Core with
     // nothing to say. Once the end of the log is known the run is following,

--- a/packages/cli/src/__tests__/events-tail-cursor.test.ts
+++ b/packages/cli/src/__tests__/events-tail-cursor.test.ts
@@ -254,6 +254,44 @@ describe("actana events tail, across a Core restart", () => {
     expect(idsOf(result.out)).toEqual([1501]);
   }, 60_000);
 
+  it("reads a history longer than one tail exactly once, in order, and then exits", async () => {
+    // The printing side of the capped-tail walk (#402 review, non-blocking
+    // note), against the Core that produces it. This is the mirror of the test
+    // above and the one shape #205's review blocked on, now reachable on a path
+    // that did not exist then: a `--limit` read re-subscribes **while printing**,
+    // so a cursor moved wrong shows up here as a duplicated line or a hole,
+    // neither of which throws or logs anywhere.
+    //
+    // 1500 events past the cursor against a cap of 1000: the first marker is a
+    // receipt for a tail the Core cut short, the walk asks again from it, and
+    // only an empty tail ends the read. The dedup underneath is the durable
+    // client's; this is what proves it holds on this path rather than assuming
+    // it does.
+    const log = arrayEventLog();
+    fillPastTheCap(log);
+    const port = await freePort();
+    const core = await coreOn(port, log);
+    fixture = makeCliFixture();
+    registerCore(fixture.paths, "inproc", core.blobText);
+
+    // A ceiling well past the log: what ends this run is the end of the
+    // history, not the count.
+    const result = await fixture.run(
+      ["events", "tail", "--json", "--since", "start", "--limit", "2000"],
+      { connect: connectCore },
+    );
+
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+    const ids = idsOf(result.out);
+    expect(ids).toHaveLength(1_500);
+    // Each exactly once, in order. A replay storm is a repeat here; a moved
+    // cursor is a gap.
+    expect(ids).toEqual(Array.from({ length: 1_500 }, (_, i) => i + 1));
+    // More than one read, so the cap was really hit and this exercised the walk
+    // rather than a single tail that happened to fit.
+    expect(log.tailReads).toBeGreaterThan(1);
+  }, 60_000);
+
   it("leaves the stored cursor alone when --since asks for a one-off rewind", async () => {
     const log = arrayEventLog();
     const port = await freePort();

--- a/packages/cli/src/__tests__/no-prompt-timing.test.ts
+++ b/packages/cli/src/__tests__/no-prompt-timing.test.ts
@@ -66,13 +66,15 @@ const SCHEDULERS = [
 /**
  * The files allowed to schedule, and the reason each is.
  *
- * One row, and it buys a wait on a Core's own verdict rather than a nudge at a
- * harness. Anything that writes to a Session is barred from this table by the
+ * Two rows, and each buys a wait on a Core's own answer rather than a nudge at
+ * a harness. Anything that writes to a Session is barred from this table by the
  * test below it — that is the boundary the rule is actually about.
  */
 const SCHEDULING_ALLOWED: Record<string, string> = {
   "harness-command.ts":
     "waits for the Core's install verdict: a deadline on this side's patience and a progress tick, neither of which re-sends anything (#161)",
+  "events-command.ts":
+    "a deadline on a subscribe the Core never answers, so `--limit` cannot be wedged by a contended Core (#402). It re-sends nothing, it cannot make an event arrive sooner, and its expiry is reported as this side giving up",
 };
 
 /** Modules that put text or keystrokes into a Session. Never allowed a timer. */

--- a/packages/cli/src/__tests__/no-prompt-timing.test.ts
+++ b/packages/cli/src/__tests__/no-prompt-timing.test.ts
@@ -21,21 +21,47 @@
 // status. Passing a number is not scheduling; that is why the sweep below looks
 // for the scheduling primitives themselves.
 //
-// **One file is allowed to hold a timer, and it is named here rather than
-// waved through** (#161, merged into #160's rule). `harness install` waits for
-// a verdict a vendor installer takes minutes to produce, so it carries a
-// deadline and a progress tick of its own. That is the same trade
-// `--wait-timeout` already makes and it fails the same way: it re-sends
-// nothing, it cannot make a Harness look installed sooner, and its expiry is
-// reported as *this side* giving up ("the Core reported no outcome within 15
-// minutes. The install may still be running there."), never as an outcome. The
-// difference from `--wait-timeout` is only which package the timer object sits
-// in, which is not the thing ADR 0026 moved.
+// **Two files are allowed to hold a timer, and both are named here rather than
+// waved through** (#161, merged into #160's rule; #402 added the second). Each
+// buys the same thing and is admitted on the same three properties — the ones
+// `--wait-timeout` already has. A listed timer **re-sends nothing**, it
+// **cannot make the thing it waits for happen any sooner**, and its expiry is
+// **reported as this side giving up** rather than as an outcome. A timer with
+// all three is a limit on patience. A timer missing any of them is the 450 ms
+// nudge wearing a table row as cover, and no reason admits it.
+//
+//   • `harness-command.ts` waits for a verdict a vendor installer takes minutes
+//     to produce, so it carries a deadline and a progress tick of its own. It
+//     re-sends no install, it cannot make a Harness look installed sooner, and
+//     it expires saying "the Core reported no outcome within 15 minutes. The
+//     install may still be running there." — this side giving up, never an
+//     outcome. The difference from `--wait-timeout` is only which package the
+//     timer object sits in, which is not the thing ADR 0026 moved.
+//
+//   • `events-command.ts` waits for a Core to answer `subscribe` at all (#402).
+//     A contended Core that never replays sends no `event` and no
+//     `eventsReplayed`, so an `events tail --limit` has neither its ceiling nor
+//     the end of the log left to end on and waits for ever — which is what an
+//     operator reported against a live Core, with the event they were waiting
+//     for already in its database. The deadline re-sends no `subscribe`, it
+//     cannot make an event arrive sooner, and it expires **non-zero**, saying
+//     the Core stopped answering and that the read did not finish. It is
+//     disarmed the moment the Core says where its log ends, and it is cleared
+//     while the link is down, so it can only ever fire at a Core that is
+//     connected and silent.
+//
+//     And note what it is not: this rule is about the path from an operator's
+//     text to a Harness's stdin, and `events tail` is a read of a log with
+//     nothing on that path at all. Being listed here does not exempt it from
+//     `TOUCHES_A_SESSION` below, which is what would catch it if that ever
+//     changed.
 //
 // The allowance is a table with a reason per row, so it stays a rule: a new
 // timer in any other file still fails, a timer in a file that writes to a
 // Session fails even if it is listed, and a row for a file that no longer
-// exists fails rather than quietly widening.
+// exists fails rather than quietly widening. Growing the table is meant to cost
+// a paragraph up here, argued the way the two above are — that cost is the rule
+// working, not friction to route around.
 //
 // **Scoped to the client half since #288**, for the same reason and by the same
 // table as the shell-out ban one file over (`module-halves.ts`). This package

--- a/packages/cli/src/event-tip.ts
+++ b/packages/cli/src/event-tip.ts
@@ -88,6 +88,22 @@ export type EventTipOptions = {
    * connection and can wait; a one-shot client cannot, and passes a reject.
    */
   onSendFailed?: () => void;
+  /**
+   * Called **instead of** the stderr line below when the hunt gives up after
+   * {@link MAX_TIP_ROUNDS} and settles for the highest id it saw.
+   *
+   * The default sentence says the caller is carrying on from an approximate
+   * number, and for the caller it was written for — a first run about to follow
+   * — that is exactly what happens. `events tail --limit` on the printing side
+   * is not: it takes the returned number as the end of the history and stops
+   * there, so "carrying on" would be told to an operator whose command has
+   * already exited (#402 review, finding 5). A caller that ends here says so in
+   * its own words, and gets to decide that an approximation is not a finished
+   * read.
+   *
+   * The number handed over is the same one `tipFrom` is about to return.
+   */
+  onRoundsExhausted?: (seen: number) => void;
 };
 
 /**
@@ -124,11 +140,15 @@ export function trackEventTip(
       if (rounds >= MAX_TIP_ROUNDS) {
         // Stated rather than swallowed. This is the one path where the number
         // handed back is approximate, and an operator reading a surprising
-        // first line deserves the reason on stderr.
-        deps.err(
-          `this Core appended events faster than they could be read (${MAX_TIP_ROUNDS} rounds); ` +
-            `carrying on from #${seen}, which may be behind its log's end.`,
-        );
+        // first line deserves the reason on stderr — from whichever caller
+        // knows what it is about to do with the number.
+        if (opts.onRoundsExhausted) opts.onRoundsExhausted(seen);
+        else {
+          deps.err(
+            `this Core appended events faster than they could be read (${MAX_TIP_ROUNDS} rounds); ` +
+              `carrying on from #${seen}, which may be behind its log's end.`,
+          );
+        }
         return seen;
       }
 

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -56,13 +56,30 @@
 //     proving #161's criterion. There was no read to finish, so it follows and
 //     stops at n, which is what `--limit` has always meant.
 //
-//   • **That a stuck subscribe cannot wedge either of them.** A Core that never
+//   • **That a stuck subscribe cannot wedge any of them.** A Core that never
 //     answers `subscribe` sends no event and no marker, so neither the ceiling
 //     nor the end of the log is ever reached and the command has nothing to do
 //     but wait — which is the other half of #402's report, a Core under
-//     contention. Until the log's end is known, a `--limit` run holds a
-//     deadline on its patience; it prints what it did get, says on stderr that
-//     the Core stopped answering, and exits.
+//     contention. So **every** `--limit` run holds a deadline on its patience
+//     until the log's end is known, on both sides of the printing switch: a
+//     first run is walking to the tip and a run with a cursor is walking to the
+//     end, and a Core that answers neither wedges both. `--limit 30` with no
+//     cursor and no `--since` is the invocation an operator is most likely to
+//     type, and it is the one this must cover.
+//
+//     It expires as *this side giving up*, never as an outcome: what was
+//     printed goes out, stderr says the Core stopped answering, and the exit is
+//     a failure — a read cut off partway is not a read that finished, and a
+//     script reads `$?` rather than English.
+//
+//     It is disarmed once the log's end is known, because past that point
+//     silence is a Core with nothing to say and waiting through it is the whole
+//     of what a follow does. And it does not run while the link is down: a
+//     dropped socket is not a Core refusing to answer, `DurableCoreClient`
+//     re-dials and replays the whole tail from the cursor, and a deadline that
+//     fired through a Core restart would truncate a read the reconnect was
+//     about to complete — breaking the promise this file's own help text makes
+//     three paragraphs down.
 //
 // Nothing here handles SIGINT, and that is deliberate. Ctrl-C ends this the way
 // it ends `tail -f`: the default signal disposition, no handler. There is
@@ -132,10 +149,18 @@ Where it ends
   it follows and stops after n events. Without --limit, a tail follows until
   Ctrl-C either way.
 
+  A --limit run gives the Core 30s to answer at all. A Core that goes silent
+  before it has said where its log ends leaves the run with nothing to end on,
+  so it stops: what arrived is on stdout, the reason is on stderr, and it exits
+  non-zero because a read that stopped partway is not a read that finished. The
+  clock comes off once the log's end is known — from there it is following, and
+  a follow waits.
+
 Reconnects
   The link re-establishes itself and replays from the cursor, so a Core restart
   or a dropped network costs neither a repeated event nor a missed one. Notices
-  about the link go to stderr; stdout carries events only.
+  about the link go to stderr; stdout carries events only. A dropped link is not
+  a Core going silent: the 30s above is not running while it is down.
 
   Ctrl-C ends it. Nothing is buffered.`;
 
@@ -223,20 +248,40 @@ async function eventsTail(
     // operator asked for still finished, and has nothing more to wait for.
     let read = 0;
     let settled = false;
-    // Only consulted while `printing` is off — once the log's end is known
-    // there is nothing left to learn, and every later marker is just a
-    // reconnect catching up.
-    const tip = trackEventTip(client, deps);
-    // The same walk, on the other side of the switch. A first run walks the log
-    // to find its tip and prints none of it; a `--limit` run walks it to find
-    // its end and prints all of it. The question asked of each marker is the
-    // same one — did this close an empty tail, or is the Core capping a replay
-    // — so it is asked with the same tracker rather than with a second opinion.
+    // One walk of the log per run, and never both of these.
     //
-    // Retired once the end is known: after that every marker is a reconnect
-    // catching up, exactly as on the other side, and there is nothing left to
-    // ask.
-    let history = limit.value !== null && fromStart ? trackEventTip(client, deps) : null;
+    // Which one is decided before the first frame and cannot change: `printing`
+    // is initialised from `fromStart` and is only ever switched *on*, so a run
+    // that starts printing never enters the `!printing` branch, and `history`
+    // is non-null only when `fromStart` — the case that branch cannot reach.
+    // They ask the same question of every marker (did this close an empty tail,
+    // or is the Core capping a replay) and it is `event-tip.ts` that answers
+    // it, so they are two of the same thing rather than two opinions.
+    //
+    // Two objects rather than one with a mode because they differ in exactly
+    // one place, and it is the one that matters: when the hunt gives up after
+    // `MAX_TIP_ROUNDS`, a run still looking for the tip really does carry on,
+    // and a run reading history is about to stop. Same walk, different sentence
+    // at the end of it.
+    const tip = trackEventTip(client, deps);
+    // Set when the walk below settled for an approximation rather than reaching
+    // the end of the log. A run that ends here has not read what it was asked
+    // for, whatever its last marker said.
+    let approximate = false;
+    let history =
+      limit.value !== null && fromStart
+        ? trackEventTip(client, deps, {
+            // The number is taken from `tipFrom`'s return where the run ends;
+            // all this needs to record is that it is an approximation.
+            onRoundsExhausted: () => {
+              approximate = true;
+            },
+          })
+        : null;
+    // Whether the Core still owes this run an answer. `--limit` is the whole of
+    // it: a tail with no ceiling is a follow, and a follow has nothing to give
+    // up on. Cleared the moment the log's end is known, whichever walk found it.
+    let timing = limit.value !== null;
     let idle: ReturnType<typeof setTimeout> | null = null;
 
     const finish = (code: number) => {
@@ -256,31 +301,39 @@ async function eventsTail(
      *
      * Re-armed on every frame that *is* an answer, so the clock only ever runs
      * while the Core is silent — a long log is a Core answering, slowly and
-     * correctly. Disarmed for good once the end of the log is known, because
-     * past that point silence is a Core with nothing to say and waiting through
-     * it is the whole of what a follow does.
+     * correctly. Armed on both sides of the printing switch, because a run
+     * walking to the tip and a run walking to the end of the history are wedged
+     * by the same silence.
      *
-     * When it fires, what was printed is what the subscribe gave up: a
-     * truncated read still succeeded, and a subscribe that answered nothing at
-     * all is a failure with a reason on stderr rather than a hang.
+     * Expiry is this side giving up and is reported as one: a read that stopped
+     * partway is not a read that finished, so it exits a failure however many
+     * events it managed. The events it did get are already on stdout and stay
+     * there — a truncated file plus a non-zero status is something a script can
+     * act on; a truncated file plus a 0 is not.
      */
     const waitForAnswer = () => {
-      if (history === null || settled) return;
+      if (!timing || settled) return;
       if (idle !== null) clearTimeout(idle);
       idle = setTimeout(() => {
         deps.err(
           `actana events tail: ${name ?? endpoint} stopped answering the event ` +
-            `subscription; stopping with ${printed} event(s) printed.`,
+            `subscription; giving up with ${printed} event(s) printed. This read did not finish.`,
         );
-        finish(read > 0 ? EXIT_OK : EXIT_FAILURE);
+        finish(EXIT_FAILURE);
       }, SUBSCRIBE_ANSWER_MS);
+    };
+
+    /** Stop timing the Core: it has answered, or there is nothing left to ask. */
+    const stopTiming = () => {
+      timing = false;
+      if (idle !== null) clearTimeout(idle);
+      idle = null;
     };
 
     /** Stop watching for the end of the log, and stop timing the Core. */
     const stopReading = () => {
       history = null;
-      if (idle !== null) clearTimeout(idle);
-      idle = null;
+      stopTiming();
     };
 
     const offEvent = client.onEvent(({ event }) => {
@@ -294,6 +347,7 @@ async function eventsTail(
         // a receipt for what the Core sent, not a statement that it has no more
         // (`event-tip.ts`).
         tip.saw(event.eventId);
+        waitForAnswer();
         return;
       }
       // Counted before the filter, and before the ceiling: this is history the
@@ -320,7 +374,14 @@ async function eventsTail(
         // A capped replay: the rest has been asked for and another marker is
         // coming. Printing stays off, which is the whole point — this is the
         // history the operator did not ask to see.
-        if (end === null) return;
+        if (end === null) {
+          waitForAnswer();
+          return;
+        }
+        // The end of the log, found. This run has its answer, so the deadline
+        // comes off here as well as in `stopReading` — from here it is a
+        // follow, and a follow waits through any amount of quiet.
+        stopTiming();
         deps.verbose(`the Core's log ends at #${end}; following from there`);
         printing = true;
         return;
@@ -338,6 +399,20 @@ async function eventsTail(
       }
       stopReading();
 
+      // Not the end of the log — the number `event-tip.ts` settled for after
+      // `MAX_TIP_ROUNDS` of a Core appending faster than this side could drain
+      // it. Its own message says the hunt is carrying on, and that sentence was
+      // written for the caller that does: this one is stopping, so it says so
+      // itself and stops the way every other unfinished read does.
+      if (approximate) {
+        deps.err(
+          `actana events tail: ${name ?? endpoint} appended events faster than they could be ` +
+            `read; giving up at #${end} with ${printed} event(s) printed. This read did not finish.`,
+        );
+        finish(EXIT_FAILURE);
+        return;
+      }
+
       // Nothing was there to read: this is a follow that has just been told the
       // log is empty past where it started, and a follow waits. `--limit` keeps
       // the meaning it has always had for it — stop after n.
@@ -352,6 +427,18 @@ async function eventsTail(
     });
 
     const offDown = client.onDisconnected(({ error }) => {
+      // The clock stops while the link is down, and this is the whole of the
+      // reason: a dropped socket is not a Core refusing to answer. Nothing can
+      // arrive to re-arm the deadline until the link is back, and
+      // `DurableCoreClient` re-dials with a backoff that tops out at five
+      // seconds and never gives up — so a deadline left running would fire
+      // through a Core restart and truncate a read the reconnect was seconds
+      // from completing, on a `core update` or a reboot. The help text below
+      // promises that a restart costs neither a repeated event nor a missed
+      // one; this is what keeps that true for a `--limit` run.
+      if (idle !== null) clearTimeout(idle);
+      idle = null;
+
       // stderr, always: on the `--json` path stdout is the event stream, and a
       // consumer parsing it should never have to recognise a status line.
       deps.err(`link to ${name ?? endpoint} dropped${error ? ` — ${error}` : ""}; reconnecting…`);
@@ -359,6 +446,10 @@ async function eventsTail(
 
     const offUp = client.onReady(() => {
       deps.verbose("link re-established; replaying from the cursor");
+      // A fresh `subscribe` has gone out on the new connection, so the Core
+      // owes an answer again and the clock starts again — from now, not from
+      // whenever the old socket last said anything.
+      waitForAnswer();
     });
 
     waitForAnswer();

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -217,6 +217,11 @@ async function eventsTail(
 
   return new Promise<number>((resolve) => {
     let printed = 0;
+    // Events the Core sent past this run's cursor, filter or no filter. What
+    // decides whether there was history to read is what the *Core* had, never
+    // what `--kind` let through — a read of a log that held nothing this
+    // operator asked for still finished, and has nothing more to wait for.
+    let read = 0;
     let settled = false;
     // Only consulted while `printing` is off — once the log's end is known
     // there is nothing left to learn, and every later marker is just a
@@ -265,9 +270,9 @@ async function eventsTail(
       idle = setTimeout(() => {
         deps.err(
           `actana events tail: ${name ?? endpoint} stopped answering the event ` +
-            `subscription; stopping with ${printed} event(s).`,
+            `subscription; stopping with ${printed} event(s) printed.`,
         );
-        finish(printed > 0 ? EXIT_OK : EXIT_FAILURE);
+        finish(read > 0 ? EXIT_OK : EXIT_FAILURE);
       }, SUBSCRIBE_ANSWER_MS);
     };
 
@@ -294,8 +299,11 @@ async function eventsTail(
       // Counted before the filter, and before the ceiling: this is history the
       // Core sent, and how much of it the operator asked to see changes nothing
       // about whether there is more of it to come.
-      history?.saw(event.eventId);
-      waitForAnswer();
+      if (history !== null) {
+        history.saw(event.eventId);
+        read += 1;
+        waitForAnswer();
+      }
       if (kinds.size > 0 && !kinds.has(event.kind)) return;
       deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
       printed += 1;
@@ -333,12 +341,12 @@ async function eventsTail(
       // Nothing was there to read: this is a follow that has just been told the
       // log is empty past where it started, and a follow waits. `--limit` keeps
       // the meaning it has always had for it — stop after n.
-      if (printed === 0) {
+      if (read === 0) {
         deps.verbose(`the Core's log ends at #${end}; nothing to read, following from there`);
         return;
       }
       deps.verbose(
-        `the Core's log ends at #${end}; --limit is a ceiling, and ${printed} event(s) is the log`,
+        `the Core's log ends at #${end}; ${read} event(s) read, ${printed} printed — --limit is a ceiling`,
       );
       finish(EXIT_OK);
     });

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -34,6 +34,36 @@
 //     already covered by the in-memory cursor; a restart is not, and a CLI is
 //     restarted constantly.
 //
+//   • **Where a `--limit` run ends.** This is #402. On a live Core,
+//     `events tail --since 13 --limit 30 --json` printed the nine events past
+//     the cursor and then sat until it was killed: the `session:finished` the
+//     operator was waiting for was event #22, already in SQLite, already on
+//     their screen, and the only way out of the loop was a thirtieth event that
+//     nobody was going to append. `--limit` is a ceiling on what gets printed,
+//     and it was being waited on as a quota.
+//
+//     So a run that was given somewhere to start from — `--since`, or a cursor
+//     a previous run left — and that **found history there** has read what it
+//     was asked for, and ends at the end of that history however few events it
+//     turned out to be. The end is found the same way a first run finds the tip
+//     and by the same code: `event-tip.ts`, one marker at a time, until one
+//     closes an empty tail.
+//
+//     A run that found *no* history is the case this deliberately leaves alone.
+//     Nothing past the cursor is what a follow looks like at the moment it
+//     starts — it is `--since start` against a log that has not been written to
+//     yet, and `events-tail-cursor.test.ts` is that run, across a Core restart,
+//     proving #161's criterion. There was no read to finish, so it follows and
+//     stops at n, which is what `--limit` has always meant.
+//
+//   • **That a stuck subscribe cannot wedge either of them.** A Core that never
+//     answers `subscribe` sends no event and no marker, so neither the ceiling
+//     nor the end of the log is ever reached and the command has nothing to do
+//     but wait — which is the other half of #402's report, a Core under
+//     contention. Until the log's end is known, a `--limit` run holds a
+//     deadline on its patience; it prints what it did get, says on stderr that
+//     the Core stopped answering, and exits.
+//
 // Nothing here handles SIGINT, and that is deliberate. Ctrl-C ends this the way
 // it ends `tail -f`: the default signal disposition, no handler. There is
 // nothing to flush — every line is written as it arrives, and the cursor file is
@@ -56,6 +86,20 @@ import type { RegistryPaths } from "./blob-registry.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
 import type { ParsedArgs } from "./cli-args.ts";
 
+/**
+ * How long a bounded run waits for a Core that has gone quiet.
+ *
+ * Armed only on a `--limit` run reading history, re-armed on every event and
+ * every marker: what it exists to catch is a subscribe that never answers, and
+ * a long log is a Core answering — slowly, and correctly. The same 30s
+ * `harness install` gives the same frame, for the same reason.
+ *
+ * Without it, "read the log and exit" still has one way not to exit, and it is
+ * the way #402 was reported: a contended Core, a subscribe that never replays,
+ * and a command with nothing to do but wait.
+ */
+const SUBSCRIBE_ANSWER_MS = 30_000;
+
 export const EVENTS_HELP = `actana events tail — follow a Core's event log
 
 Usage
@@ -67,7 +111,7 @@ Flags
   --since <id>     start after this event id, instead of the stored cursor
   --since start    start at the beginning of the log the Core still holds
   --kind <kind>    only this kind; repeat the flag for more than one
-  --limit <n>      stop after n events instead of following
+  --limit <n>      print at most n events, then exit
   --verbose        explain the steps, on stderr. Never prints a blob.
 
 Where it starts
@@ -77,6 +121,16 @@ Where it starts
 
   --since does not move the stored cursor: a one-off rewind leaves the
   follow-along stream where it was.
+
+Where it ends
+  --limit is a ceiling, not a quota. A run that starts from --since or a stored
+  cursor and finds events already in the log prints them and exits at the end of
+  that history, however far short of n it stops. It does not wait for a Core to
+  produce the difference.
+
+  With nothing in the log past where it started, there is no history to read, so
+  it follows and stops after n events. Without --limit, a tail follows until
+  Ctrl-C either way.
 
 Reconnects
   The link re-establishes itself and replays from the cursor, so a Core restart
@@ -168,16 +222,60 @@ async function eventsTail(
     // there is nothing left to learn, and every later marker is just a
     // reconnect catching up.
     const tip = trackEventTip(client, deps);
+    // The same walk, on the other side of the switch. A first run walks the log
+    // to find its tip and prints none of it; a `--limit` run walks it to find
+    // its end and prints all of it. The question asked of each marker is the
+    // same one — did this close an empty tail, or is the Core capping a replay
+    // — so it is asked with the same tracker rather than with a second opinion.
+    //
+    // Retired once the end is known: after that every marker is a reconnect
+    // catching up, exactly as on the other side, and there is nothing left to
+    // ask.
+    let history = limit.value !== null && fromStart ? trackEventTip(client, deps) : null;
+    let idle: ReturnType<typeof setTimeout> | null = null;
 
     const finish = (code: number) => {
       if (settled) return;
       settled = true;
+      if (idle !== null) clearTimeout(idle);
       offEvent();
       offReplayed();
       offDown();
       offUp();
       client.close();
       resolve(code);
+    };
+
+    /**
+     * Re-arm the deadline on the Core's answer to `subscribe`.
+     *
+     * Re-armed on every frame that *is* an answer, so the clock only ever runs
+     * while the Core is silent — a long log is a Core answering, slowly and
+     * correctly. Disarmed for good once the end of the log is known, because
+     * past that point silence is a Core with nothing to say and waiting through
+     * it is the whole of what a follow does.
+     *
+     * When it fires, what was printed is what the subscribe gave up: a
+     * truncated read still succeeded, and a subscribe that answered nothing at
+     * all is a failure with a reason on stderr rather than a hang.
+     */
+    const waitForAnswer = () => {
+      if (history === null || settled) return;
+      if (idle !== null) clearTimeout(idle);
+      idle = setTimeout(() => {
+        deps.err(
+          `actana events tail: ${name ?? endpoint} stopped answering the event ` +
+            `subscription; stopping with ${printed} event(s).`,
+        );
+        finish(printed > 0 ? EXIT_OK : EXIT_FAILURE);
+      }, SUBSCRIBE_ANSWER_MS);
+    };
+
+    /** Stop watching for the end of the log, and stop timing the Core. */
+    const stopReading = () => {
+      history = null;
+      if (idle !== null) clearTimeout(idle);
+      idle = null;
     };
 
     const offEvent = client.onEvent(({ event }) => {
@@ -193,6 +291,11 @@ async function eventsTail(
         tip.saw(event.eventId);
         return;
       }
+      // Counted before the filter, and before the ceiling: this is history the
+      // Core sent, and how much of it the operator asked to see changes nothing
+      // about whether there is more of it to come.
+      history?.saw(event.eventId);
+      waitForAnswer();
       if (kinds.size > 0 && !kinds.has(event.kind)) return;
       deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
       printed += 1;
@@ -215,6 +318,29 @@ async function eventsTail(
         return;
       }
       deps.verbose(`caught up to #${lastEventId}`);
+      if (history === null) return;
+
+      // Everything the Core holds past this run's cursor has now been sent —
+      // unless this marker closed a capped tail, in which case the tracker has
+      // already asked again and another marker is coming.
+      const end = history.tipFrom(lastEventId);
+      if (end === null) {
+        waitForAnswer();
+        return;
+      }
+      stopReading();
+
+      // Nothing was there to read: this is a follow that has just been told the
+      // log is empty past where it started, and a follow waits. `--limit` keeps
+      // the meaning it has always had for it — stop after n.
+      if (printed === 0) {
+        deps.verbose(`the Core's log ends at #${end}; nothing to read, following from there`);
+        return;
+      }
+      deps.verbose(
+        `the Core's log ends at #${end}; --limit is a ceiling, and ${printed} event(s) is the log`,
+      );
+      finish(EXIT_OK);
     });
 
     const offDown = client.onDisconnected(({ error }) => {
@@ -227,6 +353,7 @@ async function eventsTail(
       deps.verbose("link re-established; replaying from the cursor");
     });
 
+    waitForAnswer();
     if (limit.value === 0) finish(EXIT_OK);
   }).catch((err: unknown) => {
     deps.err(`actana events tail: ${errorText(err)}`);


### PR DESCRIPTION
Fixes the hang in `actana events tail --limit` reported as #402 (hunt `F6`, live on pairdemo 2026-09-02).

## What the operator saw

`actana events tail --since 13 --limit 30 --json` sat until it was killed. The events past `#13` were already in
SQLite — `session:finished` among them, as `#22` — and the command had already printed them. The only way out of the
printing loop in `events-command.ts` was a thirtieth event that nobody was going to append: `--limit` was being waited
on as a quota rather than applied as a ceiling.

## What changed

`packages/cli/src/events-command.ts`, and nothing else in the tree.

1. **A `--limit` run that read history ends at the end of that history.** A run given somewhere to start from —
   `--since`, or a cursor a previous run left — that finds events there has read what it was asked for, and exits
   however far short of `n` it stops. The end of the log is found the way a first run finds the tip and by the same
   code, `event-tip.ts`: one marker at a time until one closes an *empty* tail, because a single `eventsReplayed` is a
   receipt for what the Core sent and not a statement that it has no more.

2. **A run that found no history is deliberately left alone.** Nothing past the cursor is what a follow looks like at
   the moment it starts — `--since start` against a log not yet written to. `events-tail-cursor.test.ts` is exactly
   that run, across a real Core restart, proving #161's criterion; there was no read to finish, so it follows and stops
   at `n`, which is what `--limit` has always meant. This is the narrowing that keeps that suite green rather than
   rewritten.

3. **A stuck subscribe cannot wedge any of them.** A contended Core that never answers `subscribe` sends no event and
   no marker, so neither the ceiling nor the end of the log is ever reached. **Every** `--limit` run — with a cursor or
   without one, walking to the end of a history or walking to the tip — holds a deadline on its patience until the log's
   end is known: the same 30s and the same argument `harness install` already carries, and listed with its reason in
   `no-prompt-timing.test.ts` rather than waved through. It re-sends nothing, it cannot make an event arrive sooner, and
   its expiry is reported as this side giving up: what was printed goes out, stderr says the Core stopped answering and
   that the read did not finish, and the run exits **non-zero** — a read that stopped partway is not a read that
   finished, and a script reads `$?` rather than English. It is disarmed once the log's end is known (past that point
   silence is a Core with nothing to say, and waiting through it is the whole of what a follow does), and it does not
   run while the link is down — a dropped socket is not a Core refusing to answer, and `DurableCoreClient` re-dials and
   replays the whole tail from the cursor.

The `--limit` help text is rewritten to say all of this in the shape an operator reads.

## How it is proven

This machine cannot reach the pairdemo Core, so the proof is at the CLI's own level, against a fake Core seeded with a
history the subscribe then fails to close. Four new cases in `packages/cli/src/__tests__/events-command.test.ts`:

- **the pairdemo run, frame for frame** — cursor at `#13`, ceiling of 30, a log that ends at `#22` with the finish in
  it: nine events on stdout and an exit;
- **history sent, then silence** — the subscribe delivers the tail and then never replays and never pushes: the nine
  events are printed and the run exits rather than holding them hostage to a marker that is not coming;
- **a subscribe that answers nothing at all** — no output, a reason on stderr, exit `1`, and no hang;
- **the two guards on the narrowing** — a run that found no history still follows, and the deadline is really disarmed
  once the Core has said where its log ends (three deadlines' worth of quiet, still following).

The first three of those fail on `HEAD~1` **by hanging**, which is the defect:

```
× exits from history when the log holds fewer events than --limit
× prints the history it was given when the subscribe never replays or pushes
× does not wedge on a subscribe that answers nothing at all
Tests  3 failed | 10 passed (13)
```

With the fix, the whole client package is green: `1190 passed | 3 skipped` across 51 files, including
`events-tail-cursor.test.ts` (the real in-process Core, a real drop, a real restart) and `no-prompt-timing.test.ts`.
`pnpm typecheck` and `pnpm lint` are clean.

## Review round 1 (`bc7f514`)

Three blocking findings and two should-fix, all addressed; the non-blocking notes taken too.

- **1 — the deadline was armed only on `--limit` *plus a cursor*.** `events tail --limit 30` with neither took the other
  side of the printing switch and could still hang for ever. Armed on both sides now, and disarmed where the tip is
  found as well as where a read ends.
- **2 — the deadline ran while the link was down**, so a Core restart truncated a read the reconnect was about to
  complete. Cleared on `onDisconnected`, restarted from `onReady`.
- **3 — `no-prompt-timing.test.ts`'s header argued one row while the table held two.** Rewritten to argue both, and to
  state the three properties a listed timer must have rather than leave them implicit.
- **4 — the exit code and the message disagreed**, so a truncated read could report success. An expiry now always exits
  non-zero and says the read did not finish, with everything it did get still on stdout.
- **5 — an approximation was reported as a finished read.** `trackEventTip` grows an `onRoundsExhausted` hook, so the
  caller that stops there says so in its own words and exits non-zero instead of printing "carrying on" at an operator
  whose command has already ended.
- **Non-blocking, taken:** `events-tail-cursor.test.ts` now reads 1500 events past a cursor **against a real Core**,
  proving the printing-side capped-tail walk delivers each exactly once and in order — the #205 shape, on a path that
  did not exist when #205 was reviewed. The two trackers keep separate allocations (they now differ in their
  end-of-hunt prose, which is the one place they are not the same walk) but the invariant that only one is ever live is
  spelled out where they are created.

Five new cases; four fail on `d611d42`, the no-cursor one by hanging.

## Follow-up

`--limit` now carries two meanings, and which one applies is inferred from the state of the log rather than said by the
operator. That is faithful to #402, whose remedy is scoped to "when the events already exist", but it is intent inferred
from log state. **#441** proposes an explicit `--follow` / `--no-follow` so it stops being inferred.

## Boundaries

The `--kind` filter defect in this same file is #403 and is untouched here. Nothing outside `packages/cli` is touched —
no Panel files (#400), nothing in `packages/shared` (#385).

Base is `fix/operator-pins-sessions-drop-cli`, the shared feature branch for this wave. Draft on purpose.

Refs #402
Follow-up: #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZJh1v8cg8ZJAkxTAV4VLt

