### PR TITLE
fix(core): Stop with a foreign session_id still settles the task

### DIFF
--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -159,6 +159,42 @@ notifications as `needs-input` creates false positives that later flip to
 These values were tuned against the failure modes above. Do not change them
 without a failure that says so.
 
+### The session-id guard, and the one event it does not drop
+
+A hook is addressed by **task id**, read out of the PTY's own environment. The
+`session_id` in the payload is a second, weaker fact: the harness's own name for
+the conversation. The pipeline stores the first one it sees on a *capture* event
+(`UserPromptSubmit`, `SessionStart`, and their Cursor spellings) and, from then
+on, drops any non-capture event carrying a different id — a `foreign-session`.
+That is what stops a stranger's question, subagent count or permission prompt
+from claiming a card it does not own, and a capture event is still free to adopt
+a new id, because a new session id means a new harness process.
+
+**A turn end is the exception** (#390). `Stop` — and Cursor's `stop` and
+`afterAgentResponse` — claims nothing; it reports that a turn ended, on a PTY
+that is this task's whatever the harness calls its session. Two shapes produce
+one under an unrecognised id: a **resume**, where the stored id belongs to a
+process that is gone and no further capture event is coming, and an **OpenCode
+child** whose `session.idle` leaked past the plugin's parent/child filter.
+Dropping it was still an *ack* — `{ ok: true, ignored: "foreign-session" }` — so
+the harness saw its hook accepted while the card sat on `running` and no
+`session:finished` ever fired.
+
+So a foreign turn end settles the task instead, on terms narrower than an owned
+one's:
+
+- **Only `running` and `needs-input` are settled** — the same pair the PTY-exit
+  settle acts on. Every other status is an answer already given. `ready` is
+  excluded for #387's reason: `CoreTaskWriter` appends `session:finished` on
+  that transition, and a Session titled "Waiting for initial prompt…" has no
+  turn to end.
+- **The subagent hold still applies.** A foreign `Stop` over a live fan-out
+  holds on `running` and arms the same drain backstop, rather than dinging
+  mid-work.
+- **The session id is not captured.** A `Stop` is not a capture event; adopting
+  an OpenCode child's id would hand the rest of that child's lifecycle the
+  Session's card.
+
 ## The hook receiver
 
 The Core exposes a small **loopback HTTP** listener a hook's shell command can
@@ -515,7 +551,11 @@ Three details are load-bearing and none of them is guessable from the docs:
   Nothing awaits the queue, so a hook still never holds up a turn.
 - **A child session is a subagent.** `session.created` carries `parentID`, so
   the plugin knows a child by name rather than guessing from ordering, and a
-  subagent's `idle` never settles the Session's card.
+  subagent's `idle` never settles the Session's card. Filtering it at the
+  source is the point: one that leaks through — a child created before the
+  plugin loaded — reaches the Core as a `Stop` under an unrecognised session
+  id, which now settles rather than being dropped (see the session-id guard
+  above), held back only by the subagent bookkeeping OpenCode does not feed.
 
 `permission.replied` is also why opencode needs no unmatched `PostToolUse`
 subscription: Claude Code fires nothing when a permission is *granted* and has

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -183,14 +183,32 @@ the harness saw its hook accepted while the card sat on `running` and no
 So a foreign turn end settles the task instead, on terms narrower than an owned
 one's:
 
-- **Only `running` and `needs-input` are settled** — the same pair the PTY-exit
-  settle acts on. Every other status is an answer already given. `ready` is
-  excluded for #387's reason: `CoreTaskWriter` appends `session:finished` on
-  that transition, and a Session titled "Waiting for initial prompt…" has no
-  turn to end.
-- **The subagent hold still applies.** A foreign `Stop` over a live fan-out
-  holds on `running` and arms the same drain backstop, rather than dinging
-  mid-work.
+- **The tracked subagents are dropped on entry**, with the recent-finish mark.
+  A turn end under an unrecognised id means a new harness process, so the old
+  session's subagents died with it — and nothing else can clear them. Their
+  `SubagentStop` died with the process, and the new session's own subagent
+  events carry the new id, so they are dropped as foreign *before* the
+  bookkeeping. The only other route out is the 2-hour `ACTIVE_SUBAGENT_TTL_MS`,
+  and waiting on it is how the first cut of this settle reproduced #390 inside
+  the fix for it: a fanned-out turn that resumed with a lost `SessionStart` sat
+  on `running` for two hours with its `Stop` acked.
+- **There is no subagent hold, deliberately.** After the clear the tracked set
+  is empty by construction, and it could not have engaged in either shape that
+  reaches here anyway: a resumed session's subagent events are dropped as
+  foreign before they are ever counted, and opencode — whose child sessions are
+  the other shape — posts no subagent lifecycle events at all, so
+  `hasActiveSubagents` is structurally false for every opencode Session. **The
+  status check below is the only real guard**, and a leaked child *can* finish
+  a working parent's `running` card. That is the residual, stated rather than
+  papered over; the parent's next `session.status: busy` corrects it.
+- **Only `running` is settled** — not `needs-input`. The PTY-exit settle acts on
+  both, and it is not a precedent that transfers: there the process is dead, so
+  an open question is moot, while here it is alive and may be blocked on exactly
+  that question. A leaked child going idle would otherwise write `finished` over
+  a parent waiting on a permission prompt, taking the pending-question overlay
+  with it. `ready` is out for #387's reason: `CoreTaskWriter` appends
+  `session:finished` on that transition, and a Session titled "Waiting for
+  initial prompt…" has no turn to end.
 - **The session id is not captured.** A `Stop` is not a capture event; adopting
   an OpenCode child's id would hand the rest of that child's lifecycle the
   Session's card.
@@ -545,17 +563,25 @@ Three details are load-bearing and none of them is guessable from the docs:
 - **`permission.asked` is the event the binary emits.** The `@opencode-ai/sdk`
   type union calls it `permission.updated`, and that string does not appear in
   the 1.18.18 binary at all. The plugin listens for both.
-- **Posts are queued, not fired in parallel.** A `Stop` that overtook the
-  `SessionStart` carrying the session id would be discarded by the Core as
-  belonging to a session it has never heard of — #230 again with a new cause.
-  Nothing awaits the queue, so a hook still never holds up a turn.
+- **Posts are queued, not fired in parallel.** Order is meaning here. A
+  `chat.message` that overtook the `SessionStart` before it would name the
+  Session from a prompt the Core cannot yet attribute, and a `permission.replied`
+  that overtook its `permission.asked` would leave the card on `needs-input`
+  for a question already answered — #230 again with a new cause. (A `Stop` that
+  overtakes the capture event is no longer among the casualties: since #390 it
+  settles rather than being discarded. That is a narrowed blast radius, not a
+  reason to stop queueing.) Nothing awaits the queue, so a hook still never
+  holds up a turn.
 - **A child session is a subagent.** `session.created` carries `parentID`, so
   the plugin knows a child by name rather than guessing from ordering, and a
   subagent's `idle` never settles the Session's card. Filtering it at the
-  source is the point: one that leaks through — a child created before the
-  plugin loaded — reaches the Core as a `Stop` under an unrecognised session
-  id, which now settles rather than being dropped (see the session-id guard
-  above), held back only by the subagent bookkeeping OpenCode does not feed.
+  source is the whole guard — one that leaks through, a child created before
+  the plugin loaded, reaches the Core as a `Stop` under an unrecognised session
+  id and now settles rather than being dropped (see the session-id guard
+  above). Nothing downstream can catch it: opencode posts no subagent lifecycle
+  events, so the pipeline has no way to see the parent still working. All that
+  narrows it is the `running`-only status check, and the parent's next
+  `session.status: busy` puts the card back.
 
 `permission.replied` is also why opencode needs no unmatched `PostToolUse`
 subscription: Claude Code fires nothing when a permission is *granted* and has

--- a/packages/core/src/__tests__/harness-status-detection.test.ts
+++ b/packages/core/src/__tests__/harness-status-detection.test.ts
@@ -161,6 +161,21 @@ describe("harness status detection on the Core (issue 84)", () => {
     expect(kinds()).toContain("session:finished");
   });
 
+  it("finishes on a Stop whose session id is not the stored one (issue 390)", async () => {
+    // The operator-visible miss: a resumed harness (or an OpenCode child whose
+    // idle leaked past the plugin's filter) posts its Stop under a session id
+    // this task never captured. It used to be acked as `foreign-session` and
+    // dropped before any status write, so the card stayed on `running` and the
+    // notification consumer never heard a thing.
+    await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
+    expect(rowStatus()).toBe("running");
+
+    await postHook({ hook_event_name: "Stop", session_id: "sess-2-after-resume" });
+
+    expect(rowStatus()).toBe("finished");
+    expect(kinds()).toContain("session:finished");
+  });
+
   it("holds the finish while a background subagent is still working", async () => {
     await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
     await postHook({

--- a/packages/core/src/__tests__/harness-status-detection.test.ts
+++ b/packages/core/src/__tests__/harness-status-detection.test.ts
@@ -176,6 +176,37 @@ describe("harness status detection on the Core (issue 84)", () => {
     expect(kinds()).toContain("session:finished");
   });
 
+  it("finishes a fanned-out turn whose resume lost its SessionStart (issue 390)", async () => {
+    // The pre-resume process's subagents can never report in — their harness is
+    // gone, and the resumed session's own subagent events carry the new id, so
+    // they are dropped as foreign. Holding on that stale set was two hours of a
+    // card on `running` with its Stop acked: #390's symptom inside the fix.
+    await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
+    await postHook({
+      hook_event_name: "SubagentStart",
+      session_id: "sess-1",
+      agent_id: "sub-1",
+    });
+
+    await postHook({ hook_event_name: "Stop", session_id: "sess-2-after-resume" });
+
+    expect(rowStatus()).toBe("finished");
+    expect(kinds()).toContain("session:finished");
+  });
+
+  it("leaves a Session waiting on a permission prompt alone (issue 390)", async () => {
+    // `needs-input` is not settled by a foreign turn end: unlike the PTY-exit
+    // settle, the process here is alive and may be blocked on that question.
+    await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
+    await postHook({ hook_event_name: "PermissionRequest", session_id: "sess-1" });
+    expect(rowStatus()).toBe("needs-input");
+
+    await postHook({ hook_event_name: "Stop", session_id: "sess-2-child" });
+
+    expect(rowStatus()).toBe("needs-input");
+    expect(kinds()).not.toContain("session:finished");
+  });
+
   it("holds the finish while a background subagent is still working", async () => {
     await postHook({ hook_event_name: "UserPromptSubmit", session_id: "sess-1" });
     await postHook({

--- a/packages/panel/src/server/__tests__/opencode-hooks-api.test.ts
+++ b/packages/panel/src/server/__tests__/opencode-hooks-api.test.ts
@@ -283,6 +283,29 @@ describe("OpenCode hook API", () => {
     });
   });
 
+  it("does not settle a Session waiting on a permission prompt (issue 390)", async () => {
+    // The parent raised the prompt and is blocked on it; a child session going
+    // idle must not write `finished` over that, which would also clear the
+    // pending question the operator still has to answer.
+    const capturedSessionId = "ses_captured_session";
+
+    await start(capturedSessionId);
+    await postHook({ hook_event_name: "PermissionRequest", session_id: capturedSessionId });
+    expect(getTask(taskId)?.status).toBe("needs-input");
+
+    const childStop = await postHook({
+      hook_event_name: "Stop",
+      session_id: "ses_leaked_child",
+    });
+
+    expect(childStop?.status).toBe(200);
+    await expect(childStop?.json()).resolves.toEqual({ ok: true, event: "Stop" });
+    expect(getTask(taskId)).toMatchObject({
+      claudeSessionId: capturedSessionId,
+      status: "needs-input",
+    });
+  });
+
   it("still settles the Session on a Stop from a different session (issue 390)", async () => {
     // A resumed OpenCode process, or a child session whose `idle` slipped past
     // the plugin's parent/child filter. This used to be acked and dropped, so

--- a/packages/panel/src/server/__tests__/opencode-hooks-api.test.ts
+++ b/packages/panel/src/server/__tests__/opencode-hooks-api.test.ts
@@ -47,6 +47,27 @@ describe("OpenCode hook API", () => {
     taskId = task.id;
   });
 
+  function postHook(body: Record<string, unknown>): Promise<Response | null> {
+    return handleApiRequest(
+      authed(`/api/hooks/opencode?taskId=${encodeURIComponent(taskId)}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+  }
+
+  /** Capture a session id and put the Session on `running`, as a turn does. */
+  async function start(sessionId: string): Promise<void> {
+    const running = await postHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: sessionId,
+      prompt: "ship opencode hooks",
+    });
+    expect(running?.status).toBe(200);
+    expect(getTask(taskId)).toMatchObject({ claudeSessionId: sessionId, status: "running" });
+  }
+
   it("captures ses_* session ids from SessionStart without changing status", async () => {
     const sessionId = "ses_3cf7dd8d4ffeUPfENpVxfFojZ2";
     const res = await handleApiRequest(
@@ -240,43 +261,50 @@ describe("OpenCode hook API", () => {
     expect(getTask(taskId)?.status).toBe("finished");
   });
 
-  it("ignores status hooks from a different captured session", async () => {
+  it("ignores claiming hooks from a different captured session", async () => {
     const capturedSessionId = "ses_captured_session";
     const foreignSessionId = "ses_foreign_session";
 
-    const running = await handleApiRequest(
-      authed(`/api/hooks/opencode?taskId=${encodeURIComponent(taskId)}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          hook_event_name: "UserPromptSubmit",
-          session_id: capturedSessionId,
-          prompt: "ship opencode hooks",
-        }),
-      }),
-    );
-    expect(running?.status).toBe(200);
+    await start(capturedSessionId);
+
+    // A permission prompt from a session this task never captured would park
+    // the card on `needs-input` for a question the operator cannot see. That
+    // is what the foreign-session guard is for, and it still holds.
+    const foreignAsk = await postHook({
+      hook_event_name: "PermissionRequest",
+      session_id: foreignSessionId,
+    });
+
+    expect(foreignAsk?.status).toBe(200);
+    await expect(foreignAsk?.json()).resolves.toEqual({ ok: true, ignored: "foreign-session" });
     expect(getTask(taskId)).toMatchObject({
       claudeSessionId: capturedSessionId,
       status: "running",
     });
+  });
 
-    const foreignStop = await handleApiRequest(
-      authed(`/api/hooks/opencode?taskId=${encodeURIComponent(taskId)}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          hook_event_name: "Stop",
-          session_id: foreignSessionId,
-        }),
-      }),
-    );
+  it("still settles the Session on a Stop from a different session (issue 390)", async () => {
+    // A resumed OpenCode process, or a child session whose `idle` slipped past
+    // the plugin's parent/child filter. This used to be acked and dropped, so
+    // the card sat on `running` with no `session:finished` ever coming — the
+    // hook was addressed by task id out of this PTY's own environment, so the
+    // turn that ended is this Session's whatever OpenCode calls the session.
+    const capturedSessionId = "ses_captured_session";
+    const foreignSessionId = "ses_foreign_session";
+
+    await start(capturedSessionId);
+
+    const foreignStop = await postHook({
+      hook_event_name: "Stop",
+      session_id: foreignSessionId,
+    });
 
     expect(foreignStop?.status).toBe(200);
-    await expect(foreignStop?.json()).resolves.toEqual({ ok: true, ignored: "foreign-session" });
+    await expect(foreignStop?.json()).resolves.toEqual({ ok: true, status: "finished" });
     expect(getTask(taskId)).toMatchObject({
+      // The stored id is untouched: a Stop is still not a capture event.
       claudeSessionId: capturedSessionId,
-      status: "running",
+      status: "finished",
     });
   });
 });

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   handleHarnessHookEvent,
+  hookResultResponse,
   type HarnessHookBody,
+  type HookPipelineResult,
   type HookPipelinePorts,
   type HookTaskFacts,
 } from "../harness-hook-pipeline";
@@ -39,13 +41,16 @@ type Harness = {
   ports: HookPipelinePorts;
   /** Every status the pipeline wrote, oldest first. */
   writes: TaskStatus[];
-  post(payload: HarnessHookBody): void;
+  /** Every session id the pipeline captured, oldest first. */
+  captured: string[];
+  post(payload: HarnessHookBody): HookPipelineResult;
 };
 
 function makeHarness(): Harness {
   const taskId = `pipeline-task-${++taskIdSeq}`;
   const task: HookTaskFacts = { status: "ready", claudeSessionId: null };
   const writes: TaskStatus[] = [];
+  const captured: string[] = [];
   const ports: HookPipelinePorts = {
     getTask: (id) => (id === taskId ? task : null),
     updateStatus: (id, status) => {
@@ -55,7 +60,9 @@ function makeHarness(): Harness {
       return true;
     },
     setSessionId: (id, sessionId) => {
-      if (id === taskId) task.claudeSessionId = sessionId;
+      if (id !== taskId) return;
+      task.claudeSessionId = sessionId;
+      captured.push(sessionId);
     },
   };
   return {
@@ -63,9 +70,9 @@ function makeHarness(): Harness {
     task,
     ports,
     writes,
-    post: (payload) => {
-      handleHarnessHookEvent(taskId, { session_id: SESSION_ID, ...payload }, ports);
-    },
+    captured,
+    post: (payload) =>
+      handleHarnessHookEvent(taskId, { session_id: SESSION_ID, ...payload }, ports),
   };
 }
 
@@ -272,6 +279,198 @@ describe("a PTY exit settles a Session that never started a turn (issue 387)", (
     h.post({ hook_event_name: EXITED, exit_code: 1 });
     // The exit of an idle session is not news, and must not overwrite the
     // finish that was actually reported.
+    expect(h.task.status).toBe("finished");
+  });
+});
+
+describe("a turn end from a session this task never captured (issue 390)", () => {
+  // The miss this pins (issue 390): a `Stop` is not a session-capture event, so
+  // one arriving under a session id that is not the stored one used to return
+  // `foreign-session` BEFORE any status write — acked with `{ ok: true }` and
+  // dropped. The card stayed on `running` and no `session:finished` ever fired,
+  // for a turn that had ended. The two ways to get there are a resumed harness
+  // (new session id, stored one belongs to a dead process) and an OpenCode
+  // child session whose `idle` leaked past the plugin's parent/child filter.
+  //
+  // The hook is addressed by task id out of the PTY's own environment, so the
+  // PTY that posted it belongs to this task whatever the harness calls its
+  // session — which is why a turn end is the one foreign event that settles.
+
+  const FOREIGN = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+  it("finishes a running task on a Stop whose session_id does not match", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "resume me" });
+    expect(h.task.status).toBe("running");
+    expect(h.task.claudeSessionId).toBe(SESSION_ID);
+
+    const result = h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+
+    expect(h.task.status).toBe("finished");
+    expect(result).toEqual({ outcome: "ok", event: "Stop", status: "finished" });
+    expect(h.writes).toEqual(["running", "finished"]);
+  });
+
+  it("answers with the status rather than an ignored foreign-session ack", () => {
+    // The ack was the operator-visible part of the miss: from the harness's
+    // side a hook that changed nothing looked exactly like one that worked.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "resume me" });
+
+    const body = hookResultResponse(h.post({ hook_event_name: "Stop", session_id: FOREIGN }));
+    expect(body).toEqual({ ok: true, body: { ok: true, status: "finished" } });
+  });
+
+  it("settles a task parked on needs-input too", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "ask me something" });
+    h.post({ hook_event_name: "Notification", notification_type: "permission_prompt" });
+    expect(h.task.status).toBe("needs-input");
+
+    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("settles Cursor's turn-end events on the same terms", () => {
+    for (const event of ["stop", "afterAgentResponse"]) {
+      const h = harness();
+      h.post({ hook_event_name: "beforeSubmitPrompt", prompt: "go" });
+      expect(h.task.status).toBe("running");
+
+      h.post({ hook_event_name: event, session_id: FOREIGN });
+      expect(h.task.status).toBe("finished");
+    }
+  });
+
+  it("does not adopt the foreign session id", () => {
+    // A `Stop` is still not a capture event. Adopting an OpenCode child's id
+    // would hand the rest of that child's lifecycle the Session's card.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "resume me" });
+    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+
+    expect(h.task.claudeSessionId).toBe(SESSION_ID);
+    expect(h.captured).toEqual([SESSION_ID]);
+  });
+
+  it("holds instead of finishing while a tracked subagent is in flight", () => {
+    // The conservative half: an OpenCode child's leaked idle must not ding a
+    // parent whose fan-out this pipeline can see is still working.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+
+    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("running");
+
+    // And the real finish still lands when the fan-out reports in.
+    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-1" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("leaves an already-settled task exactly as it settled", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+    h.post({ hook_event_name: "Stop" });
+    expect(h.task.status).toBe("finished");
+
+    const result = h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("finished");
+    // No `status` echoed: the settle is conditional, like the PTY-exit one.
+    expect(result).toEqual({ outcome: "ok", event: "Stop" });
+    expect(h.writes).toEqual(["running", "finished"]);
+  });
+
+  it("leaves a ready Session alone rather than dinging a turn it never ran", () => {
+    // `CoreTaskWriter` appends `session:finished` on that transition, and a
+    // Session still titled "Waiting for initial prompt…" has no turn to end —
+    // #387's reasoning, unchanged.
+    const h = harness();
+    h.post({ hook_event_name: "SessionStart", source: "startup" });
+    expect(h.task.status).toBe("ready");
+
+    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("ready");
+    expect(h.writes).toEqual([]);
+  });
+
+  it("still drops every other foreign event", () => {
+    // The guard is narrowed to turn ends, not lifted. A foreign question, a
+    // foreign subagent count, a foreign permission prompt and a foreign
+    // interrupt all still claim the task for a session it does not own.
+    // (The capture events are not in this list on purpose: adopting a new
+    // session id is what they are for, and #390 did not touch that.)
+    for (const payload of [
+      { hook_event_name: "SubagentStart", agent_id: "foreign-sub" },
+      { hook_event_name: "PreToolUse", tool_name: "AskUserQuestion" },
+      { hook_event_name: "Notification", notification_type: "permission_prompt" },
+      { hook_event_name: "UserInterrupt" },
+    ] satisfies HarnessHookBody[]) {
+      const h = harness();
+      h.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+      const before = h.writes.length;
+
+      const result = h.post({ ...payload, session_id: FOREIGN });
+      expect(result.outcome).toBe("foreign-session");
+      expect(h.task.status).toBe("running");
+      expect(h.writes).toHaveLength(before);
+    }
+  });
+});
+
+describe("matching-session Stop behaviour is unchanged (issue 390)", () => {
+  it("finishes on a Stop carrying the captured session id", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "do the thing" });
+    const result = h.post({ hook_event_name: "Stop" });
+
+    expect(result).toEqual({ outcome: "ok", event: "Stop", status: "finished" });
+    expect(h.task.status).toBe("finished");
+    expect(h.writes).toEqual(["running", "finished"]);
+    expect(h.task.claudeSessionId).toBe(SESSION_ID);
+  });
+
+  it("finishes on a Stop for a task that captured no session id at all", () => {
+    // The guard never fires without a stored id, so this path did not change
+    // and must not have: it is every Session before its first capture event.
+    const h = harness();
+    const result = handleHarnessHookEvent(h.taskId, { hook_event_name: "Stop" }, h.ports);
+
+    expect(result).toEqual({ outcome: "ok", event: "Stop", status: "finished" });
+    expect(h.task.status).toBe("finished");
+  });
+
+  it("still downgrades a matching Stop to running while subagents work", () => {
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+
+    const held = h.post({ hook_event_name: "Stop" });
+    expect(held).toEqual({ outcome: "ok", event: "Stop", status: "running" });
+    expect(h.task.status).toBe("running");
+
+    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-1" });
+    expect(h.post({ hook_event_name: "Stop" })).toEqual({
+      outcome: "ok",
+      event: "Stop",
+      status: "finished",
+    });
+  });
+
+  it("still finishes a matching Stop over an already-settled task", () => {
+    // Unconditional, unlike the foreign settle: an owned Stop has the last
+    // word on its own session, and narrowing that would be a behaviour change.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "go" });
+    h.post({ hook_event_name: "UserInterrupt" });
+    expect(h.task.status).toBe("interrupted");
+
+    expect(h.post({ hook_event_name: "Stop" })).toEqual({
+      outcome: "ok",
+      event: "Stop",
+      status: "finished",
+    });
     expect(h.task.status).toBe("finished");
   });
 });

--- a/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
+++ b/packages/shared/src/__tests__/harness-hook-pipeline.test.ts
@@ -321,14 +321,22 @@ describe("a turn end from a session this task never captured (issue 390)", () =>
     expect(body).toEqual({ ok: true, body: { ok: true, status: "finished" } });
   });
 
-  it("settles a task parked on needs-input too", () => {
+  it("leaves a task parked on needs-input waiting (review finding 3)", () => {
+    // The PTY-exit settle acts on `running` and `needs-input` together, and
+    // that is not a precedent that transfers: there the process is dead, so an
+    // open question is moot. Here it is alive and may be blocked on exactly
+    // that question — a leaked OpenCode child going idle must not write
+    // `finished` over a parent waiting on a permission prompt, which would
+    // also take the Panel's pending-question overlay with it.
     const h = harness();
     h.post({ hook_event_name: "UserPromptSubmit", prompt: "ask me something" });
     h.post({ hook_event_name: "Notification", notification_type: "permission_prompt" });
     expect(h.task.status).toBe("needs-input");
 
-    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
-    expect(h.task.status).toBe("finished");
+    const result = h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("needs-input");
+    expect(result).toEqual({ outcome: "ok", event: "Stop" });
+    expect(h.writes).toEqual(["running", "needs-input"]);
   });
 
   it("settles Cursor's turn-end events on the same terms", () => {
@@ -353,20 +361,69 @@ describe("a turn end from a session this task never captured (issue 390)", () =>
     expect(h.captured).toEqual([SESSION_ID]);
   });
 
-  it("holds instead of finishing while a tracked subagent is in flight", () => {
-    // The conservative half: an OpenCode child's leaked idle must not ding a
-    // parent whose fan-out this pipeline can see is still working.
+  it("settles a fanned-out turn whose resume lost its SessionStart (review finding 1)", () => {
+    // The wedge an earlier draft of this fix had, and issue 390's own symptom
+    // reproduced inside the fix for it. A clean resume never reaches the
+    // foreign branch — `SessionStart` is a capture event, so it adopts the new
+    // id and clears the dead process's subagents. This is the resume where
+    // that POST was LOST, so the pre-resume process's tracked subagents are
+    // still counted, and nothing can ever clear them: their `SubagentStop` died
+    // with the process, and the resumed session's own subagent events carry the
+    // new id, so they are dropped as foreign before the bookkeeping runs. The
+    // only other way out was the two-hour TTL — two hours of a card on
+    // `running` with its `Stop` acked.
     const h = harness();
     h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
     h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-2" });
 
-    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
-    expect(h.task.status).toBe("running");
+    const result = h.post({ hook_event_name: "Stop", session_id: FOREIGN });
 
-    // And the real finish still lands when the fan-out reports in.
-    h.post({ hook_event_name: "SubagentStop", agent_id: "sub-1" });
-    h.post({ hook_event_name: "Stop" });
     expect(h.task.status).toBe("finished");
+    expect(result).toEqual({ outcome: "ok", event: "Stop", status: "finished" });
+  });
+
+  it("drops the tracked subagents on entry, so the next turn is not held", () => {
+    // The clear is what makes the settle honest rather than conditional, and
+    // it must outlive this event: a stale entry left behind would hold the
+    // NEXT turn's owned Stop for the whole TTL.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+    h.post({ hook_event_name: "SubagentStart", agent_id: "sub-1" });
+    h.post({ hook_event_name: "Stop", session_id: FOREIGN });
+    expect(h.task.status).toBe("finished");
+
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "next turn" });
+    expect(h.post({ hook_event_name: "Stop" })).toEqual({
+      outcome: "ok",
+      event: "Stop",
+      status: "finished",
+    });
+  });
+
+  it("does not hold on subagents posted under the foreign id either", () => {
+    // Review finding 2: the hold this function used to carry could not engage
+    // in either shape that reaches it. A resumed session's subagent events
+    // carry the NEW id, so they never reach `noteSubagentStart` at all — they
+    // are dropped as foreign, exactly like every other foreign claim — and
+    // opencode, whose child sessions are the other shape, posts no subagent
+    // lifecycle events in the first place.
+    const h = harness();
+    h.post({ hook_event_name: "UserPromptSubmit", prompt: "fan out" });
+
+    const start = h.post({
+      hook_event_name: "SubagentStart",
+      session_id: FOREIGN,
+      agent_id: "resumed-sub",
+    });
+    expect(start).toEqual({ outcome: "foreign-session", event: "SubagentStart" });
+
+    // Nothing was tracked, so the turn end settles straight through.
+    expect(h.post({ hook_event_name: "Stop", session_id: FOREIGN })).toEqual({
+      outcome: "ok",
+      event: "Stop",
+      status: "finished",
+    });
   });
 
   it("leaves an already-settled task exactly as it settled", () => {

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -119,6 +119,20 @@ function isSubagentLifecycleEvent(event: string): boolean {
   );
 }
 
+/**
+ * The turn-end family: every event whose mapping is `finished`. Named apart
+ * from that mapping because the foreign-session branch below has to recognise
+ * a turn end BEFORE any status is written, and reading the mapping there would
+ * make every future `finished` mapping a foreign settle by accident.
+ */
+function isTurnEndEvent(event: string): boolean {
+  return (
+    event === HARNESS_HOOK_EVENTS.stop ||
+    event === HARNESS_HOOK_EVENTS.cursorStop ||
+    event === HARNESS_HOOK_EVENTS.cursorAfterAgentResponse
+  );
+}
+
 function reconcileSessionId(
   task: HookTaskFacts,
   taskId: string,
@@ -184,7 +198,35 @@ export function handleHarnessHookEvent(
       clearSubagentActivity(id);
     },
   });
-  if (sessionResult === "foreign-session") return { outcome: "foreign-session", event };
+  if (sessionResult === "foreign-session") {
+    // A turn end is the one foreign event that must not be dropped (issue 390).
+    //
+    // Everything else the guard rejects is an event that would CLAIM the task
+    // for a session it does not own — a question overlay, a subagent count, a
+    // `running` from a stranger's prompt — and dropping those is the whole
+    // point of the guard. A `Stop` claims nothing. It reports that a turn
+    // ended, and the task it reports about is not in question: the hook was
+    // addressed by task id, out of the PTY's own environment, so the PTY that
+    // posted this belongs to this task whatever the harness calls its session.
+    //
+    // Dropping it was still an ack — `{ ok: true, ignored: "foreign-session" }`
+    // — so the harness saw its hook accepted, the card stayed on `running`, and
+    // no `session:finished` ever fired. Nothing else was coming: the session id
+    // is only re-captured by `UserPromptSubmit`/`SessionStart`, and a resumed
+    // harness that already submitted its prompt fires neither again. That is
+    // the operator-visible miss, and it is worse than any settle: an ack for a
+    // hook that changed nothing is indistinguishable, from the harness side,
+    // from one that worked.
+    //
+    // Two shapes reach here. A RESUME — the harness came back with a new
+    // session id and the stored one belongs to a process that is gone — where
+    // the settle is simply correct. And an OPENCODE CHILD, whose `session.idle`
+    // leaked past the plugin's own parent/child filter; there the parent may
+    // still be working, which is why the settle below is the conservative one
+    // rather than a plain fall-through into the status write.
+    if (!isTurnEndEvent(event)) return { outcome: "foreign-session", event };
+    return settleForeignTurnEnd(taskId, task, event, ports);
+  }
 
   // Sub-agent lifecycle bookkeeping. Claude fires the top-level Stop when the
   // FOREGROUND turn ends — background subagents keep running, then their
@@ -364,6 +406,51 @@ export function hookResultResponse(result: HookPipelineResult): {
           : { ok: true, event: result.event },
       };
   }
+}
+
+/**
+ * Settle a task on a turn end that arrived under a session id this task never
+ * captured. Deliberately narrower than the matching-session path, in the two
+ * places where a foreign turn end is weaker evidence than an owned one:
+ *
+ *  - **Only a task still claiming active work is settled.** `running` and
+ *    `needs-input` are the statuses that go on being wrong until something
+ *    corrects them, and they are the same pair the PTY-exit settle acts on.
+ *    Every other status is an answer already given, and a `Stop` from a
+ *    session this task never captured is the weakest evidence there is for
+ *    overwriting one. `ready` is excluded for the reason #387 spelled out:
+ *    `CoreTaskWriter` appends `session:finished` on that transition, so a
+ *    stray child's turn end would ding a Session still titled "Waiting for
+ *    initial prompt…" — a Session that never ran a turn to end.
+ *  - **The subagent hold still applies.** Work this pipeline can see in flight
+ *    outranks a turn end from anywhere, so a foreign `Stop` over a live
+ *    fan-out holds on `running` and arms the same drain backstop a matching
+ *    one would, rather than dinging mid-work.
+ *
+ * The session id is NOT captured here. A `Stop` is not a capture event, and
+ * adopting an OpenCode child's id would hand the rest of that child's
+ * lifecycle the Session's card.
+ */
+function settleForeignTurnEnd(
+  taskId: string,
+  task: HookTaskFacts,
+  event: string,
+  ports: HookPipelinePorts,
+): HookPipelineResult {
+  if (task.status !== "running" && task.status !== "needs-input") {
+    // No `status` on the result, for the reason the exit settle gives: the
+    // settle is conditional, and echoing one would claim a transition that did
+    // not happen. The outcome is still `ok` — the hook was understood.
+    return { outcome: "ok", event };
+  }
+  if (hasActiveSubagents(taskId)) {
+    ports.updateStatus(taskId, "running");
+    armDeferredFinish(taskId, (id) => finishQuietTask(id, ports));
+    return { outcome: "ok", event };
+  }
+  if (!ports.updateStatus(taskId, "finished")) return { outcome: "task-not-found", event };
+  noteTaskFinished(taskId);
+  return { outcome: "ok", event, status: "finished" };
 }
 
 /**

--- a/packages/shared/src/harness-hook-pipeline.ts
+++ b/packages/shared/src/harness-hook-pipeline.ts
@@ -218,12 +218,21 @@ export function handleHarnessHookEvent(
     // hook that changed nothing is indistinguishable, from the harness side,
     // from one that worked.
     //
-    // Two shapes reach here. A RESUME — the harness came back with a new
-    // session id and the stored one belongs to a process that is gone — where
-    // the settle is simply correct. And an OPENCODE CHILD, whose `session.idle`
-    // leaked past the plugin's own parent/child filter; there the parent may
-    // still be working, which is why the settle below is the conservative one
-    // rather than a plain fall-through into the status write.
+    // Two shapes reach here, and neither is a clean one.
+    //
+    // A RESUME whose capture event was LOST. A clean resume never gets this
+    // far: Claude Code fires `SessionStart`, the capture branch above adopts
+    // the new id and clears the dead process's subagents, and the `Stop` that
+    // follows matches. So this branch fires when that `SessionStart` dropped —
+    // and the settle is simply correct, because the stored id belongs to a
+    // process that is gone.
+    //
+    // An OPENCODE CHILD whose `session.idle` leaked past the plugin's own
+    // parent/child filter; there the parent may still be working. Nothing in
+    // this pipeline can see that work — opencode posts no subagent lifecycle
+    // events at all — so the only thing standing between a leaked child and a
+    // working parent's card is the status check in `settleForeignTurnEnd`.
+    // That is stated plainly there rather than dressed up as a guarantee.
     if (!isTurnEndEvent(event)) return { outcome: "foreign-session", event };
     return settleForeignTurnEnd(taskId, task, event, ports);
   }
@@ -410,22 +419,48 @@ export function hookResultResponse(result: HookPipelineResult): {
 
 /**
  * Settle a task on a turn end that arrived under a session id this task never
- * captured. Deliberately narrower than the matching-session path, in the two
- * places where a foreign turn end is weaker evidence than an owned one:
+ * captured.
  *
- *  - **Only a task still claiming active work is settled.** `running` and
- *    `needs-input` are the statuses that go on being wrong until something
- *    corrects them, and they are the same pair the PTY-exit settle acts on.
- *    Every other status is an answer already given, and a `Stop` from a
- *    session this task never captured is the weakest evidence there is for
- *    overwriting one. `ready` is excluded for the reason #387 spelled out:
- *    `CoreTaskWriter` appends `session:finished` on that transition, so a
- *    stray child's turn end would ding a Session still titled "Waiting for
- *    initial prompt…" — a Session that never ran a turn to end.
- *  - **The subagent hold still applies.** Work this pipeline can see in flight
- *    outranks a turn end from anywhere, so a foreign `Stop` over a live
- *    fan-out holds on `running` and arms the same drain backstop a matching
- *    one would, rather than dinging mid-work.
+ * **The tracked subagents are dropped on entry, and that is load-bearing.** A
+ * turn end under an unrecognised id means a new harness process — the same
+ * sentence the `setSessionId` wrapper writes when a capture event adopts a new
+ * id — so the old session's subagents died with it. Nothing else can clear
+ * them: their `SubagentStop` can never arrive, and the new session's own
+ * subagent events carry the new id, so they hit the foreign return above
+ * BEFORE the bookkeeping and are dropped. The only other route out is the two
+ * hour `ACTIVE_SUBAGENT_TTL_MS`, and holding on that stale set is how an
+ * earlier draft of this function reproduced issue 390 inside the fix for it: a
+ * fanned-out turn that resumed with a lost `SessionStart` sat on `running` for
+ * two hours with its `Stop` acked.
+ *
+ * `clearTaskFinished` goes with it by the `sessionProcessExited` precedent: no
+ * re-invocation can follow the process that stamped the old finish, so a
+ * laggard lifecycle POST from it must read as stale rather than heal the card.
+ * It drops a mark, it does not suppress one — when the settle below proceeds,
+ * `noteTaskFinished` stamps a fresh finish, so the one-second heal window
+ * behaves exactly as it does after any other hook-driven finish. The clear is
+ * what the paths that do NOT settle are left with.
+ *
+ * **There is no subagent hold here, deliberately.** It would be theatre. After
+ * the clear the set is empty by construction, and it could not have engaged in
+ * either shape that reaches this function anyway: a resumed session's subagent
+ * events are dropped as foreign before `noteSubagentStart` is ever reached, and
+ * opencode — the harness the child shape belongs to — posts no subagent
+ * lifecycle events at all, so `hasActiveSubagents` is structurally false for
+ * every opencode Session. The status check below is the only real guard, and
+ * saying so is worth more than a branch that can only fire on stale state.
+ *
+ * **Only `running` is settled.** Not `needs-input`: the pair the PTY-exit
+ * settle acts on looks like the right precedent and is not one, because there
+ * the process is DEAD and an open question is moot, while here it is alive and
+ * may be blocked on exactly that question. A leaked opencode child going idle
+ * would otherwise write `finished` over a parent waiting on a permission
+ * prompt — and the Panel clears the pending question on any transition off
+ * `needs-input`, so the overlay would go with it. `ready` is out for #387's
+ * reason: `CoreTaskWriter` appends `session:finished` on that transition, and a
+ * Session titled "Waiting for initial prompt…" has no turn to end. Every other
+ * status is an answer already given, and a turn end from a session this task
+ * never captured is the weakest evidence there is for overwriting one.
  *
  * The session id is NOT captured here. A `Stop` is not a capture event, and
  * adopting an OpenCode child's id would hand the rest of that child's
@@ -437,15 +472,12 @@ function settleForeignTurnEnd(
   event: string,
   ports: HookPipelinePorts,
 ): HookPipelineResult {
-  if (task.status !== "running" && task.status !== "needs-input") {
+  clearSubagentActivity(taskId);
+  clearTaskFinished(taskId);
+  if (task.status !== "running") {
     // No `status` on the result, for the reason the exit settle gives: the
     // settle is conditional, and echoing one would claim a transition that did
     // not happen. The outcome is still `ok` — the hook was understood.
-    return { outcome: "ok", event };
-  }
-  if (hasActiveSubagents(taskId)) {
-    ports.updateStatus(taskId, "running");
-    armDeferredFinish(taskId, (id) => finishQuietTask(id, ports));
     return { outcome: "ok", event };
   }
   if (!ports.updateStatus(taskId, "finished")) return { outcome: "task-not-found", event };


### PR DESCRIPTION
## Summary

A `Stop` is not a session-capture event, so `harness-hook-pipeline.ts`'s foreign-session guard returned **before** `updateStatus` for any turn end whose `session_id` was not the stored one — and it returned an *ack*: `{ ok: true, ignored: "foreign-session" }`. The card stayed on `running`, no `session:finished` fired, and the harness saw its hook accepted. Nothing else was coming either: the id is only re-captured by `UserPromptSubmit` / `SessionStart`, and a resumed harness that already submitted its prompt fires neither again.

The hook is addressed by **task id**, read out of the PTY's own environment, so the PTY that posted a turn end belongs to this task whatever the harness calls its session. `Stop` — and Cursor's `stop` / `afterAgentResponse` — now settle instead of being dropped.

Two shapes reach that branch, and neither is a clean one:

- **A resume whose capture event was lost.** A clean resume never gets there — `SessionStart` is a capture event, so it adopts the new id, clears the dead process's subagents, and the following `Stop` matches. This branch fires when that POST dropped, and the stored id belongs to a process that is gone.
- **An OpenCode child** whose `session.idle` leaked past the plugin's own `parentID` filter. There the parent may still be working.

### What `settleForeignTurnEnd` does

- **Drops the tracked subagents on entry, with the recent-finish mark.** A turn end under an unrecognised id means a new harness process, so the old session's subagents died with it — the same sentence the `setSessionId` wrapper already writes. Nothing else can clear them: their `SubagentStop` died with the process, and the resumed session's own subagent events carry the new id, so they hit the foreign return *before* the bookkeeping. `clearTaskFinished` goes with it by the `sessionProcessExited` precedent; it drops a mark rather than suppressing one, since `noteTaskFinished` re-stamps when the settle proceeds.
- **Has no subagent hold, deliberately.** After the clear the set is empty by construction, and the hold could not have engaged in either shape anyway: a resumed session's subagent events are dropped as foreign before they are ever counted, and opencode posts *no* subagent lifecycle events at all, so `hasActiveSubagents` is structurally false for every opencode Session. **The status check is the only real guard.** A leaked child *can* finish a working parent's `running` card; that residual is stated in the code, the docs and §Residual risk below rather than papered over.
- **Settles `running` only.** Not `needs-input`: the PTY-exit settle acts on both, and that is not a precedent that transfers — there the process is dead, so an open question is moot, while here it is alive and may be blocked on exactly that question. A leaked child going idle would otherwise write `finished` over a parent waiting on a permission prompt, taking the Panel's pending-question overlay with it. `ready` is out for #387's reason: `CoreTaskWriter` appends `session:finished` on that transition, and a Session titled "Waiting for initial prompt…" has no turn to end.
- **Does not capture the session id.** A `Stop` is not a capture event; adopting an OpenCode child's id would hand the rest of that child's lifecycle the Session's card.

Everything else the guard rejects still is: a foreign question, subagent count, permission prompt or interrupt claims the task for a session it does not own, and the capture events go on adopting a new id exactly as before. The A-heal race window and the `ready` sweep landed by #385 and #387 are built on, not rewritten — `subagent-activity.ts` is not touched at all.

## Review round 1 — what changed

Review at `9e392ea` requested changes; `f73d107` addresses all four findings. See [the reply comment](https://github.com/actana/control/pull/453#issuecomment-5515445937) for the point-by-point.

1. **BLOCKING — stale subagents wedged the settle for ~2h.** Fixed by `clearSubagentActivity` + `clearTaskFinished` on entry. Pinned by three new tests plus a Core-side one.
2. **The hold could not engage in either named scenario.** Dropped, and said plainly in the code comment, the docs bullet and this body. The test that posted subagent events under the *matching* id is replaced by one posting them under the **foreign** id, showing them dropped and the settle proceeding.
3. **`needs-input` settled over a live process.** Restricted to `running` only, with the reasoning recorded.
4. **Nit — the "posts are queued" doc bullet.** Reworded; it no longer justifies itself with a `Stop` that overtakes `SessionStart` being discarded, and names the orderings that still break.

## Related issues

Refs #390

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing behavior to change)
- [ ] ♻️ Refactor (no functional change)
- [x] 📚 Documentation
- [ ] 🔧 Build / CI / tooling

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/E2E tests added/updated
- [ ] Manually verified (describe steps below)

`packages/shared/src/__tests__/harness-hook-pipeline.test.ts` — `a turn end from a session this task never captured (issue 390)`:

- finishes a running task on a `Stop` whose `session_id` does not match, and answers with the status rather than the `ignored: "foreign-session"` ack;
- **settles a fanned-out turn whose resume lost its `SessionStart`** — the ~2h wedge from finding 1;
- **drops the tracked subagents on entry, so the next turn's owned `Stop` is not held**;
- **does not hold on subagents posted under the foreign id either** — they return `foreign-session`, and the settle proceeds;
- **leaves a task parked on `needs-input` waiting** (finding 3), with the exact result object and write sequence;
- settles Cursor's `stop` / `afterAgentResponse` on the same terms;
- does not adopt the foreign session id;
- leaves an already-settled task and a `ready` Session exactly as they were;
- every other foreign event is still dropped as `foreign-session`.

Plus a `matching-session Stop behaviour is unchanged` block pinning the owned path end to end (finish, the no-captured-id case, the subagent downgrade, and the unconditional finish over a settled task).

`packages/core/src/__tests__/harness-status-detection.test.ts` — on the Core: a `Stop` under a post-resume id finishes the row **and** appends `session:finished`; the same with a live fan-out tracked (finding 1); and a Session on `needs-input` is left waiting with no ding (finding 3).

`packages/panel/src/server/__tests__/opencode-hooks-api.test.ts` — over HTTP: a foreign claiming event (`PermissionRequest`) is still dropped; a foreign `Stop` answers `{ ok: true, status: "finished" }` with the stored id untouched; and a leaked child's `Stop` over a `needs-input` parent answers `{ ok: true, event: "Stop" }` and changes nothing.

Local runs, all green: `pnpm lint` (0 errors), `pnpm typecheck`, `pnpm test` — all 6 stages, 331 test files. Shared 27, core 19, panel hook suites 53.

## Residual risk

A leaked OpenCode child's `session.idle` with no matching parent activity will finish a parent that is still working on `running`. Nothing in this pipeline can see that work — opencode posts no subagent lifecycle events — so the status check is the only guard, and this is the trade the issue itself frames ("or nack visibly; ack-and-ignore is the operator-visible miss"). Three things bound it: the plugin filters children at the source by `parentID`, so a leak needs a child created before the plugin loaded; a parent blocked on a permission prompt is now excluded outright; and the parent's next `session.status: busy` puts the card back on `running`.

## Checklist

- [x] This PR targets the **open train** (`beta/x.y.z`), not `main` — stacked on `fix/operator-pins-sessions-drop-cli`, which targets the train
- [x] My PR title **and every commit in the branch** follow [Conventional Commits](https://www.conventionalcommits.org/), and my branch name follows the [branching convention](../CONTRIBUTING.md#branch-naming) — `commitlint --from origin/fix/operator-pins-sessions-drop-cli --to HEAD` run locally over both commits: 0 problems
- [x] I performed a self-review of my own code
- [x] I commented hard-to-understand areas / added docs where needed
- [x] I added tests proving my fix/feature works, and all tests pass locally
- [x] I updated documentation (README, docs/, changelog entry) where relevant — `docs/harness-status-detection.md`: the session-id guard section and the OpenCode bullets
- [x] No secrets, credentials, or personal data are included in this change
- [x] Dependent changes have been merged (or this PR is marked as draft/stacked) — draft, stacked on `fix/operator-pins-sessions-drop-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFY4g9AwbTLVX94heQZKp5
