### PR TITLE
fix(panel): a repeat pin selection can never clear the scope

### DIFF
--- a/packages/panel/src/lib/__tests__/terminal-store.test.ts
+++ b/packages/panel/src/lib/__tests__/terminal-store.test.ts
@@ -3,7 +3,7 @@ import type { Task } from "~/db/schema";
 import {
   archivedSessionsEligibleForReap,
   commandForTask,
-  nextActiveTaskId,
+  nextActiveByProject,
   resolveActiveTaskIdForProject,
   type OpenTerminal,
 } from "../terminal-store";
@@ -130,17 +130,58 @@ describe("commandForTask", () => {
   });
 });
 
-describe("nextActiveTaskId", () => {
-  it("keeps a stale persisted active task open when no session is materialized", () => {
-    expect(nextActiveTaskId("task-1", "task-1", false)).toBe("task-1");
-  });
+describe("nextActiveByProject", () => {
+  const scope = "project-1";
 
-  it("hides a task that is already active and materialized", () => {
-    expect(nextActiveTaskId("task-1", "task-1", true)).toBeNull();
+  it("selects a task in a scope that had none", () => {
+    expect(nextActiveByProject({}, scope, "task-1")).toEqual({ [scope]: "task-1" });
   });
 
   it("switches active tasks", () => {
-    expect(nextActiveTaskId("task-1", "task-2", true)).toBe("task-2");
+    expect(nextActiveByProject({ [scope]: "task-1" }, scope, "task-2")).toEqual({
+      [scope]: "task-2",
+    });
+  });
+
+  // #380 AC1: the pin click is navigation, not a toggle. A repeat request for
+  // the already-active task must leave it selected — returning null here is
+  // what deselected the scope and closed the panel under the operator.
+  it("keeps the task active when it is requested again", () => {
+    expect(nextActiveByProject({ [scope]: "task-1" }, scope, "task-1")).toEqual({
+      [scope]: "task-1",
+    });
+  });
+
+  it("returns the same map object for a repeat request so no re-render is forced", () => {
+    const prev = { [scope]: "task-1" };
+    expect(nextActiveByProject(prev, scope, "task-1")).toBe(prev);
+  });
+
+  it("re-selects a task whose session is already materialized", () => {
+    // The old signature took a `hasMaterializedSession` flag and deselected
+    // when it was true; materialization is no longer part of the decision.
+    const prev = { [scope]: "task-1" };
+    expect(nextActiveByProject(prev, scope, "task-1")[scope]).toBe("task-1");
+  });
+
+  // #380 AC2: a rapid A -> B -> A burst follows the last click and never
+  // passes through a null (panel-closing) selection.
+  it("follows the last click across a rapid A -> B -> A burst", () => {
+    const seen: (string | null)[] = [];
+    let state: Record<string, string | null> = { [scope]: "task-a" };
+    for (const requested of ["task-a", "task-b", "task-a"]) {
+      state = nextActiveByProject(state, scope, requested);
+      seen.push(state[scope] ?? null);
+    }
+    expect(seen).toEqual(["task-a", "task-b", "task-a"]);
+    expect(seen).not.toContain(null);
+    expect(state[scope]).toBe("task-a");
+  });
+
+  it("leaves other scopes untouched", () => {
+    expect(
+      nextActiveByProject({ "project-2": "task-9" }, scope, "task-1"),
+    ).toEqual({ "project-2": "task-9", [scope]: "task-1" });
   });
 });
 

--- a/packages/panel/src/lib/__tests__/terminal-store.test.ts
+++ b/packages/panel/src/lib/__tests__/terminal-store.test.ts
@@ -143,9 +143,10 @@ describe("nextActiveByProject", () => {
     });
   });
 
-  // #380 AC1: the pin click is navigation, not a toggle. A repeat request for
-  // the already-active task must leave it selected — returning null here is
-  // what deselected the scope and closed the panel under the operator.
+  // Selection is navigation, not a toggle: a repeat request for the
+  // already-active task leaves it selected. The old `nextActiveTaskId` returned
+  // null here whenever a session was materialized, and a null scope is the panel
+  // close. Materialization is no longer an input to the decision at all.
   it("keeps the task active when it is requested again", () => {
     expect(nextActiveByProject({ [scope]: "task-1" }, scope, "task-1")).toEqual({
       [scope]: "task-1",
@@ -157,16 +158,10 @@ describe("nextActiveByProject", () => {
     expect(nextActiveByProject(prev, scope, "task-1")).toBe(prev);
   });
 
-  it("re-selects a task whose session is already materialized", () => {
-    // The old signature took a `hasMaterializedSession` flag and deselected
-    // when it was true; materialization is no longer part of the decision.
-    const prev = { [scope]: "task-1" };
-    expect(nextActiveByProject(prev, scope, "task-1")[scope]).toBe("task-1");
-  });
-
-  // #380 AC2: a rapid A -> B -> A burst follows the last click and never
-  // passes through a null (panel-closing) selection.
-  it("follows the last click across a rapid A -> B -> A burst", () => {
+  // A rapid burst follows the last request and never passes through a null
+  // (panel-closing) selection. Seeded on A and requesting A first, so this is a
+  // repeat-A -> B -> A: a superset of the plain A -> B -> A burst.
+  it("follows the last request across a rapid repeat-A -> B -> A burst", () => {
     const seen: (string | null)[] = [];
     let state: Record<string, string | null> = { [scope]: "task-a" };
     for (const requested of ["task-a", "task-b", "task-a"]) {

--- a/packages/panel/src/lib/terminal-store.tsx
+++ b/packages/panel/src/lib/terminal-store.tsx
@@ -367,14 +367,31 @@ function isRemoteTask(taskId: string): boolean {
   return remoteTaskIds.has(taskId);
 }
 
-export function nextActiveTaskId(
-  currentTaskId: string | null,
-  requestedTaskId: string,
-  hasMaterializedSession: boolean
-): string | null {
-  return currentTaskId === requestedTaskId && hasMaterializedSession
-    ? null
-    : requestedTaskId;
+/**
+ * The scope-to-active-task map after a request to select `requestedTaskId`.
+ *
+ * Selecting a session — a pin in the sidebar, a card in the list — is
+ * navigation, not a toggle: the requested task always ends up active. A repeat
+ * request for the already-active task therefore keeps it selected (the caller
+ * re-focuses its terminal) instead of clearing the scope, and a rapid
+ * A -> B -> A burst lands on A. Clearing the selection here on a repeat click
+ * was what closed the panel under the operator and made those bursts bounce.
+ *
+ * Deselect is its own gesture with its own path: the session panel's close
+ * button and the `terminal.close` hotkey both call `deselect`. `projects.$id.tsx`
+ * documents the same rule for card clicks.
+ *
+ * Returns `activeByProject` unchanged when the request is a no-op, so callers
+ * can hand the result straight to `setState` without forcing a re-render.
+ */
+export function nextActiveByProject(
+  activeByProject: Record<string, string | null>,
+  scopeKey: string,
+  requestedTaskId: string
+): Record<string, string | null> {
+  return activeByProject[scopeKey] === requestedTaskId
+    ? activeByProject
+    : { ...activeByProject, [scopeKey]: requestedTaskId };
 }
 
 /** Grace period before an un-selected archived session's PTY is reaped. */
@@ -583,9 +600,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
     const session = sessionsRef.current.find((s) => s.taskId === taskId);
     if (!session) return;
     const scopeKey = scopeKeyForProject(session.project);
-    setActiveByProject((prev) =>
-      prev[scopeKey] === taskId ? prev : { ...prev, [scopeKey]: taskId },
-    );
+    setActiveByProject((prev) => nextActiveByProject(prev, scopeKey, taskId));
   }, []);
   const getGridFocusedTaskId = useCallback(() => gridFocusedTaskIdRef.current, []);
   // Pending "New row" request: the grid drops the next new session into a fresh
@@ -666,9 +681,6 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
       opts?: { awaitCreate?: boolean; coreId?: string | null },
     ) => {
       const scopeKey = scopeKeyForProject(project);
-      const hadSession = sessionsRef.current.some(
-        (p) => p.taskId === task.id && scopeKeyForProject(p.project) === scopeKey
-      );
       setSessions((prev) => {
         const existing = prev.find(
           (p) => p.taskId === task.id && scopeKeyForProject(p.project) === scopeKey
@@ -700,11 +712,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
         };
         return [...prev, next];
       });
-      setActiveByProject((prev) => {
-        const curr = prev[scopeKey] ?? null;
-        const next = nextActiveTaskId(curr, task.id, hadSession);
-        return curr === next ? prev : { ...prev, [scopeKey]: next };
-      });
+      setActiveByProject((prev) => nextActiveByProject(prev, scopeKey, task.id));
     },
     []
   );
@@ -755,9 +763,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
           },
         ];
       });
-      setActiveByProject((prev) =>
-        prev[scopeKey] === task.id ? prev : { ...prev, [scopeKey]: task.id }
-      );
+      setActiveByProject((prev) => nextActiveByProject(prev, scopeKey, task.id));
     },
     []
   );
@@ -830,9 +836,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
 
   const setActiveSession = useCallback((project: ScopedProject, taskId: string) => {
     const scopeKey = scopeKeyForProject(project);
-    setActiveByProject((prev) =>
-      prev[scopeKey] === taskId ? prev : { ...prev, [scopeKey]: taskId }
-    );
+    setActiveByProject((prev) => nextActiveByProject(prev, scopeKey, taskId));
   }, []);
 
   const adoptTaskId = useCallback((fromTaskId: string, task: Task) => {

--- a/packages/panel/src/lib/terminal-store.tsx
+++ b/packages/panel/src/lib/terminal-store.tsx
@@ -65,7 +65,15 @@ type Ctx = {
   activeFor: (projectId: string) => OpenTerminal | null;
   /** The active taskId persisted for `projectId` (null = explicitly closed). */
   activeTaskIdFor: (projectId: string) => string | null;
-  /** Click a card: select if not active, deselect (hide panel) if already active. */
+  /**
+   * Select `task` in `project`'s scope. Navigation, not a toggle: the requested
+   * task always ends up active, so calling this for the already-active task
+   * keeps it selected rather than hiding the panel. See `nextActiveByProject`.
+   *
+   * The name is a misnomer kept on purpose — renaming it would touch
+   * `projects.$id.tsx`, which parallel tickets own. Read it as "select". To
+   * hide the panel, call `deselect`; nothing here will do it for you.
+   */
   toggle: (
     project: ScopedProject,
     task: Task,
@@ -372,17 +380,23 @@ function isRemoteTask(taskId: string): boolean {
  *
  * Selecting a session — a pin in the sidebar, a card in the list — is
  * navigation, not a toggle: the requested task always ends up active. A repeat
- * request for the already-active task therefore keeps it selected (the caller
- * re-focuses its terminal) instead of clearing the scope, and a rapid
- * A -> B -> A burst lands on A. Clearing the selection here on a repeat click
- * was what closed the panel under the operator and made those bursts bounce.
+ * request for the already-active task keeps it selected, and a rapid
+ * A -> B -> A burst lands on A. Returns `activeByProject` unchanged when the
+ * request is a no-op, so callers can hand the result straight to `setState`
+ * without forcing a re-render; the caller's own focus request still fires.
  *
- * Deselect is its own gesture with its own path: the session panel's close
- * button and the `terminal.close` hotkey both call `deselect`. `projects.$id.tsx`
- * documents the same rule for card clicks.
+ * This replaced `nextActiveTaskId`, which returned `null` — a cleared scope,
+ * which is the panel close — when the requested task was already active and
+ * its session was materialized. Every call site guarded that combination away,
+ * so the branch was not reachable through today's callers (#443 review); it is
+ * removed as a trap, before a sixth caller arrives without the guard. It is
+ * *not* evidence for the operator symptom in #380, which stays open.
  *
- * Returns `activeByProject` unchanged when the request is a no-op, so callers
- * can hand the result straight to `setState` without forcing a re-render.
+ * Clearing a scope is a separate gesture with its own writers: `deselect`
+ * (the pane's hide affordance, the `terminal.close` hotkey, and the
+ * delete/archive-with-no-replacement paths), `close` and `closeForProject`.
+ * Nothing on a selection path may clear. `projects.$id.tsx` documents the same
+ * rule for card clicks.
  */
 export function nextActiveByProject(
   activeByProject: Record<string, string | null>,


### PR DESCRIPTION
> **Re-framed after review.** The first version of this PR claimed it cured the operator symptom in #380 (B1). The review traced every call site and showed the `null` branch it removes is not reachable through today's callers, so that claim was wrong. This is a hardening refactor plus a shared reducer. **#380 stays open** — see [the note posted there](https://github.com/actana/control/issues/380).

## What this is

`nextActiveTaskId` in `packages/panel/src/lib/terminal-store.tsx` returned `null` when the requested task was already the scope's active one and its session was materialized. A `null` scope value **is** the panel close — it is what `deselect`, `close` and `closeForProject` write. Having a *selection* path able to produce it is a trap.

It is replaced by `nextActiveByProject(activeByProject, scopeKey, requestedTaskId)`, which always lands on the requested task and returns the map identity when the request is a no-op, so a repeat selection cannot clear a scope and forces no re-render. The five hand-written copies of that same selection write — `toggle`, `openSession`, `setActiveSession`, the grid's focus-in write, and now the reducer itself — collapse onto one tested function.

## What this is not

It is not a fix for B1's symptom, and the review is right that the original description said otherwise. The `null` branch had one production caller (`toggle`), and every one of its six call sites guards away the combination that produced it:

| Call site | Guard |
| --- | --- |
| `projects.$id.tsx:558` | effect returns unless the scope's active id is `null` |
| `projects.$id.tsx:635` | inside `active?.taskId !== task.id`; the equal case is routed to `rehydrate` on the line above |
| `projects.$id.tsx:802` | a freshly minted optimistic task id, never already active |
| `projects.$id.tsx:1081` | guarded by `if (!currentId)` |
| `projects.$id.tsx:1092` | returns early on `nextTask.id === currentId` |
| `projects.$id.tsx:1244` | only runs once the earlier branch established there is no active session |

And the pin/card click never reaches `toggle` at all: `onToggle: selectTerminal` (`projects.$id.tsx:1704`) → `selectTerminal` (`:1375`) → `terminals.openSession`, whose selection write already read `prev[scopeKey] === task.id ? prev : {...}` before this PR. `projects.$id.tsx:558` is a sixth call site the review's list did not include; it is guarded too.

So: this removes the trap before a seventh caller arrives without the guard. B1 needs the Panel UI actually clicked on the base branch before it can be closed.

### One thing worth recording

`activeFor` and `activeTaskIdFor` (`terminal-store.tsx:1143-1167`) close over the render's `activeByProject`, not a ref. `openRequestedSession` (`projects.$id.tsx:592-640`) reads both **after** `await api.getTask(...)`, while `toggle`'s updater reads the committed `prev`. A selection committed during that await would leave the guard reading a stale snapshot — the one shape in which the old `null` branch could have fired. That is a race on the notification-open path, not a repeat click, so it is not B1, and it is now moot. Naming it here so the "unreachable" claim is precise rather than absolute. No test is added for it: exercising it needs `projects.$id.tsx`, which parallel tickets own and this PR must not edit, and there is no existing harness that renders `TerminalProvider`.

## Review findings addressed

- **Blocking 1 — the `Ctx.toggle` contract doc.** `terminal-store.tsx:68` promised "select if not active, deselect (hide panel) if already active", which the code no longer does. Rewritten to state the real rule, and it now calls out that `toggle` is a misnomer kept on purpose because renaming it would touch `projects.$id.tsx`.
- **Blocking 2 — delivery.** Resolution taken: **the second option, re-frame honestly.** Title, body, and the new commit message all say the branch was unreachable through current callers. No closing keyword anywhere — `Refs #380`, never `Closes`, so the merge cannot close the issue. A note is posted on #380.
- **Non-blocking — duplicate test.** "re-selects a task whose session is already materialized" dropped; its comment folded onto the repeat-request test above it.
- **Non-blocking — burst test name.** Renamed to "follows the last request across a rapid repeat-A -> B -> A burst", which is what it seeds.

The `nextActiveByProject` docstring also lost its unsupported causal story and now records that the branch was unreachable, plus every writer that legitimately clears a scope.

## Mechanics

Two commits; the first is left as pushed rather than amended, because rewriting it needs a force push. The second states the correction explicitly and supersedes the first's causal claim.

Tests: 22 in `terminal-store.test.ts`, full panel suite 146 files / 1565 tests green (1566 before, minus the dropped duplicate). `tsc --noEmit` and `eslint` clean.

Still a draft. Base unchanged: `fix/operator-pins-sessions-drop-cli`.

Refs #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGZcdyMnRX7cTYPyareJTT
