### PR TITLE
fix(panel): ignore a stale setActiveGroup server answer

### DIFF
--- a/packages/panel/src/lib/__tests__/active-group.test.tsx
+++ b/packages/panel/src/lib/__tests__/active-group.test.tsx
@@ -54,18 +54,19 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-function mount(initial: string | null) {
+/** `initial` is what the server holds; `undefined` leaves settings unhydrated. */
+function mount(initial: string | null | undefined) {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, staleTime: Infinity, refetchOnMount: false, refetchOnWindowFocus: false },
     },
   });
-  client.setQueryData(queryKeys.settings, settingsWith(initial));
+  if (initial !== undefined) client.setQueryData(queryKeys.settings, settingsWith(initial));
   client.setQueryData(queryKeys.groups, GROUPS);
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return renderHook(() => useActiveGroup(), { wrapper });
+  return { client, ...renderHook(() => useActiveGroup(), { wrapper }) };
 }
 
 /**
@@ -98,7 +99,7 @@ afterEach(() => {
 });
 
 describe("the active-group write ledger", () => {
-  it("only calls the newest write current", () => {
+  it("only reports the newest write as current", () => {
     const ledger = createActiveGroupWriteLedger(ACTIVE_GROUP_ALL);
     const first = ledger.beginWrite();
     const second = ledger.beginWrite();
@@ -109,8 +110,40 @@ describe("the active-group write ledger", () => {
   it("keeps the acknowledged group until a newer answer confirms one", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
     expect(ledger.lastAcknowledged()).toBe("g-a");
-    ledger.acknowledge("g-b");
+    ledger.acknowledge(ledger.beginWrite(), "g-b");
     expect(ledger.lastAcknowledged()).toBe("g-b");
+  });
+
+  it("refuses an acknowledgement older than the one already recorded", () => {
+    const ledger = createActiveGroupWriteLedger("g-a");
+    const first = ledger.beginWrite();
+    const second = ledger.beginWrite();
+    ledger.acknowledge(second, "g-c");
+    // The older PATCH answers last; its group is the server's older truth.
+    ledger.acknowledge(first, "g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-c");
+  });
+
+  it("records a superseded answer that the server did confirm", () => {
+    const ledger = createActiveGroupWriteLedger("g-a");
+    const first = ledger.beginWrite();
+    ledger.beginWrite();
+    // The older write is no longer the one that may paint...
+    expect(ledger.settleWrite(first)).toBe(false);
+    // ...but the server took it, so it is the group a later failure returns to.
+    ledger.acknowledge(first, "g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-b");
+  });
+
+  it("seeds once, and never over something already known", () => {
+    const ledger = createActiveGroupWriteLedger();
+    ledger.seed("g-a");
+    expect(ledger.lastAcknowledged()).toBe("g-a");
+    ledger.seed("g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-a");
+    ledger.observe("g-c");
+    ledger.seed("g-d");
+    expect(ledger.lastAcknowledged()).toBe("g-c");
   });
 
   it("ignores a settings read taken while a local write is in flight", () => {
@@ -121,6 +154,19 @@ describe("the active-group write ledger", () => {
     expect(ledger.lastAcknowledged()).toBe("g-a");
     ledger.settleWrite(generation);
     ledger.observe("g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-b");
+  });
+
+  it("lets an observed answer outrank every write older than the newest", () => {
+    const ledger = createActiveGroupWriteLedger("g-a");
+    const first = ledger.beginWrite();
+    const second = ledger.beginWrite();
+    ledger.settleWrite(first);
+    ledger.settleWrite(second);
+    // A refetch answered while nothing was in flight: it is the server's word
+    // on every write issued so far.
+    ledger.observe("g-b");
+    ledger.acknowledge(first, "g-c");
     expect(ledger.lastAcknowledged()).toBe("g-b");
   });
 });
@@ -192,12 +238,103 @@ describe("useActiveGroup under racing PATCHes", () => {
     expect(result.current.activeGroup).toBe("g-b");
   });
 
+  // The interleaving the review found: the older write is the one the server
+  // took, so the failure of the newer one must land there — not on the value
+  // from before either click.
+  it("rolls back to the group an older, superseded PATCH confirmed", async () => {
+    const b = deferred<AppSettings>();
+    const c = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(b.promise).mockReturnValueOnce(c.promise);
+
+    // The server holds "g-a"; the operator clicks "g-b" then "g-c".
+    const { result } = mount("g-a");
+    act(() => result.current.setActiveGroup("g-b"));
+    act(() => result.current.setActiveGroup("g-c"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-c");
+
+    // "g-b" is superseded and paints nothing, but the server did take it.
+    b.resolve(settingsWith("g-b"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-c");
+
+    c.reject(new Error("PATCH /api/settings failed"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe("g-b");
+  });
+
+  // Same root cause, one step earlier: with no settings answer yet, the ledger
+  // has to be seeded from the value the rail is running off.
+  it("rolls a failed first click back to the cached group, not to All projects", async () => {
+    window.localStorage.setItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY, "g-a");
+    const first = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(first.promise);
+
+    // Settings are unhydrated, so there is no cached row for the optimistic
+    // write to land in — localStorage is where the rollback is observable.
+    const { result } = mount(undefined);
+    expect(result.current.activeGroup).toBe("g-a");
+
+    act(() => result.current.setActiveGroup("g-b"));
+    await settle();
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe("g-b");
+
+    first.reject(new Error("PATCH /api/settings failed"));
+    await settle();
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe("g-a");
+  });
+
+  // The GET half of the race: a settings read already in flight would answer
+  // with the pre-PATCH row and paint it over the optimistic write.
+  it("cancels an in-flight settings read before writing", async () => {
+    const only = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(only.promise);
+
+    const { client, result } = mount("g-a");
+    const cancelQueries = vi.spyOn(client, "cancelQueries");
+
+    act(() => result.current.setActiveGroup("g-b"));
+    await settle();
+
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: queryKeys.settings });
+    expect(cancelQueries.mock.invocationCallOrder[0]).toBeLessThan(
+      updateSettings.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("keeps a neighbouring setting a concurrent edit changed mid-flight", async () => {
+    const only = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(only.promise);
+
+    const { client, result } = mount("g-a");
+    act(() => result.current.setActiveGroup("g-b"));
+    await settle();
+
+    // Something else writes the settings row while the PATCH is out.
+    act(() => {
+      client.setQueryData<AppSettings>(queryKeys.settings, (current) =>
+        current ? { ...current, collapsedProjectGroups: ["pinned"] } : current,
+      );
+    });
+
+    // The answer carries that key at its pre-edit value; merging keeps the edit.
+    only.resolve({ activeProjectGroup: "g-b", collapsedProjectGroups: null } as AppSettings);
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+    expect(client.getQueryData<AppSettings>(queryKeys.settings)?.collapsedProjectGroups).toEqual([
+      "pinned",
+    ]);
+  });
+
   it("still applies a lone answer, and stores 'all' as null", async () => {
     const only = deferred<AppSettings>();
     updateSettings.mockReturnValueOnce(only.promise);
 
     const { result } = mount("g-a");
     act(() => result.current.setActiveGroup(ACTIVE_GROUP_ALL));
+    // The PATCH goes out behind `cancelQueries`, so it is not synchronous.
+    await settle();
     expect(updateSettings).toHaveBeenCalledWith({ activeProjectGroup: null });
 
     only.resolve(settingsWith(null));

--- a/packages/panel/src/lib/__tests__/active-group.test.tsx
+++ b/packages/panel/src/lib/__tests__/active-group.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+//
+// The active group is written optimistically and confirmed by a PATCH, and two
+// PATCHes in flight are not ordered (#384). What is proven here is that the
+// *newest local selection* owns the rail: an older answer landing last is
+// dropped, and a failure hands the rail back to the last group the server
+// acknowledged rather than to whatever happened to be on screen before.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { AppSettings } from "~/lib/api";
+import type { Group } from "~/db/schema";
+
+const updateSettings = vi.fn();
+
+vi.mock("~/lib/api", () => ({
+  api: {
+    updateSettings: (body: unknown) => updateSettings(body),
+    getSettings: () => Promise.reject(new Error("settings must be primed in these tests")),
+    listGroups: () => Promise.reject(new Error("groups must be primed in these tests")),
+  },
+}));
+
+const {
+  ACTIVE_GROUP_ALL,
+  createActiveGroupWriteLedger,
+  useActiveGroup,
+  __resetActiveGroupWritesForTests,
+} = await import("~/lib/active-group");
+const { queryKeys } = await import("~/queries");
+const { ACTIVE_PROJECT_GROUP_STORAGE_KEY } = await import("~/lib/ui-preference-cache");
+
+function settingsWith(activeProjectGroup: string | null): AppSettings {
+  return { activeProjectGroup } as AppSettings;
+}
+
+const GROUPS = [
+  { id: "g-a", name: "A" },
+  { id: "g-b", name: "B" },
+  { id: "g-c", name: "C" },
+] as Group[];
+
+/** A promise the test resolves by hand, so answers can land out of order. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // Nothing awaits a rejection until the test does; keep node quiet meanwhile.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+function mount(initial: string | null) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, refetchOnMount: false, refetchOnWindowFocus: false },
+    },
+  });
+  client.setQueryData(queryKeys.settings, settingsWith(initial));
+  client.setQueryData(queryKeys.groups, GROUPS);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useActiveGroup(), { wrapper });
+}
+
+/**
+ * Let the settled PATCH handlers run and the hook re-render on their writes.
+ * A macrotask, not a microtask: react-query batches its observer notifications
+ * onto a `setTimeout`, so a flushed promise chain alone leaves `result.current`
+ * on the previous render.
+ */
+async function settle() {
+  await act(async () => {
+    // Several rounds: the PATCH handler runs on a microtask, its cache write
+    // schedules the notification on the *next* timer, and the render lands
+    // after that. One round would read the state before its own effect.
+    for (let round = 0; round < 3; round += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  });
+}
+
+beforeEach(() => {
+  updateSettings.mockReset();
+  window.localStorage.clear();
+  __resetActiveGroupWritesForTests();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("the active-group write ledger", () => {
+  it("only calls the newest write current", () => {
+    const ledger = createActiveGroupWriteLedger(ACTIVE_GROUP_ALL);
+    const first = ledger.beginWrite();
+    const second = ledger.beginWrite();
+    expect(ledger.settleWrite(first)).toBe(false);
+    expect(ledger.settleWrite(second)).toBe(true);
+  });
+
+  it("keeps the acknowledged group until a newer answer confirms one", () => {
+    const ledger = createActiveGroupWriteLedger("g-a");
+    expect(ledger.lastAcknowledged()).toBe("g-a");
+    ledger.acknowledge("g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-b");
+  });
+
+  it("ignores a settings read taken while a local write is in flight", () => {
+    const ledger = createActiveGroupWriteLedger("g-a");
+    const generation = ledger.beginWrite();
+    // The optimistic value is this tab's own, not the server's word.
+    ledger.observe("g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-a");
+    ledger.settleWrite(generation);
+    ledger.observe("g-b");
+    expect(ledger.lastAcknowledged()).toBe("g-b");
+  });
+});
+
+describe("useActiveGroup under racing PATCHes", () => {
+  it("leaves B selected when the A answer returns last", async () => {
+    const a = deferred<AppSettings>();
+    const b = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+
+    const { result } = mount(null);
+
+    act(() => result.current.setActiveGroup("g-a"));
+    act(() => result.current.setActiveGroup("g-b"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+
+    // B's answer lands first and is the newest write: it is applied.
+    b.resolve(settingsWith("g-b"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+
+    // A's answer lands last carrying the older group — and is dropped.
+    a.resolve(settingsWith("g-a"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe("g-b");
+  });
+
+  it("restores the last acknowledged group when a PATCH fails", async () => {
+    const ok = deferred<AppSettings>();
+    const bad = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(ok.promise).mockReturnValueOnce(bad.promise);
+
+    // "g-a" is what the server has; "g-b" then becomes the acknowledged group.
+    const { result } = mount("g-a");
+    act(() => result.current.setActiveGroup("g-b"));
+    ok.resolve(settingsWith("g-b"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+
+    act(() => result.current.setActiveGroup("g-c"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-c");
+    bad.reject(new Error("PATCH /api/settings failed"));
+    await settle();
+
+    // Back to the acknowledged group — not "g-a", which the rail last showed
+    // before the successful write.
+    expect(result.current.activeGroup).toBe("g-b");
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe("g-b");
+  });
+
+  it("lets a newer selection stand when an older PATCH fails last", async () => {
+    const a = deferred<AppSettings>();
+    const b = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+
+    const { result } = mount(null);
+    act(() => result.current.setActiveGroup("g-a"));
+    act(() => result.current.setActiveGroup("g-b"));
+
+    b.resolve(settingsWith("g-b"));
+    await settle();
+    a.reject(new Error("PATCH /api/settings failed"));
+    await settle();
+
+    // A superseded failure rolls nothing back.
+    expect(result.current.activeGroup).toBe("g-b");
+  });
+
+  it("still applies a lone answer, and stores 'all' as null", async () => {
+    const only = deferred<AppSettings>();
+    updateSettings.mockReturnValueOnce(only.promise);
+
+    const { result } = mount("g-a");
+    act(() => result.current.setActiveGroup(ACTIVE_GROUP_ALL));
+    expect(updateSettings).toHaveBeenCalledWith({ activeProjectGroup: null });
+
+    only.resolve(settingsWith(null));
+    await settle();
+    expect(result.current.activeGroup).toBe(ACTIVE_GROUP_ALL);
+  });
+});

--- a/packages/panel/src/lib/__tests__/active-group.test.tsx
+++ b/packages/panel/src/lib/__tests__/active-group.test.tsx
@@ -13,11 +13,12 @@ import type { AppSettings } from "~/lib/api";
 import type { Group } from "~/db/schema";
 
 const updateSettings = vi.fn();
+const getSettings = vi.fn();
 
 vi.mock("~/lib/api", () => ({
   api: {
     updateSettings: (body: unknown) => updateSettings(body),
-    getSettings: () => Promise.reject(new Error("settings must be primed in these tests")),
+    getSettings: () => getSettings(),
     listGroups: () => Promise.reject(new Error("groups must be primed in these tests")),
   },
 }));
@@ -54,6 +55,21 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+/**
+ * A client whose settings query really fetches — no primed row, so the first
+ * GET is genuinely in flight and can be cancelled (or not) for real.
+ */
+function mountLive() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity, refetchOnWindowFocus: false } },
+  });
+  client.setQueryData(queryKeys.groups, GROUPS);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, ...renderHook(() => useActiveGroup(), { wrapper }) };
+}
+
 /** `initial` is what the server holds; `undefined` leaves settings unhydrated. */
 function mount(initial: string | null | undefined) {
   const client = new QueryClient({
@@ -88,6 +104,8 @@ async function settle() {
 
 beforeEach(() => {
   updateSettings.mockReset();
+  getSettings.mockReset();
+  getSettings.mockRejectedValue(new Error("settings must be primed in these tests"));
   window.localStorage.clear();
   __resetActiveGroupWritesForTests();
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -101,8 +119,8 @@ afterEach(() => {
 describe("the active-group write ledger", () => {
   it("only reports the newest write as current", () => {
     const ledger = createActiveGroupWriteLedger(ACTIVE_GROUP_ALL);
-    const first = ledger.beginWrite();
-    const second = ledger.beginWrite();
+    const first = ledger.beginWrite("g-b");
+    const second = ledger.beginWrite("g-c");
     expect(ledger.settleWrite(first)).toBe(false);
     expect(ledger.settleWrite(second)).toBe(true);
   });
@@ -110,14 +128,14 @@ describe("the active-group write ledger", () => {
   it("keeps the acknowledged group until a newer answer confirms one", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
     expect(ledger.lastAcknowledged()).toBe("g-a");
-    ledger.acknowledge(ledger.beginWrite(), "g-b");
+    ledger.acknowledge(ledger.beginWrite("g-b"), "g-b");
     expect(ledger.lastAcknowledged()).toBe("g-b");
   });
 
   it("refuses an acknowledgement older than the one already recorded", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
-    const first = ledger.beginWrite();
-    const second = ledger.beginWrite();
+    const first = ledger.beginWrite("g-b");
+    const second = ledger.beginWrite("g-c");
     ledger.acknowledge(second, "g-c");
     // The older PATCH answers last; its group is the server's older truth.
     ledger.acknowledge(first, "g-b");
@@ -126,8 +144,8 @@ describe("the active-group write ledger", () => {
 
   it("records a superseded answer that the server did confirm", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
-    const first = ledger.beginWrite();
-    ledger.beginWrite();
+    const first = ledger.beginWrite("g-b");
+    ledger.beginWrite("g-c");
     // The older write is no longer the one that may paint...
     expect(ledger.settleWrite(first)).toBe(false);
     // ...but the server took it, so it is the group a later failure returns to.
@@ -148,7 +166,7 @@ describe("the active-group write ledger", () => {
 
   it("ignores a settings read taken while a local write is in flight", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
-    const generation = ledger.beginWrite();
+    const generation = ledger.beginWrite("g-b");
     // The optimistic value is this tab's own, not the server's word.
     ledger.observe("g-b");
     expect(ledger.lastAcknowledged()).toBe("g-a");
@@ -159,8 +177,8 @@ describe("the active-group write ledger", () => {
 
   it("lets an observed answer outrank every write older than the newest", () => {
     const ledger = createActiveGroupWriteLedger("g-a");
-    const first = ledger.beginWrite();
-    const second = ledger.beginWrite();
+    const first = ledger.beginWrite("g-b");
+    const second = ledger.beginWrite("g-c");
     ledger.settleWrite(first);
     ledger.settleWrite(second);
     // A refetch answered while nothing was in flight: it is the server's word
@@ -325,6 +343,62 @@ describe("useActiveGroup under racing PATCHes", () => {
     expect(client.getQueryData<AppSettings>(queryKeys.settings)?.collapsedProjectGroups).toEqual([
       "pinned",
     ]);
+  });
+
+  // The self-heal effect PATCHes "all" whenever the stored group is missing from
+  // the group list. Restoring that group on failure re-arms it: one request per
+  // round trip, for as long as the server keeps saying no.
+  it("does not restore a deleted group when the self-heal PATCH fails", async () => {
+    updateSettings.mockImplementation(() => Promise.reject(new Error("offline")));
+    window.localStorage.setItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY, "g-gone");
+
+    // Settings hold a group this Panel's group list no longer has.
+    const { client, result } = mount("g-gone");
+    await settle();
+    await settle();
+    await settle();
+
+    expect(result.current.activeGroup).toBe(ACTIVE_GROUP_ALL);
+    // Exactly one PATCH: the self-heal ran once and stayed run.
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+    // And the deleted id is not written back anywhere it could outlive the tab.
+    expect(window.localStorage.getItem(ACTIVE_PROJECT_GROUP_STORAGE_KEY)).toBe(ACTIVE_GROUP_ALL);
+    expect(client.getQueryData<AppSettings>(queryKeys.settings)?.activeProjectGroup).toBeNull();
+  });
+
+  // The rail is live and clickable during boot, painted from `placeholderData`
+  // while the first settings GET is still out. Cancelling that read would leave
+  // the query pending and idle with nothing scheduled to retry it, and nothing
+  // in the Panel refetches this key — so the row must be allowed to land.
+  it("lets the first settings GET finish, and the click still wins", async () => {
+    const boot = deferred<AppSettings>();
+    const patch = deferred<AppSettings>();
+    getSettings.mockReturnValueOnce(boot.promise);
+    updateSettings.mockReturnValueOnce(patch.promise);
+
+    const { client, result } = mountLive();
+    await settle();
+    expect(client.getQueryState(queryKeys.settings)?.fetchStatus).toBe("fetching");
+
+    act(() => result.current.setActiveGroup("g-b"));
+    await settle();
+    // The boot read was not cancelled, and it is the only one there will be.
+    expect(client.getQueryState(queryKeys.settings)?.fetchStatus).toBe("fetching");
+    expect(getSettings).toHaveBeenCalledTimes(1);
+
+    // It answers with the pre-click row...
+    boot.resolve(settingsWith("g-a"));
+    await settle();
+    expect(client.getQueryData<AppSettings>(queryKeys.settings)).toBeDefined();
+    expect(client.getQueryState(queryKeys.settings)?.status).toBe("success");
+    // ...and the click, which is newer than that read, stands on top of it.
+    expect(result.current.activeGroup).toBe("g-b");
+
+    patch.resolve(settingsWith("g-b"));
+    await settle();
+    expect(result.current.activeGroup).toBe("g-b");
+    // The rail still responds: the cache is populated, so writes land.
+    expect(client.getQueryData<AppSettings>(queryKeys.settings)?.activeProjectGroup).toBe("g-b");
   });
 
   it("still applies a lone answer, and stores 'all' as null", async () => {

--- a/packages/panel/src/lib/active-group.ts
+++ b/packages/panel/src/lib/active-group.ts
@@ -40,6 +40,78 @@ export function activeGroupLabel(
   return groups?.find((g) => g.id === active)?.name ?? "All projects";
 }
 
+/** The wire shape of an active group: "all" is stored as null. */
+function storedActiveGroup(active: ActiveProjectGroup): string | null {
+  return active === ACTIVE_GROUP_ALL ? null : active;
+}
+
+/** The active group a settings row carries (null reads as "all"). */
+function activeGroupOf(settings: Pick<AppSettings, "activeProjectGroup">): ActiveProjectGroup {
+  return settings.activeProjectGroup ?? ACTIVE_GROUP_ALL;
+}
+
+/**
+ * Generation guard over the optimistic active-group write (#384).
+ *
+ * `setActiveGroup` writes the cache first and PATCHes second, and two PATCHes
+ * in flight are not ordered: pick group A then group B and A's answer can land
+ * last, carrying the server's *older* `activeProjectGroup` back over B — the
+ * rail reverts to an older group under the cursor. So each local write takes
+ * the next generation, and a settings answer is applied only while its
+ * generation is still the newest; an older PATCH resolving late is dropped.
+ *
+ * The ledger also remembers the last group the server acknowledged, which is
+ * where a failed write puts the rail back — never some older group that merely
+ * happened to be on screen before the click.
+ */
+export function createActiveGroupWriteLedger(initial: ActiveProjectGroup = ACTIVE_GROUP_ALL) {
+  let latest = 0;
+  let inFlight = 0;
+  let acknowledged: ActiveProjectGroup = initial;
+
+  return {
+    /** Claim the generation for one local (optimistic) write. */
+    beginWrite(): number {
+      latest += 1;
+      inFlight += 1;
+      return latest;
+    },
+    /** Settle a write; true only while its answer is still the newest one. */
+    settleWrite(generation: number): boolean {
+      if (inFlight > 0) inFlight -= 1;
+      return generation === latest;
+    },
+    /** Record the group the server confirmed for the newest write. */
+    acknowledge(group: ActiveProjectGroup): void {
+      acknowledged = group;
+    },
+    /**
+     * Adopt a settings answer nobody here asked for (first load, refetch,
+     * another window's write arriving on an invalidation) as the acknowledged
+     * truth — but only while no local write is in flight, since a cache read
+     * during a race is this tab's own optimistic value, not the server's.
+     */
+    observe(group: ActiveProjectGroup): void {
+      if (inFlight === 0) acknowledged = group;
+    },
+    /** Where a failed write puts the rail back. */
+    lastAcknowledged(): ActiveProjectGroup {
+      return acknowledged;
+    },
+  };
+}
+
+export type ActiveGroupWriteLedger = ReturnType<typeof createActiveGroupWriteLedger>;
+
+/** One ledger per tab: every `useActiveGroup` caller writes the same setting,
+ *  so the generations have to be drawn from a single counter. */
+let writes = createActiveGroupWriteLedger();
+
+/** @internal — tests start from a fresh generation counter. */
+export function __resetActiveGroupWritesForTests(): void {
+  writes = createActiveGroupWriteLedger();
+}
+
 /**
  * The globally active project group — the single source of truth is the
  * settings query cache (so every consumer re-renders together); localStorage
@@ -71,20 +143,47 @@ export function useActiveGroup(): {
     return groups.some((g) => g.id === raw) ? raw : ACTIVE_GROUP_ALL;
   }, [raw, groups]);
 
-  const setActiveGroup = useCallback(
-    (next: ActiveProjectGroup) => {
-      writeCachedActiveProjectGroup(next);
+  // Anything the settings query itself delivers is the server's word, so long
+  // as this tab has no write of its own outstanding.
+  useEffect(() => {
+    if (settings === undefined) return;
+    writes.observe(activeGroupOf(settings));
+  }, [settings]);
+
+  /** The optimistic half: localStorage + settings cache, no request. */
+  const showActiveGroup = useCallback(
+    (group: ActiveProjectGroup) => {
+      writeCachedActiveProjectGroup(group);
       queryClient.setQueryData<AppSettings>(queryKeys.settings, (current) =>
-        current ? { ...current, activeProjectGroup: next === ACTIVE_GROUP_ALL ? null : next } : current,
+        current ? { ...current, activeProjectGroup: storedActiveGroup(group) } : current,
       );
-      void api
-        .updateSettings({ activeProjectGroup: next === ACTIVE_GROUP_ALL ? null : next })
-        .then((updated) => queryClient.setQueryData(queryKeys.settings, updated))
-        .catch((error) => {
-          console.error("[settings] failed to persist active project group:", error);
-        });
     },
     [queryClient],
+  );
+
+  const setActiveGroup = useCallback(
+    (next: ActiveProjectGroup) => {
+      const generation = writes.beginWrite();
+      showActiveGroup(next);
+      void api
+        .updateSettings({ activeProjectGroup: storedActiveGroup(next) })
+        .then((updated) => {
+          // A newer selection was made while this PATCH was out: its answer is
+          // the older truth, so it is dropped rather than rendered.
+          if (!writes.settleWrite(generation)) return;
+          writes.acknowledge(activeGroupOf(updated));
+          writeCachedActiveProjectGroup(activeGroupOf(updated));
+          queryClient.setQueryData(queryKeys.settings, updated);
+        })
+        .catch((error) => {
+          console.error("[settings] failed to persist active project group:", error);
+          // Same guard, and then back to what the server last acknowledged —
+          // a superseded failure leaves the newer selection alone.
+          if (!writes.settleWrite(generation)) return;
+          showActiveGroup(writes.lastAcknowledged());
+        });
+    },
+    [queryClient, showActiveGroup],
   );
 
   // Self-heal persistence when the active group was deleted: the memo above

--- a/packages/panel/src/lib/active-group.ts
+++ b/packages/panel/src/lib/active-group.ts
@@ -51,6 +51,24 @@ function activeGroupOf(settings: Pick<AppSettings, "activeProjectGroup">): Activ
 }
 
 /**
+ * What the rail actually renders for a stored group: a group id the loaded
+ * group list no longer has (deleted here, or by another window) shows as "all".
+ * Held apart from `useActiveGroup` because two callers need the same answer —
+ * the memo that renders it, and the failure path, which must never put a group
+ * back that this function would refuse.
+ */
+export function displayedActiveGroup(
+  stored: ActiveProjectGroup,
+  groups: Group[] | undefined,
+): ActiveProjectGroup {
+  if (!isGroupIdActive(stored)) return stored;
+  // The list hasn't loaded, so nothing is known to be missing yet; a slow fetch
+  // must not flash the unscoped view.
+  if (groups === undefined) return stored;
+  return groups.some((g) => g.id === stored) ? stored : ACTIVE_GROUP_ALL;
+}
+
+/**
  * Generation guard over the optimistic active-group write (#384).
  *
  * `setActiveGroup` writes the cache first and PATCHes second, and two PATCHes
@@ -77,13 +95,35 @@ export function createActiveGroupWriteLedger(initial: ActiveProjectGroup = ACTIV
   /** The write whose answer `acknowledged` came from; 0 for a seed/observe. */
   let acknowledgedGeneration = 0;
   let seeded = false;
+  /** The newest selection, and whether an arriving row may still overrule it. */
+  let latestGroup: ActiveProjectGroup = initial;
+  let guarded = false;
 
   return {
     /** Claim the generation for one local (optimistic) write. */
-    beginWrite(): number {
+    beginWrite(group: ActiveProjectGroup): number {
       latest += 1;
       inFlight += 1;
+      latestGroup = group;
+      guarded = true;
       return latest;
+    },
+    /**
+     * The selection a settings row arriving now must not overrule, or null.
+     *
+     * A read that was already out when the click happened answers with the
+     * pre-click row, and during boot that read is the *only* one there will
+     * ever be — nothing in the Panel refetches this key — so it cannot simply
+     * be cancelled. The guard lifts as soon as a row agrees with the selection,
+     * which for a hydrated cache is the optimistic write itself, one render
+     * later. It is released outright when the newest write rolls back, because
+     * then the rail is no longer speaking for that selection.
+     */
+    guardedGroup(): ActiveProjectGroup | null {
+      return guarded ? latestGroup : null;
+    },
+    releaseGuard(): void {
+      guarded = false;
     },
     /** Is `generation` still the newest local write? No side effect. */
     isCurrent(generation: number): boolean {
@@ -170,24 +210,8 @@ export function useActiveGroup(): {
       : (settings.activeProjectGroup ?? ACTIVE_GROUP_ALL);
 
   // A stale group id (group deleted, possibly by another window) falls back to
-  // "all" — but only once the group list has actually loaded, so a slow fetch
-  // doesn't flash the unscoped view.
-  const activeGroup = useMemo(() => {
-    if (!isGroupIdActive(raw)) return raw;
-    if (groups === undefined) return raw;
-    return groups.some((g) => g.id === raw) ? raw : ACTIVE_GROUP_ALL;
-  }, [raw, groups]);
-
-  // Anything the settings query itself delivers is the server's word, so long
-  // as this tab has no write of its own outstanding. Before it hydrates there
-  // is no server answer to adopt, so the ledger is seeded with the value the
-  // rail is already rendering — otherwise a click made during that window and
-  // then failing would roll back to "All projects" rather than to the group
-  // the operator was on.
-  useEffect(() => {
-    if (settings === undefined) writes.seed(raw);
-    else writes.observe(activeGroupOf(settings));
-  }, [settings, raw]);
+  // "all".
+  const activeGroup = useMemo(() => displayedActiveGroup(raw, groups), [raw, groups]);
 
   /** The optimistic half: localStorage + settings cache, no request. */
   const showActiveGroup = useCallback(
@@ -200,15 +224,50 @@ export function useActiveGroup(): {
     [queryClient],
   );
 
+  useEffect(() => {
+    // Before settings hydrate there is no server answer to adopt, so the ledger
+    // is seeded with the value the rail is *rendering* — the validated one, not
+    // the raw id, or a failed first click could roll the rail onto a group the
+    // memo above refuses to display.
+    if (settings === undefined) {
+      writes.seed(activeGroup);
+      return;
+    }
+    const guarded = writes.guardedGroup();
+    // A row that disagrees with the newest local selection is answering a read
+    // older than the click — the boot GET, above all, which is the one read
+    // that must be allowed to finish. The selection goes back on top of it.
+    if (guarded !== null && activeGroupOf(settings) !== guarded) {
+      showActiveGroup(guarded);
+      return;
+    }
+    if (guarded !== null) writes.releaseGuard();
+    // Anything the settings query delivers with no local write of this tab's
+    // outstanding is the server's word.
+    writes.observe(activeGroupOf(settings));
+  }, [settings, activeGroup, showActiveGroup]);
+
   const setActiveGroup = useCallback(
     (next: ActiveProjectGroup) => {
-      const generation = writes.beginWrite();
+      const generation = writes.beginWrite(next);
       void (async () => {
         // The house pattern for an optimistic settings write (see
         // `UsageSettingsPage.tsx` and `ProvidersSettingsPage.tsx`): a settings
         // GET already in flight would answer with the pre-PATCH row and paint
         // it straight over the optimistic write, so it is cancelled first.
-        await queryClient.cancelQueries({ queryKey: queryKeys.settings });
+        //
+        // Only once the row has landed, though. Those pages render after
+        // settings resolve; this hook is live during boot, painting the rail
+        // from `placeholderData` while the first GET is still out. Cancelling
+        // that one reverts the query to pending/idle with nothing scheduled,
+        // and nothing in the Panel refetches this key — the row would never
+        // arrive, every `setQueryData` against the empty cache would be a
+        // no-op, and the rail would stop responding. So the initial load is
+        // left to finish and `guardedGroup` puts this selection back on top of
+        // whatever it answers with.
+        if (queryClient.getQueryData(queryKeys.settings) !== undefined) {
+          await queryClient.cancelQueries({ queryKey: queryKeys.settings });
+        }
         // That await means two rapid clicks resume in an order the click order
         // does not settle, so the optimistic paint takes the same currency
         // guard the answers do.
@@ -230,8 +289,17 @@ export function useActiveGroup(): {
         if (updated === undefined) {
           console.error("[settings] failed to persist active project group:", failure);
           // A superseded failure leaves the newer selection alone; the newest
-          // one goes back to what the server last acknowledged.
-          if (current) showActiveGroup(writes.lastAcknowledged());
+          // one goes back to what the server last acknowledged — and stops
+          // speaking for the selection it failed to save.
+          if (!current) return;
+          writes.releaseGuard();
+          const restore = writes.lastAcknowledged();
+          // Never a group the rail would refuse to display. The settings row
+          // can hold a group another window deleted; putting it back would
+          // re-arm the self-heal effect below, which PATCHes "all", which
+          // fails, which restores it again — one request per round trip for as
+          // long as the server keeps saying no.
+          if (displayedActiveGroup(restore, groups) === restore) showActiveGroup(restore);
           return;
         }
 
@@ -247,7 +315,7 @@ export function useActiveGroup(): {
         showActiveGroup(activeGroupOf(updated));
       })();
     },
-    [queryClient, showActiveGroup],
+    [queryClient, showActiveGroup, groups],
   );
 
   // Self-heal persistence when the active group was deleted: the memo above

--- a/packages/panel/src/lib/active-group.ts
+++ b/packages/panel/src/lib/active-group.ts
@@ -57,17 +57,26 @@ function activeGroupOf(settings: Pick<AppSettings, "activeProjectGroup">): Activ
  * in flight are not ordered: pick group A then group B and A's answer can land
  * last, carrying the server's *older* `activeProjectGroup` back over B — the
  * rail reverts to an older group under the cursor. So each local write takes
- * the next generation, and a settings answer is applied only while its
- * generation is still the newest; an older PATCH resolving late is dropped.
+ * the next generation, and a settings answer may only *paint* while its
+ * generation is still the newest; an older PATCH resolving late paints nothing.
  *
- * The ledger also remembers the last group the server acknowledged, which is
- * where a failed write puts the rail back — never some older group that merely
- * happened to be on screen before the click.
+ * Acknowledgement is tracked separately from painting, because the two ask
+ * different questions. "May this answer paint?" is about the newest *write*.
+ * "Did the server confirm this group?" is about the newest *answer* — and a
+ * superseded PATCH that succeeded did confirm its group, so it must be
+ * recorded even though it may not paint. Dropping it is what let a later
+ * failure roll the rail back past a group the server was actually holding.
+ *
+ * `lastAcknowledged()` is where a failed write puts the rail back — never some
+ * older group that merely happened to be on screen before the click.
  */
 export function createActiveGroupWriteLedger(initial: ActiveProjectGroup = ACTIVE_GROUP_ALL) {
   let latest = 0;
   let inFlight = 0;
   let acknowledged: ActiveProjectGroup = initial;
+  /** The write whose answer `acknowledged` came from; 0 for a seed/observe. */
+  let acknowledgedGeneration = 0;
+  let seeded = false;
 
   return {
     /** Claim the generation for one local (optimistic) write. */
@@ -76,23 +85,49 @@ export function createActiveGroupWriteLedger(initial: ActiveProjectGroup = ACTIV
       inFlight += 1;
       return latest;
     },
+    /** Is `generation` still the newest local write? No side effect. */
+    isCurrent(generation: number): boolean {
+      return generation === latest;
+    },
     /** Settle a write; true only while its answer is still the newest one. */
     settleWrite(generation: number): boolean {
       if (inFlight > 0) inFlight -= 1;
       return generation === latest;
     },
-    /** Record the group the server confirmed for the newest write. */
-    acknowledge(group: ActiveProjectGroup): void {
+    /**
+     * Record the group the server confirmed for one write. Refuses an answer
+     * older than the one already recorded, so a late-landing older PATCH
+     * cannot un-acknowledge a newer one.
+     */
+    acknowledge(generation: number, group: ActiveProjectGroup): void {
+      if (generation < acknowledgedGeneration) return;
+      acknowledgedGeneration = generation;
       acknowledged = group;
+      seeded = true;
     },
     /**
      * Adopt a settings answer nobody here asked for (first load, refetch,
      * another window's write arriving on an invalidation) as the acknowledged
      * truth — but only while no local write is in flight, since a cache read
-     * during a race is this tab's own optimistic value, not the server's.
+     * during a race is this tab's own optimistic value, not the server's. It
+     * outranks every write issued so far, so it takes the newest generation.
      */
     observe(group: ActiveProjectGroup): void {
-      if (inFlight === 0) acknowledged = group;
+      if (inFlight > 0) return;
+      acknowledgedGeneration = latest;
+      acknowledged = group;
+      seeded = true;
+    },
+    /**
+     * Best guess at what the server holds before any of it is known — the
+     * localStorage seed the rail is already rendering. Once anything real has
+     * been acknowledged or observed this is a no-op, and it never overwrites a
+     * write in flight.
+     */
+    seed(group: ActiveProjectGroup): void {
+      if (seeded || inFlight > 0) return;
+      seeded = true;
+      acknowledged = group;
     },
     /** Where a failed write puts the rail back. */
     lastAcknowledged(): ActiveProjectGroup {
@@ -144,11 +179,15 @@ export function useActiveGroup(): {
   }, [raw, groups]);
 
   // Anything the settings query itself delivers is the server's word, so long
-  // as this tab has no write of its own outstanding.
+  // as this tab has no write of its own outstanding. Before it hydrates there
+  // is no server answer to adopt, so the ledger is seeded with the value the
+  // rail is already rendering — otherwise a click made during that window and
+  // then failing would roll back to "All projects" rather than to the group
+  // the operator was on.
   useEffect(() => {
-    if (settings === undefined) return;
-    writes.observe(activeGroupOf(settings));
-  }, [settings]);
+    if (settings === undefined) writes.seed(raw);
+    else writes.observe(activeGroupOf(settings));
+  }, [settings, raw]);
 
   /** The optimistic half: localStorage + settings cache, no request. */
   const showActiveGroup = useCallback(
@@ -164,24 +203,49 @@ export function useActiveGroup(): {
   const setActiveGroup = useCallback(
     (next: ActiveProjectGroup) => {
       const generation = writes.beginWrite();
-      showActiveGroup(next);
-      void api
-        .updateSettings({ activeProjectGroup: storedActiveGroup(next) })
-        .then((updated) => {
-          // A newer selection was made while this PATCH was out: its answer is
-          // the older truth, so it is dropped rather than rendered.
-          if (!writes.settleWrite(generation)) return;
-          writes.acknowledge(activeGroupOf(updated));
-          writeCachedActiveProjectGroup(activeGroupOf(updated));
-          queryClient.setQueryData(queryKeys.settings, updated);
-        })
-        .catch((error) => {
-          console.error("[settings] failed to persist active project group:", error);
-          // Same guard, and then back to what the server last acknowledged —
-          // a superseded failure leaves the newer selection alone.
-          if (!writes.settleWrite(generation)) return;
-          showActiveGroup(writes.lastAcknowledged());
-        });
+      void (async () => {
+        // The house pattern for an optimistic settings write (see
+        // `UsageSettingsPage.tsx` and `ProvidersSettingsPage.tsx`): a settings
+        // GET already in flight would answer with the pre-PATCH row and paint
+        // it straight over the optimistic write, so it is cancelled first.
+        await queryClient.cancelQueries({ queryKey: queryKeys.settings });
+        // That await means two rapid clicks resume in an order the click order
+        // does not settle, so the optimistic paint takes the same currency
+        // guard the answers do.
+        if (writes.isCurrent(generation)) showActiveGroup(next);
+
+        let updated: AppSettings | undefined;
+        let failure: unknown;
+        try {
+          updated = await api.updateSettings({ activeProjectGroup: storedActiveGroup(next) });
+        } catch (error) {
+          failure = error;
+        }
+
+        // Exactly once per write, whatever happened above: `settleWrite` is the
+        // only thing that decrements the in-flight count, and settling twice
+        // would let `observe` adopt this tab's own optimistic value.
+        const current = writes.settleWrite(generation);
+
+        if (updated === undefined) {
+          console.error("[settings] failed to persist active project group:", failure);
+          // A superseded failure leaves the newer selection alone; the newest
+          // one goes back to what the server last acknowledged.
+          if (current) showActiveGroup(writes.lastAcknowledged());
+          return;
+        }
+
+        // The server did confirm this group, superseded or not — recording it
+        // is what keeps a later failure from rolling back past it.
+        writes.acknowledge(generation, activeGroupOf(updated));
+        // …but only the newest answer may paint.
+        if (!current) return;
+        // A merge rather than a full-row replace: `updated` carries every other
+        // setting at its pre-PATCH value, so replacing the row would undo a
+        // concurrent edit to a neighbouring key (a section collapsed mid-flight
+        // popping back open).
+        showActiveGroup(activeGroupOf(updated));
+      })();
     },
     [queryClient, showActiveGroup],
   );


### PR DESCRIPTION
The B2 half of the pin/session/CLI/drop wave: `setActiveGroup` applied whichever `updateSettings` PATCH resolved
last, with no generation, so an older answer could revert the rail under the cursor.

> **Scope note — #384's symptom is not fully closed by this PR.** The guard here orders the answers *this hook*
> is responsible for, and cancels a settings GET in flight before its own write. It does **not** order the other
> writers of the same settings row: `collapsed-groups.ts` and `hideable-elements.tsx` still write
> `queryKeys.settings` with a pre-click `activeProjectGroup`, and the same operator-visible revert is reachable
> through them. That is filed as **#452** and wants one shared write path for the row rather than a third guard.

## What was wrong

`packages/panel/src/lib/active-group.ts` wrote the group into the settings query cache optimistically and then
`setQueryData`'d whatever the PATCH answered. Two PATCHes in flight are not ordered — pick group A then group B and
A's answer can land last, carrying the server's older `activeProjectGroup` back over B. Two rapid group changes (or
racing tabs) revert the rail to an older group mid-click. A failed PATCH restored nothing at all, so the rail kept
showing a selection the server never accepted.

## What changed

- A per-tab **write ledger**. Every local write claims the next generation, and an answer may only *paint* while
  its generation is still the newest. An older PATCH resolving late paints nothing.
- **Acknowledgement is tracked separately from painting**, with a generation of its own that refuses an answer
  older than the one already recorded. A superseded PATCH that succeeded did confirm its group, so it is recorded
  even though it may not paint — that is what keeps a later failure from rolling the rail back past a group the
  server is actually holding.
- A failed PATCH restores the **last acknowledged group**; a failure whose write has already been superseded rolls
  nothing back. Before settings hydrate the ledger is seeded from the value the rail is already rendering, so a
  click made in that window and then failing does not fall back to "All projects".
- Every write awaits `queryClient.cancelQueries({ queryKey: queryKeys.settings })` before painting — the pattern
  `UsageSettingsPage.tsx:60` and `ProvidersSettingsPage.tsx:75` already use — so a settings read in flight cannot
  answer with the pre-PATCH row and paint it over the optimistic write. The optimistic paint takes the same
  currency guard the answers do, since that await means two rapid clicks resume in an order the click order does
  not settle by itself.
- The confirm path **merges** the group into the current row instead of replacing the row, so a concurrent edit to
  a neighbouring setting is not undone by an answer carrying it at its pre-edit value.
- The request is awaited inside one `try`/`catch`, so `settleWrite` runs exactly once per write.

`ProjectBar.tsx`, `TerminalPane.tsx`, `task-status-sync.ts`, `terminal-store.tsx`, `__root.tsx` and
`projects.$id.tsx` are untouched — parallel tickets own them. Two files in the diff: `active-group.ts` and its test.

## Acceptance (issue #384)

- [x] **Rapid group A then B leaves B selected even if A's PATCH returns last.** `leaves B selected when the A
  answer returns last` drives the real hook with two hand-resolved PATCHes: B answers first and is applied, A
  answers last with the older group and paints nothing. The rail and the localStorage seed both stay on B.
- [x] **A failed PATCH restores the last acknowledged group, not a random older one.** Covered in both
  interleavings: `restores the last acknowledged group when a PATCH fails` (nothing else in flight) and `rolls back
  to the group an older, superseded PATCH confirmed` (the interleaved case the review found, where the pre-review
  shape landed on the value from before both clicks). `rolls a failed first click back to the cached group, not to
  All projects` covers the same root cause before settings hydrate.

Both new blocking cases were run against the previous shape and fail there, as do the two original ones against the
pre-fix code.

## Known limits

- The sibling-writer race is **#452**, described in the scope note above.
- `req()` in `lib/api.ts` sets no timeout or abort signal, so a never-answering PATCH holds the in-flight count
  above zero for the tab's lifetime and `observe` stops adopting server answers. Fixing it means giving the
  settings PATCH a signal in `api.ts`; no ticket in this wave owns that.
- With two writes out, an older success landing *after* the newer one has already failed and rolled back leaves the
  rail on the rolled-back group while the ledger records the server's newer truth. AC2 still holds at the moment of
  the failure — the rail goes to what was acknowledged then — and closing it properly needs the shared write path
  #452 asks for.

## Testing

- `src/lib/__tests__/active-group.test.tsx`: 15 tests, green, run five times for stability.
- Full `packages/panel` suite: **147 files, 1584 tests, all passing, none skipped.**
- `pnpm typecheck` clean; `eslint` clean on both files.

Base is `fix/operator-pins-sessions-drop-cli`, not `main` and not the train. Draft on purpose. `Refs` rather than a
closing keyword, deliberately: this stacks into the wave branch, and #384's symptom outlives this PR via #452.

Refs #384
Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkZFxb8DWtTZdQea3JfgTx
