### PR TITLE
fix(core): treat ready as stranded — sweep and PTY-exit settle it

### DIFF
--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -23,6 +23,7 @@ about everything else on a Core — as an Event replayed off its cursor.
 | Hook delivery misses | `packages/core/src/harness-hook-delivery.ts` |
 | Quiet-Session backstop | `packages/core/src/core-session-backstop.ts` |
 | Boot sweep | `packages/core/src/core-session-sweep.ts` |
+| Relaunch reset | `packages/core/src/core-session-relaunch.ts` |
 
 The Panel keeps a hook endpoint (`POST /api/hooks/<slug>`) for its own remaining
 local task rows, running the same shared pipeline. A Core-owned Session never
@@ -35,11 +36,13 @@ outside the process. The Core installs them per workspace at spawn time, so each
 Session reports its own state.
 
 A new Session starts in `ready` (terminal spawned, prompt waiting). The first
-hook flips it.
+hook flips it — and if no hook ever comes, a dead-process fallback does (see
+below): `ready` is not a resting place for a Session whose process is gone.
 
 | Hook event                         | Mapped status   | Meaning                                  |
 | ---------------------------------- | --------------- | ---------------------------------------- |
 | _(spawn)_                          | `ready`         | Terminal up, operator hasn't typed yet   |
+| _(agent respawn)_                  | `ready`         | Harness up again for a Session that never worked |
 | `UserPromptSubmit`                 | `running`       | Prompt submitted; work began             |
 | `Stop`                             | `finished`\*    | Foreground turn ended (see below)        |
 | `SubagentStart` / `SubagentStop`   | _(bookkeeping)_ | Tracks still-active subagents            |
@@ -305,6 +308,21 @@ Sessions whose process is gone:
   The Panel's own exit patch no longer fires for a Core-owned row: it was
   unconditional, so it would overwrite an `interrupted` Session with `finished`
   and raise a spurious `session:finished` besides.
+
+  **`ready` settles here too** (issue 387), and it is the one status in scope
+  that describes no work. A *bare* Session — spawned with no prompt, sitting on
+  "Waiting for initial prompt…" — never leaves `ready` until its first
+  `UserPromptSubmit`, so not one hook ever fires for it and there is no `Stop`
+  to wait for. Left out, its row went on claiming to be waiting for a prompt
+  for as long as the database existed; one was found alive on a Core hours
+  after its PTY died, and still there after the container was recreated.
+
+  It settles on a scale of its own: **`disconnected`, whatever the exit code**.
+  `terminated` would say a turn was killed, and `finished` would say work
+  completed — `CoreTaskWriter` appends `session:finished` on exactly that
+  transition, so a bare Session the operator closes with `/exit` would ring a
+  completion ding for a turn that never ran. `disconnected` claims only that
+  the process went away, which is the whole of what is known.
 - **Boot sweep** — `core-session-sweep.ts` runs once per Core boot, before the
   PTY core, the hook receiver or the core-link server can produce a Session of
   this run. At that moment no PTY of this process exists, so every row still
@@ -314,11 +332,44 @@ Sessions whose process is gone:
   `task:updated` event a connected Panel re-renders from — a sweep nobody is
   told about leaves the operator looking at the same wrong card.
 
+  **Spawned `ready` rows are orphans too** (issue 387), for the same reason the
+  PTY-exit settle covers them: a bare Session's PTY dies with the Core and no
+  hook was ever going to report it. They cannot be swept on the status alone,
+  because `ready` is also the status of a Session the operator created and has
+  not started — flipping a queue of unstarted work to `disconnected` on every
+  restart would trade one wrong card for many. The discriminator is whether
+  this Core ever spawned a *harness* for the row, read from the `pty:spawn` in
+  the event log (`queryStrandedReadyTasks`). The row cannot answer it: there is
+  no "was started" column, and the harness session id is no help either, since
+  Claude Code's `SessionStart` captures one before any turn. A `ready` row with
+  no agent spawn behind it is left alone. The evidence is permanent — nothing
+  prunes `event_log` — so the first boot after this shipped settled every
+  historical spawned `ready` row in one batch, and every boot since sees only
+  what the run before it stranded.
+
+  The quiet-Session backstop deliberately does **not** see these rows: it reads
+  the narrow `listActiveTasks`, and a bare Session waiting on its first prompt
+  is allowed to sit silent for as long as the operator likes.
+
   `disconnected` rather than `finished` or `terminated`: it is the status the
   Panel already uses for a process that went away without reporting, and it
   claims nothing about how the work ended. The Panel has had this sweep for its
   own rows all along; what it never had was scope over Core-owned ones, which is
   every Session on a remote Core (issue 243).
+- **Relaunch reset** — the mirror of the two above (`core-session-relaunch.ts`).
+  Once `ready` is a status a Session can leave, something has to write it back:
+  the operator reopens a settled bare Session, the Core spawns a healthy
+  harness, it waits at its prompt, and no hook fires until the first prompt —
+  so the card would read `disconnected` over a live harness, on every harness
+  family. On an **agent** spawn (never a `shell` or `shellSession` one), a row
+  in a settled status that has **never worked** goes back to `ready`.
+
+  "Never worked" is read from the event log, not the row: every status change
+  on a Core-owned row appends a `task:updated` carrying the status that was
+  *patched* (`queryTaskEverWorked`), and any status other than `ready` /
+  `disconnected` says a turn happened — including on a harness that goes
+  straight from `ready` to `finished` without ever reporting `running`. A
+  `finished` Session being reopened is being resumed, and keeps its card.
 
 ## Terminal-input fallback
 
@@ -336,6 +387,12 @@ Session had neither hooks nor a fallback and never left `ready`.
 The narrower question matters: Cursor and Codex both take our hooks file and
 report a turn's *end*, so "hooks were installed" would suppress the fallback and
 leave their Sessions on `ready` for the whole first turn.
+
+Note that neither of those failures parks a Session on `ready` forever any more
+(issue 387). A Session sitting on `ready` whose PTY then dies is settled by the
+PTY-exit path, and one whose Core dies under it is settled by the boot sweep;
+what a missing `running` signal costs is a card that under-reports a live turn,
+not a row that outlives its process.
 
 ### The CLI has no equivalent, and says so
 

--- a/packages/core/src/__tests__/core-link-relaunch-port.test.ts
+++ b/packages/core/src/__tests__/core-link-relaunch-port.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PtyCoreLinkServer,
+  type WebSocketLike,
+  type WebSocketServerLike,
+} from "../pty-core-link-server";
+import type { PtyCore, PtyCoreEvent } from "../pty-manager";
+
+// Which spawns ask the relaunch port (issue 387, review finding 2).
+//
+// The port is what puts a bare Session's card back on `ready` when a harness
+// comes up for it again. The decision of WHETHER to reset is the port's
+// (`core-session-relaunch.ts`, tested there against real rows); the decision
+// of whether to ask it at all is here, and it is a narrow one: an agent spawn
+// asks, and the two shell variants — which carry a `taskId` for routing and
+// are not harness work — never do.
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  private listeners: Record<string, Listener[]> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+  on(event: string, cb: Listener): void {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  removeAllListeners(): void {
+    this.listeners = {};
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners[event] ?? []) cb(...args);
+  }
+  receive(frame: unknown): void {
+    this.emit("message", JSON.stringify(frame));
+  }
+  ofType(type: string): Array<Record<string, unknown>> {
+    return this.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((frame) => frame.type === type);
+  }
+}
+
+class FakeWebSocketServer {
+  private connCb: ((ws: WebSocketLike) => void) | null = null;
+  connect(ws: FakeWebSocket): void {
+    this.connCb?.(ws as unknown as WebSocketLike);
+  }
+  close(): void {}
+  on(event: string, cb: Listener): void {
+    if (event === "connection") this.connCb = cb as (ws: WebSocketLike) => void;
+  }
+}
+
+function mockCore() {
+  let nextPty = 0;
+  const core = {
+    setEmitTarget: (_fn: ((event: PtyCoreEvent) => void) | null) => {},
+    spawn: async () => ({ ptyId: `pty-${++nextPty}`, hooksReportTurnStart: true }),
+    write: () => true,
+    resize: () => true,
+    kill: () => true,
+    killLaunchProcesses: async () => ({ ptyCount: 0, ports: [] }),
+    findByTask: () => ({ ptyId: null }),
+    taskIdForPty: () => null,
+    replay: () => ({ data: "", nextSeq: 0 }),
+    killAll: () => {},
+  };
+  return core as unknown as PtyCore;
+}
+
+describe("which spawns ask the relaunch port (issue 387)", () => {
+  let wss: FakeWebSocketServer;
+  let server: PtyCoreLinkServer;
+  let asked: string[];
+
+  async function spawn(opts: Record<string, unknown>, reqId: string): Promise<void> {
+    const ws = new FakeWebSocket();
+    wss.connect(ws);
+    ws.receive({ type: "spawn", reqId, opts });
+    await vi.waitFor(() => expect(ws.ofType("spawned").length).toBeGreaterThan(0));
+  }
+
+  beforeEach(() => {
+    wss = new FakeWebSocketServer();
+    asked = [];
+    server = new PtyCoreLinkServer(mockCore(), {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      relaunchPort: { agentSpawned: (taskId) => void asked.push(taskId) },
+      liveEventPollMs: 10_000,
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it("asks for an agent spawn — the relaunch a settled bare Session gets", async () => {
+    await spawn({ taskId: "t-1", cwd: "/w", command: "claude", agent: "claude-code" }, "a1");
+    expect(asked).toEqual(["t-1"]);
+  });
+
+  it("never asks for a plain shell, which is not harness work", async () => {
+    await spawn({ taskId: "t-1", cwd: "/w", command: "bash", shell: true }, "s1");
+    expect(asked).toEqual([]);
+  });
+
+  it("never asks for a VM Shell Session, for the same reason", async () => {
+    await spawn({ taskId: "term_vm_1", command: "", shellSession: true }, "v1");
+    expect(asked).toEqual([]);
+  });
+
+  it("is optional — a Core with no port spawns exactly as before", async () => {
+    server.close();
+    wss = new FakeWebSocketServer();
+    server = new PtyCoreLinkServer(mockCore(), {
+      port: 0,
+      createServer: () => wss as unknown as WebSocketServerLike,
+      liveEventPollMs: 10_000,
+    });
+    await spawn({ taskId: "t-1", cwd: "/w", command: "claude", agent: "claude-code" }, "n1");
+    expect(asked).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/core-session-relaunch.test.ts
+++ b/packages/core/src/__tests__/core-session-relaunch.test.ts
@@ -1,0 +1,168 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapCoreDb } from "../core-db-bootstrap";
+import {
+  configureCoreMutationStore,
+  coreMutationStore,
+  disposeCoreMutationStore,
+} from "../core-mutation-store";
+import {
+  configureCoreQueryStore,
+  coreQueryStore,
+  disposeCoreQueryStore,
+  taskEverWorked,
+} from "../core-query-store";
+import {
+  appendEvent,
+  configureEventLogStore,
+  disposeEventLogStore,
+  getLastEventId,
+  readEventTail,
+} from "../event-log-store";
+import { CoreTaskWriter } from "../core-task-writer";
+import { readySessionOnAgentSpawn } from "../core-session-relaunch";
+
+// The other half of issue 387, against this Core's real SQLite and real event
+// log. The sweep moves a bare Session OFF `ready`; this is what puts it back
+// when a harness is spawned for it again — and what must not touch a Session
+// that actually worked.
+
+describe("putting a relaunched Session back on ready", () => {
+  let userDataDir: string;
+  let writer: CoreTaskWriter;
+
+  const insert = (taskId: string, status: string) => {
+    coreMutationStore.mutateTask({
+      op: "create",
+      taskId,
+      projectId: "p1",
+      title: taskId,
+      agent: "claude-code",
+      status: "ready",
+    });
+    // Written as a patch, not as the create's status, so the row's history in
+    // the event log is the one a real Session leaves behind.
+    if (status !== "ready") writer.mutate({ op: "update", taskId, status });
+  };
+  const statusOf = (taskId: string) => coreQueryStore.getTask(taskId)?.status;
+  const relaunch = (taskId: string) =>
+    readySessionOnAgentSpawn({ writer, everWorked: taskEverWorked }, taskId);
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-session-relaunch-"));
+    bootstrapCoreDb(userDataDir);
+    configureCoreMutationStore(userDataDir);
+    configureCoreQueryStore(userDataDir);
+    configureEventLogStore(userDataDir);
+    writer = new CoreTaskWriter({
+      mutationPort: coreMutationStore,
+      queryPort: coreQueryStore,
+      eventLog: { appendEvent, getLastEventId, readEventTail },
+    });
+    coreMutationStore.mutateProject({
+      op: "create",
+      projectId: "p1",
+      name: "Warehouse",
+      path: userDataDir,
+    });
+  });
+
+  afterEach(() => {
+    disposeCoreMutationStore();
+    disposeCoreQueryStore();
+    disposeEventLogStore();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("resets the bare Session the sweep settled", () => {
+    // Exactly the row issue 387 strands: created `ready`, never prompted,
+    // settled `disconnected` when its PTY died. A harness is up for it again.
+    insert("t-bare", "disconnected");
+
+    expect(relaunch("t-bare")).toBe(true);
+    expect(statusOf("t-bare")).toBe("ready");
+  });
+
+  it("leaves a Session that actually worked exactly as it settled", () => {
+    // `finished` is the operator's record of what that Session did, and
+    // reopening it is a resume, not a fresh start.
+    insert("t-worked", "running");
+    writer.mutate({ op: "update", taskId: "t-worked", status: "finished" });
+
+    expect(relaunch("t-worked")).toBe(false);
+    expect(statusOf("t-worked")).toBe("finished");
+  });
+
+  it("leaves a Session that worked and was then swept", () => {
+    // The sweep settles a `running` row to `disconnected` too. That row has a
+    // turn behind it, so the same `disconnected` must not be reset.
+    insert("t-swept", "running");
+    writer.mutate({ op: "update", taskId: "t-swept", status: "disconnected" });
+
+    expect(relaunch("t-swept")).toBe(false);
+    expect(statusOf("t-swept")).toBe("disconnected");
+  });
+
+  it("does not disturb a live turn, or a Session already ready", () => {
+    insert("t-running", "running");
+    insert("t-waiting", "needs-input");
+    insert("t-ready", "ready");
+
+    expect(relaunch("t-running")).toBe(false);
+    expect(relaunch("t-waiting")).toBe(false);
+    expect(relaunch("t-ready")).toBe(false);
+    expect(statusOf("t-running")).toBe("running");
+    expect(statusOf("t-waiting")).toBe("needs-input");
+    expect(statusOf("t-ready")).toBe("ready");
+  });
+
+  it("appends the event a connected Panel re-renders the card from", () => {
+    insert("t-bare", "disconnected");
+    const before = getLastEventId();
+
+    relaunch("t-bare");
+
+    const appended = readEventTail(before, 100);
+    const updates = appended.filter((e) => e.kind === "task:updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].taskId).toBe("t-bare");
+    expect(appended.map((e) => e.kind)).not.toContain("session:finished");
+  });
+
+  it("is a no-op the second time, because the first one moved the row", () => {
+    insert("t-bare", "disconnected");
+    expect(relaunch("t-bare")).toBe(true);
+    const after = getLastEventId();
+
+    expect(relaunch("t-bare")).toBe(false);
+    expect(getLastEventId()).toBe(after);
+  });
+
+  it("stays quiet about a Session this Core does not have", () => {
+    expect(relaunch("t-missing")).toBe(false);
+    expect(relaunch("")).toBe(false);
+  });
+
+  it("does not let a failed write take the spawn down", () => {
+    insert("t-bare", "disconnected");
+    const failing = new CoreTaskWriter({
+      mutationPort: {
+        mutateProject: coreMutationStore.mutateProject,
+        mutateTask: (mutation) => {
+          if (mutation.op === "update") throw new Error("row vanished");
+          return coreMutationStore.mutateTask(mutation);
+        },
+        listSessions: coreMutationStore.listSessions,
+      },
+      queryPort: coreQueryStore,
+      eventLog: { appendEvent, getLastEventId, readEventTail },
+    });
+
+    expect(
+      readySessionOnAgentSpawn({ writer: failing, everWorked: taskEverWorked }, "t-bare"),
+    ).toBe(false);
+    expect(statusOf("t-bare")).toBe("disconnected");
+  });
+});

--- a/packages/core/src/__tests__/core-session-sweep.test.ts
+++ b/packages/core/src/__tests__/core-session-sweep.test.ts
@@ -12,7 +12,7 @@ import {
   configureCoreQueryStore,
   coreQueryStore,
   disposeCoreQueryStore,
-  listActiveTasks,
+  listBootSweepTasks,
 } from "../core-query-store";
 import {
   appendEvent,
@@ -50,6 +50,9 @@ describe("settling the Sessions a Core restart stranded", () => {
     }
   };
   const statusOf = (taskId: string) => coreQueryStore.getTask(taskId)?.status;
+  /** The `pty:spawn` the Core appends when it starts a harness for a task. */
+  const spawnPty = (taskId: string) =>
+    appendEvent("pty:spawn", JSON.stringify({ taskId }), { ptyId: `pty-${taskId}`, taskId });
 
   beforeEach(() => {
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ac-session-sweep-"));
@@ -81,7 +84,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     insert("t-running", "running");
     insert("t-waiting", "needs-input");
 
-    const settled = sweepStrandedSessions({ listActiveTasks, writer });
+    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
 
     expect(settled.sort()).toEqual(["t-running", "t-waiting"]);
     expect(statusOf("t-running")).toBe("disconnected");
@@ -93,17 +96,64 @@ describe("settling the Sessions a Core restart stranded", () => {
     // claim about work whose end was actually reported.
     insert("t-finished", "finished");
     insert("t-interrupted", "interrupted");
+    // A Session the operator created and has not started: `ready`, no PTY, no
+    // `pty:spawn` behind it. Issue 387 widened the sweep to `ready`, and this
+    // row is the reason that widening is evidence-gated rather than a status
+    // filter — a queue of unstarted work must not read as a fleet of deaths.
     insert("t-ready", "ready");
 
-    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
     expect(statusOf("t-finished")).toBe("finished");
     expect(statusOf("t-interrupted")).toBe("interrupted");
     expect(statusOf("t-ready")).toBe("ready");
   });
 
+  it("sweeps the bare Session a dead PTY left on ready (issue 387)", () => {
+    // The live pairdemo zombie: spawned before a container recreate, never
+    // prompted, so `running` / `needs-input` never described it and no Stop
+    // was ever going to arrive. It outlived the recreate on the old filter.
+    insert("t-zombie", "ready");
+    spawnPty("t-zombie");
+    insert("t-unstarted", "ready");
+
+    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([
+      "t-zombie",
+    ]);
+    expect(statusOf("t-zombie")).toBe("disconnected");
+    expect(statusOf("t-unstarted")).toBe("ready");
+  });
+
+  it("sweeps a leftover ready row alongside the rows that claim to be working", () => {
+    insert("t-running", "running");
+    insert("t-zombie", "ready");
+    spawnPty("t-zombie");
+
+    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+
+    expect(settled.sort()).toEqual(["t-running", "t-zombie"]);
+    expect(statusOf("t-running")).toBe("disconnected");
+    expect(statusOf("t-zombie")).toBe("disconnected");
+  });
+
+  it("settles a swept ready row without claiming its work finished", () => {
+    insert("t-zombie", "ready");
+    spawnPty("t-zombie");
+    const before = getLastEventId();
+
+    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+
+    const appended = readEventTail(before, 100);
+    expect(appended.filter((e) => e.kind === "task:updated").map((e) => e.taskId)).toEqual([
+      "t-zombie",
+    ]);
+    // Nobody knows how that Session would have ended — no ding rides out.
+    expect(appended.map((e) => e.kind)).not.toContain("session:finished");
+  });
+
   it("sweeps an archived row too — it is the same stale row, one tab away", () => {
     insert("t-archived", "running", true);
-    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual(["t-archived"]);
+    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    expect(settled).toEqual(["t-archived"]);
     expect(statusOf("t-archived")).toBe("disconnected");
   });
 
@@ -111,7 +161,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     insert("t-running", "running");
     const before = getLastEventId();
 
-    sweepStrandedSessions({ listActiveTasks, writer });
+    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
 
     const appended = readEventTail(before, 100);
     const updates = appended.filter((e) => e.kind === "task:updated");
@@ -123,10 +173,10 @@ describe("settling the Sessions a Core restart stranded", () => {
 
   it("is a no-op on the second boot, because the first one settled everything", () => {
     insert("t-running", "running");
-    sweepStrandedSessions({ listActiveTasks, writer });
+    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
     const after = getLastEventId();
 
-    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
     expect(getLastEventId()).toBe(after);
   });
 
@@ -150,14 +200,14 @@ describe("settling the Sessions a Core restart stranded", () => {
       eventLog: { appendEvent, getLastEventId, readEventTail },
     });
 
-    expect(sweepStrandedSessions({ listActiveTasks, writer: failing })).toEqual(["t-b"]);
+    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer: failing })).toEqual(["t-b"]);
     expect(statusOf("t-b")).toBe("disconnected");
     expect(statusOf("t-a")).toBe("running");
   });
 
   it("sweeps nothing, and says nothing, on a Core with no stranded rows", () => {
     const before = getLastEventId();
-    expect(sweepStrandedSessions({ listActiveTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
     expect(getLastEventId()).toBe(before);
   });
 });

--- a/packages/core/src/__tests__/core-session-sweep.test.ts
+++ b/packages/core/src/__tests__/core-session-sweep.test.ts
@@ -84,7 +84,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     insert("t-running", "running");
     insert("t-waiting", "needs-input");
 
-    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    const settled = sweepStrandedSessions({ listBootSweepTasks, writer });
 
     expect(settled.sort()).toEqual(["t-running", "t-waiting"]);
     expect(statusOf("t-running")).toBe("disconnected");
@@ -102,7 +102,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     // filter — a queue of unstarted work must not read as a fleet of deaths.
     insert("t-ready", "ready");
 
-    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listBootSweepTasks, writer })).toEqual([]);
     expect(statusOf("t-finished")).toBe("finished");
     expect(statusOf("t-interrupted")).toBe("interrupted");
     expect(statusOf("t-ready")).toBe("ready");
@@ -116,7 +116,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     spawnPty("t-zombie");
     insert("t-unstarted", "ready");
 
-    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([
+    expect(sweepStrandedSessions({ listBootSweepTasks, writer })).toEqual([
       "t-zombie",
     ]);
     expect(statusOf("t-zombie")).toBe("disconnected");
@@ -128,7 +128,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     insert("t-zombie", "ready");
     spawnPty("t-zombie");
 
-    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    const settled = sweepStrandedSessions({ listBootSweepTasks, writer });
 
     expect(settled.sort()).toEqual(["t-running", "t-zombie"]);
     expect(statusOf("t-running")).toBe("disconnected");
@@ -140,7 +140,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     spawnPty("t-zombie");
     const before = getLastEventId();
 
-    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    sweepStrandedSessions({ listBootSweepTasks, writer });
 
     const appended = readEventTail(before, 100);
     expect(appended.filter((e) => e.kind === "task:updated").map((e) => e.taskId)).toEqual([
@@ -152,7 +152,7 @@ describe("settling the Sessions a Core restart stranded", () => {
 
   it("sweeps an archived row too — it is the same stale row, one tab away", () => {
     insert("t-archived", "running", true);
-    const settled = sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    const settled = sweepStrandedSessions({ listBootSweepTasks, writer });
     expect(settled).toEqual(["t-archived"]);
     expect(statusOf("t-archived")).toBe("disconnected");
   });
@@ -161,7 +161,7 @@ describe("settling the Sessions a Core restart stranded", () => {
     insert("t-running", "running");
     const before = getLastEventId();
 
-    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    sweepStrandedSessions({ listBootSweepTasks, writer });
 
     const appended = readEventTail(before, 100);
     const updates = appended.filter((e) => e.kind === "task:updated");
@@ -173,10 +173,10 @@ describe("settling the Sessions a Core restart stranded", () => {
 
   it("is a no-op on the second boot, because the first one settled everything", () => {
     insert("t-running", "running");
-    sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer });
+    sweepStrandedSessions({ listBootSweepTasks, writer });
     const after = getLastEventId();
 
-    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listBootSweepTasks, writer })).toEqual([]);
     expect(getLastEventId()).toBe(after);
   });
 
@@ -200,14 +200,14 @@ describe("settling the Sessions a Core restart stranded", () => {
       eventLog: { appendEvent, getLastEventId, readEventTail },
     });
 
-    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer: failing })).toEqual(["t-b"]);
+    expect(sweepStrandedSessions({ listBootSweepTasks, writer: failing })).toEqual(["t-b"]);
     expect(statusOf("t-b")).toBe("disconnected");
     expect(statusOf("t-a")).toBe("running");
   });
 
   it("sweeps nothing, and says nothing, on a Core with no stranded rows", () => {
     const before = getLastEventId();
-    expect(sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer })).toEqual([]);
+    expect(sweepStrandedSessions({ listBootSweepTasks, writer })).toEqual([]);
     expect(getLastEventId()).toBe(before);
   });
 });

--- a/packages/core/src/__tests__/harness-status-detection.test.ts
+++ b/packages/core/src/__tests__/harness-status-detection.test.ts
@@ -196,6 +196,28 @@ describe("harness status detection on the Core (issue 84)", () => {
     expect(rowStatus()).toBe("terminated");
   });
 
+  it("settles a bare Session left on ready when its PTY dies (issue 387)", async () => {
+    // The zombie found live on pairdemo: spawned, never prompted, so not one
+    // hook ever arrived for it and no Stop was ever coming. The row is created
+    // `ready` in beforeEach and nothing here posts a hook at all.
+    const status = new CoreHarnessStatus({ writer });
+    expect(rowStatus()).toBe("ready");
+
+    status.sessionExited(TASK_ID, 1);
+
+    expect(rowStatus()).toBe("disconnected");
+    // `disconnected` is not a finish: no ding for a Session that never worked.
+    expect(kinds()).not.toContain("session:finished");
+    expect(kinds()).toContain("task:updated");
+  });
+
+  it("finishes a bare Session whose PTY exited cleanly", async () => {
+    const status = new CoreHarnessStatus({ writer });
+    status.sessionExited(TASK_ID, 0);
+    expect(rowStatus()).toBe("finished");
+    expect(kinds()).toContain("session:finished");
+  });
+
   it("reports a Session parked on a dialog nobody answered as needs-input", async () => {
     // Issue 177 finding 3. Prompt delivery abandons rather than guessing (ADR
     // 0026 D5), and until now that decision was a log line on the Core: the

--- a/packages/core/src/__tests__/harness-status-detection.test.ts
+++ b/packages/core/src/__tests__/harness-status-detection.test.ts
@@ -211,11 +211,14 @@ describe("harness status detection on the Core (issue 84)", () => {
     expect(kinds()).toContain("task:updated");
   });
 
-  it("finishes a bare Session whose PTY exited cleanly", async () => {
+  it("raises no completion ding for a bare Session whose PTY exited cleanly", async () => {
+    // A clean exit of a Session that never ran a turn is still only a process
+    // going away. `finished` here would append `session:finished` and ding the
+    // operator for "Waiting for initial prompt…".
     const status = new CoreHarnessStatus({ writer });
     status.sessionExited(TASK_ID, 0);
-    expect(rowStatus()).toBe("finished");
-    expect(kinds()).toContain("session:finished");
+    expect(rowStatus()).toBe("disconnected");
+    expect(kinds()).not.toContain("session:finished");
   });
 
   it("reports a Session parked on a dialog nobody answered as needs-input", async () => {

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -96,6 +96,7 @@ import {
   coreQueryStore,
   listActiveTasks,
   listBootSweepTasks,
+  taskEverWorked,
 } from "./core-query-store";
 import {
   configureCoreMutationStore,
@@ -110,6 +111,7 @@ import { CoreTitleGenerator } from "./core-title-generator";
 import { startHarnessHookReceiver, type HarnessHookReceiver } from "./harness-hook-receiver";
 import { HookDeliveryMonitor, hookMissLogPath } from "./harness-hook-delivery";
 import { sweepStrandedSessions } from "./core-session-sweep";
+import { readySessionOnAgentSpawn } from "./core-session-relaunch";
 import { CoreSessionBackstop } from "./core-session-backstop";
 import { verifyBearer, type BearerSecret } from "@actana/shared/core-link-bearer";
 import { loadOrMintMaterial, type LoadOrMintResult } from "./core-first-run";
@@ -241,7 +243,7 @@ async function startCore(): Promise<void> {
   // `listBootSweepTasks` widens that read by the one class of orphan the
   // status filter could never see: a bare Session left on `ready`, whose PTY
   // spawned and died without a single hook ever firing for it (issue 387).
-  sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer: taskWriter });
+  sweepStrandedSessions({ listBootSweepTasks, writer: taskWriter });
 
   const titleGenerator = new CoreTitleGenerator({ writer: taskWriter });
   const harnessStatus = new CoreHarnessStatus({
@@ -417,6 +419,14 @@ async function startCore(): Promise<void> {
     // Session gets named at all (issue 84).
     promptPort: {
       submitted: (taskId, prompt) => titleGenerator.schedule(taskId, prompt),
+    },
+    // The other side of issue 387's sweep: a bare Session that settled while
+    // it had never run a turn is put back on `ready` when a harness is spawned
+    // for it again. Nothing else would — no hook fires until the first prompt,
+    // so the card would read `disconnected` over a healthy harness.
+    relaunchPort: {
+      agentSpawned: (taskId) =>
+        void readySessionOnAgentSpawn({ writer: taskWriter, everWorked: taskEverWorked }, taskId),
     },
     // Issue 11: back the `agentsAvailabilityList` frame with the current
     // snapshot from the Core's own PATH probe. The event stream carries

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -95,6 +95,7 @@ import {
   disposeCoreQueryStore,
   coreQueryStore,
   listActiveTasks,
+  listBootSweepTasks,
 } from "./core-query-store";
 import {
   configureCoreMutationStore,
@@ -236,7 +237,11 @@ async function startCore(): Promise<void> {
   // them. Swept here: after the writer exists (each settle appends the event a
   // Panel re-renders from) and before the PTY core, the hook receiver or the
   // core-link server can produce a Session of THIS run that would be in scope.
-  sweepStrandedSessions({ listActiveTasks, writer: taskWriter });
+  //
+  // `listBootSweepTasks` widens that read by the one class of orphan the
+  // status filter could never see: a bare Session left on `ready`, whose PTY
+  // spawned and died without a single hook ever firing for it (issue 387).
+  sweepStrandedSessions({ listActiveTasks: listBootSweepTasks, writer: taskWriter });
 
   const titleGenerator = new CoreTitleGenerator({ writer: taskWriter });
   const harnessStatus = new CoreHarnessStatus({

--- a/packages/core/src/core-query-store.ts
+++ b/packages/core/src/core-query-store.ts
@@ -20,6 +20,7 @@ import {
   countArchivedTasks,
   queryActiveTasks,
   queryArchivedTasks,
+  queryStrandedReadyTasks,
   queryProjects,
   queryTask,
   queryTasks,
@@ -173,6 +174,39 @@ export function listActiveTasks(): CoreLinkTaskSnapshot[] {
     log.warn("core-query.list-active-tasks-failed", { error: String(err) });
     return [];
   }
+}
+
+/**
+ * Every `ready` task this Core once spawned a PTY for (issue 387).
+ *
+ * The companion to {@link listActiveTasks}, kept as its own read for the same
+ * reason the SQL is its own query: `ready` needs the event-log evidence that a
+ * process ever existed, and a Core whose event log is unreadable must still
+ * sweep the rows that need no such evidence. Degrades to `[]` on its own.
+ */
+export function listStrandedReadyTasks(): CoreLinkTaskSnapshot[] {
+  const conn = ensureConnection();
+  if (!conn) return [];
+  try {
+    return queryStrandedReadyTasks(conn as unknown as CoreQuerySqlite);
+  } catch (err) {
+    log.warn("core-query.list-stranded-ready-tasks-failed", { error: String(err) });
+    return [];
+  }
+}
+
+/**
+ * Everything the boot sweep settles: the rows that claim a live process, plus
+ * the `ready` rows a dead PTY left behind (issue 387).
+ *
+ * The union lives here, next to the two reads, rather than in the sweep — the
+ * sweep's job is to settle what it is handed, and the backstop, which shares
+ * {@link listActiveTasks}, must NOT see the `ready` rows: a bare Session
+ * waiting on its first prompt is allowed to sit silent for as long as the
+ * operator likes, and settling it for being quiet would be a bug.
+ */
+export function listBootSweepTasks(): CoreLinkTaskSnapshot[] {
+  return [...listActiveTasks(), ...listStrandedReadyTasks()];
 }
 
 /** Close the connection. Called on Core shutdown. */

--- a/packages/core/src/core-query-store.ts
+++ b/packages/core/src/core-query-store.ts
@@ -21,6 +21,7 @@ import {
   queryActiveTasks,
   queryArchivedTasks,
   queryStrandedReadyTasks,
+  queryTaskEverWorked,
   queryProjects,
   queryTask,
   queryTasks,
@@ -207,6 +208,26 @@ export function listStrandedReadyTasks(): CoreLinkTaskSnapshot[] {
  */
 export function listBootSweepTasks(): CoreLinkTaskSnapshot[] {
   return [...listActiveTasks(), ...listStrandedReadyTasks()];
+}
+
+/**
+ * Has this Session ever reported work (issue 387, review finding 2)? The read
+ * behind the relaunch reset in `core-session-relaunch.ts`.
+ *
+ * Answers `false` on an unavailable DB, like every read here. That is the safe
+ * direction: `false` only permits a reset the caller has already narrowed to a
+ * settled row, and a Core that cannot read its log should not be refusing to
+ * correct a card either.
+ */
+export function taskEverWorked(taskId: string): boolean {
+  const conn = ensureConnection();
+  if (!conn) return false;
+  try {
+    return queryTaskEverWorked(conn as unknown as CoreQuerySqlite, taskId);
+  } catch (err) {
+    log.warn("core-query.task-ever-worked-failed", { taskId, error: String(err) });
+    return false;
+  }
 }
 
 /** Close the connection. Called on Core shutdown. */

--- a/packages/core/src/core-session-relaunch.ts
+++ b/packages/core/src/core-session-relaunch.ts
@@ -1,0 +1,91 @@
+// Putting a relaunched Session back on `ready` (issue 387, review finding 2).
+//
+// Issue 387 made `ready` a status a Session can leave: a bare Session whose
+// PTY died settles to `disconnected`, by the PTY-exit path or by the boot
+// sweep. That fixed the zombie and opened the mirror of it. Nothing in this
+// Core ever writes `ready` back, and a bare Session was never going to be
+// written back by a hook either — it has run no turn, so no hook fires for it
+// until the operator's first prompt. So the operator reopens a swept Session,
+// the Core spawns a perfectly healthy harness, it sits at its prompt, and the
+// card says `disconnected` until the operator types. That is the same class of
+// bug as the zombie: a card that does not describe the Session.
+//
+// This is the write-back, and it is deliberately narrow. Three things must all
+// hold before a row moves:
+//
+//  - **An agent spawn.** A `shell` or `shellSession` PTY carries a `taskId`
+//    for routing and is not harness work; neither may reset a Session's card.
+//  - **A settled status.** `ready` needs no reset, and `running` /
+//    `needs-input` are claims about a live turn that a spawn does not refute.
+//  - **A Session that has never worked.** The one that matters. A `finished`
+//    Session being reopened is being RESUMED, and its card must keep saying
+//    `finished` — the operator's own record of what that Session did. Only a
+//    Session with no turn behind it has nothing to lose by going back to the
+//    status it never really left.
+//
+// The last one is a read of this Core's event log, not of the row: see
+// `queryTaskEverWorked` for why the row cannot answer it. Everything else a
+// spawn could tell us — the launch command, the harness family — is either
+// unavailable here or a guess, and this write is operator-visible.
+//
+// Like every other status change on this Core it goes through
+// {@link CoreTaskWriter}, so the `task:updated` a connected Panel re-renders
+// from is appended with it.
+
+import log from "@actana/shared/log";
+import type { TaskStatus } from "@actana/shared/domain";
+import type { CoreTaskWriter } from "./core-task-writer";
+
+/** The status a relaunched Session that never worked goes back to. */
+const RELAUNCH_STATUS: TaskStatus = "ready";
+
+/**
+ * The statuses a spawn may reset. Everything a Session settles on, and nothing
+ * that describes a live turn — a spawn is not evidence against `running`.
+ * `ready` is absent because a row already there needs no write.
+ */
+const SETTLED_STATUSES: ReadonlySet<string> = new Set([
+  "finished",
+  "terminated",
+  "disconnected",
+  "interrupted",
+]);
+
+export type CoreSessionRelaunchDeps = {
+  /** The one seam a task row changes through, events included. */
+  writer: CoreTaskWriter;
+  /** Has any status change on this row ever described a turn? */
+  everWorked: (taskId: string) => boolean;
+};
+
+/**
+ * An agent PTY was just spawned for this Session. Put its row back on `ready`
+ * when — and only when — the row is settled and the Session never worked.
+ * Returns `true` when the row moved.
+ *
+ * Called after the spawn succeeded, so a refused spawn changes nothing. A
+ * write that throws is logged and swallowed: a card left one status stale is a
+ * far smaller failure than a spawn that answers `spawnError` because of it.
+ */
+export function readySessionOnAgentSpawn(
+  deps: CoreSessionRelaunchDeps,
+  taskId: string,
+): boolean {
+  if (!taskId) return false;
+  const task = deps.writer.readTask(taskId);
+  if (!task || !SETTLED_STATUSES.has(task.status)) return false;
+  if (deps.everWorked(taskId)) return false;
+  try {
+    const updated = deps.writer.mutate({
+      op: "update",
+      taskId,
+      status: RELAUNCH_STATUS,
+    });
+    if (!updated) return false;
+    log.info("session-relaunch.reset", { taskId, from: task.status });
+    return true;
+  } catch (err) {
+    log.warn("session-relaunch.reset-failed", { taskId, error: String(err) });
+    return false;
+  }
+}

--- a/packages/core/src/core-session-sweep.ts
+++ b/packages/core/src/core-session-sweep.ts
@@ -45,8 +45,15 @@ const STRANDED_STATUS = "disconnected";
 
 export type CoreSessionSweepDeps = {
   /**
-   * Every row this Core still claims is working. `listActiveTasks` from
+   * Every row a PTY of the previous run left behind. `listBootSweepTasks` from
    * `core-query-store.ts` in the daemon; an array in tests.
+   *
+   * That is the rows claiming `running` / `needs-input`, plus the `ready` rows
+   * this Core once spawned a PTY for (issue 387) — a bare Session waiting on
+   * its first prompt never leaves `ready`, so no status filter would ever have
+   * caught it and no hook was ever going to arrive for it either. A `ready`
+   * row with no `pty:spawn` behind it is not in the list and must not be: that
+   * is a Session the operator has simply not started yet.
    */
   listActiveTasks: () => CoreLinkTaskSnapshot[];
   /** The one seam a task row changes through, events included. */
@@ -54,8 +61,8 @@ export type CoreSessionSweepDeps = {
 };
 
 /**
- * Settle every Session this Core's database still claims is working, and
- * return the ids that moved.
+ * Settle every Session a PTY of the previous run stranded, and return the ids
+ * that moved.
  *
  * Called once per boot. A row that vanishes between the read and the write
  * (deleted by a Panel racing the boot) answers `null` from the writer and is

--- a/packages/core/src/core-session-sweep.ts
+++ b/packages/core/src/core-session-sweep.ts
@@ -55,7 +55,7 @@ export type CoreSessionSweepDeps = {
    * row with no `pty:spawn` behind it is not in the list and must not be: that
    * is a Session the operator has simply not started yet.
    */
-  listActiveTasks: () => CoreLinkTaskSnapshot[];
+  listBootSweepTasks: () => CoreLinkTaskSnapshot[];
   /** The one seam a task row changes through, events included. */
   writer: CoreTaskWriter;
 };
@@ -71,7 +71,7 @@ export type CoreSessionSweepDeps = {
  * of the fleet's Sessions wedged.
  */
 export function sweepStrandedSessions(deps: CoreSessionSweepDeps): string[] {
-  const stranded = deps.listActiveTasks();
+  const stranded = deps.listBootSweepTasks();
   if (stranded.length === 0) return [];
 
   const settled: string[] = [];

--- a/packages/core/src/pty-core-link-server.ts
+++ b/packages/core/src/pty-core-link-server.ts
@@ -378,6 +378,12 @@ export type PtyCoreLinkServerOptions = {
    */
   promptPort?: { submitted(taskId: string, prompt: string): void };
   /**
+   * An agent PTY was spawned for this Session (issue 387, review finding 2).
+   * Optional: a Core without it simply never resets a relaunched Session's
+   * card. See `core-session-relaunch.ts` for what the port does with it.
+   */
+  relaunchPort?: { agentSpawned(taskId: string): void };
+  /**
    * Snapshot of this Core's CLI availability (issue 11). When omitted, the
    * `agentsAvailabilityList` frame answers with an empty map — the Panel's
    * per-Core availability store then falls back to "checking…" until the
@@ -655,6 +661,7 @@ export class PtyCoreLinkServer {
   private readonly directoryPort: CoreDirectoryPort | null;
   private readonly execPort: CoreExecPort | null;
   private readonly promptPort: { submitted(taskId: string, prompt: string): void } | null;
+  private readonly relaunchPort: { agentSpawned(taskId: string): void } | null;
   private readonly protocolVersion: string;
   private readonly announceMultiConnection: boolean;
   private readonly announceFiles: boolean;
@@ -730,6 +737,7 @@ export class PtyCoreLinkServer {
     this.directoryPort = opts.directoryPort ?? null;
     this.execPort = opts.execPort ?? null;
     this.promptPort = opts.promptPort ?? null;
+    this.relaunchPort = opts.relaunchPort ?? null;
     this.protocolVersion = opts.protocolVersion ?? CORE_LINK_PROTOCOL_VERSION;
     this.announceMultiConnection = opts.announceMultiConnection ?? true;
     this.taskWriter =
@@ -1437,6 +1445,14 @@ export class PtyCoreLinkServer {
           // wants this PTY still has to ask.
           conn.subscribePty(ptyId, false);
           this.recordPtySpawn(ptyId, frame.opts.taskId, shellSession);
+          // A harness is alive for this Session again. If its row settled
+          // while it had never run a turn — the bare Session issue 387 sweeps
+          // — the card is now wrong in the other direction, and nothing else
+          // will correct it: no hook fires until the first prompt. The port
+          // decides; a shell spawn never asks (issue 387, review finding 2).
+          if (frame.opts.shellSession !== true && frame.opts.agent) {
+            this.relaunchPort?.agentSpawned(frame.opts.taskId);
+          }
           // `hooksReportTurnStart` is what lets the Panel arm its
           // terminal-input fallback on reality rather than on the harness
           // family (issue 84): a Session whose hooks will not announce the

--- a/packages/panel/src/lib/__tests__/harness-command.test.ts
+++ b/packages/panel/src/lib/__tests__/harness-command.test.ts
@@ -212,6 +212,40 @@ describe("harnessLaunchMode", () => {
     ).toBe("resume");
   });
 
+  it("starts Claude Code fresh until a session id is captured (issue 387)", () => {
+    // The bare Session issue 387 settles: never prompted, so no hook ever
+    // captured an id for it, and the settle moved it off `ready`. Resuming
+    // would be `claude --resume` into a conversation that never existed.
+    expect(
+      harnessLaunchMode({
+        ...baseTask,
+        agent: "claude-code",
+        status: "disconnected",
+        claudeSessionId: null,
+      } satisfies Task),
+    ).toBe("new");
+    expect(
+      harnessLaunchMode({
+        ...baseTask,
+        agent: "claude-code",
+        status: "finished",
+        claudeSessionId: null,
+      } satisfies Task),
+    ).toBe("new");
+    // A Session that did have a turn still resumes off its captured id, and a
+    // fresh one still starts new — neither half of the gate moved.
+    expect(
+      harnessLaunchMode({
+        ...baseTask,
+        agent: "claude-code",
+        status: "disconnected",
+      } satisfies Task),
+    ).toBe("resume");
+    expect(
+      harnessLaunchMode({ ...baseTask, agent: "claude-code", status: "ready" } satisfies Task),
+    ).toBe("new");
+  });
+
   it("starts OpenCode fresh until a ses_* id is captured", () => {
     expect(
       harnessLaunchMode({

--- a/packages/panel/src/lib/harness-command.ts
+++ b/packages/panel/src/lib/harness-command.ts
@@ -23,7 +23,19 @@ export function harnessUsesPersistedSession(agent: Harness): boolean {
 
 export function harnessLaunchMode(task: Task): HarnessLaunchMode {
   if (task.agent === "claude-code") {
-    return task.status === "ready" ? "new" : "resume";
+    // Both halves are load-bearing, the way they are for codex below.
+    //
+    // `status !== "ready"` alone read as "this Session has had a conversation",
+    // which was true only while `ready` was a one-way status. Issue 387 moves a
+    // Session off `ready` when its PTY dies — so a bare Session that was never
+    // prompted, and therefore never had a session id captured for it, now
+    // reaches this branch reading `disconnected`. Resuming it means
+    // `claude --resume <id>` against a conversation that never existed: the
+    // spawn dies on the spot, and the operator is shown the retry notice.
+    //
+    // A Session with no captured id has nothing to resume INTO, whatever its
+    // status says, so it starts new.
+    return task.claudeSessionId && task.status !== "ready" ? "resume" : "new";
   }
   if (task.agent === "cursor-cli") {
     return "resume";

--- a/packages/shared/src/__tests__/core-query.test.ts
+++ b/packages/shared/src/__tests__/core-query.test.ts
@@ -5,6 +5,7 @@ import {
   queryActiveTasks,
   queryArchivedTasks,
   queryProjects,
+  queryStrandedReadyTasks,
   queryTasks,
   type CoreQuerySqlite,
 } from "../core-query";
@@ -101,6 +102,27 @@ function insertTask(
     t.icon ?? null,
     t.updatedAt ?? 1,
   );
+}
+
+/** The Core's event log, as far as the stranded-ready read needs it. */
+function addEventLog(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE event_log (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      pty_id TEXT,
+      task_id TEXT,
+      payload TEXT NOT NULL
+    );
+  `);
+}
+
+/** Record the `pty:spawn` the Core appends when it starts a harness. */
+function spawnedPty(db: Database.Database, taskId: string | null): void {
+  db.prepare(
+    "INSERT INTO event_log (ts, kind, pty_id, task_id, payload) VALUES (?, ?, ?, ?, ?)",
+  ).run(1, "pty:spawn", "pty-1", taskId, "{}");
 }
 
 describe("queryProjects", () => {
@@ -322,6 +344,96 @@ describe("queryActiveTasks (the Core's boot sweep read, issue 243)", () => {
   it("returns empty when the tasks table does not exist", () => {
     const empty = new Database(":memory:");
     expect(queryActiveTasks(asQuery(empty))).toEqual([]);
+    empty.close();
+  });
+});
+
+describe("queryStrandedReadyTasks (the ready zombie, issue 387)", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = openDb();
+    addEventLog(db);
+  });
+
+  it("finds a ready row a PTY was spawned for, and no other ready row", () => {
+    // The bare Session: a PTY of some previous run, no hook ever fired, still
+    // sitting on "Waiting for initial prompt…" hours after the process died.
+    insertTask(db, { taskId: "t-zombie", projectId: "p1", status: "ready" });
+    spawnedPty(db, "t-zombie");
+    // The Session the operator created and has not started. It has no process
+    // because it never had one — sweeping it would be the regression.
+    insertTask(db, { taskId: "t-unstarted", projectId: "p1", status: "ready" });
+
+    expect(queryStrandedReadyTasks(asQuery(db)).map((t) => t.taskId)).toEqual(["t-zombie"]);
+  });
+
+  it("leaves every other status to the query that owns it", () => {
+    for (const status of ["running", "needs-input", "finished", "disconnected"]) {
+      insertTask(db, { taskId: `t-${status}`, projectId: "p1", status });
+      spawnedPty(db, `t-${status}`);
+    }
+    expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
+  });
+
+  it("ignores a spawn recorded against some other Session", () => {
+    insertTask(db, { taskId: "t-ready", projectId: "p1", status: "ready" });
+    spawnedPty(db, "t-other");
+    expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
+  });
+
+  it("does not read a shell PTY, which belongs to no task at all", () => {
+    insertTask(db, { taskId: "t-ready", projectId: "p1", status: "ready" });
+    spawnedPty(db, null);
+    expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
+  });
+
+  it("includes an archived row, and spans every project", () => {
+    insertTask(db, { taskId: "t-arch", projectId: "p1", status: "ready", archived: true });
+    spawnedPty(db, "t-arch");
+    insertTask(db, { taskId: "t-p2", projectId: "p2", status: "ready" });
+    spawnedPty(db, "t-p2");
+    expect(queryStrandedReadyTasks(asQuery(db)).map((t) => t.taskId).sort()).toEqual([
+      "t-arch",
+      "t-p2",
+    ]);
+  });
+
+  it("maps the row the way every other listing here does", () => {
+    insertTask(db, {
+      taskId: "t-zombie",
+      projectId: "p1",
+      status: "ready",
+      title: "Waiting for initial prompt…",
+      agent: "opencode",
+      pinned: true,
+      updatedAt: 42,
+    });
+    spawnedPty(db, "t-zombie");
+    expect(queryStrandedReadyTasks(asQuery(db))[0]).toMatchObject({
+      taskId: "t-zombie",
+      projectId: "p1",
+      title: "Waiting for initial prompt…",
+      agent: "opencode",
+      status: "ready",
+      pinned: true,
+      archived: false,
+      claudeSessionId: null,
+      updatedAt: 42,
+    });
+  });
+
+  it("returns empty when there is no event log to read the evidence from", () => {
+    // A Core whose log never bootstrapped sweeps nothing extra rather than
+    // failing its whole boot read — and rather than sweeping every ready row.
+    const noLog = openDb();
+    insertTask(noLog, { taskId: "t-ready", projectId: "p1", status: "ready" });
+    expect(queryStrandedReadyTasks(asQuery(noLog))).toEqual([]);
+    noLog.close();
+  });
+
+  it("returns empty when the tasks table does not exist", () => {
+    const empty = new Database(":memory:");
+    expect(queryStrandedReadyTasks(asQuery(empty))).toEqual([]);
     empty.close();
   });
 });

--- a/packages/shared/src/__tests__/core-query.test.ts
+++ b/packages/shared/src/__tests__/core-query.test.ts
@@ -6,6 +6,7 @@ import {
   queryArchivedTasks,
   queryProjects,
   queryStrandedReadyTasks,
+  queryTaskEverWorked,
   queryTasks,
   type CoreQuerySqlite,
 } from "../core-query";
@@ -118,11 +119,32 @@ function addEventLog(db: Database.Database): void {
   `);
 }
 
-/** Record the `pty:spawn` the Core appends when it starts a harness. */
-function spawnedPty(db: Database.Database, taskId: string | null): void {
+/**
+ * Record the `pty:spawn` the Core appends when it starts a PTY, in the shape
+ * `recordPtySpawn` actually writes — `shellSession` is in the payload, and it
+ * is `false` for an agent spawn and for a plain `shell: true` spawn alike.
+ */
+function spawnedPty(
+  db: Database.Database,
+  taskId: string | null,
+  shellSession = false,
+): void {
   db.prepare(
     "INSERT INTO event_log (ts, kind, pty_id, task_id, payload) VALUES (?, ?, ?, ?, ?)",
-  ).run(1, "pty:spawn", "pty-1", taskId, "{}");
+  ).run(1, "pty:spawn", "pty-1", taskId, JSON.stringify({ ptyId: "pty-1", taskId, shellSession }));
+}
+
+/** A `task:updated` the way `CoreTaskWriter` writes it: status only when patched. */
+function taskUpdated(db: Database.Database, taskId: string, status?: string): void {
+  db.prepare(
+    "INSERT INTO event_log (ts, kind, pty_id, task_id, payload) VALUES (?, ?, ?, ?, ?)",
+  ).run(
+    1,
+    "task:updated",
+    null,
+    taskId,
+    JSON.stringify({ taskId, projectId: "p1", ...(status === undefined ? {} : { status }) }),
+  );
 }
 
 describe("queryProjects", () => {
@@ -381,9 +403,26 @@ describe("queryStrandedReadyTasks (the ready zombie, issue 387)", () => {
     expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
   });
 
-  it("does not read a shell PTY, which belongs to no task at all", () => {
+  it("does not read a VM Shell Session spawn as harness evidence", () => {
+    // `shellSession: true` carries a taskId for routing and is not harness
+    // work — a shell opened against a Session must not settle its card.
     insertTask(db, { taskId: "t-ready", projectId: "p1", status: "ready" });
-    spawnedPty(db, null);
+    spawnedPty(db, "t-ready", true);
+    expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
+
+    // The agent spawn for the same row still is evidence.
+    spawnedPty(db, "t-ready");
+    expect(queryStrandedReadyTasks(asQuery(db)).map((t) => t.taskId)).toEqual(["t-ready"]);
+  });
+
+  it("does not read a plain shell spawn, whose task id names no row", () => {
+    // A `shell: true` spawn records `shellSession: false`, the same as an
+    // agent — it is separated by its id instead. The CLI addresses those with
+    // a synthetic `cli_shell_<uuid>`, which no `tasks` row carries, so the
+    // join drops it. Pinning the shape here is what keeps that true.
+    insertTask(db, { taskId: "t-ready", projectId: "p1", status: "ready" });
+    spawnedPty(db, "cli_shell_2f1c9a4e-0d3b-4c77-9f21-6b8e5a0d1c34");
+    spawnedPty(db, "user-terminal-1");
     expect(queryStrandedReadyTasks(asQuery(db))).toEqual([]);
   });
 
@@ -435,6 +474,58 @@ describe("queryStrandedReadyTasks (the ready zombie, issue 387)", () => {
     const empty = new Database(":memory:");
     expect(queryStrandedReadyTasks(asQuery(empty))).toEqual([]);
     empty.close();
+  });
+});
+
+describe("queryTaskEverWorked (the relaunch reset's gate, issue 387)", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = openDb();
+    addEventLog(db);
+  });
+
+  it("is false for a Session whose row only ever moved between ready and disconnected", () => {
+    // The bare Session: born `ready`, settled `disconnected` by the sweep or
+    // the PTY-exit path, and nothing in between. Nothing here is a turn.
+    taskUpdated(db, "t-bare", "disconnected");
+    expect(queryTaskEverWorked(asQuery(db), "t-bare")).toBe(false);
+  });
+
+  it("is false when the row changed without a status patch at all", () => {
+    // A rename, a pin, an archive: `CoreTaskWriter` omits `status` from the
+    // payload unless the mutation carried one, which is what makes this read
+    // possible in the first place.
+    taskUpdated(db, "t-renamed");
+    expect(queryTaskEverWorked(asQuery(db), "t-renamed")).toBe(false);
+  });
+
+  it("is true for every status that only a turn produces", () => {
+    for (const status of ["running", "needs-input", "interrupted", "finished", "terminated"]) {
+      const taskId = `t-${status}`;
+      taskUpdated(db, taskId, "disconnected");
+      taskUpdated(db, taskId, status);
+      expect(queryTaskEverWorked(asQuery(db), taskId)).toBe(true);
+    }
+  });
+
+  it("is true for a harness that goes straight from ready to finished", () => {
+    // Some harnesses never report `running`; the finish is the only patch.
+    taskUpdated(db, "t-quiet", "finished");
+    expect(queryTaskEverWorked(asQuery(db), "t-quiet")).toBe(true);
+  });
+
+  it("reads only this Session's own history", () => {
+    taskUpdated(db, "t-other", "running");
+    expect(queryTaskEverWorked(asQuery(db), "t-bare")).toBe(false);
+  });
+
+  it("ignores events that are not task:updated", () => {
+    spawnedPty(db, "t-bare");
+    expect(queryTaskEverWorked(asQuery(db), "t-bare")).toBe(false);
+  });
+
+  it("is false when there is no event log to read", () => {
+    expect(queryTaskEverWorked(asQuery(openDb()), "t-bare")).toBe(false);
   });
 });
 

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -206,3 +206,68 @@ describe("in-turn subagents hold the finish", () => {
     expect(h.task.status).toBe("finished");
   });
 });
+
+describe("a PTY exit settles a Session that never started a turn (issue 387)", () => {
+  // The live zombie this pins: a bare Session on `ready`, PTY spawned, no
+  // prompt ever submitted — so no hook ever fired for it, and no Stop was
+  // ever coming. Before this, the exit settle skipped `ready` and the row
+  // went on saying "Waiting for initial prompt…" hours after its process died.
+  const EXITED = "MissionControlSessionEnded";
+
+  it("settles a ready Session to disconnected when its PTY dies badly", () => {
+    const h = harness();
+    expect(h.task.status).toBe("ready");
+
+    h.post({ hook_event_name: EXITED, exit_code: 1 });
+
+    // Not `terminated`: nothing was killed mid-turn, because there was no
+    // turn. All that is known is that the process went away.
+    expect(h.task.status).toBe("disconnected");
+    expect(h.writes).toEqual(["disconnected"]);
+  });
+
+  it("settles a ready Session to finished when the exit was clean", () => {
+    const h = harness();
+    h.post({ hook_event_name: EXITED, exit_code: 0 });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("settles without a Stop hook ever arriving", () => {
+    const h = harness();
+    // The whole point: the Session is spawned and left alone. Nothing but the
+    // exit is ever posted, and the row still moves off `ready`.
+    h.post({ hook_event_name: "SessionStart", source: "startup" });
+    expect(h.task.status).toBe("ready");
+
+    h.post({ hook_event_name: EXITED, exit_code: 143 });
+    expect(h.task.status).toBe("disconnected");
+  });
+
+  it("keeps the running/needs-input settle on its own scale", () => {
+    // `terminated` still means a turn that was killed — widening `ready` must
+    // not have widened this.
+    const running = harness();
+    running.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+    running.post({ hook_event_name: EXITED, exit_code: 1 });
+    expect(running.task.status).toBe("terminated");
+
+    const waiting = harness();
+    waiting.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+    waiting.post({ hook_event_name: "Notification", notification_type: "permission_prompt" });
+    expect(waiting.task.status).toBe("needs-input");
+    waiting.post({ hook_event_name: EXITED, exit_code: 0 });
+    expect(waiting.task.status).toBe("finished");
+  });
+
+  it("still leaves an already-settled Session exactly as it settled", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+
+    h.post({ hook_event_name: EXITED, exit_code: 1 });
+    // The exit of an idle session is not news, and must not overwrite the
+    // finish that was actually reported.
+    expect(h.task.status).toBe("finished");
+  });
+});

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -226,10 +226,14 @@ describe("a PTY exit settles a Session that never started a turn (issue 387)", (
     expect(h.writes).toEqual(["disconnected"]);
   });
 
-  it("settles a ready Session to finished when the exit was clean", () => {
+  it("settles a ready Session to disconnected on a clean exit too", () => {
+    // Not `finished`. That transition is what `CoreTaskWriter` appends
+    // `session:finished` on, and a Session that never ran a turn must not ring
+    // a completion ding — the boot sweep settles the same Session silently.
     const h = harness();
     h.post({ hook_event_name: EXITED, exit_code: 0 });
-    expect(h.task.status).toBe("finished");
+    expect(h.task.status).toBe("disconnected");
+    expect(h.writes).toEqual(["disconnected"]);
   });
 
   it("settles without a Stop hook ever arriving", () => {

--- a/packages/shared/src/core-query.ts
+++ b/packages/shared/src/core-query.ts
@@ -231,10 +231,30 @@ export function queryActiveTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSnapshot[
  * harness session id stays `null` precisely in the bare case, where no hook
  * ever arrives to set it.
  *
+ * Only an agent spawn is evidence. A `pty:spawn` is recorded for the `shell`
+ * and `shellSession` variants too, which carry a `taskId` for routing but are
+ * not harness work. The VM-shell variant is excluded here by the payload's
+ * `shellSession` flag. The plain `shell: true` variant is not distinguishable
+ * in the payload — it records `shellSession: false`, the same as an agent —
+ * and is separated by its task id instead: those spawns are addressed with a
+ * synthetic id (`cli_shell_<uuid>`, or a user-terminal id) that matches no
+ * `tasks` row, so the join drops them. The test pins that shape.
+ *
  * Archived rows are included and no project filter applies, for the same
- * reasons as {@link queryActiveTasks}. A log whose `pty:spawn` has aged out
- * answers nothing for that row, which fails toward leaving it alone. Returns
- * an empty array when either table is absent.
+ * reasons as {@link queryActiveTasks}.
+ *
+ * **The evidence is permanent.** Nothing in this repo prunes `event_log` —
+ * there is no `DELETE FROM event_log` anywhere — so a `pty:spawn` recorded a
+ * year ago still answers for its row. The consequence is a one-time batch: on
+ * the first Core boot after this ships, EVERY historical `ready` row that ever
+ * had a harness spawned settles to `disconnected` at once, each appending its
+ * own `task:updated`. That is the backlog of zombies this query exists to
+ * find, arriving in one go because nothing was looking for them before; every
+ * later boot sees only what the run before it stranded. If `event_log` ever
+ * grows a retention window, a row whose spawn has aged out stops being swept —
+ * it would read as never-started, which is the safe direction to fail in.
+ *
+ * Returns an empty array when either table is absent.
  */
 export function queryStrandedReadyTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSnapshot[] {
   let rows: TaskRow[];
@@ -250,7 +270,9 @@ export function queryStrandedReadyTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSn
          WHERE t.status = 'ready'
            AND EXISTS (
              SELECT 1 FROM event_log e
-             WHERE e.task_id = t.id AND e.kind = 'pty:spawn'
+             WHERE e.task_id = t.id
+               AND e.kind = 'pty:spawn'
+               AND e.payload NOT LIKE '%"shellSession":true%'
            )
          ORDER BY t.updated_at DESC`,
       )
@@ -259,6 +281,59 @@ export function queryStrandedReadyTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSn
     return [];
   }
   return rows.map(taskRowToSnapshot);
+}
+
+/**
+ * Has this Session ever reported work — has any status change on its row ever
+ * described a turn (issue 387, review finding 2)?
+ *
+ * The question a relaunch has to answer. Issue 387 moves a stranded `ready`
+ * row to a settled status, and nothing writes `ready` back, so a bare Session
+ * the operator reopens would sit at `disconnected` while its harness waits at
+ * the prompt. Resetting the row on spawn is only right for a Session that
+ * never worked: a genuinely finished one is being resumed, and its card must
+ * keep saying so.
+ *
+ * The row cannot answer it. `claude_session_id` is captured on `SessionStart`
+ * for Claude Code — the Core installs that hook — so a bare Session that has
+ * never run a turn can still carry an id. What does answer it is the event
+ * log, where every status change on a Core-owned row is a `task:updated`
+ * carrying the status that was PATCHED (`core-task-writer.ts` is careful to
+ * record the patch rather than the resulting row, for exactly this kind of
+ * reader).
+ *
+ * So: a turn is any patched status other than the two a Session can reach
+ * without ever having worked — `ready` (its birth, and this reset) and
+ * `disconnected` (the sweep and the PTY-exit settle). `running`,
+ * `needs-input`, `interrupted`, `finished` and `terminated` each say a turn
+ * happened, including on a harness that goes straight from `ready` to
+ * `finished` without ever reporting `running`.
+ *
+ * Matched with `LIKE` against the payload because the status rides in the JSON
+ * body rather than a column; `status` is the last key the writer emits, and the
+ * `"status":"…"` shape is fully quoted, so the patterns cannot straddle fields.
+ * The read is bounded by `event_log_task_idx`. Answers `false` when either the
+ * log or the row is unreadable — the safe direction, because `false` only ever
+ * permits a reset that the caller's own status check has already narrowed to a
+ * settled row.
+ */
+export function queryTaskEverWorked(sqlite: CoreQuerySqlite, taskId: string): boolean {
+  try {
+    const rows = sqlite
+      .prepare(
+        `SELECT 1 AS hit FROM event_log
+         WHERE task_id = ?
+           AND kind = 'task:updated'
+           AND payload LIKE '%"status":"%'
+           AND payload NOT LIKE '%"status":"ready"%'
+           AND payload NOT LIKE '%"status":"disconnected"%'
+         LIMIT 1`,
+      )
+      .all(taskId);
+    return rows.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/shared/src/core-query.ts
+++ b/packages/shared/src/core-query.ts
@@ -208,6 +208,60 @@ export function queryActiveTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSnapshot[
 }
 
 /**
+ * Every `ready` task on this Core that a PTY was once spawned for (issue 387).
+ *
+ * `ready` is the status a Session is born in, so it cannot be swept on the
+ * strength of the status alone: a Session the operator created and has not
+ * started yet is `ready`, has no process, and is correctly `ready` — flipping
+ * it to `disconnected` on every Core restart would make a whole queue of
+ * unstarted work look like it had died.
+ *
+ * What separates the two is whether this Core ever spawned a PTY for the row.
+ * A bare Session — one started with no prompt, sitting on "Waiting for initial
+ * prompt…" — spawns its harness immediately and stays `ready` until the first
+ * `UserPromptSubmit`, so no hook ever fires for it and no status writer ever
+ * touches it. Kill the Core under it and nothing comes back: the boot sweep's
+ * `running` / `needs-input` filter never saw it, and the row outlived a
+ * container recreate still claiming to be waiting for a prompt that nothing
+ * was left to read. That is the zombie this query finds.
+ *
+ * The evidence is the `pty:spawn` the Core appended when it started the
+ * harness. It is read from the event log rather than the task row because the
+ * row records no such thing — there is no "was started" column, and the
+ * harness session id stays `null` precisely in the bare case, where no hook
+ * ever arrives to set it.
+ *
+ * Archived rows are included and no project filter applies, for the same
+ * reasons as {@link queryActiveTasks}. A log whose `pty:spawn` has aged out
+ * answers nothing for that row, which fails toward leaving it alone. Returns
+ * an empty array when either table is absent.
+ */
+export function queryStrandedReadyTasks(sqlite: CoreQuerySqlite): CoreLinkTaskSnapshot[] {
+  let rows: TaskRow[];
+  try {
+    rows = sqlite
+      .prepare(
+        `SELECT t.id AS id, t.project_id AS project_id, t.title AS title,
+                t.title_manually_set AS title_manually_set,
+                t.claude_session_id AS claude_session_id, t.agent AS agent,
+                t.status AS status, t.pinned AS pinned, t.archived AS archived,
+                t.icon AS icon, t.updated_at AS updated_at
+         FROM tasks t
+         WHERE t.status = 'ready'
+           AND EXISTS (
+             SELECT 1 FROM event_log e
+             WHERE e.task_id = t.id AND e.kind = 'pty:spawn'
+           )
+         ORDER BY t.updated_at DESC`,
+      )
+      .all() as TaskRow[];
+  } catch {
+    return [];
+  }
+  return rows.map(taskRowToSnapshot);
+}
+
+/**
  * How many archived tasks this Core holds, optionally scoped to one project.
  *
  * The Panel needs this number continuously — it gates the Archived tab, labels

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -259,12 +259,17 @@ export function handleHarnessHookEvent(
   // as long as the database exists — a zombie found alive on a Core hours
   // after its PTY died, and still there after the container was recreated.
   //
-  // It settles on a scale of its own: `disconnected`, not `terminated`. A
-  // non-zero exit out of a turn is a turn that was killed, which is what
-  // `terminated` says; a non-zero exit out of a Session that never ran a turn
-  // says only that the process went away, which is the one thing
-  // `disconnected` claims and the honest answer here. A clean exit is a clean
-  // exit in either case.
+  // It settles on a scale of its own: `disconnected`, whatever the exit code.
+  // Neither of the other two answers is true of a Session that never ran a
+  // turn. `terminated` says a turn was killed. `finished` says work completed,
+  // and it is not just a label — `CoreTaskWriter` appends `session:finished`
+  // on exactly that transition, so an operator who opens a bare Session and
+  // types `/exit` would get a completion ding for a Session still titled
+  // "Waiting for initial prompt…". `disconnected` claims only that the process
+  // went away, which is the whole of what is known. #387's acceptance allows
+  // either ("disconnected or finished"); this is the one that agrees with the
+  // boot sweep, which settles the same Session with the same reasoning and
+  // deliberately raises no notification.
   if (event === HARNESS_HOOK_EVENTS.sessionProcessExited) {
     clearSubagentActivity(taskId);
     // No re-invocation can follow a dead process: laggard subagent POSTs still
@@ -273,7 +278,7 @@ export function handleHarnessHookEvent(
     if (task.status === "running" || task.status === "needs-input") {
       ports.updateStatus(taskId, payload.exit_code === 0 ? "finished" : "terminated");
     } else if (task.status === "ready") {
-      ports.updateStatus(taskId, payload.exit_code === 0 ? "finished" : "disconnected");
+      ports.updateStatus(taskId, "disconnected");
     }
     // No `status` on the result: the settle is conditional, and a host that
     // echoed one would be claiming a transition that may not have happened.

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -248,6 +248,23 @@ export function handleHarnessHookEvent(
   // showing active work is wrong — settle it by exit code. Tasks already in a
   // settled state (finished, interrupted, …) keep it: the exit of an idle
   // session isn't news. Dead process ⇒ its subagents died with it.
+  //
+  // `ready` is in scope too (issue 387), and it is the one status here that
+  // does not describe work in progress. It describes a Session that has not
+  // started one — a bare Session sitting on "Waiting for initial prompt…",
+  // whose harness is up and whose first `UserPromptSubmit` has not arrived.
+  // Nothing else settles it: no hook ever fired for that Session, so there is
+  // no Stop to wait for, and the boot sweep's status filter did not see it
+  // either. Left out, its row goes on claiming to be waiting for a prompt for
+  // as long as the database exists — a zombie found alive on a Core hours
+  // after its PTY died, and still there after the container was recreated.
+  //
+  // It settles on a scale of its own: `disconnected`, not `terminated`. A
+  // non-zero exit out of a turn is a turn that was killed, which is what
+  // `terminated` says; a non-zero exit out of a Session that never ran a turn
+  // says only that the process went away, which is the one thing
+  // `disconnected` claims and the honest answer here. A clean exit is a clean
+  // exit in either case.
   if (event === HARNESS_HOOK_EVENTS.sessionProcessExited) {
     clearSubagentActivity(taskId);
     // No re-invocation can follow a dead process: laggard subagent POSTs still
@@ -255,6 +272,8 @@ export function handleHarnessHookEvent(
     clearTaskFinished(taskId);
     if (task.status === "running" || task.status === "needs-input") {
       ports.updateStatus(taskId, payload.exit_code === 0 ? "finished" : "terminated");
+    } else if (task.status === "ready") {
+      ports.updateStatus(taskId, payload.exit_code === 0 ? "finished" : "disconnected");
     }
     // No `status` on the result: the settle is conditional, and a host that
     // echoed one would be claiming a transition that may not have happened.


### PR DESCRIPTION
Closes #387 (F1).

## The zombie

A Session on pairdemo sat at `ready`, "Waiting for initial prompt…", LIVE empty, hours after its PTY died — and survived a Core container recreate. The CLI said the Session "has no harness running" while the card said it was waiting for a prompt.

`ready` is the status a bare Session lives in: the harness is spawned, and nothing moves the row until the first `UserPromptSubmit`. So no hook ever fires for it, which means:

- `sessionProcessExited` in `harness-hook-pipeline.ts` only patched `running | needs-input`, so the PTY's death settled nothing.
- the boot sweep read the same two statuses through `queryActiveTasks`, so the recreate did not catch it either.

Two blind spots, one row, no third thing that was ever going to come back for it.

## What changed

**The PTY-exit settle (`packages/shared/src/harness-hook-pipeline.ts`).** `ready` is now in scope, on a scale of its own: a clean exit is `finished`, and anything else is `disconnected` rather than `terminated`. A non-zero exit out of a turn is a turn that was killed, which is what `terminated` says; a non-zero exit out of a Session that never ran a turn says only that the process went away.

Nothing else in that branch moved. The already-settled guard, the subagent clears, and the in-turn gate #385 added are untouched.

**The boot sweep (`packages/shared/src/core-query.ts`, `packages/core/src/core-query-store.ts`, `core-entry.ts`).** A new `queryStrandedReadyTasks` finds the `ready` rows this Core once spawned a PTY for, and `listBootSweepTasks` hands the sweep that list alongside the rows that claim a live process.

`ready` deliberately is **not** swept on the status alone. It is also the status of a Session the operator created and has not started yet — sweeping those would flip a whole queue of unstarted work to `disconnected` on every Core restart. The discriminator is the `pty:spawn` the Core appended when it started the harness, read from the event log because the task row records no such thing: there is no "was started" column, and the harness session id stays `null` in exactly the bare case. A `ready` row with no spawn behind it is left alone, and a log whose spawn has aged out fails the same safe way.

The union is assembled in the query store, not in the sweep, because the quiet-Session backstop shares `listActiveTasks` and must **not** see `ready`: a bare Session waiting on its first prompt is allowed to sit silent indefinitely, and settling it for being quiet would be a new bug. Only the boot sweep reads the wider list.

## Tests

- `harness-hook-pipeline.test.ts` — a `ready` Session settles to `disconnected` on a bad exit and `finished` on a clean one, with no Stop hook ever posted; `running`/`needs-input` keep the `terminated` scale; an already-finished row is still left alone.
- `core-query.test.ts` — `queryStrandedReadyTasks` finds the spawned `ready` row and not the unstarted one, ignores another Session's spawn and a shell PTY that belongs to no task, spans projects and archived rows, and returns `[]` when there is no event log to read.
- `core-session-sweep.test.ts` — the boot sweep settles a leftover `ready` row beside the `running` ones, leaves the unstarted `ready` row alone, and appends `task:updated` without a `session:finished`.
- `harness-status-detection.test.ts` — end to end on the Core: the row is created `ready`, no hook is ever posted, `sessionExited` settles it.

The Stop and OpenCode idle-finish suites are green: a healthy OpenCode stop still emits `session:finished`.

`pnpm typecheck`, `pnpm lint` (0 errors) and `pnpm test` all pass.

## Boundaries

No Panel files touched — nothing near `__root.tsx` (#379) or `terminal-store.tsx` (#380). Built on the merged #385 change to `harness-hook-pipeline.ts` without widening or undoing it, and it does not take the foreign-session path #390 will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RZuD4w44wp8ZMR3iMxzYB
