### PR TITLE
fix(panel): Enter after settlement must not post running

### DIFF
--- a/packages/panel/src/components/views/TerminalPane.tsx
+++ b/packages/panel/src/components/views/TerminalPane.tsx
@@ -63,6 +63,7 @@ import {
   advanceTerminalRunningFallback,
   harnessUsesTerminalPromptFallback,
   IDLE_TERMINAL_RUNNING_FALLBACK,
+  noteTerminalWrite,
   type TerminalRunningFallback,
 } from "~/lib/task-status-sync";
 import { accumulateTerminalPrompt } from "~/lib/terminal-prompt-capture";
@@ -979,8 +980,9 @@ export function TerminalPane({
         null;
       // The Enter→running fallback for a Session whose hooks never announce a
       // turn's start: the one-shot latch AND the turn the operator is composing
-      // in this pane (issue 386). Rebuilt with the surface, like every other
-      // per-pane scratch value here.
+      // in this pane (issue 386). Declared with the surface but reset per pty
+      // in `wireTerminalInput` — a half-typed line, or a `pasting` latch, must
+      // not survive into the next harness process.
       let runningFallback: TerminalRunningFallback = IDLE_TERMINAL_RUNNING_FALLBACK;
       let promptCaptureBuffer = "";
       let promptTitlePosted = false;
@@ -1003,6 +1005,13 @@ export function TerminalPane({
       const writeToPty = async (data: string) => {
         const ptyId = activePtyId;
         if (!ptyId || !ptyApi || !mayWriteRef.current) return false;
+        // Every byte on this path skips xterm's keyboard, so `onData` never
+        // sees it: the dropped project path, the key map's Cmd+Backspace. Fold
+        // it into the same turn the fallback watches, or a dropped path
+        // followed by Enter starts a real turn against a card still reading
+        // `finished` (issue 386). It composes only — the Enter that submits it
+        // comes back through `onData`, which is where the PATCH is decided.
+        runningFallback = noteTerminalWrite(runningFallback, data);
         return ptyApi.write(ptyId, data);
       };
 
@@ -1215,6 +1224,13 @@ export function TerminalPane({
       };
 
       const wireTerminalInput = (ptyId: string) => {
+        // A new pty is a new harness process at a fresh prompt. Anything half
+        // entered against the last one is gone from the screen and must go from
+        // the pane's mirror of it too: a surviving composition makes the first
+        // stray Enter post `running`, and a surviving `pasting` latch swallows
+        // every `\r` for the life of the pane.
+        runningFallback = IDLE_TERMINAL_RUNNING_FALLBACK;
+        promptCaptureBuffer = "";
         term.onData((data) => {
           // A Reader sends nothing and reports nothing (issue 147). The return
           // is before the status and prompt-capture side effects deliberately:
@@ -1263,6 +1279,17 @@ export function TerminalPane({
                   taskId: descriptor.taskId,
                   status: "running",
                 });
+              } catch {
+                // Only the status mutation un-latches, and only its own catch
+                // may do it. Sharing one `try` with the title and the cache
+                // invalidations below meant a title-generator hiccup AFTER a
+                // successful PATCH cleared the latch anyway — and, because this
+                // handler re-reads the live value, a late failure from turn N
+                // could clear a latch turn N+1 had just set.
+                runningFallback = { ...runningFallback, posted: false };
+                return;
+              }
+              try {
                 // The prompt patches no column of its own: it only asks a
                 // title generator to name the session. Which generator depends
                 // on who owns the row — the Core's, for a Core-owned Session
@@ -1287,9 +1314,8 @@ export function TerminalPane({
                   queryClient.invalidateQueries({ queryKey: queryKeys.projects }),
                 ]);
               } catch {
-                // The PATCH never landed — un-latch so the operator's next
-                // submitted turn tries again.
-                runningFallback = { ...runningFallback, posted: false };
+                // The row is already `running`; a missed title or a stale cache
+                // is not worth un-latching a turn that did start.
               }
             })();
           }

--- a/packages/panel/src/components/views/TerminalPane.tsx
+++ b/packages/panel/src/components/views/TerminalPane.tsx
@@ -60,9 +60,10 @@ import {
 } from "~/lib/harness-command";
 import { getDefaultModelForHarness } from "~/lib/default-model-store";
 import {
-  terminalInputStartsTurn,
+  advanceTerminalRunningFallback,
   harnessUsesTerminalPromptFallback,
-  shouldResetTerminalRunningFallback,
+  IDLE_TERMINAL_RUNNING_FALLBACK,
+  type TerminalRunningFallback,
 } from "~/lib/task-status-sync";
 import { accumulateTerminalPrompt } from "~/lib/terminal-prompt-capture";
 import { prefetchTerminalModules } from "~/lib/prefetch-terminal-modules";
@@ -976,7 +977,11 @@ export function TerminalPane({
       let duringReplayData: SequencedPtyData[] = [];
       let duringReplayExit: { ptyId: string; exitCode: number; signal?: number } | null =
         null;
-      let fallbackRunningPosted = false;
+      // The Enter→running fallback for a Session whose hooks never announce a
+      // turn's start: the one-shot latch AND the turn the operator is composing
+      // in this pane (issue 386). Rebuilt with the surface, like every other
+      // per-pane scratch value here.
+      let runningFallback: TerminalRunningFallback = IDLE_TERMINAL_RUNNING_FALLBACK;
       let promptCaptureBuffer = "";
       let promptTitlePosted = false;
       const stopWatchingColorScheme = watchTerminalColorScheme((colorScheme) => {
@@ -1234,15 +1239,21 @@ export function TerminalPane({
             submittedPrompt = captured.submitted;
           }
 
-          // Cursor CLI still does not fire beforeSubmitPrompt, so Enter is the
-          // per-turn running signal. Re-arm after the task leaves "running"
-          // (stop → finished, needs-input, etc.) so a second prompt in the same
-          // session updates the card again.
-          if (shouldResetTerminalRunningFallback(liveTaskStatusRef.current)) {
-            fallbackRunningPosted = false;
-          }
-          if (!fallbackRunningPosted && terminalInputStartsTurn(task.agent, data, hooksReportTurnStart)) {
-            fallbackRunningPosted = true;
+          // Cursor CLI still does not fire beforeSubmitPrompt, so a submitted
+          // prompt is the per-turn running signal. "Submitted" is the whole
+          // point of issue 386: the latch re-arms once the task leaves
+          // "running" (stop → finished, needs-input, …) so a second prompt in
+          // the same session updates the card again — but on its own that made
+          // every newline after settlement a new turn, so a stray Enter or a
+          // pasted path resurrected `running`. The fallback now waits for the
+          // operator to actually enter something and submit it.
+          const fallbackStep = advanceTerminalRunningFallback(runningFallback, {
+            data,
+            currentStatus: liveTaskStatusRef.current,
+            hooksReportTurnStart,
+          });
+          runningFallback = fallbackStep.state;
+          if (fallbackStep.postRunning) {
             void (async () => {
               try {
                 // Same routing as the exit patch above: a turn-start status is
@@ -1276,7 +1287,9 @@ export function TerminalPane({
                   queryClient.invalidateQueries({ queryKey: queryKeys.projects }),
                 ]);
               } catch {
-                fallbackRunningPosted = false;
+                // The PATCH never landed — un-latch so the operator's next
+                // submitted turn tries again.
+                runningFallback = { ...runningFallback, posted: false };
               }
             })();
           }

--- a/packages/panel/src/lib/__tests__/task-status-sync.test.ts
+++ b/packages/panel/src/lib/__tests__/task-status-sync.test.ts
@@ -1,31 +1,43 @@
 import { describe, expect, it } from "vitest";
 import {
+  advanceTerminalTurn,
   harnessUsesTerminalPromptFallback,
+  IDLE_TERMINAL_TURN,
   shouldResetTerminalRunningFallback,
   terminalInputStartsTurn,
 } from "../task-status-sync";
 
+/** Fold a script of onData chunks, keeping every submit the run produced. */
+function typeInto(chunks: string[]) {
+  let state = IDLE_TERMINAL_TURN;
+  const submits: boolean[] = [];
+  for (const chunk of chunks) {
+    const step = advanceTerminalTurn(state, chunk);
+    state = step.state;
+    submits.push(step.submittedTurn);
+  }
+  return { state, submits, submitted: submits.some(Boolean) };
+}
+
 describe("terminal status sync", () => {
   it("stands the fallback down only for a Session whose hooks actually went in", () => {
     // The Core installed them for this spawn — the hooks report the turn.
-    expect(terminalInputStartsTurn("claude-code", "\r", true)).toBe(false);
-    expect(terminalInputStartsTurn("cursor-cli", "implement this\r", true)).toBe(false);
+    expect(terminalInputStartsTurn(true, true)).toBe(false);
   });
 
   it("keeps the fallback armed for a hook-capable harness whose hooks did NOT go in", () => {
     // The regression this rule exists for (issue 84): claude-code is a family
     // that supports hooks, so the old family-set check exempted it — leaving a
     // Session with neither hooks nor a fallback, stuck on `ready` forever.
-    expect(terminalInputStartsTurn("claude-code", "\r", false)).toBe(true);
-    expect(terminalInputStartsTurn("opencode", "\r", false)).toBe(true);
+    expect(terminalInputStartsTurn(false, true)).toBe(true);
+    expect(terminalInputStartsTurn(false, false)).toBe(false);
   });
 
   it("marks input-driven agents as running when the user submits input", () => {
     expect(harnessUsesTerminalPromptFallback("cursor-cli")).toBe(true);
     expect(harnessUsesTerminalPromptFallback("codex")).toBe(false);
-    expect(terminalInputStartsTurn("cursor-cli", "hello", false)).toBe(false);
-    expect(terminalInputStartsTurn("cursor-cli", "implement this\r", false)).toBe(true);
-    expect(terminalInputStartsTurn("codex", "\r", false)).toBe(true);
+    expect(typeInto(["hello"]).submitted).toBe(false);
+    expect(typeInto(["implement this\r"]).submitted).toBe(true);
   });
 
   it("re-arms the Enter→running fallback after a turn leaves running", () => {
@@ -35,5 +47,64 @@ describe("terminal status sync", () => {
     expect(shouldResetTerminalRunningFallback("finished")).toBe(true);
     expect(shouldResetTerminalRunningFallback("needs-input")).toBe(true);
     expect(shouldResetTerminalRunningFallback("ready")).toBe(true);
+  });
+});
+
+describe("advanceTerminalTurn", () => {
+  it("submits only a newline that terminates composed text", () => {
+    expect(typeInto(["fix ", "login", "\r"]).submitted).toBe(true);
+    // A bare Enter at an empty prompt enters nothing (issue 386).
+    expect(typeInto(["\r"]).submitted).toBe(false);
+    expect(typeInto(["\n"]).submitted).toBe(false);
+    expect(typeInto(["\r", "\r", "\n"]).submitted).toBe(false);
+    // Whitespace is not something the operator entered either.
+    expect(typeInto(["   \r"]).submitted).toBe(false);
+  });
+
+  it("clears the composition on submit, so the next Enter starts nothing", () => {
+    const run = typeInto(["ship it\r", "\r"]);
+    expect(run.submits).toEqual([true, false]);
+    expect(run.state.composed).toBe("");
+  });
+
+  it("treats a bracketed paste as text, never as a submit", () => {
+    // xterm wraps a paste in ESC[200~ … ESC[201~ whenever the harness has
+    // bracketed paste on, which every TUI harness here does. Pasting is the
+    // terminal inserting characters; it is not pressing Return — so a pasted
+    // path, even one carrying newlines, starts no turn.
+    const path = typeInto(["\x1b[200~/home/core/repos/control\x1b[201~"]);
+    expect(path.submitted).toBe(false);
+    expect(path.state.composed).toBe("/home/core/repos/control");
+    expect(typeInto(["\x1b[200~one\ntwo\n\x1b[201~"]).submitted).toBe(false);
+    // …and the Enter the operator presses afterwards submits what was pasted.
+    const state = advanceTerminalTurn(IDLE_TERMINAL_TURN, "\x1b[200~./notes.md\x1b[201~").state;
+    expect(advanceTerminalTurn(state, "\r").submittedTurn).toBe(true);
+  });
+
+  it("survives a paste split across chunks", () => {
+    const run = typeInto(["\x1b[200~/home/core", "/repos\x1b[201~", "\r"]);
+    expect(run.submits).toEqual([false, false, true]);
+  });
+
+  it("ignores terminal-generated replies and cursor keys", () => {
+    // Focus reports and device-attribute answers ride onData too; none of them
+    // is the operator entering anything.
+    expect(typeInto(["\x1b[I"]).state.composed).toBe("");
+    expect(typeInto(["\x1b[?62;c"]).state.composed).toBe("");
+    const arrows = typeInto(["hi", "\x1b[A", "\x1b[B", "\r"]);
+    expect(arrows.state.composed).toBe("");
+    expect(arrows.submitted).toBe(true);
+  });
+
+  it("honours backspace, so a fully erased line submits nothing", () => {
+    expect(typeInto(["ab\x7f\x7f", "\r"]).submitted).toBe(false);
+    expect(typeInto(["ship\x7f it", "\r"]).submitted).toBe(true);
+    expect(typeInto(["ship\x7f"]).state.composed).toBe("shi");
+  });
+
+  it("handles a chunk that submits and then keeps typing", () => {
+    const step = advanceTerminalTurn(IDLE_TERMINAL_TURN, "go\rnext");
+    expect(step.submittedTurn).toBe(true);
+    expect(step.state.composed).toBe("next");
   });
 });

--- a/packages/panel/src/lib/__tests__/task-status-sync.test.ts
+++ b/packages/panel/src/lib/__tests__/task-status-sync.test.ts
@@ -86,12 +86,27 @@ describe("advanceTerminalTurn", () => {
     expect(run.submits).toEqual([false, false, true]);
   });
 
+  it("holds a paste marker cut in half by a chunk boundary", () => {
+    // The opening marker needs all six bytes in one chunk to be recognised.
+    // Split at `ESC[200`, the `200` used to land in the composition as literal
+    // text and the pane never entered the paste at all.
+    const opening = typeInto(["\x1b[200", "~/a/b\x1b[201~"]);
+    expect(opening.state.composed).toBe("/a/b");
+    expect(opening.state.pasting).toBe(false);
+    expect(opening.submitted).toBe(false);
+    // The closing marker matters more: miss it and the pane pastes for ever,
+    // swallowing every Enter for the life of the pane.
+    const closing = typeInto(["\x1b[200~/a/b\x1b[201", "~", "\r"]);
+    expect(closing.submits).toEqual([false, false, true]);
+    expect(closing.state.pasting).toBe(false);
+  });
+
   it("ignores terminal-generated replies and cursor keys", () => {
     // Focus reports and device-attribute answers ride onData too; none of them
     // is the operator entering anything.
     expect(typeInto(["\x1b[I"]).state.composed).toBe("");
     expect(typeInto(["\x1b[?62;c"]).state.composed).toBe("");
-    const arrows = typeInto(["hi", "\x1b[A", "\x1b[B", "\r"]);
+    const arrows = typeInto(["hi", "\x1b[C", "\x1b[D", "\r"]);
     expect(arrows.state.composed).toBe("");
     expect(arrows.submitted).toBe(true);
   });
@@ -100,6 +115,46 @@ describe("advanceTerminalTurn", () => {
     expect(typeInto(["ab\x7f\x7f", "\r"]).submitted).toBe(false);
     expect(typeInto(["ship\x7f it", "\r"]).submitted).toBe(true);
     expect(typeInto(["ship\x7f"]).state.composed).toBe("shi");
+  });
+
+  it("honours the line cancels the harness itself honours", () => {
+    // Ctrl+C, Ctrl+U and Esc empty the line outright.
+    expect(typeInto(["hello", "\x03"]).state.composed).toBe("");
+    expect(typeInto(["hello", "\x15"]).state.composed).toBe("");
+    expect(typeInto(["hello", "\x1b"]).state.composed).toBe("");
+    // Ctrl+W kills the trailing WORD (with the space before it, as readline's
+    // unix-word-rubout does) — modelled as such rather than as a full clear, so
+    // "hello world" Ctrl+W Enter still submits "hello".
+    expect(typeInto(["hello", "\x17"]).state.composed).toBe("");
+    expect(typeInto(["hello world", "\x17"]).state.composed).toBe("hello");
+    // Delete takes one character, like Backspace does.
+    expect(typeInto(["h", "\x1b[3~"]).state.composed).toBe("");
+    expect(typeInto(["hello", "\x1b[3~"]).state.composed).toBe("hell");
+  });
+
+  it("counts a recalled prompt it cannot see as input standing at the prompt", () => {
+    // Up-arrow puts a previous prompt back on the line. The pane never sees
+    // those bytes, but the operator's Enter submits them all the same.
+    expect(typeInto(["\x1b[A", "\r"]).submitted).toBe(true);
+    expect(typeInto(["\x1bOA", "\r"]).submitted).toBe(true);
+    expect(typeInto(["\x1b[B", "\r"]).submitted).toBe(true);
+    // …and a cancel takes the recalled line away again.
+    expect(typeInto(["\x1b[A", "\x03", "\r"]).submitted).toBe(false);
+    expect(typeInto(["\x1b[A", "\x1b", "\r"]).submitted).toBe(false);
+    // A submit consumes it, so the next bare Enter starts nothing.
+    expect(typeInto(["\x1b[A", "\r", "\r"]).submits).toEqual([false, true, false]);
+  });
+
+  it("does not treat Shift+Enter as a submit", () => {
+    // The key map writes `ESC CR` for Shift+Enter — a newline inside the
+    // composer, not a submission of it.
+    expect(typeInto(["\x1b\r"]).submitted).toBe(false);
+    expect(typeInto(["line one", "\x1b\r", "line two", "\r"]).submits).toEqual([
+      false,
+      false,
+      false,
+      true,
+    ]);
   });
 
   it("handles a chunk that submits and then keeps typing", () => {

--- a/packages/panel/src/lib/__tests__/terminal-running-fallback.test.ts
+++ b/packages/panel/src/lib/__tests__/terminal-running-fallback.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceTerminalRunningFallback,
+  IDLE_TERMINAL_RUNNING_FALLBACK,
+  type TerminalRunningFallback,
+} from "../task-status-sync";
+
+/**
+ * Issue 386. `TerminalPane`'s `onData` handler is one call to
+ * `advanceTerminalRunningFallback` per chunk, and `postRunning` is the PATCH
+ * that flips the Session's card to `running`. These are that handler's story
+ * scripts: a pane whose Session reports no turn START (Cursor CLI always,
+ * Codex until its hooks are reviewed), driven chunk by chunk with the row's
+ * status as the Core last reported it.
+ *
+ * The bug was the latch re-arming on "not currently running" alone, which made
+ * every CR/LF after settlement a turn start — a stray Enter, a paste, a
+ * drop-path write, each one resurrecting `running` on a finished Session.
+ */
+function drive(
+  script: Array<{ data: string; status: string }>,
+  opts: { hooksReportTurnStart?: boolean } = {},
+) {
+  let state: TerminalRunningFallback = IDLE_TERMINAL_RUNNING_FALLBACK;
+  const posts: string[] = [];
+  for (const step of script) {
+    const next = advanceTerminalRunningFallback(state, {
+      data: step.data,
+      currentStatus: step.status,
+      hooksReportTurnStart: opts.hooksReportTurnStart ?? false,
+    });
+    state = next.state;
+    if (next.postRunning) posts.push(step.data);
+  }
+  return { state, posts };
+}
+
+describe("the Enter→running fallback after a Session settles", () => {
+  it("does not PATCH running when the operator presses Enter on a finished Session", () => {
+    // Acceptance 1. The turn ran, `stop` flipped the row to finished, and the
+    // operator taps Enter at the harness's idle prompt — twice, because the
+    // latch must not open on the second one either.
+    const run = drive([
+      { data: "review this\r", status: "ready" },
+      { data: "\r", status: "finished" },
+      { data: "\r", status: "finished" },
+      { data: "\n", status: "finished" },
+    ]);
+    expect(run.posts).toEqual(["review this\r"]);
+  });
+
+  it("does not PATCH running when a path is pasted into a finished Session", () => {
+    // Acceptance 1, the other half. A path pasted at the idle prompt arrives
+    // bracketed; a path dropped from the Panel's own UI does not even reach
+    // onData (it is written straight to the pty). Neither starts a turn.
+    const run = drive([
+      { data: "\x1b[200~/home/core/repos/control/README.md\x1b[201~", status: "finished" },
+      { data: "\x1b[200~one\ntwo\n\x1b[201~", status: "finished" },
+    ]);
+    expect(run.posts).toEqual([]);
+    expect(run.state.turn.composed).toContain("README.md");
+  });
+
+  it("still PATCHes running when the operator actually starts a new turn", () => {
+    // Acceptance 2. The Session finished, and the operator types a real prompt
+    // — pasted path and all — then presses Enter. Nothing else will report
+    // this turn's start, so the fallback must.
+    const run = drive([
+      { data: "first prompt\r", status: "ready" },
+      { data: "\r", status: "finished" },
+      { data: "n", status: "finished" },
+      { data: "ow do ", status: "finished" },
+      { data: "\x1b[200~./notes.md\x1b[201~", status: "finished" },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(run.posts).toEqual(["first prompt\r", "\r"]);
+  });
+
+  it("posts once per turn while the Session is running", () => {
+    // The latch: a submit mid-turn (an answer to the harness's own prompt)
+    // must not re-PATCH a row that is already running.
+    const run = drive([
+      { data: "go\r", status: "ready" },
+      { data: "yes\r", status: "running" },
+      { data: "more\r", status: "running" },
+    ]);
+    expect(run.posts).toEqual(["go\r"]);
+  });
+
+  it("re-arms across turns, so every genuine prompt updates the card", () => {
+    const run = drive([
+      { data: "one\r", status: "ready" },
+      { data: "two\r", status: "finished" },
+      { data: "three\r", status: "finished" },
+    ]);
+    expect(run.posts).toEqual(["one\r", "two\r", "three\r"]);
+  });
+
+  it("stays out of the way when the Session's hooks report the turn's start", () => {
+    const run = drive(
+      [
+        { data: "a real prompt\r", status: "ready" },
+        { data: "\r", status: "finished" },
+      ],
+      { hooksReportTurnStart: true },
+    );
+    expect(run.posts).toEqual([]);
+  });
+
+  it("lets a failed PATCH be retried by the next submitted turn", () => {
+    // The pane un-latches in its catch; from there the next real prompt must
+    // post again rather than be swallowed by a latch that never opened a row.
+    let state = advanceTerminalRunningFallback(IDLE_TERMINAL_RUNNING_FALLBACK, {
+      data: "go\r",
+      currentStatus: "ready",
+      hooksReportTurnStart: false,
+    }).state;
+    state = { ...state, posted: false };
+    const retry = advanceTerminalRunningFallback(state, {
+      data: "go again\r",
+      currentStatus: "ready",
+      hooksReportTurnStart: false,
+    });
+    expect(retry.postRunning).toBe(true);
+  });
+});

--- a/packages/panel/src/lib/__tests__/terminal-running-fallback.test.ts
+++ b/packages/panel/src/lib/__tests__/terminal-running-fallback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   advanceTerminalRunningFallback,
   IDLE_TERMINAL_RUNNING_FALLBACK,
+  noteTerminalWrite,
   type TerminalRunningFallback,
 } from "../task-status-sync";
 
@@ -15,15 +16,26 @@ import {
  *
  * The bug was the latch re-arming on "not currently running" alone, which made
  * every CR/LF after settlement a turn start — a stray Enter, a paste, a
- * drop-path write, each one resurrecting `running` on a finished Session.
+ * drop-path write, each one resurrecting `running` on a finished Session. The
+ * turn state is the gate that replaced it, so these scripts are also where its
+ * two failure directions are held apart: a cancelled line must not post, and a
+ * turn whose bytes never came through `onData` must.
  */
+type Chunk = { data: string; status: string } | { write: string };
+
 function drive(
-  script: Array<{ data: string; status: string }>,
-  opts: { hooksReportTurnStart?: boolean } = {},
+  script: Chunk[],
+  opts: { hooksReportTurnStart?: boolean; from?: TerminalRunningFallback } = {},
 ) {
-  let state: TerminalRunningFallback = IDLE_TERMINAL_RUNNING_FALLBACK;
+  let state: TerminalRunningFallback = opts.from ?? IDLE_TERMINAL_RUNNING_FALLBACK;
   const posts: string[] = [];
   for (const step of script) {
+    // `write` is the pane's `writeToPty`: bytes it sends on the operator's
+    // behalf, which never pass through xterm's keyboard.
+    if ("write" in step) {
+      state = noteTerminalWrite(state, step.write);
+      continue;
+    }
     const next = advanceTerminalRunningFallback(state, {
       data: step.data,
       currentStatus: step.status,
@@ -52,13 +64,48 @@ describe("the Enter→running fallback after a Session settles", () => {
   it("does not PATCH running when a path is pasted into a finished Session", () => {
     // Acceptance 1, the other half. A path pasted at the idle prompt arrives
     // bracketed; a path dropped from the Panel's own UI does not even reach
-    // onData (it is written straight to the pty). Neither starts a turn.
+    // onData. Neither starts a turn.
     const run = drive([
       { data: "\x1b[200~/home/core/repos/control/README.md\x1b[201~", status: "finished" },
       { data: "\x1b[200~one\ntwo\n\x1b[201~", status: "finished" },
     ]);
     expect(run.posts).toEqual([]);
     expect(run.state.turn.composed).toContain("README.md");
+  });
+
+  it("does not PATCH running when the operator types, cancels, then presses Enter", () => {
+    // Acceptance 1's residual case. At a FINISHED Session the operator starts a
+    // prompt, changes their mind, backs out — Ctrl+C, or Esc, which is how you
+    // leave the Codex composer — and taps Enter at the now-empty prompt. The
+    // line the harness is holding is empty; the pane's mirror of it must be too.
+    for (const cancel of ["\x03", "\x15", "\x17", "\x1b"]) {
+      const run = drive([
+        { data: "hello", status: "finished" },
+        { data: cancel, status: "finished" },
+        { data: "\r", status: "finished" },
+      ]);
+      expect(run.posts, `cancel ${JSON.stringify(cancel)}`).toEqual([]);
+    }
+    // Delete, likewise, when it takes the only character on the line.
+    const del = drive([
+      { data: "h", status: "finished" },
+      { data: "\x1b[3~", status: "finished" },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(del.posts).toEqual([]);
+  });
+
+  it("still PATCHes running when an edit leaves text on the line", () => {
+    // The other direction of the same finding: cancels must not be modelled so
+    // bluntly that a real prompt stops posting. Ctrl+W takes a word, Delete
+    // takes a character, and what is left is still a turn.
+    const run = drive([
+      { data: "fix the login bug", status: "finished" },
+      { data: "\x17", status: "finished" },
+      { data: "\x1b[3~", status: "finished" },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(run.posts).toEqual(["\r"]);
   });
 
   it("still PATCHes running when the operator actually starts a new turn", () => {
@@ -74,6 +121,53 @@ describe("the Enter→running fallback after a Session settles", () => {
       { data: "\r", status: "finished" },
     ]);
     expect(run.posts).toEqual(["first prompt\r", "\r"]);
+  });
+
+  it("PATCHes running for a turn whose bytes never came through onData", () => {
+    // Acceptance 2's gap. Two ways to start a turn without typing it:
+    //
+    //   1. A path dropped from the Panel's own UI. `wireTerminalFileDrop`
+    //      calls `writeToPty` → `ptyApi.write`, so the bytes reach the pty
+    //      without passing through xterm's keyboard — `onData` never sees them.
+    //   2. Up-arrow prompt recall, where the harness puts a previous prompt
+    //      back on the line and the pane only ever sees the cursor key.
+    //
+    // Either way the Enter that follows starts real work on a Session whose
+    // hooks will not say so, so the card must move.
+    const dropped = drive([
+      { data: "first prompt\r", status: "ready" },
+      { write: "/home/core/repos/control " },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(dropped.posts).toEqual(["first prompt\r", "\r"]);
+
+    const recalled = drive([
+      { data: "first prompt\r", status: "ready" },
+      { data: "\x1b[A", status: "finished" },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(recalled.posts).toEqual(["first prompt\r", "\r"]);
+
+    // …and a drop the operator then backs out of is not a turn. Cmd+Backspace
+    // reaches the pty through `writeToPty` too, as `\x15`.
+    const abandoned = drive([
+      { write: "/home/core/repos/control " },
+      { write: "\x15" },
+      { data: "\r", status: "finished" },
+    ]);
+    expect(abandoned.posts).toEqual([]);
+  });
+
+  it("keeps a paste marker split across chunks out of the composition", () => {
+    // Split at `ESC[200`, the `200` used to land in the composition as text —
+    // enough to make the next Enter post `running` on a finished Session.
+    const run = drive([
+      { data: "\x1b[200", status: "finished" },
+      { data: "~/a/b\x1b[201~", status: "finished" },
+    ]);
+    expect(run.posts).toEqual([]);
+    expect(run.state.turn.composed).toBe("/a/b");
+    expect(run.state.turn.pasting).toBe(false);
   });
 
   it("posts once per turn while the Session is running", () => {
@@ -108,8 +202,9 @@ describe("the Enter→running fallback after a Session settles", () => {
   });
 
   it("lets a failed PATCH be retried by the next submitted turn", () => {
-    // The pane un-latches in its catch; from there the next real prompt must
-    // post again rather than be swallowed by a latch that never opened a row.
+    // The pane un-latches in the status mutation's own catch; from there the
+    // next real prompt must post again rather than be swallowed by a latch
+    // that never opened a row.
     let state = advanceTerminalRunningFallback(IDLE_TERMINAL_RUNNING_FALLBACK, {
       data: "go\r",
       currentStatus: "ready",
@@ -122,5 +217,24 @@ describe("the Enter→running fallback after a Session settles", () => {
       hooksReportTurnStart: false,
     });
     expect(retry.postRunning).toBe(true);
+  });
+
+  it("starts every pty from the idle state, carrying nothing over", () => {
+    // The pane resets to IDLE_TERMINAL_RUNNING_FALLBACK in `wireTerminalInput`,
+    // which is re-called per pty. Without it a half-typed line survives into
+    // the next harness process — the first stray Enter there posts `running` —
+    // and worse, an unclosed `pasting` latch swallows every `\r` for the life
+    // of the pane, killing the fallback outright.
+    const halfTyped = drive([{ data: "half a prompt", status: "finished" }]).state;
+    const pasting = drive([{ data: "\x1b[200~/a/b", status: "finished" }]).state;
+    expect(pasting.turn.pasting).toBe(true);
+
+    // Carried into the next pty, each one is a bug…
+    expect(drive([{ data: "\r", status: "finished" }], { from: halfTyped }).posts).toEqual(["\r"]);
+    expect(drive([{ data: "type\r", status: "finished" }], { from: pasting }).posts).toEqual([]);
+
+    // …and from the idle state the pane resets to, neither is.
+    expect(drive([{ data: "\r", status: "finished" }]).posts).toEqual([]);
+    expect(drive([{ data: "type\r", status: "finished" }]).posts).toEqual(["type\r"]);
   });
 });

--- a/packages/panel/src/lib/task-status-sync.ts
+++ b/packages/panel/src/lib/task-status-sync.ts
@@ -4,7 +4,9 @@ import { isTerminalAutoReply } from "~/lib/terminal-user-input";
 // Cursor CLI installs .cursor/hooks.json (beforeSubmitPrompt/stop/sessionStart),
 // but beforeSubmitPrompt still does not fire in cursor-agent — only stop /
 // sessionStart / tool hooks do. Capture submitted prompts from the terminal so
-// titles and icons can still be generated, and use Enter as the running signal.
+// titles and icons can still be generated, and read a turn's start from the
+// terminal too — from a prompt the operator SUBMITS, never from a bare newline
+// (issue 386).
 const HARNESSES_WITH_TERMINAL_PROMPT_FALLBACK = new Set<Harness>(["cursor-cli"]);
 
 export function harnessUsesTerminalPromptFallback(agent: Harness): boolean {
@@ -15,26 +17,65 @@ const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 const BACKSPACE = "\x7f";
 const CTRL_H = "\b";
+const CTRL_C = "\x03";
+const CTRL_U = "\x15";
+const CTRL_W = "\x17";
+const ESC = "\x1b";
+const DELETE = "\x1b[3~";
+// Up / Down, in both the normal and application-cursor encodings.
+const RECALL_KEYS = new Set(["\x1b[A", "\x1b[B", "\x1bOA", "\x1bOB"]);
 
 // Anchored at the cursor, so the scanner can step over a complete escape
 // sequence instead of over its first byte. Same shapes `terminal-user-input`
-// classifies, plus a catch-all for a bare/truncated ESC.
+// classifies, plus a catch-all for ESC + one byte (Alt-b, Shift+Enter's
+// `ESC CR`, …).
 const ESCAPE_AT =
   /(?:\x1b\[[0-9:;<=>?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1bP[\s\S]*?\x1b\\|\x1bO[\s\S]|\x1b[\s\S]?)/y;
+
+// A sequence that has begun and has not yet been terminated — the tail of a
+// chunk that was split mid-escape. Deliberately does NOT match a lone ESC:
+// that is the Esc *key*, which cancels a composition, and waiting for a byte
+// that will never come would swallow it.
+const INCOMPLETE_TAIL = /^(?:\x1b\[[0-9:;<=>?]*[ -/]*|\x1b\][^\x07\x1b]*|\x1bP[\s\S]*|\x1bO)$/;
+
+// A stream that never terminates a sequence must not grow this without bound.
+// Past the cap the tail is dropped: it is terminal noise, not composition.
+const MAX_PARTIAL_ESCAPE = 256;
 
 /**
  * What the operator has entered into this pane but not yet submitted.
  *
- * `composed` is the printable text standing at the harness's own prompt;
- * `pasting` records that we are inside a bracketed paste (ESC[200~ … ESC[201~),
- * where newlines are pasted *text*, never a submit.
+ * - `composed` — the printable text standing at the harness's own prompt.
+ * - `recalled` — text is standing there that this pane never saw: the operator
+ *   pressed Up to recall a previous prompt. Enter submits it just the same.
+ * - `pasting` — inside a bracketed paste (ESC[200~ … ESC[201~), where newlines
+ *   are pasted *text*, never a submit.
+ * - `partial` — a trailing escape sequence cut in half by a chunk boundary,
+ *   held over so the next chunk can complete it.
  */
 export type TerminalTurnState = {
   composed: string;
+  recalled: boolean;
   pasting: boolean;
+  partial: string;
 };
 
-export const IDLE_TERMINAL_TURN: TerminalTurnState = { composed: "", pasting: false };
+export const IDLE_TERMINAL_TURN: TerminalTurnState = {
+  composed: "",
+  recalled: false,
+  pasting: false,
+  partial: "",
+};
+
+/** Is there input standing at the prompt for a newline to submit? */
+function hasPendingInput(state: { composed: string; recalled: boolean }): boolean {
+  return state.recalled || state.composed.trim().length > 0;
+}
+
+/** Drop the trailing word, as Ctrl+W does at a readline prompt. */
+function killWord(composed: string): string {
+  return composed.replace(/\s*\S*$/, "");
+}
 
 /**
  * Fold one chunk of terminal input into the turn state.
@@ -43,48 +84,90 @@ export const IDLE_TERMINAL_TURN: TerminalTurnState = { composed: "", pasting: fa
  * on (issue 386). It is NOT "the bytes contained a CR or an LF": after a
  * Session settles, a stray Enter, a pasted path, or a drop-path write all
  * carry a newline while starting nothing, and each one used to PATCH the row
- * back to `running`. A turn starts only when a newline SUBMITS text the
- * operator actually composed here — which is also why a paste alone never
- * submits: the terminal is inserting text, not pressing Return.
+ * back to `running`. A turn starts only when a newline submits input that is
+ * actually standing at the prompt.
+ *
+ * Which means the cancels have to be honoured too, or the mirror drifts from
+ * the harness's real prompt in both directions. Ctrl+C, Ctrl+U and Esc empty
+ * the line; Ctrl+W kills the trailing word; Delete and Backspace take one
+ * character. Model them and "typed, changed my mind, pressed Enter" stops
+ * posting `running` — while an edit that leaves text behind still posts, which
+ * clearing on every edit key would have broken.
  */
 export function advanceTerminalTurn(
   state: TerminalTurnState,
   data: string,
 ): { state: TerminalTurnState; submittedTurn: boolean } {
+  const input = state.partial + data;
   // Focus reports, cursor-position and device-attribute replies ride the same
   // stream as keystrokes; none of them is the operator entering anything.
-  if (isTerminalAutoReply(data)) return { state, submittedTurn: false };
+  if (isTerminalAutoReply(input)) return { state: { ...state, partial: "" }, submittedTurn: false };
   let composed = state.composed;
+  let recalled = state.recalled;
   let pasting = state.pasting;
+  let partial = "";
   let submittedTurn = false;
   let i = 0;
-  while (i < data.length) {
-    if (data.startsWith(PASTE_START, i)) {
+  while (i < input.length) {
+    if (input.startsWith(PASTE_START, i)) {
       pasting = true;
       i += PASTE_START.length;
       continue;
     }
-    if (data.startsWith(PASTE_END, i)) {
+    if (input.startsWith(PASTE_END, i)) {
       pasting = false;
       i += PASTE_END.length;
       continue;
     }
-    const char = data[i]!;
+    const char = input[i]!;
+    if (char === ESC) {
+      const tail = input.slice(i);
+      // Cut in half by the chunk boundary — hold it over rather than letting
+      // the `200` of a split `ESC[200~` land in the composition as text, or the
+      // `201` of a split closing marker leave the pane pasting for ever.
+      if (tail.length > 1 && INCOMPLETE_TAIL.test(tail)) {
+        partial = tail.length <= MAX_PARTIAL_ESCAPE ? tail : "";
+        break;
+      }
+    }
     if (pasting) {
       // Everything between the markers is literal text, newlines included.
       if (char >= " " || char === "\t" || char === "\r" || char === "\n") composed += char;
       i += 1;
       continue;
     }
-    if (char === "\x1b") {
+    if (char === ESC) {
+      const tail = input.slice(i);
+      if (tail === ESC) {
+        // The Esc key: back out of the composer, exactly as the harness does.
+        composed = "";
+        recalled = false;
+        i += 1;
+        continue;
+      }
       ESCAPE_AT.lastIndex = i;
-      const escape = ESCAPE_AT.exec(data);
-      i += escape ? escape[0].length : 1;
+      const escape = ESCAPE_AT.exec(input);
+      const sequence = escape ? escape[0] : ESC;
+      if (sequence === DELETE) composed = composed.slice(0, -1);
+      else if (RECALL_KEYS.has(sequence)) recalled = true;
+      i += sequence.length;
       continue;
     }
     if (char === "\r" || char === "\n") {
-      if (composed.trim().length > 0) submittedTurn = true;
+      if (hasPendingInput({ composed, recalled })) submittedTurn = true;
       composed = "";
+      recalled = false;
+      i += 1;
+      continue;
+    }
+    if (char === CTRL_C || char === CTRL_U) {
+      composed = "";
+      recalled = false;
+      i += 1;
+      continue;
+    }
+    if (char === CTRL_W) {
+      composed = killWord(composed);
       i += 1;
       continue;
     }
@@ -96,7 +179,7 @@ export function advanceTerminalTurn(
     if (char >= " " || char === "\t") composed += char;
     i += 1;
   }
-  return { state: { composed, pasting }, submittedTurn };
+  return { state: { composed, recalled, pasting, partial }, submittedTurn };
 }
 
 /**
@@ -161,4 +244,22 @@ export function advanceTerminalRunningFallback(
   const postRunning =
     !posted && terminalInputStartsTurn(input.hooksReportTurnStart, submittedTurn);
   return { state: { turn, posted: posted || postRunning }, postRunning };
+}
+
+/**
+ * Fold text the pane wrote to the pty ON the operator's behalf into the same
+ * turn — a path dropped from the Panel's own UI, a key-map sequence like
+ * Cmd+Backspace. None of it passes through xterm's keyboard, so `onData` never
+ * sees it, and before this the pane's mirror of the prompt did not either: drop
+ * a path onto a finished Cursor CLI Session and press Enter and a real turn
+ * started with the card still reading `finished`.
+ *
+ * It composes but never posts. The submit that starts the turn is the
+ * operator's Enter, and that still arrives through `onData`.
+ */
+export function noteTerminalWrite(
+  state: TerminalRunningFallback,
+  data: string,
+): TerminalRunningFallback {
+  return { ...state, turn: advanceTerminalTurn(state.turn, data).state };
 }

--- a/packages/panel/src/lib/task-status-sync.ts
+++ b/packages/panel/src/lib/task-status-sync.ts
@@ -1,4 +1,5 @@
 import type { Harness } from "@actana/shared/domain";
+import { isTerminalAutoReply } from "~/lib/terminal-user-input";
 
 // Cursor CLI installs .cursor/hooks.json (beforeSubmitPrompt/stop/sessionStart),
 // but beforeSubmitPrompt still does not fire in cursor-agent — only stop /
@@ -10,8 +11,96 @@ export function harnessUsesTerminalPromptFallback(agent: Harness): boolean {
   return HARNESSES_WITH_TERMINAL_PROMPT_FALLBACK.has(agent);
 }
 
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+const BACKSPACE = "\x7f";
+const CTRL_H = "\b";
+
+// Anchored at the cursor, so the scanner can step over a complete escape
+// sequence instead of over its first byte. Same shapes `terminal-user-input`
+// classifies, plus a catch-all for a bare/truncated ESC.
+const ESCAPE_AT =
+  /(?:\x1b\[[0-9:;<=>?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1bP[\s\S]*?\x1b\\|\x1bO[\s\S]|\x1b[\s\S]?)/y;
+
 /**
- * Does this keystroke start a turn for a Session nothing else will report?
+ * What the operator has entered into this pane but not yet submitted.
+ *
+ * `composed` is the printable text standing at the harness's own prompt;
+ * `pasting` records that we are inside a bracketed paste (ESC[200~ … ESC[201~),
+ * where newlines are pasted *text*, never a submit.
+ */
+export type TerminalTurnState = {
+  composed: string;
+  pasting: boolean;
+};
+
+export const IDLE_TERMINAL_TURN: TerminalTurnState = { composed: "", pasting: false };
+
+/**
+ * Fold one chunk of terminal input into the turn state.
+ *
+ * `submittedTurn` is the fresh turn-start signal the running fallback is gated
+ * on (issue 386). It is NOT "the bytes contained a CR or an LF": after a
+ * Session settles, a stray Enter, a pasted path, or a drop-path write all
+ * carry a newline while starting nothing, and each one used to PATCH the row
+ * back to `running`. A turn starts only when a newline SUBMITS text the
+ * operator actually composed here — which is also why a paste alone never
+ * submits: the terminal is inserting text, not pressing Return.
+ */
+export function advanceTerminalTurn(
+  state: TerminalTurnState,
+  data: string,
+): { state: TerminalTurnState; submittedTurn: boolean } {
+  // Focus reports, cursor-position and device-attribute replies ride the same
+  // stream as keystrokes; none of them is the operator entering anything.
+  if (isTerminalAutoReply(data)) return { state, submittedTurn: false };
+  let composed = state.composed;
+  let pasting = state.pasting;
+  let submittedTurn = false;
+  let i = 0;
+  while (i < data.length) {
+    if (data.startsWith(PASTE_START, i)) {
+      pasting = true;
+      i += PASTE_START.length;
+      continue;
+    }
+    if (data.startsWith(PASTE_END, i)) {
+      pasting = false;
+      i += PASTE_END.length;
+      continue;
+    }
+    const char = data[i]!;
+    if (pasting) {
+      // Everything between the markers is literal text, newlines included.
+      if (char >= " " || char === "\t" || char === "\r" || char === "\n") composed += char;
+      i += 1;
+      continue;
+    }
+    if (char === "\x1b") {
+      ESCAPE_AT.lastIndex = i;
+      const escape = ESCAPE_AT.exec(data);
+      i += escape ? escape[0].length : 1;
+      continue;
+    }
+    if (char === "\r" || char === "\n") {
+      if (composed.trim().length > 0) submittedTurn = true;
+      composed = "";
+      i += 1;
+      continue;
+    }
+    if (char === BACKSPACE || char === CTRL_H) {
+      composed = composed.slice(0, -1);
+      i += 1;
+      continue;
+    }
+    if (char >= " " || char === "\t") composed += char;
+    i += 1;
+  }
+  return { state: { composed, pasting }, submittedTurn };
+}
+
+/**
+ * Does this submitted turn start a turn for a Session nothing else will report?
  *
  * The suppression follows reality, not the harness family (issue 84). It used
  * to check a static "these families have lifecycle hooks" set, which was true
@@ -28,12 +117,11 @@ export function harnessUsesTerminalPromptFallback(agent: Harness): boolean {
  * need this.
  */
 export function terminalInputStartsTurn(
-  agent: Harness,
-  data: string,
   hooksReportTurnStart: boolean,
+  submittedTurn: boolean,
 ): boolean {
   if (hooksReportTurnStart) return false;
-  return data.includes("\r") || data.includes("\n");
+  return submittedTurn;
 }
 
 /**
@@ -43,4 +131,34 @@ export function terminalInputStartsTurn(
  */
 export function shouldResetTerminalRunningFallback(currentStatus: string): boolean {
   return currentStatus !== "running";
+}
+
+/** The pane's whole Enter→running fallback: the latch and the turn it watches. */
+export type TerminalRunningFallback = {
+  turn: TerminalTurnState;
+  posted: boolean;
+};
+
+export const IDLE_TERMINAL_RUNNING_FALLBACK: TerminalRunningFallback = {
+  turn: IDLE_TERMINAL_TURN,
+  posted: false,
+};
+
+/**
+ * Decide, for one chunk of terminal input, whether to PATCH the row `running`.
+ *
+ * Two gates, and both must open. `posted` is the per-turn one-shot, re-armed
+ * as soon as the row leaves `running` so a second prompt in the same Session
+ * still updates the card. The turn state is the one issue 386 added: re-arming
+ * on "not running" alone made every post-settlement newline a turn start.
+ */
+export function advanceTerminalRunningFallback(
+  state: TerminalRunningFallback,
+  input: { data: string; currentStatus: string; hooksReportTurnStart: boolean },
+): { state: TerminalRunningFallback; postRunning: boolean } {
+  const { state: turn, submittedTurn } = advanceTerminalTurn(state.turn, input.data);
+  const posted = shouldResetTerminalRunningFallback(input.currentStatus) ? false : state.posted;
+  const postRunning =
+    !posted && terminalInputStartsTurn(input.hooksReportTurnStart, submittedTurn);
+  return { state: { turn, posted: posted || postRunning }, postRunning };
 }


### PR DESCRIPTION
Closes #386 — hunt ID `A-enter`, the pin/session/CLI/drop wave.

## The bug

The Enter→running fallback exists for a Session whose hooks never announce a turn's **start**: Cursor CLI always, Codex until its
hooks are reviewed. Both report a turn's end; neither reports its beginning, so the Panel infers the beginning from the terminal.

It inferred it from too little. The one-shot latch re-armed on `shouldResetTerminalRunningFallback` alone — "the row is not
currently running" — and the turn-start test was `data.includes("\r") || data.includes("\n")`. Once a Session settled, **any**
terminal input carrying a newline PATCHed the row back to `running`: a stray Enter at the idle prompt, a pasted path, a drop-path
write. The card then lied about a Session that had finished.

## The fix

Gate the fallback on a fresh turn-start signal, not on "the task is not running".

- `advanceTerminalTurn(state, data)` folds each `onData` chunk into what the operator has composed in this pane, and reports
  `submittedTurn` only when a newline **submits text they actually entered**.
- A bare Enter submits nothing — the composition is empty.
- A bracketed paste (`ESC[200~` … `ESC[201~`) is the terminal inserting characters, not pressing Return. A pasted path — even a
  multi-line one — composes without submitting; the Enter the operator presses afterwards submits it, as it should. A path
  dropped from the Panel's own UI never reaches `onData` at all (it is written straight to the pty).
- Terminal-generated replies (focus reports, device attributes, cursor-position answers) are skipped through the existing
  `isTerminalAutoReply` classifier; escape sequences are stepped over whole; backspace pops, so a fully erased line submits nothing.
- `advanceTerminalRunningFallback` now owns both gates — the per-turn one-shot and the turn state — so `TerminalPane`'s `onData`
  handler is a single call, and the regression is testable without dragging xterm into jsdom.

Acceptance 2 holds by construction: a harness that never reports turn start still posts `running` the moment the operator types a
prompt and presses Enter, and the latch still re-arms across turns so every genuine prompt updates the card.

## Tests

- `packages/panel/src/lib/__tests__/terminal-running-fallback.test.ts` (new) — the operator's story, chunk by chunk: Enter on a
  finished Session posts nothing; a pasted path posts nothing; a real prompt after settlement posts `running`; one post per turn
  while running; re-arming across turns; hooks-report-turn-start stands the fallback down; a failed PATCH is retried.
- `packages/panel/src/lib/__tests__/task-status-sync.test.ts` — extended for the composition tracker (submit vs. bare Enter,
  bracketed paste including one split across chunks, escape sequences, backspace, submit-then-keep-typing).

Whole Panel suite green: **147 files, 1583 tests**. `pnpm typecheck` and `eslint` clean.

## Base

Targets `fix/operator-pins-sessions-drop-cli` (the wave branch), cut from `0b3b099` which already carries the merged A-heal
change from #385. Not `main`, not `beta/0.4.5`. Left as a draft.

Scope kept to `TerminalPane.tsx` + `task-status-sync.ts` and their tests. T2 (#393, two tabs typing / `onData` disposal) also
lives in `TerminalPane.tsx` and is **not** taken here — it is a later wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2jjKPy8zd5bV6NU7Q7GzR
