### PR TITLE
fix(panel): Cmd-digit addresses rail pins and keeps coreId

### DIFF
--- a/packages/panel/src/lib/__tests__/rail-projects.test.ts
+++ b/packages/panel/src/lib/__tests__/rail-projects.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { Group } from "~/db/schema";
 import {
   clusterPinnedByGroup,
+  getRailClusters,
+  mergeRailProjects,
+  railNavigateSearch,
+  resolveRailChordTarget,
   usesDirectRailProjectShortcuts,
   type RailProject,
 } from "~/lib/rail-projects";
@@ -68,5 +72,82 @@ describe("usesDirectRailProjectShortcuts", () => {
     expect(
       usesDirectRailProjectShortcuts([group("dev", "Dev")], ACTIVE_GROUP_UNGROUPED),
     ).toBe(true);
+  });
+});
+
+// #379: the rail badges number the MERGED pin list — the Panel's own rows plus
+// every Core's pins — so a chord read off `useProjects` alone addressed a
+// different list than the one the operator is looking at.
+describe("rail chords address the merged pin list (#379)", () => {
+  function corePin(
+    id: string,
+    coreId: string,
+    groupId: string | null,
+    pinnedOrder: number,
+  ): RailProject {
+    return { ...project(id, groupId, pinnedOrder), coreId };
+  }
+
+  const panelPins = [project("panel-a", null, 0), project("panel-b", null, 2)];
+  const remotePins = [corePin("core-a", "core-1", null, 1), corePin("core-b", "core-2", null, 3)];
+
+  it("resolves visible badge N to the Nth merged pin, Core pins included", () => {
+    const merged = mergeRailProjects(panelPins, remotePins);
+    const clusters = getRailClusters(merged, [], ACTIVE_GROUP_ALL);
+
+    // One flat cluster, badges 1..4 in pinned order — panel, Core, panel, Core.
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]!.projects.map((p) => p.id)).toEqual([
+      "panel-a",
+      "core-a",
+      "panel-b",
+      "core-b",
+    ]);
+    for (const [badge, id] of [
+      [1, "panel-a"],
+      [2, "core-a"],
+      [3, "panel-b"],
+      [4, "core-b"],
+    ] as const) {
+      expect(resolveRailChordTarget(clusters, null, badge)?.id).toBe(id);
+    }
+  });
+
+  it("would have opened the wrong pin from the Panel's own rows alone", () => {
+    // The bug, pinned down: badge 2 is a Core pin, but the unmerged list makes
+    // it `panel-b`. Merging is what makes the chord agree with the badge.
+    const unmerged = getRailClusters(panelPins, [], ACTIVE_GROUP_ALL);
+    expect(resolveRailChordTarget(unmerged, null, 2)?.id).toBe("panel-b");
+  });
+
+  it("carries ?coreId= for a Core pin and omits it for a Panel row", () => {
+    const clusters = getRailClusters(mergeRailProjects(panelPins, remotePins), [], ACTIVE_GROUP_ALL);
+
+    expect(railNavigateSearch(resolveRailChordTarget(clusters, null, 2)!)).toEqual({
+      coreId: "core-1",
+    });
+    expect(railNavigateSearch(resolveRailChordTarget(clusters, null, 4)!)).toEqual({
+      coreId: "core-2",
+    });
+    expect(railNavigateSearch(resolveRailChordTarget(clusters, null, 1)!)).toBeUndefined();
+  });
+
+  it("resolves a group→project chord against the same clusters the rail draws", () => {
+    const groups = [group("alpha", "Alpha"), group("omega", "Omega")];
+    const merged = mergeRailProjects(
+      [project("panel-alpha", "alpha", 0)],
+      [corePin("core-omega", "core-9", "omega", 1), corePin("core-alpha", "core-9", "alpha", 2)],
+    );
+    const clusters = getRailClusters(merged, groups, ACTIVE_GROUP_ALL);
+
+    // Group 1 badge 2 is the Core's Alpha pin; group 2 badge 1 its Omega pin.
+    expect(resolveRailChordTarget(clusters, 1, 2)?.id).toBe("core-alpha");
+    expect(resolveRailChordTarget(clusters, 2, 1)?.id).toBe("core-omega");
+    expect(railNavigateSearch(resolveRailChordTarget(clusters, 1, 2)!)).toEqual({
+      coreId: "core-9",
+    });
+    // A Cmd release mid-chord jumps to the group's first project — same list.
+    expect(resolveRailChordTarget(clusters, 1, 1)?.id).toBe("panel-alpha");
+    expect(resolveRailChordTarget(clusters, 3, 1)).toBeUndefined();
   });
 });

--- a/packages/panel/src/lib/rail-projects.ts
+++ b/packages/panel/src/lib/rail-projects.ts
@@ -7,6 +7,8 @@ import {
 } from "~/shared/ui-preferences";
 
 export type RailProject = PinnedOrderable & {
+  /** The Core that owns this row; absent/null means the Panel's own rows. */
+  coreId?: string | null;
   groupId: string | null;
   name: string;
 };
@@ -92,4 +94,46 @@ export function getRailClusters<T extends RailProject>(
   }
   const cluster = getGroupRailCluster(projects, groups, activeGroup);
   return cluster.projects.length > 0 ? [cluster] : [];
+}
+
+/**
+ * The rail's project list: the Panel's own rows plus every Core's pins, tagged
+ * with the Core that owns them (see `useRemotePinnedProjects`). Concatenation
+ * order matches ProjectBar's so a pinned-order tie breaks the same way in both;
+ * `getPinnedProjects` orders the result from there.
+ */
+export function mergeRailProjects<T extends RailProject>(
+  panelProjects: readonly T[] | undefined,
+  remotePinned: readonly T[],
+): T[] {
+  return [...(panelProjects ?? []), ...remotePinned];
+}
+
+/**
+ * The project a rail chord addresses, given the clusters the rail renders.
+ *
+ * Badges number projects from 1 *within their cluster*, so a chord is a group
+ * digit (absent when the rail is one flat directly-addressable list) plus a
+ * project digit — and this resolves both against the very clusters the badges
+ * were drawn from. Hotkeys and badges disagreeing is the whole of #379.
+ */
+export function resolveRailChordTarget<T extends RailProject>(
+  clusters: readonly RailCluster<T>[],
+  groupDigit: number | null,
+  projectDigit: number,
+): T | undefined {
+  const cluster = groupDigit == null ? clusters[0] : clusters[groupDigit - 1];
+  return cluster?.projects[projectDigit - 1];
+}
+
+/** All a rail navigation needs: which project, and which Core owns it. */
+export type RailTarget = { id: string; coreId?: string | null };
+
+/**
+ * The search params a rail navigation carries. A Core-owned pin must keep its
+ * `?coreId=`, or the project page addresses the Panel's own DB instead of the
+ * Core that owns the row — a 404, or the wrong project (#379).
+ */
+export function railNavigateSearch(target: RailTarget): { coreId: string } | undefined {
+  return target.coreId ? { coreId: target.coreId } : undefined;
 }

--- a/packages/panel/src/routes/__root.tsx
+++ b/packages/panel/src/routes/__root.tsx
@@ -9,7 +9,14 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
-import { getRailClusters, usesDirectRailProjectShortcuts } from "~/lib/rail-projects";
+import {
+  getRailClusters,
+  mergeRailProjects,
+  railNavigateSearch,
+  resolveRailChordTarget,
+  usesDirectRailProjectShortcuts,
+  type RailTarget,
+} from "~/lib/rail-projects";
 import { isAuthPath } from "~/lib/auth-paths";
 import { TopBar, type Crumb } from "~/components/ui/TopBar";
 import { Btn } from "~/components/ui/Btn";
@@ -45,6 +52,7 @@ import {
   HeaderActionsSlot,
 } from "~/components/ui/HeaderActionsSlot";
 import { useSettings, useProjects } from "~/queries";
+import { useRemotePinnedProjects } from "~/lib/use-fleet";
 import { ProviderUsageIndicator } from "~/components/views/ProviderUsageIndicator";
 import { UpdateBanner } from "~/components/views/UpdateBanner";
 import { FirstRunGate } from "~/components/views/FirstRunGate";
@@ -251,6 +259,15 @@ function Shell() {
   useWindowIdleController();
   const { data: settings } = useSettings();
   const { data: projects } = useProjects();
+  // The rail draws its badges from the Panel's own rows PLUS every Core's pins
+  // (ProjectBar merges the same two lists). The rail chords below address that
+  // merged list, or a Core pin's badge would open whatever Panel-local project
+  // happened to sit in that slot — or nothing at all (#379).
+  const { projects: remotePinnedProjects } = useRemotePinnedProjects();
+  const railProjects = useMemo(
+    () => mergeRailProjects(projects, remotePinnedProjects),
+    [projects, remotePinnedProjects],
+  );
   const { activeGroup, setActiveGroup, groups } = useActiveGroup();
   // Pure actions (stable identity) + narrow flip-only subscriptions, so a
   // background session-status tick doesn't re-render the whole shell. The active
@@ -477,6 +494,19 @@ function Shell() {
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, []);
+  // One place every rail chord navigates through, so a Core-owned pin can never
+  // lose its `?coreId=`: without it the project route falls back to the Panel's
+  // own DB and the page 404s or shows the wrong project (#379).
+  const navigateToRailTarget = useCallback(
+    (target: RailTarget) => {
+      router.navigate({
+        to: "/projects/$id",
+        params: { id: target.id },
+        search: railNavigateSearch(target),
+      });
+    },
+    [router],
+  );
   // Cmd/Ctrl + [ / ] are non-rebindable terminal-focused shortcuts.
   // Capture phase: a focused xterm textarea swallows these on bubble.
   // ⌘T used to be in here too; it is `terminal.newTab` above now, so the
@@ -505,19 +535,19 @@ function Shell() {
         }
         const digit = Number(e.key);
         // Same clusters the rail renders — badges and hotkeys must agree.
-        const clusters = getRailClusters(projects ?? [], groups, activeGroup);
-        const navigateTo = (id: string) => {
+        const clusters = getRailClusters(railProjects, groups, activeGroup);
+        const navigateTo = (target: RailTarget) => {
           e.preventDefault();
           e.stopPropagation();
-          router.navigate({ to: "/projects/$id", params: { id } });
+          navigateToRailTarget(target);
         };
 
         // A single group is active, or no real groups exist: the rail is one
         // flat project list, so the digit addresses a project directly.
         if (usesDirectRailProjectShortcuts(groups, activeGroup)) {
           pendingRailGroupRef.current = null;
-          const target = clusters[0]?.projects[digit - 1];
-          if (target) navigateTo(target.id);
+          const target = resolveRailChordTarget(clusters, null, digit);
+          if (target) navigateTo(target);
           else e.preventDefault();
           return;
         }
@@ -533,10 +563,10 @@ function Shell() {
           if (clusters[digit - 1]) pendingRailGroupRef.current = digit;
           return;
         }
-        const groupIdx = pendingRailGroupRef.current - 1;
+        const groupDigit = pendingRailGroupRef.current;
         pendingRailGroupRef.current = null;
-        const target = clusters[groupIdx]?.projects[digit - 1];
-        if (target) navigateTo(target.id);
+        const target = resolveRailChordTarget(clusters, groupDigit, digit);
+        if (target) navigateTo(target);
         return;
       }
     };
@@ -547,9 +577,9 @@ function Shell() {
       const pending = pendingRailGroupRef.current;
       pendingRailGroupRef.current = null;
       if (pending == null || usesDirectRailProjectShortcuts(groups, activeGroup)) return;
-      const clusters = getRailClusters(projects ?? [], groups, activeGroup);
-      const target = clusters[pending - 1]?.projects[0];
-      if (target) router.navigate({ to: "/projects/$id", params: { id: target.id } });
+      const clusters = getRailClusters(railProjects, groups, activeGroup);
+      const target = resolveRailChordTarget(clusters, pending, 1);
+      if (target) navigateToRailTarget(target);
     };
     // Losing focus mid-chord (e.g. clicking away while Cmd is held) would
     // otherwise leave a group digit pending and misread the next chord.
@@ -564,7 +594,7 @@ function Shell() {
       window.removeEventListener("keyup", onKeyUp, true);
       window.removeEventListener("blur", onBlur);
     };
-  }, [activeGroup, cycleNext, cyclePrev, groups, projects, router]);
+  }, [activeGroup, cycleNext, cyclePrev, groups, navigateToRailTarget, railProjects]);
 
   return (
     <>


### PR DESCRIPTION
Closes #379 (S2).

## The bug

The left rail draws its hotkey badges from the **merged** pin list: the Panel's own rows plus every Core's pins, fetched
by `useRemotePinnedProjects` and tagged with the Core that owns them. The Cmd/Ctrl+digit handler in
`packages/panel/src/routes/__root.tsx` read `useProjects()` alone.

Two lists, one set of badges. With Core pins on the rail:

1. Badge N and chord N addressed different projects — the chord hit whatever Panel-local project sat in slot N, or
   nothing at all when the Panel had fewer pins than the rail showed.
2. The navigate omitted `search.coreId`, so even a correct hit asked the project route for a Core-owned project without
   naming the Core — the page 404s or quietly loads the Panel's own DB.

## The fix

Both halves move into `~/lib/rail-projects`, where they are pure and testable:

- **`mergeRailProjects(panelProjects, remotePinned)`** — the same list `ProjectBar` merges, in the same concatenation
  order, so a `pinnedOrder` tie breaks identically in the rail and in the chord.
- **`resolveRailChordTarget(clusters, groupDigit, projectDigit)`** — resolves a chord against the very clusters the
  badges were drawn from. Covers all three paths: the two-level All-mode group→project chord, the single-digit flat
  rail, and the Cmd-release jump to a group's first project.
- **`railNavigateSearch(target)`** — `{ coreId }` for a Core-owned pin, `undefined` for a Panel row. Every chord
  navigation is funnelled through one `navigateToRailTarget` callback, so a future caller cannot drop it again.

`RailProject` gains the optional `coreId` the merged rows already carry.

## Cost

Calling `useRemotePinnedProjects` in the shell adds a second per-Core `listProjects` fan-out. `PanelLinkClient.watch` is
refcounted, so the Core subscription itself is shared and costs no extra subscribe frame; the extra read matches how
`useCores` is already called from several places. Sharing the fetch would mean reworking the hook, which touches
`ProjectBar`'s read path — out of scope here, and `ProjectBar.tsx` is owned by other tickets in this wave.

## Tests

Four cases added to `packages/panel/src/lib/__tests__/rail-projects.test.ts`:

- badge N resolves to the Nth **merged** pin across an interleaved panel/Core pinned order;
- the same resolution against the unmerged list returns the wrong project — the bug, pinned down;
- a Core pin's navigation carries `{ coreId }`, a Panel row's carries nothing;
- a group→project chord resolves against the rendered clusters, Core pin and `coreId` included.

`packages/panel`: 9/9 in `rail-projects.test.ts`, `pnpm typecheck` clean, `pnpm lint` 0 errors.

## Boundaries

Touches only `__root.tsx`, `lib/rail-projects.ts` and its test. No change to `ProjectBar.tsx`, `projects.$id.tsx`,
`lib/terminal-store.tsx` or `packages/shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vsnw9CXT1HUr1n9uKuxt68