### PR TITLE
fix(core): idle TUI redraws must not starve the session backstop

### DIFF
--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -157,21 +157,32 @@ spinner and a clock for as long as the process lives. Counted as activity,
 those bytes mean fifteen minutes of total silence never arrives and the card
 claims `running` indefinitely.
 
-So the bytes are read rather than counted. `pty-output-activity.ts` reduces
-each five-second burst of PTY output to the words on screen — escapes, control
-bytes, spinner glyphs and **digits** dropped, whitespace collapsed — and calls
-the burst
+So the bytes are read rather than counted. `pty-output-activity.ts` takes each
+five-second burst of PTY output and asks three questions in order:
 
-- **`output`** when it carries a word the last two bursts (about ten seconds of
-  screen) do not already contain: a tool result, a diff, a line of prose;
-- **`redraw`** when every word in it was already on screen a moment ago: the
-  same frame with the counter moved on.
+1. **Did the burst erase anything?** A repaint is defined by what it destroys —
+   a carriage return, an erase, a cursor jump. A burst that only appends
+   scrolled the screen, so it is `output` by construction. This is what keeps
+   appended progress (pytest's dots, a log line) from reading as a spinner. The
+   exception is a burst with no controls that follows one that repainted: that
+   is the tail of a frame, not a new line.
+2. **Do the digits belong to a clock?** Digits are dropped only from a *line*
+   that carries a spinner glyph or an elapsed-time pattern (`1m 12s`, `0:42`),
+   and kept everywhere else — so `Downloading 41.2 MB / 900 MB`, `Compiled 41
+   files` and `Tests 41 passed` stay the changing content they are.
+3. **Is any word new?** What survives — escapes, control bytes and spinner
+   glyphs dropped, whitespace collapsed — is the frame's words. The burst is
+   `output` when it carries a word the last two bursts (about ten seconds of
+   screen) do not already contain, and `redraw` when every word in it was
+   already on screen a moment ago. The scan runs from the *end* of the burst,
+   where a TUI puts what is new, and a number is matched whole (`40` is a
+   substring of `(400)`) while a word is matched loosely, so a burst boundary
+   inside `Think`/`ing` is not read as two new words a second.
 
-A word shorter than three characters is ignored, because a burst boundary can
-fall inside a word and `Think` + `ing` must not read as two new words a second.
 The memory is two bursts and not the whole turn on purpose: a harness that
-reads the same file twice is working, not repainting. Hooks are always
-`output` — nothing a harness bothers to POST is a repaint.
+reads the same file twice is working, not repainting. A hook is its own kind of
+activity and always counts as progress — nothing a harness bothers to POST is a
+repaint.
 
 The backstop therefore has two rules, and a `running` Session settles on
 whichever fires first:
@@ -179,24 +190,54 @@ whichever fires first:
 | Rule | Fires when | Window |
 | --- | --- | --- |
 | Quiet | nothing at all — no hook, no byte of any kind | 15 minutes |
-| Idle | bytes still arriving (heard within the last 2 minutes), but nothing new on screen and no hook | 5 minutes |
+| Idle | bytes still arriving (heard within the last 2 minutes), nothing new on screen, no hook, **and** nothing printed since the last hook | 8 minutes, confirmed by 2 consecutive sweeps |
 
 The idle rule is the finish-class backstop the quiet rule cannot be: it does not
-wait for the redraws to stop, because they never do. It applies only to a
-Session this Core has actually heard bytes from — a row it has only ever read
-from the database is judged by the quiet rule alone, since a Core that heard no
-bytes cannot know whether the ones it missed were redraws. Which settles it is
-in `session-backstop.settled`'s `rule` field.
+wait for the redraws to stop, because they never do. Three things narrow it, and
+each is there for a failure that was found rather than imagined:
 
-The trade is knowingly paid, and it is the same one the fifteen-minute window
-already made: a turn that puts nothing new on screen for five minutes, on a
-harness whose hooks are also not arriving, gets a card that reads `finished`
-while it is still going — as does output that changes only in its digits
-(`Compiled 41 files`, `Compiled 42 files`), which is indistinguishable from a
-counter. Nothing is killed, no process is touched, and the next hook, the next
-new thing on screen, or the next `UserPromptSubmit` puts the row back on
-`running`. Before any of this, a lost `Stop` wedged the Session until a human
-edited the row by hand — while the Panel said the opposite.
+- **It applies only to a Session this Core has heard bytes from.** A row it has
+  only ever read from the database is judged by the quiet rule alone, since a
+  Core that heard no bytes cannot know whether the ones it missed were redraws.
+- **It defers to hooks.** If a Session has printed anything real since its last
+  hook, it is mid-turn and the rule stands down: a single `Bash` call emits no
+  hook until it completes (Claude Code installs `PreToolUse` with an
+  `AskUserQuestion` matcher), so a six-minute build has nothing but its TUI to
+  say so. The rule is for the harness that cannot report itself at all — Codex
+  before `/hooks` has been reviewed.
+- **It asks twice.** The condition must hold across two consecutive sweeps, one
+  minute apart, before a row moves.
+
+Which rule settled a row is in `session-backstop.settled`'s `rule` field.
+
+### The idle rule takes its own finish back
+
+A `finished` written by the **idle rule** is marked, and the next `output`-class
+burst or hook on that Session inside half an hour returns the row to `running`
+(`session-backstop.reopened`). Nothing else is marked: an operator's finish, a
+hook's finish and the quiet rule's finish are never reopened by stray bytes, and
+a row anyone else has moved since is left exactly as they left it.
+
+This exists because the obvious recovery does not: `harness-hook-events.ts` maps
+only `UserPromptSubmit`, `CursorBeforeSubmitPrompt` and `PermissionReplied` to
+`running` — `PostToolUse`, `SubagentStart` and `SubagentStop` map to nothing —
+and the PTY output path writes no status at all. Without the marker, a row
+settled early stays `finished` until the operator's next prompt.
+
+What a wrong idle settle still costs, stated rather than argued away: it emits
+`session:finished` (the operator's completion toast, and the signal `actana
+session wait` unblocks on) and clears the tracked subagent set. The reopen puts
+the status back; it cannot un-send a notification or restore that set, which
+expires on its own after two hours.
+
+The classifier's own limits, which bound how often that can happen: a turn whose
+tool prints nothing at all is indistinguishable from one that ended; a progress
+line that is both spinner-prefixed and nothing but numbers has its digits
+dropped as a clock; and the rule depends on the spinner phrase being static — a
+harness whose spinner rotates its gerund (`✻ Herding… / Simmering… /
+Pondering…`) puts a new word on screen every rotation, so the idle rule never
+fires for it at all. Before any of this, a lost `Stop` wedged the Session until
+a human edited the row by hand — while the Panel said the opposite.
 
 `Notification` is also intentionally narrowed to `permission_prompt`. Claude Code
 sends idle input reminders through the same hook event, so treating all

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -235,19 +235,30 @@ burst returns the row to `running` inside half an hour
 (`session-backstop.reopened`). Three things end that claim, and each of them
 ends it for good:
 
-- **Any hook.** A hook hands the row to the pipeline, which decides the status
-  from the event — a `Stop` writes the authoritative `finished`, a
-  `UserPromptSubmit` writes `running`. So no hook of any kind reopens anything,
-  and a post-turn `SubagentStart`, `SubagentStop` or unmatched `PostToolUse`
-  cannot heal a finished card, which is the bug #385 closed.
 - **Anyone else writing the row.** The settle records the row's `updatedAt` and
   the reopen requires it unchanged. Asking only whether the row still says
   `finished` is not enough: a real `Stop` writes `finished` over a `finished`,
   and the post-turn composer paint that follows would otherwise reopen it.
+  This is also the only thing that reads a hook — a hook the pipeline wrote a
+  status for moved the row; `SubagentStart`, `SubagentStop` and an unmatched
+  `PostToolUse` write nothing, decide nothing, and leave the recovery armed,
+  which matters because `PostToolUse` is installed unmatched and fires on every
+  ordinary tool call.
 - **The PTY exiting**, and the half-hour grace expiring.
 
-An operator's finish and the quiet rule's finish are never marked in the first
-place.
+No hook of any kind *reopens* a row: only an `output`-class burst does, so a
+post-turn helper cannot heal a finished card, which is the bug #385 closed. An
+operator's finish and the quiet rule's finish are never marked in the first
+place. The marker is spent only once the reopening write has landed, so a
+failed write leaves the next burst able to try again.
+
+An idle-rule finish is reopened by **anything new on that screen**, and the
+classifier cannot tell the harness's own output from the echo of an operator
+typing into the composer — so a correct finish can be taken back by somebody
+starting to type and not pressing Enter. Pressing Enter makes it right again (a
+`UserPromptSubmit` is a real new turn); the exposed window is "typed but not
+submitted", and it is tracked as
+[#475](https://github.com/actana/control/issues/475).
 
 This exists because the obvious recovery does not: `harness-hook-events.ts` maps
 only `UserPromptSubmit`, `CursorBeforeSubmitPrompt` and `PermissionReplied` to

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -22,6 +22,7 @@ about everything else on a Core — as an Event replayed off its cursor.
 | PTY exit settle | `packages/core/src/pty-manager.ts` → `onSessionExit` |
 | Hook delivery misses | `packages/core/src/harness-hook-delivery.ts` |
 | Quiet-Session backstop | `packages/core/src/core-session-backstop.ts` |
+| Redraw vs. real output | `packages/core/src/pty-output-activity.ts` |
 | Boot sweep | `packages/core/src/core-session-sweep.ts` |
 | Relaunch reset | `packages/core/src/core-session-relaunch.ts` |
 
@@ -130,9 +131,10 @@ fourth is armed by nothing, which is the point (issue 243):
   background work), and when the PTY process exits.
 - **The quiet-Session backstop** (`core-session-backstop.ts`) sweeps the
   database once a minute and settles any row still claiming `running` that has
-  gone quiet. Nothing arms it, so it covers the case the three above cannot: a
-  turn whose terminal `Stop` was the POST that dropped, where nothing was held,
-  nothing was healed and no subagent was ever tracked.
+  gone quiet — or that is still painting a TUI with nothing new on it. Nothing
+  arms it, so it covers the case the three above cannot: a turn whose terminal
+  `Stop` was the POST that dropped, where nothing was held, nothing was healed
+  and no subagent was ever tracked.
 
 Elapsed time is not what "quiet" means, and it could not be — a turn may run for
 hours. A working harness never stops talking: every tool call fires the
@@ -145,11 +147,56 @@ being told. A live PTY makes that settle a `finished`; no live PTY makes it a
 `disconnected`, because a process that went away did not finish. `needs-input`
 is never swept — a Session waiting on a human may wait silently forever.
 
-The trade is knowingly paid: a harness that works in total silence for longer
-than the window gets a card that reads `finished` while it is still going.
-Nothing is killed, and the next `UserPromptSubmit` puts the row back on
-`running`. Before it, a lost `Stop` wedged the Session until a human edited the
-row by hand — while the Panel said the opposite.
+### Idle redraws are not activity (issue 391)
+
+That rule has a hole in it, and it is the case an operator hits most: the
+harness whose hooks are not arriving is usually the harness whose TUI is still
+on screen. Codex before its hooks have been reviewed with `/hooks`, or any
+harness whose terminal `Stop` was the POST that dropped, keeps painting a
+spinner and a clock for as long as the process lives. Counted as activity,
+those bytes mean fifteen minutes of total silence never arrives and the card
+claims `running` indefinitely.
+
+So the bytes are read rather than counted. `pty-output-activity.ts` reduces
+each five-second burst of PTY output to the words on screen — escapes, control
+bytes, spinner glyphs and **digits** dropped, whitespace collapsed — and calls
+the burst
+
+- **`output`** when it carries a word the last two bursts (about ten seconds of
+  screen) do not already contain: a tool result, a diff, a line of prose;
+- **`redraw`** when every word in it was already on screen a moment ago: the
+  same frame with the counter moved on.
+
+A word shorter than three characters is ignored, because a burst boundary can
+fall inside a word and `Think` + `ing` must not read as two new words a second.
+The memory is two bursts and not the whole turn on purpose: a harness that
+reads the same file twice is working, not repainting. Hooks are always
+`output` — nothing a harness bothers to POST is a repaint.
+
+The backstop therefore has two rules, and a `running` Session settles on
+whichever fires first:
+
+| Rule | Fires when | Window |
+| --- | --- | --- |
+| Quiet | nothing at all — no hook, no byte of any kind | 15 minutes |
+| Idle | bytes still arriving (heard within the last 2 minutes), but nothing new on screen and no hook | 5 minutes |
+
+The idle rule is the finish-class backstop the quiet rule cannot be: it does not
+wait for the redraws to stop, because they never do. It applies only to a
+Session this Core has actually heard bytes from — a row it has only ever read
+from the database is judged by the quiet rule alone, since a Core that heard no
+bytes cannot know whether the ones it missed were redraws. Which settles it is
+in `session-backstop.settled`'s `rule` field.
+
+The trade is knowingly paid, and it is the same one the fifteen-minute window
+already made: a turn that puts nothing new on screen for five minutes, on a
+harness whose hooks are also not arriving, gets a card that reads `finished`
+while it is still going — as does output that changes only in its digits
+(`Compiled 41 files`, `Compiled 42 files`), which is indistinguishable from a
+counter. Nothing is killed, no process is touched, and the next hook, the next
+new thing on screen, or the next `UserPromptSubmit` puts the row back on
+`running`. Before any of this, a lost `Stop` wedged the Session until a human
+edited the row by hand — while the Panel said the opposite.
 
 `Notification` is also intentionally narrowed to `permission_prompt`. Claude Code
 sends idle input reminders through the same hook event, so treating all

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -167,17 +167,25 @@ five-second burst of PTY output and asks three questions in order:
    exception is a burst with no controls that follows one that repainted: that
    is the tail of a frame, not a new line.
 2. **Do the digits belong to a clock?** Digits are dropped only from a *line*
-   that carries a spinner glyph or an elapsed-time pattern (`1m 12s`, `0:42`),
-   and kept everywhere else — so `Downloading 41.2 MB / 900 MB`, `Compiled 41
-   files` and `Tests 41 passed` stay the changing content they are.
+   that carries a spinner glyph or a duration (`1m 12s`, `2h`), and kept
+   everywhere else — so `Downloading 41.2 MB / 900 MB`, `Compiled 41 files`,
+   `[12:34:07] Compiled 43 files` and `✔ 43 passed` stay the changing content
+   they are. Both halves are deliberately narrow: the glyph set is the braille,
+   sparkle and circle frames a spinner cycles (not ✔ ✗ ❯, which are status
+   marks), and a duration needs its unit letter (`\d+:\d{2}` alone is the
+   wall-clock stamp a build prints in front of every line).
 3. **Is any word new?** What survives — escapes, control bytes and spinner
    glyphs dropped, whitespace collapsed — is the frame's words. The burst is
    `output` when it carries a word the last two bursts (about ten seconds of
    screen) do not already contain, and `redraw` when every word in it was
    already on screen a moment ago. The scan runs from the *end* of the burst,
-   where a TUI puts what is new, and a number is matched whole (`40` is a
-   substring of `(400)`) while a word is matched loosely, so a burst boundary
-   inside `Think`/`ing` is not read as two new words a second.
+   where a TUI puts what is new, and as deep as the memory it is compared
+   against — deep enough to find a line painted above a static footer, and no
+   deeper, since the part that cannot be remembered would otherwise read as
+   new. A number is matched whole (`40` is a substring of `(400)`) while a word
+   is matched loosely, so a burst boundary inside `Think`/`ing` is not read as
+   two new words a second. A burst that erases the display and puts nothing in
+   its place empties the memory: the screen is blank, so the next line is new.
 
 The memory is two bursts and not the whole turn on purpose: a harness that
 reads the same file twice is working, not repainting. A hook is its own kind of
@@ -199,12 +207,19 @@ each is there for a failure that was found rather than imagined:
 - **It applies only to a Session this Core has heard bytes from.** A row it has
   only ever read from the database is judged by the quiet rule alone, since a
   Core that heard no bytes cannot know whether the ones it missed were redraws.
-- **It defers to hooks.** If a Session has printed anything real since its last
-  hook, it is mid-turn and the rule stands down: a single `Bash` call emits no
-  hook until it completes (Claude Code installs `PreToolUse` with an
-  `AskUserQuestion` matcher), so a six-minute build has nothing but its TUI to
-  say so. The rule is for the harness that cannot report itself at all — Codex
-  before `/hooks` has been reviewed.
+- **It defers to hooks, for fifteen minutes.** If a Session has printed
+  anything real since its last hook, it is mid-turn and the rule stands down: a
+  single `Bash` call emits no hook until it completes (Claude Code installs
+  `PreToolUse` with an `AskUserQuestion` matcher), so a six-minute build has
+  nothing but its TUI to say so. The deference is **bounded**, because
+  deferring forever would mean a dropped `Stop` on a harness whose hooks work
+  is never settled at all — the other half of #391. Past the bound the screen
+  is the only evidence left and the rule reads it, so:
+
+  | harness | settles after its last new output |
+  | --- | --- |
+  | never sent a hook (Codex before `/hooks`) | ~9–10 minutes |
+  | hooks arrive, `Stop` dropped | ~16–17 minutes |
 - **It asks twice.** The condition must hold across two consecutive sweeps, one
   minute apart, before a row moves.
 
@@ -213,10 +228,18 @@ Which rule settled a row is in `session-backstop.settled`'s `rule` field.
 ### The idle rule takes its own finish back
 
 A `finished` written by the **idle rule** is marked, and the next `output`-class
-burst or hook on that Session inside half an hour returns the row to `running`
-(`session-backstop.reopened`). Nothing else is marked: an operator's finish, a
-hook's finish and the quiet rule's finish are never reopened by stray bytes, and
-a row anyone else has moved since is left exactly as they left it.
+burst — or a hook the event map reads as `running` — returns the row to
+`running` inside half an hour (`session-backstop.reopened`). Nothing else is
+marked: an operator's finish, a hook's finish and the quiet rule's finish are
+never reopened by stray bytes, and a row anyone else has moved since is left
+exactly as they left it.
+
+Which hooks may reopen is the same seam the pipeline uses, and for the same
+reason: `mapHookEventToStatus` returning `running` (`UserPromptSubmit`,
+`beforeSubmitPrompt`, `PermissionReplied`, an `AskUserQuestion` `PostToolUse`).
+`SubagentStart`, `SubagentStop` and an unmatched `PostToolUse` map to nothing
+precisely so a post-turn helper cannot heal a finished card, and this path does
+not undo that.
 
 This exists because the obvious recovery does not: `harness-hook-events.ts` maps
 only `UserPromptSubmit`, `CursorBeforeSubmitPrompt` and `PermissionReplied` to

--- a/docs/harness-status-detection.md
+++ b/docs/harness-status-detection.md
@@ -166,14 +166,17 @@ five-second burst of PTY output and asks three questions in order:
    appended progress (pytest's dots, a log line) from reading as a spinner. The
    exception is a burst with no controls that follows one that repainted: that
    is the tail of a frame, not a new line.
-2. **Do the digits belong to a clock?** Digits are dropped only from a *line*
-   that carries a spinner glyph or a duration (`1m 12s`, `2h`), and kept
-   everywhere else — so `Downloading 41.2 MB / 900 MB`, `Compiled 41 files`,
-   `[12:34:07] Compiled 43 files` and `✔ 43 passed` stay the changing content
-   they are. Both halves are deliberately narrow: the glyph set is the braille,
-   sparkle and circle frames a spinner cycles (not ✔ ✗ ❯, which are status
-   marks), and a duration needs its unit letter (`\d+:\d{2}` alone is the
-   wall-clock stamp a build prints in front of every line).
+2. **Do the digits belong to a clock?** Every digit is dropped from a line a
+   *spinner* is drawing, because the whole line is a frame — clock, token
+   count, context percentage. On every other line only the **duration token**
+   itself is dropped (`12.3s`, `1m 12s`), never the rest of the line's digits:
+   `Compiled 41 files in 3.2s`, `✔ 43 passed in 12.3s` and
+   `[1,234 / 5,678] Compiling …; 45s` are what a build actually prints, and
+   their counts are their only changing content. Both halves are deliberately
+   narrow: the glyph set is the braille, sparkle and circle frames a spinner
+   cycles (not ✔ ✗ ❯, which are status marks), and a duration needs its unit
+   letter (`\d+:\d{2}` alone is the wall-clock stamp a build prints in front of
+   every line).
 3. **Is any word new?** What survives — escapes, control bytes and spinner
    glyphs dropped, whitespace collapsed — is the frame's words. The burst is
    `output` when it carries a word the last two bursts (about ten seconds of
@@ -198,7 +201,7 @@ whichever fires first:
 | Rule | Fires when | Window |
 | --- | --- | --- |
 | Quiet | nothing at all — no hook, no byte of any kind | 15 minutes |
-| Idle | bytes still arriving (heard within the last 2 minutes), nothing new on screen, no hook, **and** nothing printed since the last hook | 8 minutes, confirmed by 2 consecutive sweeps |
+| Idle | bytes still arriving (heard within the last 2 minutes), nothing new on screen, no hook, **and** nothing printed since the last hook *within the 15-minute deference bound below* | 8 minutes, confirmed by 2 consecutive sweeps |
 
 The idle rule is the finish-class backstop the quiet rule cannot be: it does not
 wait for the redraws to stop, because they never do. Three things narrow it, and
@@ -228,18 +231,23 @@ Which rule settled a row is in `session-backstop.settled`'s `rule` field.
 ### The idle rule takes its own finish back
 
 A `finished` written by the **idle rule** is marked, and the next `output`-class
-burst — or a hook the event map reads as `running` — returns the row to
-`running` inside half an hour (`session-backstop.reopened`). Nothing else is
-marked: an operator's finish, a hook's finish and the quiet rule's finish are
-never reopened by stray bytes, and a row anyone else has moved since is left
-exactly as they left it.
+burst returns the row to `running` inside half an hour
+(`session-backstop.reopened`). Three things end that claim, and each of them
+ends it for good:
 
-Which hooks may reopen is the same seam the pipeline uses, and for the same
-reason: `mapHookEventToStatus` returning `running` (`UserPromptSubmit`,
-`beforeSubmitPrompt`, `PermissionReplied`, an `AskUserQuestion` `PostToolUse`).
-`SubagentStart`, `SubagentStop` and an unmatched `PostToolUse` map to nothing
-precisely so a post-turn helper cannot heal a finished card, and this path does
-not undo that.
+- **Any hook.** A hook hands the row to the pipeline, which decides the status
+  from the event — a `Stop` writes the authoritative `finished`, a
+  `UserPromptSubmit` writes `running`. So no hook of any kind reopens anything,
+  and a post-turn `SubagentStart`, `SubagentStop` or unmatched `PostToolUse`
+  cannot heal a finished card, which is the bug #385 closed.
+- **Anyone else writing the row.** The settle records the row's `updatedAt` and
+  the reopen requires it unchanged. Asking only whether the row still says
+  `finished` is not enough: a real `Stop` writes `finished` over a `finished`,
+  and the post-turn composer paint that follows would otherwise reopen it.
+- **The PTY exiting**, and the half-hour grace expiring.
+
+An operator's finish and the quiet rule's finish are never marked in the first
+place.
 
 This exists because the obvious recovery does not: `harness-hook-events.ts` maps
 only `UserPromptSubmit`, `CursorBeforeSubmitPrompt` and `PermissionReplied` to
@@ -252,6 +260,17 @@ What a wrong idle settle still costs, stated rather than argued away: it emits
 session wait` unblocks on) and clears the tracked subagent set. The reopen puts
 the status back; it cannot un-send a notification or restore that set, which
 expires on its own after two hours.
+
+**A harness parked on a dialog nobody matched is settled too.** Only
+`hasClaudeInterruptPrompt` and `hasCodexHookReviewPrompt` turn a screen into
+`needs-input`; any other permission or approval box repaints statically, which
+is the idle condition exactly, so the Session is settled `finished` at ~9–10
+minutes while it waits for a human — and `needs-input` being out of the sweep's
+scope does not help, because the row never reached `needs-input`. The reopen
+cannot help either until somebody answers. This is the same harness class the
+rule targets (the one whose hooks are not arriving is the one whose
+`needs-input` hook is also not arriving), and it is tracked as
+[#469](https://github.com/actana/control/issues/469) rather than fixed here.
 
 The classifier's own limits, which bound how often that can happen: a turn whose
 tool prints nothing at all is indistinguishable from one that ended; a progress

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -24,6 +24,7 @@ import {
 import { CoreTaskWriter } from "../core-task-writer";
 import { CoreSessionBackstop } from "../core-session-backstop";
 import { PtyOutputActivityWatcher } from "../pty-output-activity";
+import { mapHookEventToStatus } from "@actana/shared/harness-hook-events";
 import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 
 // The backstop nobody has to arm (issue 243 part 2), against this Core's real
@@ -373,14 +374,33 @@ describe("settling a turn whose end nobody reported", () => {
       expect(statusOf("t-1")).toBe("running");
     });
 
-    it("returns the row to running for a hook, too", () => {
+    it("returns the row to running for a hook that means the turn is running", () => {
       insert("t-1", "running");
       const backstop = makeBackstop();
       settleByIdleRule(backstop);
 
+      // `UserPromptSubmit`, `PermissionReplied`, an `AskUserQuestion`
+      // `PostToolUse` — the events `mapHookEventToStatus` reads as `running`.
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "turn");
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("is not reopened by a post-turn helper's hook", () => {
+      // Review of PR 455, round 2, finding 2. `SubagentStart`, `SubagentStop`
+      // and an unmatched `PostToolUse` map to no status precisely so a
+      // post-turn helper cannot heal a finished card (#385, `5d33f0c`). They
+      // reach this as `hook`: activity, never a reopen.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      nowMs += 5 * MINUTE;
+      backstop.noteActivity("t-1", "hook");
+      expect(statusOf("t-1")).toBe("finished");
       nowMs += MINUTE;
       backstop.noteActivity("t-1", "hook");
-      expect(statusOf("t-1")).toBe("running");
+      expect(statusOf("t-1")).toBe("finished");
     });
 
     it("is not reopened by more of the same repainting", () => {
@@ -445,29 +465,67 @@ describe("settling a turn whose end nobody reported", () => {
   // ─── Review of PR 455, finding 2: a harness whose hooks work is not judged
   // on its pixels ───
   describe("deferring to a harness that can report itself", () => {
-    it("never settles a long tool call on a hooked harness", () => {
+    /** Paint a spinner frame every second for `ms`, reporting each as a redraw. */
+    const paintFor = (backstop: CoreSessionBackstop, ms: number) => {
+      for (let elapsed = 0; elapsed < ms; elapsed += FRAME_MS) {
+        nowMs += FRAME_MS;
+        backstop.noteActivity("t-1", "redraw");
+      }
+    };
+
+    it("never settles a tool call inside the deference bound", () => {
       // Claude Code installs `PreToolUse` with an `AskUserQuestion` matcher, so
-      // a single `Bash` call emits no hook at all until it completes. Half an
-      // hour of `pnpm build` behind a spinner, on a harness whose hooks are
-      // working perfectly, must not be called over.
+      // a single `Bash` call emits no hook at all until it completes. Ten
+      // minutes of `pnpm build` behind a spinner, on a harness whose hooks are
+      // working, must not be called over — and the eight-minute window would
+      // otherwise reach it at nine.
       insert("t-1", "running");
       const backstop = makeBackstop();
 
       backstop.noteActivity("t-1", "hook");
       nowMs += MINUTE;
       backstop.noteActivity("t-1", "output");
-      for (let minute = 0; minute < 30; minute += 1) {
-        for (let second = 0; second < 60; second += 1) {
-          nowMs += FRAME_MS;
-          backstop.noteActivity("t-1", "redraw");
-        }
+      for (let minute = 0; minute < 13; minute += 1) {
+        paintFor(backstop, MINUTE);
         expect(backstop.sweepOnce()).toEqual([]);
       }
       expect(statusOf("t-1")).toBe("running");
 
-      // And the tool finally completes: `PostToolUse` lands, the count of
-      // output since the last hook resets, and nothing has been lost.
+      // And the tool completes: `PostToolUse` lands, the count of output since
+      // the last hook resets, and the deference starts again from here.
       backstop.noteActivity("t-1", "hook");
+      paintFor(backstop, 5 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("settles a dropped Stop on a hooked harness, on the longer clock", () => {
+      // Review of PR 455, round 2, finding 1: the deference used to last
+      // forever, so the second failure #391 names — "a dropped Stop POST" —
+      // was never settled at all. Four hours of spinner read `running`.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+
+      backstop.noteActivity("t-1", "hook");
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "output");
+
+      // The turn ends. Its `Stop` drops. The TUI paints on.
+      paintFor(backstop, 13 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
+
+      // Past the quarter-hour the deference is bounded at, the screen is the
+      // only evidence left and the rule reads it — two sweeps, as ever.
+      paintFor(backstop, 3 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      paintFor(backstop, MINUTE);
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
+
+      // And a tool call that really was running for seventeen minutes takes
+      // its finish back the moment it prints.
+      backstop.noteActivity("t-1", "output");
       expect(statusOf("t-1")).toBe("running");
     });
 
@@ -486,6 +544,26 @@ describe("settling a turn whose end nobody reported", () => {
       nowMs += MINUTE;
       expect(backstop.sweepOnce()).toEqual(["t-1"]);
       expect(statusOf("t-1")).toBe("finished");
+    });
+  });
+
+  // The seam `core-entry.ts` keys the activity kind on. It lives in
+  // `harness-hook-events.ts`, which this PR does not touch — so what is pinned
+  // here is the contract the wiring depends on: which events may take a
+  // backstop finish back, and which must never.
+  describe("which hooks are allowed to take a finish back", () => {
+    it("maps a turn's own events to running, and helpers' to nothing", () => {
+      for (const hook_event_name of ["UserPromptSubmit", "beforeSubmitPrompt", "PermissionReplied"]) {
+        expect(mapHookEventToStatus({ hook_event_name })).toBe("running");
+      }
+      for (const hook_event_name of ["SubagentStart", "SubagentStop", "PostToolUse"]) {
+        expect(mapHookEventToStatus({ hook_event_name })).not.toBe("running");
+      }
+      // The one `PostToolUse` that does mean the turn resumed: the operator
+      // answered the question it asked.
+      expect(
+        mapHookEventToStatus({ hook_event_name: "PostToolUse", tool_name: "AskUserQuestion" }),
+      ).toBe("running");
     });
   });
 
@@ -525,9 +603,10 @@ describe("settling a turn whose end nobody reported", () => {
       const watcher = new PtyOutputActivityWatcher();
 
       // Half an hour of a live turn: a spinner every second, and a tool line
-      // nobody has seen before every twenty. Words, not numbers — a line that
-      // differs from the last one only in its digits is a counter, and this
-      // reads counters as the repaints they are (see `pty-output-activity.ts`).
+      // nobody has seen before every twenty. Words, not numbers — not because
+      // a number would fail (since `c0283d9` a digit only reads as a clock on
+      // a line carrying a spinner glyph or an elapsed-time pattern), but so
+      // this test turns on the thing it is about: new content on screen.
       const words = "resolver adapter migration checkout transcript envelope".split(" ");
       for (let second = 0; second < 30 * 60; second += 1) {
         const chunk =

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -37,7 +37,7 @@ import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 const QUIET_MS = 15 * 60 * 1000;
 const MINUTE = 60 * 1000;
 /** The idle-redraw window this file leaves at its production default. */
-const IDLE_MS = 5 * MINUTE;
+const IDLE_MS = 8 * MINUTE;
 /** How often a painting TUI writes a frame. */
 const FRAME_MS = 1000;
 
@@ -244,18 +244,40 @@ describe("settling a turn whose end nobody reported", () => {
       const backstop = makeBackstop();
       const before = getLastEventId();
 
-      // Four minutes of clock. The old rule sees a chatty harness; this one
-      // sees a screen on which nothing has happened.
-      paintFor(backstop, 4 * MINUTE);
+      // Seven minutes of clock. The old rule sees a chatty harness; this one
+      // sees a screen on which nothing has happened — but not yet for long
+      // enough.
+      paintFor(backstop, 7 * MINUTE);
       expect(backstop.sweepOnce()).toEqual([]);
       expect(statusOf("t-1")).toBe("running");
 
-      // Past five, and the operator gets the finish nobody reported — well
-      // inside the quarter-hour that would never have arrived.
+      // Past eight, and one sweep is still not enough: the rule asks twice,
+      // because one sweep is one sample of a screen.
       paintFor(backstop, 2 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
+
+      // The second sweep agrees, and the operator gets the finish nobody
+      // reported — well inside the quarter-hour that would never have arrived.
+      paintFor(backstop, MINUTE);
       expect(backstop.sweepOnce()).toEqual(["t-1"]);
       expect(statusOf("t-1")).toBe("finished");
       expect(kindsSince(before)).toContain("session:finished");
+    });
+
+    it("starts the two sweeps over when something new appears", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+
+      paintFor(backstop, IDLE_MS + MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+
+      // A tool result lands between the two sweeps. The run is broken, and the
+      // window starts again from here.
+      backstop.noteActivity("t-1", "output");
+      paintFor(backstop, MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
     });
 
     it("never settles a turn that is still putting things on screen", () => {
@@ -277,11 +299,11 @@ describe("settling a turn whose end nobody reported", () => {
       const backstop = makeBackstop();
 
       // A long tool call: nothing but the spinner on screen, but the harness
-      // is POSTing `PostToolUse` at the receiver, which calls this with no
-      // kind at all. A hook is never a repaint.
+      // is POSTing `PostToolUse` at the receiver, which calls this with `hook`.
+      // A hook is never a repaint.
       for (let minute = 0; minute < 30; minute += 1) {
         paintFor(backstop, MINUTE);
-        if (minute % 4 === 0) backstop.noteActivity("t-1");
+        if (minute % 4 === 0) backstop.noteActivity("t-1", "hook");
         expect(backstop.sweepOnce()).toEqual([]);
       }
       expect(statusOf("t-1")).toBe("running");
@@ -309,8 +331,161 @@ describe("settling a turn whose end nobody reported", () => {
       const backstop = makeBackstop();
 
       paintFor(backstop, IDLE_MS + MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      paintFor(backstop, MINUTE);
       expect(backstop.sweepOnce()).toEqual(["t-1"]);
       expect(statusOf("t-1")).toBe("disconnected");
+    });
+  });
+
+  // ─── Review of PR 455, finding 1: the finish this rule writes comes back ───
+  //
+  // The argument for a window shorter than fifteen minutes is that the mistake
+  // is cheap. Nothing made it cheap: a `PostToolUse` maps to no status, and the
+  // PTY output path writes none at all, so a row settled early stayed
+  // `finished` until the operator's next prompt. The rule now takes it back —
+  // and only the rule's own finishes, never anybody else's.
+  describe("taking back a finish the idle rule wrote", () => {
+    const paintFor = (backstop: CoreSessionBackstop, ms: number) => {
+      for (let elapsed = 0; elapsed < ms; elapsed += FRAME_MS) {
+        nowMs += FRAME_MS;
+        backstop.noteActivity("t-1", "redraw");
+      }
+    };
+    /** Paint until the idle rule has settled the row, and assert it did. */
+    const settleByIdleRule = (backstop: CoreSessionBackstop) => {
+      paintFor(backstop, IDLE_MS + MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      paintFor(backstop, MINUTE);
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
+    };
+
+    it("returns the row to running when real output finally arrives", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      // The six-minute build prints its first line. The turn was live all
+      // along, and the card says so again without an operator touching it.
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("returns the row to running for a hook, too", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "hook");
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("is not reopened by more of the same repainting", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      paintFor(backstop, 5 * MINUTE);
+      expect(statusOf("t-1")).toBe("finished");
+    });
+
+    it("never reopens a finish the quiet rule wrote", () => {
+      // The marker is set by the idle rule alone. A Session that went silent
+      // and was settled for it is finished, and bytes arriving later — an
+      // operator scrolling the pane, a harness's parting paint — do not undo
+      // an operator-visible finish.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      nowMs += QUIET_MS + MINUTE;
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
+
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("finished");
+    });
+
+    it("leaves a row alone once someone else has moved it", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      // The operator archived it, or the PTY exit settled it. Whatever the row
+      // says now, it is not this rule's `finished` any more.
+      coreMutationStore.mutateTask({ op: "update", taskId: "t-1", status: "terminated" });
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("terminated");
+    });
+
+    it("stops offering to reopen once the grace has passed", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      nowMs += 31 * MINUTE;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("finished");
+    });
+
+    it("does not reopen a Session whose process is gone", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+
+      // The PTY exit path calls this; there are no more bytes coming, and any
+      // that do arrive belong to nothing.
+      backstop.forget("t-1");
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("finished");
+    });
+  });
+
+  // ─── Review of PR 455, finding 2: a harness whose hooks work is not judged
+  // on its pixels ───
+  describe("deferring to a harness that can report itself", () => {
+    it("never settles a long tool call on a hooked harness", () => {
+      // Claude Code installs `PreToolUse` with an `AskUserQuestion` matcher, so
+      // a single `Bash` call emits no hook at all until it completes. Half an
+      // hour of `pnpm build` behind a spinner, on a harness whose hooks are
+      // working perfectly, must not be called over.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+
+      backstop.noteActivity("t-1", "hook");
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "output");
+      for (let minute = 0; minute < 30; minute += 1) {
+        for (let second = 0; second < 60; second += 1) {
+          nowMs += FRAME_MS;
+          backstop.noteActivity("t-1", "redraw");
+        }
+        expect(backstop.sweepOnce()).toEqual([]);
+      }
+      expect(statusOf("t-1")).toBe("running");
+
+      // And the tool finally completes: `PostToolUse` lands, the count of
+      // output since the last hook resets, and nothing has been lost.
+      backstop.noteActivity("t-1", "hook");
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("still settles a harness that has never sent a hook", () => {
+      // Codex before `/hooks` has been reviewed: no hook has ever arrived, so
+      // the screen is the only witness there is, and the rule reads it.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      backstop.noteActivity("t-1", "output");
+
+      for (let second = 0; second < 10 * 60; second += 1) {
+        nowMs += FRAME_MS;
+        backstop.noteActivity("t-1", "redraw");
+      }
+      expect(backstop.sweepOnce()).toEqual([]);
+      nowMs += MINUTE;
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
     });
   });
 

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -24,6 +24,8 @@ import {
 import { CoreTaskWriter } from "../core-task-writer";
 import { CoreSessionBackstop } from "../core-session-backstop";
 import { PtyOutputActivityWatcher } from "../pty-output-activity";
+import { CoreHarnessStatus } from "../core-harness-status";
+import type { HarnessHookBody } from "@actana/shared/harness-hook-pipeline";
 import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 
 // The backstop nobody has to arm (issue 243 part 2), against this Core's real
@@ -352,6 +354,18 @@ describe("settling a turn whose end nobody reported", () => {
         backstop.noteActivity("t-1", "redraw");
       }
     };
+    /**
+     * A hook, through the real pipeline and then to the backstop — the wiring
+     * `core-entry.ts` has, so what the pipeline does or does not write to the
+     * row is part of what is under test.
+     */
+    const deliverHook = (backstop: CoreSessionBackstop, payload: HarnessHookBody) => {
+      const harnessStatus = new CoreHarnessStatus({ writer });
+      const result = harnessStatus.receiveHook("t-1", payload);
+      if (result.ok && result.body?.ignored !== "foreign-session") {
+        backstop.noteActivity("t-1", "hook");
+      }
+    };
     /** Paint until the idle rule has settled the row, and assert it did. */
     const settleByIdleRule = (backstop: CoreSessionBackstop) => {
       paintFor(backstop, IDLE_MS + MINUTE);
@@ -373,25 +387,86 @@ describe("settling a turn whose end nobody reported", () => {
       expect(statusOf("t-1")).toBe("running");
     });
 
-    it("is not reopened by a hook, whatever the hook means", () => {
-      // A hook hands the row back to the pipeline, which decides the status
-      // from the event: a `UserPromptSubmit` writes `running` there, a `Stop`
-      // writes `finished`. Either way this rule's claim on the row is over —
-      // and it must be, because a `Stop` writes `finished` over a `finished`
-      // and reopening that is the post-turn resurrection #385 closed.
+    it("is not reopened by a Stop, which decided the row itself", () => {
+      // Driven through the real pipeline rather than a synthetic kind: a
+      // terminal `Stop` writes `finished` over this rule's `finished`, which
+      // moves `updated_at` and ends the claim. The post-turn composer paint
+      // that follows must find nothing to take back (review of PR 455, round
+      // 3) — and the previous version of this test used a bare
+      // `noteActivity(id, "hook")`, which never touches the pipeline, which is
+      // how round 4's regression got past it.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      settleByIdleRule(backstop);
+      const after = getLastEventId();
+
+      nowMs += 30 * 1000;
+      deliverHook(backstop, { hook_event_name: "Stop" });
+      expect(statusOf("t-1")).toBe("finished");
+
+      nowMs += 30 * 1000;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("finished");
+      // The `Stop`'s own write is a `finished` over a `finished`, so it raises
+      // no second notification either.
+      expect(kindsSince(after)).not.toContain("session:finished");
+    });
+
+    it("is still reopened after a tool call's hook, which decided nothing", () => {
+      // Review of PR 455, round 4. `PostToolUse` is installed unmatched, so
+      // every ordinary tool call fires one — within milliseconds of the tool
+      // completing, while this classifier reports once every five seconds, so
+      // hook-then-output is the normal ordering. The pipeline writes nothing
+      // for it on a row that is not `needs-input`, so it has decided nothing
+      // and the recovery must survive it.
       insert("t-1", "running");
       const backstop = makeBackstop();
       settleByIdleRule(backstop);
 
-      nowMs += MINUTE;
-      backstop.noteActivity("t-1", "hook");
+      nowMs += 30 * 1000;
+      deliverHook(backstop, { hook_event_name: "PostToolUse", tool_name: "Bash" });
       expect(statusOf("t-1")).toBe("finished");
 
-      // And the marker is gone with it: the composer paint that follows a real
-      // `Stop` finds nothing to take back (review of PR 455, round 3).
-      nowMs += MINUTE;
+      // The build's output lands half a minute later, and the turn is visibly
+      // not over.
+      nowMs += 30 * 1000;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("survives a reopen write that failed, and tries again", () => {
+      // The marker is spent only once the write has landed: a SQLite busy
+      // against the concurrent event-log writer must not cost the one chance
+      // this rule has to take its own finish back (review of PR 455, round 4).
+      insert("t-1", "running");
+      let reopenFails = true;
+      const flaky = {
+        readTask: (taskId: string) => writer.readTask(taskId),
+        mutate: (mutation: { op: string; status?: string }) => {
+          if (reopenFails && mutation.op === "update" && mutation.status === "running") {
+            throw new Error("database is locked");
+          }
+          return writer.mutate(mutation as never);
+        },
+      } as unknown as CoreTaskWriter;
+      const backstop = new CoreSessionBackstop({
+        listActiveTasks,
+        writer: flaky,
+        hasLivePty: (taskId) => livePtys.has(taskId),
+        now: () => nowMs,
+        quietMs: QUIET_MS,
+      });
+      settleByIdleRule(backstop);
+
+      nowMs += 30 * 1000;
       backstop.noteActivity("t-1", "output");
       expect(statusOf("t-1")).toBe("finished");
+
+      // Five seconds later the next burst arrives, and the database is back.
+      reopenFails = false;
+      nowMs += 5 * 1000;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("running");
     });
 
     it("never takes back a finish another writer wrote over it", () => {

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../event-log-store";
 import { CoreTaskWriter } from "../core-task-writer";
 import { CoreSessionBackstop } from "../core-session-backstop";
+import { PtyOutputActivityWatcher } from "../pty-output-activity";
 import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 
 // The backstop nobody has to arm (issue 243 part 2), against this Core's real
@@ -35,6 +36,10 @@ import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 
 const QUIET_MS = 15 * 60 * 1000;
 const MINUTE = 60 * 1000;
+/** The idle-redraw window this file leaves at its production default. */
+const IDLE_MS = 5 * MINUTE;
+/** How often a painting TUI writes a frame. */
+const FRAME_MS = 1000;
 
 describe("settling a turn whose end nobody reported", () => {
   let userDataDir: string;
@@ -214,5 +219,150 @@ describe("settling a turn whose end nobody reported", () => {
     backstop.stop();
     backstop.stop();
     expect(statusOf("t-1")).toBe("running");
+  });
+
+  // ─── Issue 391: the harness that is idle and still painting ───
+  //
+  // The rule above reads any byte as work, and the harness whose hooks are not
+  // arriving is exactly the harness whose TUI is still on screen: Codex before
+  // `/hooks` has been reviewed paints a spinner and a clock for as long as the
+  // process lives. Fifteen minutes of total silence never comes, so the card
+  // claims `running` until a human edits the row. These pin both halves of the
+  // acceptance: an idle harness settles on a window an operator can wait out,
+  // and a turn that is still printing real output is never settled at all.
+  describe("an idle TUI that never stops repainting", () => {
+    /** Paint a spinner frame every second for `ms`, reporting each as a redraw. */
+    const paintFor = (backstop: CoreSessionBackstop, ms: number) => {
+      for (let elapsed = 0; elapsed < ms; elapsed += FRAME_MS) {
+        nowMs += FRAME_MS;
+        backstop.noteActivity("t-1", "redraw");
+      }
+    };
+
+    it("settles inside the idle window, though the bytes never stop", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      const before = getLastEventId();
+
+      // Four minutes of clock. The old rule sees a chatty harness; this one
+      // sees a screen on which nothing has happened.
+      paintFor(backstop, 4 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
+
+      // Past five, and the operator gets the finish nobody reported — well
+      // inside the quarter-hour that would never have arrived.
+      paintFor(backstop, 2 * MINUTE);
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
+      expect(kindsSince(before)).toContain("session:finished");
+    });
+
+    it("never settles a turn that is still putting things on screen", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+
+      // Two hours of real work: the spinner paints between bursts, and every
+      // few minutes a tool result, a diff or a line of prose lands.
+      for (let minute = 0; minute < 120; minute += 1) {
+        paintFor(backstop, MINUTE);
+        if (minute % 3 === 0) backstop.noteActivity("t-1", "output");
+        expect(backstop.sweepOnce()).toEqual([]);
+      }
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("counts a hook as something happening, not a repaint", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+
+      // A long tool call: nothing but the spinner on screen, but the harness
+      // is POSTing `PostToolUse` at the receiver, which calls this with no
+      // kind at all. A hook is never a repaint.
+      for (let minute = 0; minute < 30; minute += 1) {
+        paintFor(backstop, MINUTE);
+        if (minute % 4 === 0) backstop.noteActivity("t-1");
+        expect(backstop.sweepOnce()).toEqual([]);
+      }
+      expect(statusOf("t-1")).toBe("running");
+    });
+
+    it("leaves a Session that went properly silent to the long window", () => {
+      // The short window is for a harness that is demonstrably still there.
+      // One that stopped writing altogether keeps the fifteen-minute grace it
+      // has always had — a silent worker is not an idle TUI.
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      backstop.noteActivity("t-1", "redraw");
+
+      nowMs += IDLE_MS + MINUTE;
+      expect(backstop.sweepOnce()).toEqual([]);
+      expect(statusOf("t-1")).toBe("running");
+
+      nowMs += QUIET_MS;
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+    });
+
+    it("settles an idle harness whose PTY is gone as disconnected", () => {
+      insert("t-1", "running");
+      livePtys.delete("t-1");
+      const backstop = makeBackstop();
+
+      paintFor(backstop, IDLE_MS + MINUTE);
+      expect(backstop.sweepOnce()).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("disconnected");
+    });
+  });
+
+  // The same two cases again, with the real classifier in the loop rather than
+  // a hand-written `kind`: bytes in, status out. This is what the operator's
+  // Codex pane actually does.
+  describe("with the PTY output classifier wired in", () => {
+    const idleFrame = (spinner: string, seconds: number) =>
+      `\x1b[2K\x1b[G${spinner} Working (${seconds}s • Esc to interrupt)`;
+
+    /** One second of PTY bytes, classified and reported exactly as the Core does. */
+    const feed = (backstop: CoreSessionBackstop, watcher: PtyOutputActivityWatcher, chunk: string) => {
+      nowMs += FRAME_MS;
+      const kind = watcher.push(chunk, nowMs);
+      if (kind) backstop.noteActivity("t-1", kind);
+    };
+
+    it("finishes a harness whose only output is a clock", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      const watcher = new PtyOutputActivityWatcher();
+
+      // The turn ended; its `Stop` dropped; the TUI is still on screen. Ten
+      // minutes of it, swept once a minute the way the Core sweeps.
+      const settled: string[] = [];
+      for (let second = 0; second < 10 * 60; second += 1) {
+        feed(backstop, watcher, idleFrame(second % 2 ? "⠹" : "⠸", second));
+        if (second % 60 === 0) settled.push(...backstop.sweepOnce());
+      }
+      expect(settled).toEqual(["t-1"]);
+      expect(statusOf("t-1")).toBe("finished");
+    });
+
+    it("leaves a turn alone while real output keeps arriving", () => {
+      insert("t-1", "running");
+      const backstop = makeBackstop();
+      const watcher = new PtyOutputActivityWatcher();
+
+      // Half an hour of a live turn: a spinner every second, and a tool line
+      // nobody has seen before every twenty. Words, not numbers — a line that
+      // differs from the last one only in its digits is a counter, and this
+      // reads counters as the repaints they are (see `pty-output-activity.ts`).
+      const words = "resolver adapter migration checkout transcript envelope".split(" ");
+      for (let second = 0; second < 30 * 60; second += 1) {
+        const chunk =
+          second % 20 === 0
+            ? `\x1b[2K\x1b[G• Read packages/core/src/${words[(second / 20) % words.length]}-${second}.ts\r\n`
+            : idleFrame(second % 2 ? "⠹" : "⠸", second);
+        feed(backstop, watcher, chunk);
+        if (second % 60 === 0) expect(backstop.sweepOnce()).toEqual([]);
+      }
+      expect(statusOf("t-1")).toBe("running");
+    });
   });
 });

--- a/packages/core/src/__tests__/core-session-backstop.test.ts
+++ b/packages/core/src/__tests__/core-session-backstop.test.ts
@@ -24,7 +24,6 @@ import {
 import { CoreTaskWriter } from "../core-task-writer";
 import { CoreSessionBackstop } from "../core-session-backstop";
 import { PtyOutputActivityWatcher } from "../pty-output-activity";
-import { mapHookEventToStatus } from "@actana/shared/harness-hook-events";
 import { clearSubagentActivity } from "@actana/shared/subagent-activity";
 
 // The backstop nobody has to arm (issue 243 part 2), against this Core's real
@@ -374,33 +373,46 @@ describe("settling a turn whose end nobody reported", () => {
       expect(statusOf("t-1")).toBe("running");
     });
 
-    it("returns the row to running for a hook that means the turn is running", () => {
+    it("is not reopened by a hook, whatever the hook means", () => {
+      // A hook hands the row back to the pipeline, which decides the status
+      // from the event: a `UserPromptSubmit` writes `running` there, a `Stop`
+      // writes `finished`. Either way this rule's claim on the row is over —
+      // and it must be, because a `Stop` writes `finished` over a `finished`
+      // and reopening that is the post-turn resurrection #385 closed.
       insert("t-1", "running");
       const backstop = makeBackstop();
       settleByIdleRule(backstop);
 
-      // `UserPromptSubmit`, `PermissionReplied`, an `AskUserQuestion`
-      // `PostToolUse` — the events `mapHookEventToStatus` reads as `running`.
       nowMs += MINUTE;
-      backstop.noteActivity("t-1", "turn");
-      expect(statusOf("t-1")).toBe("running");
+      backstop.noteActivity("t-1", "hook");
+      expect(statusOf("t-1")).toBe("finished");
+
+      // And the marker is gone with it: the composer paint that follows a real
+      // `Stop` finds nothing to take back (review of PR 455, round 3).
+      nowMs += MINUTE;
+      backstop.noteActivity("t-1", "output");
+      expect(statusOf("t-1")).toBe("finished");
     });
 
-    it("is not reopened by a post-turn helper's hook", () => {
-      // Review of PR 455, round 2, finding 2. `SubagentStart`, `SubagentStop`
-      // and an unmatched `PostToolUse` map to no status precisely so a
-      // post-turn helper cannot heal a finished card (#385, `5d33f0c`). They
-      // reach this as `hook`: activity, never a reopen.
+    it("never takes back a finish another writer wrote over it", () => {
+      // The shape the round-3 review drove: the real terminal `Stop` lands
+      // just after the idle rule settled, the pipeline writes the
+      // authoritative finish — `finished` over `finished`, so the status alone
+      // cannot tell them apart — and then the post-turn TUI paints its
+      // composer. Only the row's `updatedAt` separates the two finishes.
       insert("t-1", "running");
       const backstop = makeBackstop();
       settleByIdleRule(backstop);
 
-      nowMs += 5 * MINUTE;
-      backstop.noteActivity("t-1", "hook");
+      nowMs += 30 * 1000;
+      coreMutationStore.mutateTask({ op: "update", taskId: "t-1", status: "finished" });
+      const after = getLastEventId();
+
+      nowMs += 30 * 1000;
+      backstop.noteActivity("t-1", "output");
       expect(statusOf("t-1")).toBe("finished");
-      nowMs += MINUTE;
-      backstop.noteActivity("t-1", "hook");
-      expect(statusOf("t-1")).toBe("finished");
+      // No reopen, so no re-settle, so no second `session:finished` toast.
+      expect(kindsSince(after)).toEqual([]);
     });
 
     it("is not reopened by more of the same repainting", () => {
@@ -544,26 +556,6 @@ describe("settling a turn whose end nobody reported", () => {
       nowMs += MINUTE;
       expect(backstop.sweepOnce()).toEqual(["t-1"]);
       expect(statusOf("t-1")).toBe("finished");
-    });
-  });
-
-  // The seam `core-entry.ts` keys the activity kind on. It lives in
-  // `harness-hook-events.ts`, which this PR does not touch — so what is pinned
-  // here is the contract the wiring depends on: which events may take a
-  // backstop finish back, and which must never.
-  describe("which hooks are allowed to take a finish back", () => {
-    it("maps a turn's own events to running, and helpers' to nothing", () => {
-      for (const hook_event_name of ["UserPromptSubmit", "beforeSubmitPrompt", "PermissionReplied"]) {
-        expect(mapHookEventToStatus({ hook_event_name })).toBe("running");
-      }
-      for (const hook_event_name of ["SubagentStart", "SubagentStop", "PostToolUse"]) {
-        expect(mapHookEventToStatus({ hook_event_name })).not.toBe("running");
-      }
-      // The one `PostToolUse` that does mean the turn resumed: the operator
-      // answered the question it asked.
-      expect(
-        mapHookEventToStatus({ hook_event_name: "PostToolUse", tool_name: "AskUserQuestion" }),
-      ).toBe("running");
     });
   });
 

--- a/packages/core/src/__tests__/pty-output-activity.test.ts
+++ b/packages/core/src/__tests__/pty-output-activity.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizePtyOutput,
+  OUTPUT_ACTIVITY_WINDOW_MS,
+  PtyOutputActivityWatcher,
+} from "../pty-output-activity";
+
+// Issue 391: the bytes a harness writes while it is idle look exactly like the
+// bytes it writes while it works — unless you read them. These pin the one
+// distinction the quiet-Session backstop rests on: did anything new appear on
+// screen, or was that the same frame again with a bigger number in it?
+
+/** A Codex-shaped idle frame: erase the line, redraw a spinner and a clock. */
+const idleFrame = (spinner: string, elapsed: string) =>
+  `\x1b[2K\x1b[G${spinner} Working (${elapsed} • Esc to interrupt)`;
+
+const WINDOW = OUTPUT_ACTIVITY_WINDOW_MS;
+
+describe("normalizePtyOutput", () => {
+  it("keeps the words and drops everything a repaint changes", () => {
+    // Escapes, the spinner glyph and the counter all go; the words stay.
+    expect(normalizePtyOutput(idleFrame("⠹", "1m 12s"))).toBe(
+      "Working (m s Esc to interrupt)",
+    );
+    // Which is the whole point: the next second reduces to the same thing.
+    expect(normalizePtyOutput(idleFrame("⠸", "1m 13s"))).toBe(
+      normalizePtyOutput(idleFrame("⠹", "1m 12s")),
+    );
+  });
+
+  it("reduces pure cursor movement to nothing at all", () => {
+    expect(normalizePtyOutput("\x1b[2J\x1b[H\x1b[?25l\r\n\x1b[?25h")).toBe("");
+  });
+
+  it("keeps an OSC title's payload out of the words", () => {
+    expect(normalizePtyOutput("\x1b]0;codex — ~/repos/control\x07ready")).toBe("ready");
+  });
+});
+
+describe("telling an idle repaint from real output", () => {
+  it("reports the first paint, then calls its repeats redraws", () => {
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+
+    // The frame arriving for the first time is something new on screen.
+    expect(watcher.push(idleFrame("⠹", "0s"), now)).toBe("output");
+
+    // Every second after that, the same frame with the clock moved on. Ten
+    // minutes of it, and not one of them is work.
+    for (let tick = 1; tick <= 120; tick += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push(idleFrame("⠸", `${tick * 5}s`), now)).toBe("redraw");
+    }
+  });
+
+  it("calls a burst with a word that was not on screen real output", () => {
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    watcher.push(idleFrame("⠹", "0s"), now);
+
+    now += WINDOW + 1;
+    expect(watcher.push(idleFrame("⠸", "5s"), now)).toBe("redraw");
+
+    // A tool call lands. Nothing about this was on screen a moment ago.
+    now += WINDOW + 1;
+    expect(
+      watcher.push("\x1b[2K\x1b[G• Ran pnpm vitest packages/core\r\n  └ 47 passed", now),
+    ).toBe("output");
+
+    // And the spinner goes back to being a spinner.
+    now += WINDOW + 1;
+    expect(watcher.push(idleFrame("⠹", "11s"), now)).toBe("redraw");
+  });
+
+  it("stays a redraw when a frame is split across the reporting window", () => {
+    // A burst boundary can fall inside a word. `Work` + `ing` must not read as
+    // two new words every five seconds, or an idle harness never settles.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    watcher.push(idleFrame("⠹", "0s"), now);
+
+    for (let tick = 1; tick <= 20; tick += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push("\x1b[2K\x1b[G⠸ Work", now)).toBe("redraw");
+      now += WINDOW + 1;
+      expect(watcher.push(`ing (${tick}s • Esc to interrupt)`, now)).toBe("redraw");
+    }
+  });
+
+  it("answers once per window and accumulates the chunks in between", () => {
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    expect(watcher.push(idleFrame("⠹", "0s"), now)).toBe("output");
+
+    // Sixty repaints inside one window cost the caller nothing.
+    for (let i = 0; i < 60; i += 1) {
+      now += 50;
+      expect(watcher.push(idleFrame("⠸", `${i}s`), now)).toBeNull();
+    }
+
+    // A chunk held back inside the window is still read when the window ends:
+    // real output that arrived mid-window is not lost to the throttle.
+    now += 10;
+    expect(watcher.push("release notes drafted", now)).toBeNull();
+    now += WINDOW + 1;
+    expect(watcher.push(idleFrame("⠹", "9s"), now)).toBe("output");
+  });
+
+  it("calls a line the screen showed a minute ago new work again", () => {
+    // The memory is the last two bursts, not the whole turn: a harness that
+    // reads the same file twice is working, and must not be read as a screen
+    // that never changed.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    const toolLine = "\x1b[2K\x1b[G• Read packages/core/src/core-entry.ts\r\n";
+    expect(watcher.push(toolLine, now)).toBe("output");
+
+    // The spinner coming back over that line is itself something new, once.
+    now += WINDOW + 1;
+    expect(watcher.push(idleFrame("⠸", "0s"), now)).toBe("output");
+    for (let tick = 1; tick < 12; tick += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push(idleFrame("⠸", `${tick * 5}s`), now)).toBe("redraw");
+    }
+
+    now += WINDOW + 1;
+    expect(watcher.push(toolLine, now)).toBe("output");
+  });
+
+  it("reads a burst that differs only in its digits as the counter it is", () => {
+    // The stated cost, pinned rather than left to be found: digits are how a
+    // spinner's clock changes, so they cannot count as new — and output whose
+    // only change is a number is therefore read as a repaint. It settles the
+    // row early; the next hook or new word puts it back on `running`.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    expect(watcher.push("\x1b[2K\x1b[GCompiled 41 files", now)).toBe("output");
+    for (let files = 42; files < 60; files += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push(`\x1b[2K\x1b[GCompiled ${files} files`, now)).toBe("redraw");
+    }
+  });
+
+  it("does not mistake a long streamed answer for a repaint", () => {
+    // A model streaming prose repaints the screen every chunk, but each
+    // repaint carries words the last one did not.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    // Every word here is long enough to count: a burst that adds only `is`
+    // adds nothing a reader would call new, and reads as a repaint.
+    const sentence =
+      "every release train gets cut manually, never from workflow, because nothing guesses versions".split(
+        " ",
+      );
+    let shown = "";
+    for (const word of sentence) {
+      shown += `${word} `;
+      now += WINDOW + 1;
+      expect(watcher.push(`\x1b[2K\x1b[G${shown}▏`, now)).toBe("output");
+    }
+  });
+});

--- a/packages/core/src/__tests__/pty-output-activity.test.ts
+++ b/packages/core/src/__tests__/pty-output-activity.test.ts
@@ -269,6 +269,56 @@ describe("the burst shapes a live turn actually produces", () => {
   });
 });
 
+// Review of PR 455, round 2, finding 3: "is this line carrying a clock" was
+// over-matching, and every over-match is a live turn read as idle.
+describe("telling a clock from the numbers that are the content", () => {
+  const runFor12Minutes = (frame: (tick: number) => string) => {
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    let output = 0;
+    for (let tick = 0; tick < (12 * 60) / 5; tick += 1) {
+      if (watcher.push(frame(tick), now) === "output") output += 1;
+      now += WINDOW + 1;
+    }
+    return output;
+  };
+
+  it("does not call a wall-clock log stamp an elapsed-time counter", () => {
+    // `\d+:\d{2}` matches the timestamp a build prints in front of every line,
+    // and calling that a clock took the count beside it with it.
+    expect(
+      runFor12Minutes((tick) => `\x1b[2K\r[12:34:${String(tick % 60).padStart(2, "0")}] Compiled ${tick} files`),
+    ).toBe(144);
+  });
+
+  it("does not call a check mark or a prompt caret a spinner", () => {
+    // ✔ and ❯ were inside the Dingbats block the pattern used to take whole.
+    expect(runFor12Minutes((tick) => `\x1b[2K\r✔ ${tick} passed`)).toBe(144);
+    expect(runFor12Minutes((tick) => `\x1b[2K\r❯ step ${tick} of 900`)).toBe(144);
+    expect(runFor12Minutes((tick) => `\x1b[2K\r• ${tick} passed`)).toBe(144);
+  });
+
+  it("still calls a braille or sparkle spinner's counter a clock", () => {
+    expect(runFor12Minutes((tick) => `\x1b[2K\r⠹ Working (${tick}s)`)).toBe(1);
+    expect(runFor12Minutes((tick) => `\x1b[2K\r✻ Thinking (${tick}s)`)).toBe(1);
+  });
+});
+
+describe("what the last burst was, when the last burst said nothing", () => {
+  it("still counts as a repaint for the burst that follows it", () => {
+    // Review of PR 455, round 2, finding 4: the empty-normalisation return
+    // used to skip re-arming the flag, so an appended line after a bare screen
+    // clear lost its "nothing was erased, so it is new" path.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    expect(watcher.push("\x1b[2K\rSpinner Working here", now)).toBe("output");
+    now += WINDOW + 1;
+    expect(watcher.push("\x1b[H\x1b[2J", now)).toBe("redraw");
+    now += WINDOW + 1;
+    expect(watcher.push("Spinner Working here\n", now)).toBe("output");
+  });
+});
+
 describe("finding what is new at the end of a very large burst", () => {
   it("sees a new tool line under a full-viewport repaint", () => {
     // Review of PR 455, finding 3: the scan was front-first and capped, but
@@ -289,5 +339,62 @@ describe("finding what is new at the end of a very large burst", () => {
     expect(
       watcher.push(`\x1b[2J\x1b[H${viewport} Ran pnpm vitest packages/core`, now),
     ).toBe("output");
+  });
+
+  it("sees a new line painted above the bottom of the screen", () => {
+    // Review of PR 455, round 2, finding 5: the scan is tail-first, which is
+    // the right bias, but a cap below a viewport's worth of words hid novelty
+    // painted above the static footer under it.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    const body = Array.from({ length: 900 }, (_, i) => `body${i}text${i % 5}`).join(" ");
+    const footer = Array.from({ length: 500 }, (_, i) => `footer${i}row${i % 3}`).join(" ");
+    expect(watcher.push(`\x1b[2J\x1b[H${body} ${footer}`, now)).toBe("output");
+
+    now += WINDOW + 1;
+    expect(watcher.push(`\x1b[2J\x1b[H${body} ${footer}`, now)).toBe("redraw");
+
+    now += WINDOW + 1;
+    expect(
+      watcher.push(`\x1b[2J\x1b[H${body} Edited packages/core/src/thing.ts ${footer}`, now),
+    ).toBe("output");
+  });
+
+  it("keeps its footing on a burst larger than either cap", () => {
+    // A hundred-row viewport on a wide terminal is well past both the pending
+    // cap (64 KB) and the remembered cap (16 KB). The tail is what is kept and
+    // the tail is what is compared, so the same screen twice is still a
+    // repaint, and a line appended under it is still work.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    const huge = Array.from(
+      { length: 12_000 },
+      (_, i) => `cell${i}col${i % 11}`,
+    ).join(" ");
+    expect(huge.length).toBeGreaterThan(128 * 1024);
+    expect(watcher.push(`\x1b[2J\x1b[H${huge}`, now)).toBe("output");
+
+    now += WINDOW + 1;
+    expect(watcher.push(`\x1b[2J\x1b[H${huge}`, now)).toBe("redraw");
+
+    now += WINDOW + 1;
+    expect(watcher.push(`\x1b[2J\x1b[H${huge} Ran pnpm build`, now)).toBe("output");
+  });
+
+  it("drops the oldest chunks of an over-long window, never the newest", () => {
+    // The cap is enforced by dropping whole chunks off the front rather than
+    // re-slicing one string per chunk, which is what the PTY data path can
+    // afford. What survives is the end of the window.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    expect(watcher.push("\x1b[2J\x1b[Hopening frame", now)).toBe("output");
+
+    // 128 chunks of a kilobyte inside one window: the oldest fall off the
+    // front, and none of them costs a report.
+    for (let i = 0; i < 128; i += 1) {
+      expect(watcher.push(`\r\x1b[K${`filler${i} `.repeat(90)}`, now + i)).toBeNull();
+    }
+    now += WINDOW + 1;
+    expect(watcher.push("\r\x1b[Ktail line that nobody has seen", now)).toBe("output");
   });
 });

--- a/packages/core/src/__tests__/pty-output-activity.test.ts
+++ b/packages/core/src/__tests__/pty-output-activity.test.ts
@@ -298,6 +298,35 @@ describe("telling a clock from the numbers that are the content", () => {
     expect(runFor12Minutes((tick) => `\x1b[2K\r• ${tick} passed`)).toBe(144);
   });
 
+  it("keeps a count that shares its line with an elapsed time", () => {
+    // Review of PR 455, round 3: one duration token used to take every digit
+    // on its line with it, and a count beside an elapsed time is the standard
+    // build-progress shape — Bazel, Gradle and every watch-mode runner print
+    // it. Each of those was a live turn read as idle.
+    expect(runFor12Minutes((tick) => `\x1b[2K\r✔ ${tick} passed in ${tick / 10}s`)).toBe(144);
+    expect(
+      runFor12Minutes((tick) => `\x1b[2K\rCompiled ${tick} files in ${tick / 10}s`),
+    ).toBe(144);
+    expect(
+      runFor12Minutes((tick) => `\x1b[2K\r[${tick},234 / 5,678] Compiling foo.cc; ${tick}s`),
+    ).toBe(144);
+  });
+
+  it("drops the duration itself, and only that", () => {
+    expect(normalizePtyOutput("\x1b[2K\r✔ 43 passed in 12.3s")).toBe("43 passed in");
+    expect(normalizePtyOutput("\x1b[2K\rCompiled 41 files in 3.2s")).toBe("Compiled 41 files in");
+    // A wall-clock stamp is not a duration, so nothing on that line is
+    // dropped at all — the stamp changes, and so does the count.
+    expect(normalizePtyOutput("\x1b[2K\r[12:34:07] Compiled 43 files")).toBe(
+      "[12:34:07] Compiled 43 files",
+    );
+    // A spinner's line is a frame, and every number on it belongs to the
+    // frame — the clock, the token count, the context percentage.
+    expect(normalizePtyOutput("\x1b[2K\r⠹ Working (1m 12s · ↑ 1.2k tokens)")).toBe(
+      "Working (m s ↑ .k tokens)",
+    );
+  });
+
   it("still calls a braille or sparkle spinner's counter a clock", () => {
     expect(runFor12Minutes((tick) => `\x1b[2K\r⠹ Working (${tick}s)`)).toBe(1);
     expect(runFor12Minutes((tick) => `\x1b[2K\r✻ Thinking (${tick}s)`)).toBe(1);

--- a/packages/core/src/__tests__/pty-output-activity.test.ts
+++ b/packages/core/src/__tests__/pty-output-activity.test.ts
@@ -127,17 +127,45 @@ describe("telling an idle repaint from real output", () => {
     expect(watcher.push(toolLine, now)).toBe("output");
   });
 
-  it("reads a burst that differs only in its digits as the counter it is", () => {
-    // The stated cost, pinned rather than left to be found: digits are how a
-    // spinner's clock changes, so they cannot count as new — and output whose
-    // only change is a number is therefore read as a repaint. It settles the
-    // row early; the next hook or new word puts it back on `running`.
+  it("keeps the digits that are a count rather than a clock", () => {
+    // Review of PR 455, finding 2. Digits are dropped only from a line that is
+    // carrying a clock — a spinner glyph, or an elapsed-time pattern. On every
+    // other line the number is the content, and `41` → `42` is the change.
     const watcher = new PtyOutputActivityWatcher();
     let now = WINDOW + 1;
     expect(watcher.push("\x1b[2K\x1b[GCompiled 41 files", now)).toBe("output");
     for (let files = 42; files < 60; files += 1) {
       now += WINDOW + 1;
-      expect(watcher.push(`\x1b[2K\x1b[GCompiled ${files} files`, now)).toBe("redraw");
+      expect(watcher.push(`\x1b[2K\x1b[GCompiled ${files} files`, now)).toBe("output");
+    }
+  });
+
+  it("keeps a coloured frame on one line, glyph and clock together", () => {
+    // Colour codes sit inside a line and often inside a word. If they ended
+    // the line, the spinner glyph and the counter would land on different
+    // ones, the counter's digits would read as content, and an idle harness
+    // would look busy forever.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    const coloured = (spinner: string, seconds: number) =>
+      `\x1b[2K\x1b[G\x1b[33m${spinner}\x1b[0m \x1b[1mWork\x1b[0ming\x1b[0m (${seconds}s)`;
+    expect(watcher.push(coloured("⠹", 0), now)).toBe("output");
+    for (let tick = 1; tick < 20; tick += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push(coloured("⠸", tick * 5), now)).toBe("redraw");
+    }
+  });
+
+  it("still reads a clock as a clock when its line carries one", () => {
+    // The other side of the same rule, and the limitation it leaves: a line
+    // that is *both* spinner-prefixed and nothing but numbers has its digits
+    // dropped, and reads as the repaint it looks like.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    expect(watcher.push(idleFrame("⠹", "0s"), now)).toBe("output");
+    for (let tick = 1; tick < 20; tick += 1) {
+      now += WINDOW + 1;
+      expect(watcher.push(idleFrame("⠸", `${tick}m ${tick}s`), now)).toBe("redraw");
     }
   });
 
@@ -158,5 +186,108 @@ describe("telling an idle repaint from real output", () => {
       now += WINDOW + 1;
       expect(watcher.push(`\x1b[2K\x1b[G${shown}▏`, now)).toBe("output");
     }
+  });
+});
+
+// The shapes the review of PR 455 ran the shipped classifier over: twelve
+// minutes of one burst per five-second window, each of them a live turn that
+// the first cut settled anyway. Every one of them must read as work.
+describe("the burst shapes a live turn actually produces", () => {
+  /** Twelve minutes of five-second bursts; returns how many read as `output`. */
+  const runFor12Minutes = (frame: (tick: number) => string) => {
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    let output = 0;
+    let longestRedrawRun = 0;
+    let run = 0;
+    for (let tick = 0; tick < (12 * 60) / 5; tick += 1) {
+      const kind = watcher.push(frame(tick), now);
+      now += WINDOW + 1;
+      if (kind === "output") {
+        output += 1;
+        run = 0;
+      } else {
+        run += 1;
+        longestRedrawRun = Math.max(longestRedrawRun, run);
+      }
+    }
+    return { output, longestRedrawRun };
+  };
+
+  it("reads a download's changing size and rate as work", () => {
+    const { output } = runFor12Minutes(
+      (tick) =>
+        `\r\x1b[KDownloading ${(41.2 + tick).toFixed(1)} MB / 900 MB at 3.${tick % 9} MB/s`,
+    );
+    expect(output).toBe(144);
+  });
+
+  it("reads a compile count as work", () => {
+    const { output } = runFor12Minutes((tick) => `\r\x1b[KCompiled ${tick} files`);
+    expect(output).toBe(144);
+  });
+
+  it("reads a test tally as work, though its duration line is a clock", () => {
+    const { output } = runFor12Minutes(
+      (tick) => `\r\x1b[K Tests ${tick} passed (400)\r\n Duration ${tick * 5}s`,
+    );
+    expect(output).toBe(144);
+  });
+
+  it("reads appended dot progress as work", () => {
+    // Nothing is erased: the dots scrolled onto the screen, so they are new
+    // whatever they say.
+    const { output } = runFor12Minutes(() => ".....");
+    expect(output).toBe(144);
+  });
+
+  it("reads distinct log lines as work", () => {
+    const { output } = runFor12Minutes(
+      (tick) => `\r\x1b[K[core] resolved harness manifest for project alpha-${tick}\r\n`,
+    );
+    expect(output).toBe(144);
+  });
+
+  it("still reads the Codex idle spinner as the repaint it is", () => {
+    // The target case, unchanged: one output burst as the frame appears, then
+    // nothing but redraws for the rest of the twelve minutes.
+    const { output, longestRedrawRun } = runFor12Minutes(
+      (tick) => `\x1b[2K\x1b[G${tick % 2 ? "⠹" : "⠸"} Working (${tick}s • Esc to interrupt)`,
+    );
+    expect(output).toBe(1);
+    expect(longestRedrawRun).toBe(143);
+  });
+
+  it("never settles on a spinner whose phrase rotates, and says so", () => {
+    // Documented limitation, pinned: a rotating gerund puts a new word on
+    // screen every rotation, so the idle rule never fires for that harness.
+    const phrases = ["Herding", "Simmering", "Pondering", "Noodling"];
+    const { output } = runFor12Minutes(
+      (tick) => `\x1b[2K\x1b[G✻ ${phrases[Math.floor(tick / 6) % phrases.length]}… (${tick}s)`,
+    );
+    expect(output).toBeGreaterThan(20);
+  });
+});
+
+describe("finding what is new at the end of a very large burst", () => {
+  it("sees a new tool line under a full-viewport repaint", () => {
+    // Review of PR 455, finding 3: the scan was front-first and capped, but
+    // `push` keeps the tail of an oversized burst and a TUI paints what is new
+    // at the bottom. A thousand words of unchanged screen must not hide it.
+    const watcher = new PtyOutputActivityWatcher();
+    let now = WINDOW + 1;
+    const viewport = Array.from(
+      { length: 1200 },
+      (_, i) => `line${i}word${i % 7}`,
+    ).join(" ");
+    expect(watcher.push(`\x1b[2J\x1b[H${viewport}`, now)).toBe("output");
+
+    now += WINDOW + 1;
+    expect(watcher.push(`\x1b[2J\x1b[H${viewport}`, now)).toBe("redraw");
+
+    now += WINDOW + 1;
+    expect(
+      watcher.push(`\x1b[2J\x1b[H${viewport} Ran pnpm vitest packages/core`, now),
+    ).toBe("output");
   });
 });

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -65,6 +65,7 @@ import {
   ensureClaudeShiftEnterBinding,
   type PtyCoreDeps,
 } from "./pty-manager";
+import { mapHookEventToStatus } from "@actana/shared/harness-hook-events";
 import { PtyCoreLinkServer } from "./pty-core-link-server";
 import { buildCoreFileRoutes, shouldAnnounceFiles } from "./core-files-wiring";
 import {
@@ -266,7 +267,19 @@ async function startCore(): Promise<void> {
       // what keeps the quiet-Session backstop off a turn that is really
       // running (issue 243). Reported as its own kind, because a Session whose
       // hooks arrive is one the idle rule must defer to (issue 391).
-      sessionBackstop?.noteActivity(taskId, "hook");
+      //
+      // Which kind depends on what the event means, and the map that already
+      // knows is the one the pipeline uses. Only an event that maps to
+      // `running` may take a backstop finish back: `SubagentStart`,
+      // `SubagentStop` and an unmatched `PostToolUse` map to nothing exactly
+      // so a post-turn helper cannot heal a finished card (#385), and this
+      // path is not allowed to reopen that door.
+      const meansRunning =
+        mapHookEventToStatus({
+          ...payload,
+          hook_event_name: payload.hook_event_name || eventNameFallback,
+        }) === "running";
+      sessionBackstop?.noteActivity(taskId, meansRunning ? "turn" : "hook");
       return harnessStatus.receiveHook(taskId, payload, eventNameFallback);
     });
   } catch (err) {

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -264,8 +264,9 @@ async function startCore(): Promise<void> {
     hookReceiver = await startHarnessHookReceiver((taskId, payload, eventNameFallback) => {
       // A hook that landed is this Session talking, whatever it said — that is
       // what keeps the quiet-Session backstop off a turn that is really
-      // running (issue 243).
-      sessionBackstop?.noteActivity(taskId);
+      // running (issue 243). Reported as its own kind, because a Session whose
+      // hooks arrive is one the idle rule must defer to (issue 391).
+      sessionBackstop?.noteActivity(taskId, "hook");
       return harnessStatus.receiveHook(taskId, payload, eventNameFallback);
     });
   } catch (err) {

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -65,7 +65,6 @@ import {
   ensureClaudeShiftEnterBinding,
   type PtyCoreDeps,
 } from "./pty-manager";
-import { mapHookEventToStatus } from "@actana/shared/harness-hook-events";
 import { PtyCoreLinkServer } from "./pty-core-link-server";
 import { buildCoreFileRoutes, shouldAnnounceFiles } from "./core-files-wiring";
 import {
@@ -263,24 +262,21 @@ async function startCore(): Promise<void> {
   let hookReceiver: HarnessHookReceiver | null = null;
   try {
     hookReceiver = await startHarnessHookReceiver((taskId, payload, eventNameFallback) => {
+      const result = harnessStatus.receiveHook(taskId, payload, eventNameFallback);
       // A hook that landed is this Session talking, whatever it said — that is
       // what keeps the quiet-Session backstop off a turn that is really
-      // running (issue 243). Reported as its own kind, because a Session whose
-      // hooks arrive is one the idle rule must defer to (issue 391).
+      // running (issue 243) — and it is also the end of the idle rule's claim
+      // on the row, because the pipeline has just decided the status (issue
+      // 391).
       //
-      // Which kind depends on what the event means, and the map that already
-      // knows is the one the pipeline uses. Only an event that maps to
-      // `running` may take a backstop finish back: `SubagentStart`,
-      // `SubagentStop` and an unmatched `PostToolUse` map to nothing exactly
-      // so a post-turn helper cannot heal a finished card (#385), and this
-      // path is not allowed to reopen that door.
-      const meansRunning =
-        mapHookEventToStatus({
-          ...payload,
-          hook_event_name: payload.hook_event_name || eventNameFallback,
-        }) === "running";
-      sessionBackstop?.noteActivity(taskId, meansRunning ? "turn" : "hook");
-      return harnessStatus.receiveHook(taskId, payload, eventNameFallback);
+      // Reported *after* the pipeline, and only for a hook the pipeline
+      // accepted: `reconcileSessionId` drops a POST carrying another session's
+      // id (base `2bdcb56`), and a hook from a harness process this Session no
+      // longer owns is not evidence that this Session is alive.
+      if (result.body?.ignored !== "foreign-session") {
+        sessionBackstop?.noteActivity(taskId, "hook");
+      }
+      return result;
     });
   } catch (err) {
     console.error(`[core-entry] hook-receiver.start-failed: ${err}`);

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -272,8 +272,10 @@ async function startCore(): Promise<void> {
       // Reported *after* the pipeline, and only for a hook the pipeline
       // accepted: `reconcileSessionId` drops a POST carrying another session's
       // id (base `2bdcb56`), and a hook from a harness process this Session no
-      // longer owns is not evidence that this Session is alive.
-      if (result.body?.ignored !== "foreign-session") {
+      // longer owns is not evidence that this Session is alive. `ok` is the
+      // positive test — it is already false for a row this Core does not have
+      // — and `foreign-session` is the one rejection that answers `ok`.
+      if (result.ok && result.body?.ignored !== "foreign-session") {
         sessionBackstop?.noteActivity(taskId, "hook");
       }
       return result;

--- a/packages/core/src/core-entry.ts
+++ b/packages/core/src/core-entry.ts
@@ -302,8 +302,11 @@ async function startCore(): Promise<void> {
     onSessionOutputSignal: ({ taskId, signal }) => harnessStatus.outputSignal(taskId, signal),
     // A harness that is working redraws its spinner into the PTY about once a
     // second. Silence there, and no hooks either, is what the backstop below
-    // reads as "this turn ended and nobody said so" (issue 243).
-    onSessionOutputActivity: ({ taskId }) => sessionBackstop?.noteActivity(taskId),
+    // reads as "this turn ended and nobody said so" (issue 243) — and a
+    // spinner that is all that is left, with nothing new on screen behind it,
+    // is what it reads as an idle TUI nobody will ever hear a `Stop` from
+    // (issue 391). The PTY core says which of the two arrived.
+    onSessionOutputActivity: ({ taskId, kind }) => sessionBackstop?.noteActivity(taskId, kind),
   };
 
   // Eagerly install Claude Code's Shift+Enter keybinding flag for terminals

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -77,9 +77,9 @@
 //      ({@link IDLE_REOPEN_MS}). Nothing else is marked, so an operator's
 //      finish and the quiet rule's finish are never reopened by stray bytes;
 //      no hook of any kind reopens anything, because a post-turn helper
-//      healing a finished card is the bug #385 closed; and the marker is
-//      dropped the moment any hook arrives or anyone else writes the row, so
-//      a finish that a real `Stop` wrote is never taken back either.
+//      healing a finished card is the bug #385 closed; and the claim ends the
+//      moment anyone else writes the row — which is how a finish that a real
+//      `Stop` wrote is never taken back, since that write moves `updatedAt`.
 //   2. **It defers to hooks, for a while.** A Session whose hooks arrive has a
 //      better witness than its pixels: if it has printed anything real since
 //      its last hook it is mid-turn — a single `Bash` call emits no hook until
@@ -95,10 +95,14 @@
 // `session:finished` (the operator's completion toast, and the signal
 // `actana session wait` unblocks on) and clears the tracked subagent set. The
 // reopen puts the status back; it cannot un-send a notification or restore
-// that set, which expires on its own (#464). And a harness parked on a
-// permission dialog nobody pattern-matched repaints it statically, which is
-// this rule's condition exactly — it is settled like any idle screen, and that
-// is #469.
+// that set, which expires on its own (#464 — which also records that a hooked
+// harness flaps the same way a hookless one does, and that `forget()` drops
+// `hookAt` with the rest of the stamps). A harness parked on a permission
+// dialog nobody pattern-matched repaints it statically, which is this rule's
+// condition exactly, so it is settled like any idle screen (#469). And the
+// reopen cannot tell the harness's own output from the echo of an operator
+// typing, so a correct finish can be taken back by somebody starting to type
+// (#475).
 //
 // Only `running` is in scope. `needs-input` is a Session waiting on a human,
 // which is a state it is allowed to sit in indefinitely and silently; a card
@@ -338,14 +342,17 @@ export class CoreSessionBackstop {
       if (oldest === undefined) break;
       this.lastActivity.delete(oldest);
     }
-    // A hook hands the row back to the pipeline: whatever it writes — a
-    // `Stop`'s finish, a `UserPromptSubmit`'s `running` — is authoritative,
-    // and a finish this rule wrote before it is not this file's to take back
-    // any more. Dropping the marker here is what keeps a post-turn composer
-    // paint from reopening a row a real `Stop` has since finished (review of
-    // PR 455, round 3).
-    if (isHook) this.idleSettled.delete(taskId);
-    else if (kind === "output") this.reopenIfIdleSettled(taskId, now);
+    // No hook ever reopens a row — a post-turn helper healing a finished card
+    // is the bug #385 closed. What a hook does *not* do is end this rule's
+    // claim on its own: `SubagentStart`, `SubagentStop` and an unmatched
+    // `PostToolUse` map to no status and the pipeline writes nothing for them,
+    // so dropping the marker there would disarm the recovery for every
+    // ordinary tool call — `PostToolUse` is installed unmatched, and it lands
+    // milliseconds after a tool completes while this classifier reports once
+    // every five seconds (review of PR 455, round 4). A hook that *did* decide
+    // the status moved the row, and {@link reopenIfIdleSettled}'s `updatedAt`
+    // comparison is what reads that — the same test, done honestly.
+    if (kind === "output") this.reopenIfIdleSettled(taskId, now);
   }
 
   /**
@@ -359,7 +366,10 @@ export class CoreSessionBackstop {
    * writes `finished` over a `finished`, and reopening that is exactly the
    * post-turn resurrection #385 closed. So the settle records the row's
    * `updatedAt` and the reopen requires it unchanged; anybody else's write,
-   * whatever status it left behind, ends this rule's claim.
+   * whatever status it left behind, ends this rule's claim. That is also the
+   * only thing that reads a hook: a hook the pipeline wrote a status for moved
+   * the row, and one it wrote nothing for decided nothing and leaves the
+   * recovery armed.
    *
    * The subagent set cleared by the settle cannot be restored, which is the
    * one part of a wrong idle settle that does not come back; it expires on
@@ -368,13 +378,24 @@ export class CoreSessionBackstop {
   private reopenIfIdleSettled(taskId: string, now: number): void {
     const marker = this.idleSettled.get(taskId);
     if (marker === undefined) return;
-    this.idleSettled.delete(taskId);
-    if (now - marker.at > (this.deps.reopenMs ?? IDLE_REOPEN_MS)) return;
+    if (now - marker.at > (this.deps.reopenMs ?? IDLE_REOPEN_MS)) {
+      this.idleSettled.delete(taskId);
+      return;
+    }
     try {
       const task = this.deps.writer.readTask(taskId);
-      if (task?.status !== "finished") return;
-      if (task.updatedAt !== marker.rowUpdatedAt) return;
+      // Somebody else's status, or somebody else's write under the same
+      // status: either way the row is theirs now and this claim is over.
+      if (task?.status !== "finished" || task.updatedAt !== marker.rowUpdatedAt) {
+        this.idleSettled.delete(taskId);
+        return;
+      }
+      // The marker is dropped only once the write has actually landed. A
+      // `mutate` that throws or answers `null` — SQLite busy against the
+      // concurrent event-log writer — must leave the next burst five seconds
+      // from now able to try again, rather than having spent the one chance.
       if (!this.deps.writer.mutate({ op: "update", taskId, status: "running" })) return;
+      this.idleSettled.delete(taskId);
       log.info("session-backstop.reopened", { taskId, quietForMs: now - marker.at });
     } catch (err) {
       log.warn("session-backstop.reopen-failed", { taskId, error: String(err) });

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -72,15 +72,21 @@
 // So the rule now pays its own bill, three ways.
 //
 //   1. **It takes the finish back.** A `finished` written by the *idle* rule
-//      is marked, and the next `output`-class burst or hook on that Session
-//      returns the row to `running` ({@link IDLE_REOPEN_MS}). Nothing else is
-//      marked, so an operator's finish, a hook's finish and the quiet rule's
-//      finish are never reopened by stray bytes.
-//   2. **It defers to hooks.** A Session whose hooks arrive has a better
-//      witness than its pixels: if it has printed anything real since its last
-//      hook it is mid-turn — a single `Bash` call emits no hook until it
-//      completes — and the idle rule stands down. The rule is for the harness
-//      that cannot report itself at all.
+//      is marked, and the next `output`-class burst — or a hook that means the
+//      turn is running — returns the row to `running`
+//      ({@link IDLE_REOPEN_MS}). Nothing else is marked, so an operator's
+//      finish, a hook's finish and the quiet rule's finish are never reopened
+//      by stray bytes; and a `SubagentStart`, a `SubagentStop` or an unmatched
+//      `PostToolUse` never reopens anything, because a post-turn helper
+//      healing a finished card is the bug #385 closed.
+//   2. **It defers to hooks, for a while.** A Session whose hooks arrive has a
+//      better witness than its pixels: if it has printed anything real since
+//      its last hook it is mid-turn — a single `Bash` call emits no hook until
+//      it completes — and the idle rule stands down. But only for
+//      {@link HOOK_DEFERENCE_MS}: deferring forever would mean a dropped
+//      `Stop` on a hooked harness is never settled at all, which is the other
+//      half of #391. Past the bound the screen is the only evidence left, and
+//      the rule reads it.
 //   3. **It asks twice.** {@link IDLE_SWEEPS_REQUIRED} consecutive sweeps must
 //      agree before a row moves.
 //
@@ -171,6 +177,26 @@ const IDLE_SWEEPS_REQUIRED = 2;
 const IDLE_REOPEN_MS = 30 * 60 * 1000;
 
 /**
+ * How long a hook keeps the idle rule off a Session that has printed something
+ * since it.
+ *
+ * The deference exists because a hooked harness mid-tool-call and a hooked
+ * harness whose `Stop` dropped look identical from here, and settling the
+ * first is the worse mistake. But an unbounded deference settles neither: the
+ * review of PR 455 drove four hours of spinner on a Session whose `Stop` had
+ * dropped and got `running`, which is the second failure #391 names, put back.
+ *
+ * So it is bounded, at the same quarter of an hour the quiet rule already
+ * calls long enough to be over. Under it, a tool call that has printed nothing
+ * new is protected — and it does not need to be protected for long, because
+ * the eight-minute window plus its confirming sweep already clears a
+ * six-minute call with no hook gate at all. Over it, the screen is the only
+ * evidence left and the idle rule reads it, so a dropped `Stop` on a hooked
+ * harness settles at about sixteen minutes rather than never.
+ */
+const HOOK_DEFERENCE_MS = 15 * 60 * 1000;
+
+/**
  * How recently bytes must have arrived for the idle rule to apply at all.
  *
  * The idle rule's whole premise is "the harness is still there, and painting".
@@ -213,19 +239,32 @@ export type CoreSessionBackstopDeps = {
   paintingMs?: number;
   /** Overrides {@link IDLE_REOPEN_MS}. */
   reopenMs?: number;
+  /** Overrides {@link HOOK_DEFERENCE_MS}. */
+  hookDeferenceMs?: number;
   intervalMs?: number;
 };
 
 /**
  * What a Session was heard doing.
  *
- * `hook` is a POST from the harness's own lifecycle hooks — the strongest
- * signal there is, and the one that says this harness *can* report itself.
- * `output` is a burst of PTY output that put something new on screen. `redraw`
- * is a burst that repainted what was already there. Only `redraw` leaves the
- * idle rule's clock running.
+ * `turn` is a hook the harness's own event map reads as the turn running —
+ * `UserPromptSubmit`, `CursorBeforeSubmitPrompt`, `PermissionReplied`, an
+ * `AskUserQuestion` `PostToolUse`. It is the only hook kind that may take back
+ * a finish: `SubagentStart`, `SubagentStop` and an unmatched `PostToolUse` map
+ * to no status precisely so they cannot resurrect a finished card (#385,
+ * `5d33f0c`), and this path must not undo that.
+ *
+ * `hook` is any other accepted hook. It is still activity — it keeps both
+ * rules off — and it is still the evidence that this harness can report
+ * itself; it simply never reopens a row.
+ *
+ * `output` is a burst of PTY output that put something new on screen; it is
+ * activity, and it does reopen an idle-settled row, because new content on
+ * screen is the harness itself saying the turn was not over. `redraw` is a
+ * burst that repainted what was already there, and is the only kind that
+ * leaves the idle rule's clock running.
  */
-export type SessionActivityKind = "hook" | "output" | "redraw";
+export type SessionActivityKind = "turn" | "hook" | "output" | "redraw";
 
 /** What this Core has heard from one Session, and what it made of it. */
 type SessionActivity = {
@@ -279,16 +318,19 @@ export class CoreSessionBackstop {
     // Re-insert so insertion order approximates recency for the cap below.
     this.lastActivity.delete(taskId);
     const progress = kind !== "redraw";
+    const isHook = kind === "hook" || kind === "turn";
+    // Only a hook that means the turn is running, or new content on screen,
+    // may take a finish back. Every other hook is activity and nothing more.
+    const mayReopen = kind === "turn" || kind === "output";
     this.lastActivity.set(taskId, {
       heardAt: now,
       // A redraw is the harness being there, not the turn getting anywhere:
       // it keeps the quiet rule off and leaves the idle rule's clock running.
       outputAt: progress ? now : (prior?.outputAt ?? 0),
-      hookAt: kind === "hook" ? now : (prior?.hookAt ?? 0),
+      hookAt: isHook ? now : (prior?.hookAt ?? 0),
       // A hook resets the count; an `output` burst adds to it. Both are read
       // by the idle rule as "this harness has more to say".
-      outputSinceHook:
-        kind === "hook" ? 0 : (prior?.outputSinceHook ?? 0) + (kind === "output" ? 1 : 0),
+      outputSinceHook: isHook ? 0 : (prior?.outputSinceHook ?? 0) + (kind === "output" ? 1 : 0),
       // Any progress breaks a run of idle sweeps.
       idleSweeps: progress ? 0 : (prior?.idleSweeps ?? 0),
     });
@@ -297,7 +339,7 @@ export class CoreSessionBackstop {
       if (oldest === undefined) break;
       this.lastActivity.delete(oldest);
     }
-    if (progress) this.reopenIfIdleSettled(taskId, now);
+    if (mayReopen) this.reopenIfIdleSettled(taskId, now);
   }
 
   /**
@@ -377,7 +419,14 @@ export class CoreSessionBackstop {
         // if it has printed anything real since its last hook, it is mid-turn
         // and the hook that ends the turn is still coming. A Session that has
         // never had a hook — the case #391 is about — has only its screen.
-        const hooksSpeakForIt = stamps.hookAt > 0 && stamps.outputSinceHook > 0;
+        // ...and only for as long as a tool call could plausibly still be
+        // running. An unbounded deference never settles a dropped `Stop` on a
+        // hooked harness, which is the other half of #391.
+        const hookDeferenceMs = this.deps.hookDeferenceMs ?? HOOK_DEFERENCE_MS;
+        const hooksSpeakForIt =
+          stamps.hookAt > 0 &&
+          stamps.outputSinceHook > 0 &&
+          now - stamps.hookAt < hookDeferenceMs;
         const idleNow = painting && !hooksSpeakForIt && now - lastOutput >= idleMs;
         stamps.idleSweeps = idleNow ? stamps.idleSweeps + 1 : 0;
         if (stamps.idleSweeps < IDLE_SWEEPS_REQUIRED) continue;

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -41,8 +41,8 @@
 // So output is read rather than counted (`pty-output-activity.ts`): a burst
 // that puts a word on screen that was not already there is `output`, and a
 // burst that repaints what is already there — spinner glyph, bigger number,
-// same words — is `redraw`. Hooks are always `output`; nothing a harness
-// bothers to POST is a repaint.
+// same words — is `redraw`. A hook is its own kind and always counts as
+// progress; nothing a harness bothers to POST is a repaint.
 //
 // That gives this file two rules rather than one, and a Session settles on
 // whichever fires first:
@@ -59,12 +59,36 @@
 // A turn that is genuinely printing output re-stamps the second rule with
 // every burst, so the rule that can end it is the same one that always could.
 //
-// The trade is stated plainly: a harness that works in total silence for
-// longer than the quiet window gets a card that says `finished` while it is
-// still going. Nothing is killed, no process is touched, and the next turn's
-// `UserPromptSubmit` puts the row back on `running`. Against that: before this
-// file, a lost `Stop` wedged a Session on `running` until a human edited the
-// row by hand — and the whole failure mode is that the Panel says otherwise.
+// ─── What a wrong idle settle costs, and how it is paid back ───
+//
+// The first cut of this said the mistake was cheap because "the next hook or
+// byte of real output puts the row back on `running`". That was not true, and
+// the review of PR 455 was right to block on it: `harness-hook-events.ts` maps
+// only `UserPromptSubmit`, `CursorBeforeSubmitPrompt` and `PermissionReplied`
+// to `running` — `PostToolUse`, `SubagentStart` and `SubagentStop` map to
+// nothing — and the PTY output path writes no status at all. A row settled
+// early stayed `finished` until the operator's next prompt.
+//
+// So the rule now pays its own bill, three ways.
+//
+//   1. **It takes the finish back.** A `finished` written by the *idle* rule
+//      is marked, and the next `output`-class burst or hook on that Session
+//      returns the row to `running` ({@link IDLE_REOPEN_MS}). Nothing else is
+//      marked, so an operator's finish, a hook's finish and the quiet rule's
+//      finish are never reopened by stray bytes.
+//   2. **It defers to hooks.** A Session whose hooks arrive has a better
+//      witness than its pixels: if it has printed anything real since its last
+//      hook it is mid-turn — a single `Bash` call emits no hook until it
+//      completes — and the idle rule stands down. The rule is for the harness
+//      that cannot report itself at all.
+//   3. **It asks twice.** {@link IDLE_SWEEPS_REQUIRED} consecutive sweeps must
+//      agree before a row moves.
+//
+// What still costs, and is not claimed otherwise: the settle emits
+// `session:finished` (the operator's completion toast, and the signal
+// `actana session wait` unblocks on) and clears the tracked subagent set. The
+// reopen puts the status back; it cannot un-send a notification or restore
+// that set, which expires on its own.
 //
 // Only `running` is in scope. `needs-input` is a Session waiting on a human,
 // which is a state it is allowed to sit in indefinitely and silently; a card
@@ -96,21 +120,55 @@ const QUIET_SETTLE_MS = 15 * 60 * 1000;
  * anything new on screen and without a hook before this settles it (issue
  * 391).
  *
- * Five minutes, and the two directions it is chosen against are not the ones
- * above. Below it sits the gap between one piece of real output and the next
- * within a live turn: a tool call that prints as it goes, a model streaming
- * prose, a build logging its steps — all of them beat five minutes by orders
- * of magnitude, and any of them re-stamps the window. Above it sits the only
- * thing this rule is for: a harness that ended its turn, never said so, and is
- * now painting a clock at an operator who is waiting on a card. Five minutes
- * is a wait; fifteen was the whole Fleet view losing its meaning.
+ * Eight minutes, raised from the five this shipped for review. The direction
+ * it is chosen against is not the quiet rule's: below it sits the gap between
+ * one piece of real output and the next inside a live turn, and the review of
+ * PR 455 found that gap is longer than a spinner tick suggests. A single
+ * `Bash` tool call emits no hook until it completes — Claude Code installs
+ * `PreToolUse` with an `AskUserQuestion` matcher — so a six-minute build on a
+ * harness whose hooks work perfectly has nothing but its TUI to say so.
+ * Eight minutes plus {@link IDLE_SWEEPS_REQUIRED} sweeps clears that build,
+ * and is still a wait an operator can sit through where "never" is not.
  *
- * What it costs: a turn whose tool prints nothing at all for five minutes, on
- * a harness whose hooks are also not arriving, reads `finished` while it runs.
- * Nothing is killed, and the next hook or byte of real output puts the row
- * back on `running`.
+ * Above it sits the only thing this rule is for: a harness that ended its turn,
+ * never said so, and is now painting a clock at an operator waiting on a card.
+ *
+ * What it costs is bounded three ways rather than argued away: the rule fires
+ * only for a Session whose hooks are not arriving (see `outputSinceHook`), only
+ * after the condition has held across two sweeps, and a `finished` it writes is
+ * taken back by the next `output`-class burst — {@link IDLE_REOPEN_MS}.
  */
-const IDLE_REDRAW_SETTLE_MS = 5 * 60 * 1000;
+const IDLE_REDRAW_SETTLE_MS = 8 * 60 * 1000;
+
+/**
+ * How many consecutive sweeps must agree before the idle rule settles a row.
+ *
+ * The sweep runs once a minute, so this is a minute of confirmation on top of
+ * the window — cheap, and it costs a mis-timed settle nothing but a minute.
+ * The review of PR 455 asked for it by name: one sweep is one sample of a
+ * screen, and a screen can be between frames.
+ */
+const IDLE_SWEEPS_REQUIRED = 2;
+
+/**
+ * How long after an idle-rule settle the same Session may be un-finished by
+ * new output.
+ *
+ * The whole argument for a window shorter than fifteen minutes is that the
+ * mistake is cheap. It was not: a hook does not un-finish a row
+ * (`harness-hook-events.ts` maps only `UserPromptSubmit`,
+ * `CursorBeforeSubmitPrompt` and `PermissionReplied` to `running`), and the PTY
+ * output path writes no status at all — so before this, a row the idle rule
+ * settled early stayed `finished` until the operator's next prompt. Now the
+ * rule that wrote it takes it back: any `output`-class burst or hook inside
+ * this window puts the row back on `running`.
+ *
+ * Half an hour, because the thing being recovered from is a long tool call, and
+ * because the marker is only ever set by this rule — an operator's finish, a
+ * hook's finish and the quiet rule's finish are never reopened, whatever the
+ * harness writes to its PTY afterwards.
+ */
+const IDLE_REOPEN_MS = 30 * 60 * 1000;
 
 /**
  * How recently bytes must have arrived for the idle rule to apply at all.
@@ -153,26 +211,53 @@ export type CoreSessionBackstopDeps = {
   idleMs?: number;
   /** Overrides {@link STILL_PAINTING_MS}. */
   paintingMs?: number;
+  /** Overrides {@link IDLE_REOPEN_MS}. */
+  reopenMs?: number;
   intervalMs?: number;
 };
 
 /**
- * What a Session was heard doing. `output` is a hook, or a burst of PTY output
- * that put something new on screen; `redraw` is a burst that repainted what
- * was already there. Only `output` holds the idle rule off.
+ * What a Session was heard doing.
+ *
+ * `hook` is a POST from the harness's own lifecycle hooks — the strongest
+ * signal there is, and the one that says this harness *can* report itself.
+ * `output` is a burst of PTY output that put something new on screen. `redraw`
+ * is a burst that repainted what was already there. Only `redraw` leaves the
+ * idle rule's clock running.
  */
-export type SessionActivityKind = "output" | "redraw";
+export type SessionActivityKind = "hook" | "output" | "redraw";
+
+/** What this Core has heard from one Session, and what it made of it. */
+type SessionActivity = {
+  /** Last time anything at all arrived — a hook, or any byte. */
+  heardAt: number;
+  /** Last time something new appeared: a hook, or an `output` burst. */
+  outputAt: number;
+  /** Last hook, or `0` if this Core has never had one for this Session. */
+  hookAt: number;
+  /**
+   * `output` bursts since that hook. The idle rule needs this to be zero for a
+   * Session whose hooks work: a harness that printed something real since its
+   * last hook is mid-turn, and its next hook is the tool call finishing.
+   */
+  outputSinceHook: number;
+  /** Consecutive sweeps in which the idle condition has held. */
+  idleSweeps: number;
+};
 
 /**
  * The Core's quiet-Session backstop. One instance per Core process; the hook
  * receiver and the PTY output path feed it, and it feeds the task writer.
  */
 export class CoreSessionBackstop {
+  /** Per Session: what this Core has heard from it. A redraw moves `heardAt` only. */
+  private readonly lastActivity = new Map<string, SessionActivity>();
   /**
-   * Per Session: when it was last heard at all, and when it was last heard
-   * saying something new. A redraw moves `heardAt` only.
+   * Sessions this instance's *idle* rule wrote a `finished` for, and when.
+   * Nothing else is ever in here — not the quiet rule, not a hook's finish,
+   * not an operator's — so nothing else can be reopened by stray bytes.
    */
-  private readonly lastActivity = new Map<string, { heardAt: number; outputAt: number }>();
+  private readonly idleSettled = new Map<string, number>();
   private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly deps: CoreSessionBackstopDeps) {}
@@ -182,9 +267,10 @@ export class CoreSessionBackstop {
    * wrote output. Cheap on purpose: it is called from the PTY data path (the
    * caller throttles and classifies) and from every accepted hook.
    *
-   * `kind` says which of the two rules at the top of this file the call feeds.
-   * It defaults to `output` because every caller that has an opinion is
-   * reporting real work: a hook that landed is not a repaint.
+   * `kind` says what was heard, and the default is `output` because a caller
+   * with no opinion is reporting real work. The hook receiver passes `hook`,
+   * which additionally tells the idle rule that this harness can report
+   * itself; the PTY path passes what the classifier made of the bytes.
    */
   noteActivity(taskId: string, kind: SessionActivityKind = "output"): void {
     if (!taskId) return;
@@ -192,22 +278,59 @@ export class CoreSessionBackstop {
     const prior = this.lastActivity.get(taskId);
     // Re-insert so insertion order approximates recency for the cap below.
     this.lastActivity.delete(taskId);
+    const progress = kind !== "redraw";
     this.lastActivity.set(taskId, {
       heardAt: now,
       // A redraw is the harness being there, not the turn getting anywhere:
       // it keeps the quiet rule off and leaves the idle rule's clock running.
-      outputAt: kind === "output" ? now : (prior?.outputAt ?? 0),
+      outputAt: progress ? now : (prior?.outputAt ?? 0),
+      hookAt: kind === "hook" ? now : (prior?.hookAt ?? 0),
+      // A hook resets the count; an `output` burst adds to it. Both are read
+      // by the idle rule as "this harness has more to say".
+      outputSinceHook:
+        kind === "hook" ? 0 : (prior?.outputSinceHook ?? 0) + (kind === "output" ? 1 : 0),
+      // Any progress breaks a run of idle sweeps.
+      idleSweeps: progress ? 0 : (prior?.idleSweeps ?? 0),
     });
     while (this.lastActivity.size > MAX_TRACKED_TASKS) {
       const oldest = this.lastActivity.keys().next().value;
       if (oldest === undefined) break;
       this.lastActivity.delete(oldest);
     }
+    if (progress) this.reopenIfIdleSettled(taskId, now);
+  }
+
+  /**
+   * Take back a `finished` this instance's idle rule wrote, because the
+   * harness has just proved the turn was still running.
+   *
+   * Only a row this rule settled is eligible, only while the marker is inside
+   * {@link IDLE_REOPEN_MS}, and only if the row still says `finished` — a
+   * status anyone else has since written is theirs, and the marker is dropped
+   * rather than argued with. The subagent set cleared by the settle cannot be
+   * restored, which is the one part of a wrong idle settle that does not come
+   * back; it expires on its own.
+   */
+  private reopenIfIdleSettled(taskId: string, now: number): void {
+    const settledAt = this.idleSettled.get(taskId);
+    if (settledAt === undefined) return;
+    this.idleSettled.delete(taskId);
+    if (now - settledAt > (this.deps.reopenMs ?? IDLE_REOPEN_MS)) return;
+    try {
+      if (this.deps.writer.readTask(taskId)?.status !== "finished") return;
+      if (!this.deps.writer.mutate({ op: "update", taskId, status: "running" })) return;
+      log.info("session-backstop.reopened", { taskId, quietForMs: now - settledAt });
+    } catch (err) {
+      log.warn("session-backstop.reopen-failed", { taskId, error: String(err) });
+    }
   }
 
   /** Forget a Session — its process is gone and something else settled it. */
   forget(taskId: string): void {
     this.lastActivity.delete(taskId);
+    // A process that is gone writes no more bytes, so nothing is left that
+    // could justify reopening the row.
+    this.idleSettled.delete(taskId);
   }
 
   start(): void {
@@ -244,12 +367,23 @@ export class CoreSessionBackstop {
       // alone — and only ever by this rule, because a Core that has heard no
       // bytes cannot know whether the ones it missed were redraws.
       const quiet = now - lastHeard >= quietMs;
-      // Idle: the harness is demonstrably still painting, and nothing new has
-      // appeared on screen for the short window (issue 391).
-      const painting = stamps !== undefined && now - stamps.heardAt <= paintingMs;
-      const lastOutput = Math.max(stamps?.outputAt ?? 0, task.updatedAt);
-      const idle = painting && now - lastOutput >= idleMs;
-      if (!quiet && !idle) continue;
+      if (!quiet && stamps) {
+        // Idle: the harness is demonstrably still painting, nothing new has
+        // appeared on screen for the window, and its hooks are not the thing
+        // carrying the turn (issue 391, narrowed by the review of PR 455).
+        const painting = now - stamps.heardAt <= paintingMs;
+        const lastOutput = Math.max(stamps.outputAt, task.updatedAt);
+        // A Session whose hooks arrive has a better witness than its pixels:
+        // if it has printed anything real since its last hook, it is mid-turn
+        // and the hook that ends the turn is still coming. A Session that has
+        // never had a hook — the case #391 is about — has only its screen.
+        const hooksSpeakForIt = stamps.hookAt > 0 && stamps.outputSinceHook > 0;
+        const idleNow = painting && !hooksSpeakForIt && now - lastOutput >= idleMs;
+        stamps.idleSweeps = idleNow ? stamps.idleSweeps + 1 : 0;
+        if (stamps.idleSweeps < IDLE_SWEEPS_REQUIRED) continue;
+      } else if (!quiet) {
+        continue;
+      }
       if (this.settle(task.taskId, quiet ? "quiet" : "idle")) settled.push(task.taskId);
     }
     return settled;
@@ -271,6 +405,16 @@ export class CoreSessionBackstop {
       clearSubagentActivity(taskId);
       if (status === "finished") noteTaskFinished(taskId);
       this.forget(taskId);
+      // Only the idle rule leaves a marker, and only a `finished` can be taken
+      // back — a `disconnected` row has no process left to change its mind.
+      if (rule === "idle" && status === "finished") {
+        this.idleSettled.set(taskId, this.now());
+        while (this.idleSettled.size > MAX_TRACKED_TASKS) {
+          const oldest = this.idleSettled.keys().next().value;
+          if (oldest === undefined) break;
+          this.idleSettled.delete(oldest);
+        }
+      }
       log.info("session-backstop.settled", { taskId, status, rule });
       return true;
     } catch (err) {

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -28,6 +28,37 @@
 // yet (it was written when the row last changed), so a Core that just booted
 // does not settle a Session it has simply not met.
 //
+// ─── Why silence alone is not enough (issue 391) ───
+//
+// That reasoning has a hole in it, and it is the case an operator hits most:
+// the harness whose hooks are not arriving is usually the harness whose TUI is
+// still on screen. Codex before its hooks have been reviewed with `/hooks`
+// paints a spinner and an elapsed-time counter into the PTY for as long as the
+// process lives, turn or no turn. Those bytes are a redraw, not work — but
+// counted as activity they mean a quarter of an hour of total silence never
+// arrives, and the card claims `running` until someone edits the row.
+//
+// So output is read rather than counted (`pty-output-activity.ts`): a burst
+// that puts a word on screen that was not already there is `output`, and a
+// burst that repaints what is already there — spinner glyph, bigger number,
+// same words — is `redraw`. Hooks are always `output`; nothing a harness
+// bothers to POST is a repaint.
+//
+// That gives this file two rules rather than one, and a Session settles on
+// whichever fires first:
+//
+//   * **Quiet** — nothing at all, no hook and no byte of any kind, for
+//     {@link QUIET_SETTLE_MS}. Unchanged, and it is the only rule that can
+//     reach a Session this process has never heard from.
+//   * **Idle** — bytes are still arriving (the TUI is painting, so the
+//     harness is there), but nothing new has appeared on screen and no hook
+//     has landed for {@link IDLE_REDRAW_SETTLE_MS}. This is the finish-class
+//     backstop the fifteen-minute rule cannot be: it does not wait for the
+//     redraws to stop, because they never do.
+//
+// A turn that is genuinely printing output re-stamps the second rule with
+// every burst, so the rule that can end it is the same one that always could.
+//
 // The trade is stated plainly: a harness that works in total silence for
 // longer than the quiet window gets a card that says `finished` while it is
 // still going. Nothing is killed, no process is touched, and the next turn's
@@ -60,6 +91,38 @@ import type { CoreTaskWriter } from "./core-task-writer";
  */
 const QUIET_SETTLE_MS = 15 * 60 * 1000;
 
+/**
+ * How long a `running` Session whose harness is still painting may go without
+ * anything new on screen and without a hook before this settles it (issue
+ * 391).
+ *
+ * Five minutes, and the two directions it is chosen against are not the ones
+ * above. Below it sits the gap between one piece of real output and the next
+ * within a live turn: a tool call that prints as it goes, a model streaming
+ * prose, a build logging its steps — all of them beat five minutes by orders
+ * of magnitude, and any of them re-stamps the window. Above it sits the only
+ * thing this rule is for: a harness that ended its turn, never said so, and is
+ * now painting a clock at an operator who is waiting on a card. Five minutes
+ * is a wait; fifteen was the whole Fleet view losing its meaning.
+ *
+ * What it costs: a turn whose tool prints nothing at all for five minutes, on
+ * a harness whose hooks are also not arriving, reads `finished` while it runs.
+ * Nothing is killed, and the next hook or byte of real output puts the row
+ * back on `running`.
+ */
+const IDLE_REDRAW_SETTLE_MS = 5 * 60 * 1000;
+
+/**
+ * How recently bytes must have arrived for the idle rule to apply at all.
+ *
+ * The idle rule's whole premise is "the harness is still there, and painting".
+ * A Session that has gone properly silent is the other rule's business, at the
+ * window that rule was tuned for — so a lull in a chatty harness never gets
+ * settled on the shorter clock by accident. A painting TUI redraws about once
+ * a second, so two minutes is slack, not a threshold.
+ */
+const STILL_PAINTING_MS = 2 * 60 * 1000;
+
 /** How often the sweep runs. Matches the deferred-finish recheck's cadence. */
 const SWEEP_INTERVAL_MS = 60 * 1000;
 
@@ -86,15 +149,30 @@ export type CoreSessionBackstopDeps = {
   /** Injected in tests. */
   now?: () => number;
   quietMs?: number;
+  /** Overrides {@link IDLE_REDRAW_SETTLE_MS}. */
+  idleMs?: number;
+  /** Overrides {@link STILL_PAINTING_MS}. */
+  paintingMs?: number;
   intervalMs?: number;
 };
+
+/**
+ * What a Session was heard doing. `output` is a hook, or a burst of PTY output
+ * that put something new on screen; `redraw` is a burst that repainted what
+ * was already there. Only `output` holds the idle rule off.
+ */
+export type SessionActivityKind = "output" | "redraw";
 
 /**
  * The Core's quiet-Session backstop. One instance per Core process; the hook
  * receiver and the PTY output path feed it, and it feeds the task writer.
  */
 export class CoreSessionBackstop {
-  private readonly lastActivity = new Map<string, number>();
+  /**
+   * Per Session: when it was last heard at all, and when it was last heard
+   * saying something new. A redraw moves `heardAt` only.
+   */
+  private readonly lastActivity = new Map<string, { heardAt: number; outputAt: number }>();
   private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly deps: CoreSessionBackstopDeps) {}
@@ -102,13 +180,24 @@ export class CoreSessionBackstop {
   /**
    * This Session just did something observable — a hook landed, or its PTY
    * wrote output. Cheap on purpose: it is called from the PTY data path (the
-   * caller throttles) and from every accepted hook.
+   * caller throttles and classifies) and from every accepted hook.
+   *
+   * `kind` says which of the two rules at the top of this file the call feeds.
+   * It defaults to `output` because every caller that has an opinion is
+   * reporting real work: a hook that landed is not a repaint.
    */
-  noteActivity(taskId: string): void {
+  noteActivity(taskId: string, kind: SessionActivityKind = "output"): void {
     if (!taskId) return;
+    const now = this.now();
+    const prior = this.lastActivity.get(taskId);
     // Re-insert so insertion order approximates recency for the cap below.
     this.lastActivity.delete(taskId);
-    this.lastActivity.set(taskId, this.now());
+    this.lastActivity.set(taskId, {
+      heardAt: now,
+      // A redraw is the harness being there, not the turn getting anywhere:
+      // it keeps the quiet rule off and leaves the idle rule's clock running.
+      outputAt: kind === "output" ? now : (prior?.outputAt ?? 0),
+    });
     while (this.lastActivity.size > MAX_TRACKED_TASKS) {
       const oldest = this.lastActivity.keys().next().value;
       if (oldest === undefined) break;
@@ -140,23 +229,37 @@ export class CoreSessionBackstop {
    */
   sweepOnce(): string[] {
     const quietMs = this.deps.quietMs ?? QUIET_SETTLE_MS;
+    const idleMs = this.deps.idleMs ?? IDLE_REDRAW_SETTLE_MS;
+    const paintingMs = this.deps.paintingMs ?? STILL_PAINTING_MS;
     const now = this.now();
     const settled: string[] = [];
 
     for (const task of this.deps.listActiveTasks()) {
       // `needs-input` is a Session waiting on a human, and may wait forever.
       if (task.status !== "running") continue;
-      const lastHeard = Math.max(this.lastActivity.get(task.taskId) ?? 0, task.updatedAt);
-      if (now - lastHeard < quietMs) continue;
-      if (this.settle(task.taskId)) settled.push(task.taskId);
+      const stamps = this.lastActivity.get(task.taskId);
+      const lastHeard = Math.max(stamps?.heardAt ?? 0, task.updatedAt);
+      // Quiet: nothing of any kind for the long window. The row's own write is
+      // the floor, so a Session this process has never met is judged on that
+      // alone — and only ever by this rule, because a Core that has heard no
+      // bytes cannot know whether the ones it missed were redraws.
+      const quiet = now - lastHeard >= quietMs;
+      // Idle: the harness is demonstrably still painting, and nothing new has
+      // appeared on screen for the short window (issue 391).
+      const painting = stamps !== undefined && now - stamps.heardAt <= paintingMs;
+      const lastOutput = Math.max(stamps?.outputAt ?? 0, task.updatedAt);
+      const idle = painting && now - lastOutput >= idleMs;
+      if (!quiet && !idle) continue;
+      if (this.settle(task.taskId, quiet ? "quiet" : "idle")) settled.push(task.taskId);
     }
     return settled;
   }
 
-  private settle(taskId: string): boolean {
-    // A live PTY means the harness is there and simply stopped talking: the
-    // turn ended and its `Stop` never arrived. No PTY means the process went
-    // away without its exit being recorded, which is not a finish at all.
+  private settle(taskId: string, rule: "quiet" | "idle"): boolean {
+    // A live PTY means the harness is there and either stopped talking or is
+    // only repainting: the turn ended and its `Stop` never arrived. No PTY
+    // means the process went away without its exit being recorded, which is
+    // not a finish at all.
     const alive = this.deps.hasLivePty ? this.deps.hasLivePty(taskId) : true;
     const status = alive ? "finished" : "disconnected";
     try {
@@ -168,10 +271,10 @@ export class CoreSessionBackstop {
       clearSubagentActivity(taskId);
       if (status === "finished") noteTaskFinished(taskId);
       this.forget(taskId);
-      log.info("session-backstop.settled", { taskId, status });
+      log.info("session-backstop.settled", { taskId, status, rule });
       return true;
     } catch (err) {
-      log.warn("session-backstop.settle-failed", { taskId, status, error: String(err) });
+      log.warn("session-backstop.settle-failed", { taskId, status, rule, error: String(err) });
       return false;
     }
   }

--- a/packages/core/src/core-session-backstop.ts
+++ b/packages/core/src/core-session-backstop.ts
@@ -72,13 +72,14 @@
 // So the rule now pays its own bill, three ways.
 //
 //   1. **It takes the finish back.** A `finished` written by the *idle* rule
-//      is marked, and the next `output`-class burst — or a hook that means the
-//      turn is running — returns the row to `running`
+//      is marked, and the next `output`-class burst returns the row to
+//      `running`
 //      ({@link IDLE_REOPEN_MS}). Nothing else is marked, so an operator's
-//      finish, a hook's finish and the quiet rule's finish are never reopened
-//      by stray bytes; and a `SubagentStart`, a `SubagentStop` or an unmatched
-//      `PostToolUse` never reopens anything, because a post-turn helper
-//      healing a finished card is the bug #385 closed.
+//      finish and the quiet rule's finish are never reopened by stray bytes;
+//      no hook of any kind reopens anything, because a post-turn helper
+//      healing a finished card is the bug #385 closed; and the marker is
+//      dropped the moment any hook arrives or anyone else writes the row, so
+//      a finish that a real `Stop` wrote is never taken back either.
 //   2. **It defers to hooks, for a while.** A Session whose hooks arrive has a
 //      better witness than its pixels: if it has printed anything real since
 //      its last hook it is mid-turn — a single `Bash` call emits no hook until
@@ -94,7 +95,10 @@
 // `session:finished` (the operator's completion toast, and the signal
 // `actana session wait` unblocks on) and clears the tracked subagent set. The
 // reopen puts the status back; it cannot un-send a notification or restore
-// that set, which expires on its own.
+// that set, which expires on its own (#464). And a harness parked on a
+// permission dialog nobody pattern-matched repaints it statically, which is
+// this rule's condition exactly — it is settled like any idle screen, and that
+// is #469.
 //
 // Only `running` is in scope. `needs-input` is a Session waiting on a human,
 // which is a state it is allowed to sit in indefinitely and silently; a card
@@ -139,9 +143,10 @@ const QUIET_SETTLE_MS = 15 * 60 * 1000;
  * Above it sits the only thing this rule is for: a harness that ended its turn,
  * never said so, and is now painting a clock at an operator waiting on a card.
  *
- * What it costs is bounded three ways rather than argued away: the rule fires
- * only for a Session whose hooks are not arriving (see `outputSinceHook`), only
- * after the condition has held across two sweeps, and a `finished` it writes is
+ * What it costs is bounded three ways rather than argued away: while a hooked
+ * Session's hooks are still speaking for it the rule stands down entirely (see
+ * `outputSinceHook` and {@link HOOK_DEFERENCE_MS}, which is what ends that);
+ * the condition must hold across two sweeps; and a `finished` it writes is
  * taken back by the next `output`-class burst — {@link IDLE_REOPEN_MS}.
  */
 const IDLE_REDRAW_SETTLE_MS = 8 * 60 * 1000;
@@ -247,24 +252,21 @@ export type CoreSessionBackstopDeps = {
 /**
  * What a Session was heard doing.
  *
- * `turn` is a hook the harness's own event map reads as the turn running —
- * `UserPromptSubmit`, `CursorBeforeSubmitPrompt`, `PermissionReplied`, an
- * `AskUserQuestion` `PostToolUse`. It is the only hook kind that may take back
- * a finish: `SubagentStart`, `SubagentStop` and an unmatched `PostToolUse` map
- * to no status precisely so they cannot resurrect a finished card (#385,
- * `5d33f0c`), and this path must not undo that.
+ * `hook` is any accepted hook. It is activity — it keeps both rules off, and
+ * it is the evidence that this harness can report itself — and it is also the
+ * end of any claim this file has on the row: a hook means the pipeline is
+ * deciding the status now, so the idle rule's marker is dropped and a finish
+ * it wrote is no longer this file's to take back. A `Stop` is a hook.
  *
- * `hook` is any other accepted hook. It is still activity — it keeps both
- * rules off — and it is still the evidence that this harness can report
- * itself; it simply never reopens a row.
+ * `output` is a burst of PTY output that put something new on screen. It is
+ * activity, and it is the one kind that may reopen an idle-settled row,
+ * because new content on screen with no hook behind it is the harness itself
+ * saying the turn was not over.
  *
- * `output` is a burst of PTY output that put something new on screen; it is
- * activity, and it does reopen an idle-settled row, because new content on
- * screen is the harness itself saying the turn was not over. `redraw` is a
- * burst that repainted what was already there, and is the only kind that
- * leaves the idle rule's clock running.
+ * `redraw` is a burst that repainted what was already there, and is the only
+ * kind that leaves the idle rule's clock running.
  */
-export type SessionActivityKind = "turn" | "hook" | "output" | "redraw";
+export type SessionActivityKind = "hook" | "output" | "redraw";
 
 /** What this Core has heard from one Session, and what it made of it. */
 type SessionActivity = {
@@ -296,7 +298,7 @@ export class CoreSessionBackstop {
    * Nothing else is ever in here — not the quiet rule, not a hook's finish,
    * not an operator's — so nothing else can be reopened by stray bytes.
    */
-  private readonly idleSettled = new Map<string, number>();
+  private readonly idleSettled = new Map<string, { at: number; rowUpdatedAt: number }>();
   private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly deps: CoreSessionBackstopDeps) {}
@@ -318,10 +320,7 @@ export class CoreSessionBackstop {
     // Re-insert so insertion order approximates recency for the cap below.
     this.lastActivity.delete(taskId);
     const progress = kind !== "redraw";
-    const isHook = kind === "hook" || kind === "turn";
-    // Only a hook that means the turn is running, or new content on screen,
-    // may take a finish back. Every other hook is activity and nothing more.
-    const mayReopen = kind === "turn" || kind === "output";
+    const isHook = kind === "hook";
     this.lastActivity.set(taskId, {
       heardAt: now,
       // A redraw is the harness being there, not the turn getting anywhere:
@@ -339,29 +338,44 @@ export class CoreSessionBackstop {
       if (oldest === undefined) break;
       this.lastActivity.delete(oldest);
     }
-    if (mayReopen) this.reopenIfIdleSettled(taskId, now);
+    // A hook hands the row back to the pipeline: whatever it writes — a
+    // `Stop`'s finish, a `UserPromptSubmit`'s `running` — is authoritative,
+    // and a finish this rule wrote before it is not this file's to take back
+    // any more. Dropping the marker here is what keeps a post-turn composer
+    // paint from reopening a row a real `Stop` has since finished (review of
+    // PR 455, round 3).
+    if (isHook) this.idleSettled.delete(taskId);
+    else if (kind === "output") this.reopenIfIdleSettled(taskId, now);
   }
 
   /**
    * Take back a `finished` this instance's idle rule wrote, because the
    * harness has just proved the turn was still running.
    *
-   * Only a row this rule settled is eligible, only while the marker is inside
-   * {@link IDLE_REOPEN_MS}, and only if the row still says `finished` — a
-   * status anyone else has since written is theirs, and the marker is dropped
-   * rather than argued with. The subagent set cleared by the settle cannot be
-   * restored, which is the one part of a wrong idle settle that does not come
-   * back; it expires on its own.
+   * Three things must hold, and the third is what makes the claim above it
+   * true: the row must be one this rule settled, the marker must be inside
+   * {@link IDLE_REOPEN_MS}, and **the row must not have been written since**.
+   * Asking only whether it still says `finished` is not enough — a real `Stop`
+   * writes `finished` over a `finished`, and reopening that is exactly the
+   * post-turn resurrection #385 closed. So the settle records the row's
+   * `updatedAt` and the reopen requires it unchanged; anybody else's write,
+   * whatever status it left behind, ends this rule's claim.
+   *
+   * The subagent set cleared by the settle cannot be restored, which is the
+   * one part of a wrong idle settle that does not come back; it expires on
+   * its own.
    */
   private reopenIfIdleSettled(taskId: string, now: number): void {
-    const settledAt = this.idleSettled.get(taskId);
-    if (settledAt === undefined) return;
+    const marker = this.idleSettled.get(taskId);
+    if (marker === undefined) return;
     this.idleSettled.delete(taskId);
-    if (now - settledAt > (this.deps.reopenMs ?? IDLE_REOPEN_MS)) return;
+    if (now - marker.at > (this.deps.reopenMs ?? IDLE_REOPEN_MS)) return;
     try {
-      if (this.deps.writer.readTask(taskId)?.status !== "finished") return;
+      const task = this.deps.writer.readTask(taskId);
+      if (task?.status !== "finished") return;
+      if (task.updatedAt !== marker.rowUpdatedAt) return;
       if (!this.deps.writer.mutate({ op: "update", taskId, status: "running" })) return;
-      log.info("session-backstop.reopened", { taskId, quietForMs: now - settledAt });
+      log.info("session-backstop.reopened", { taskId, quietForMs: now - marker.at });
     } catch (err) {
       log.warn("session-backstop.reopen-failed", { taskId, error: String(err) });
     }
@@ -457,7 +471,10 @@ export class CoreSessionBackstop {
       // Only the idle rule leaves a marker, and only a `finished` can be taken
       // back — a `disconnected` row has no process left to change its mind.
       if (rule === "idle" && status === "finished") {
-        this.idleSettled.set(taskId, this.now());
+        // The row as this rule left it. Anything that moves `updatedAt` after
+        // this — a real `Stop`, an operator, the Panel — takes the row out of
+        // this rule's hands for good.
+        this.idleSettled.set(taskId, { at: this.now(), rowUpdatedAt: updated.updatedAt });
         while (this.idleSettled.size > MAX_TRACKED_TASKS) {
           const oldest = this.idleSettled.keys().next().value;
           if (oldest === undefined) break;

--- a/packages/core/src/pty-manager.ts
+++ b/packages/core/src/pty-manager.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import { getAppTheme } from "./app-theme";
 import { ensureStatuslineTap } from "@actana/shared/statusline-tap";
 import { PtyOutputBatcher } from "./pty-output-batch";
+import { PtyOutputActivityWatcher, type PtyOutputActivityKind } from "./pty-output-activity";
 import { sliceReplayWindow, type PtyReplayWindow } from "./pty-replay-window";
 import {
   resolveHarnessCommandMeetingVersion,
@@ -160,13 +161,6 @@ const ptys = new Map<string, Pty>();
 const RING_LIMIT_BYTES = 1_000_000;
 
 /**
- * How often a talking PTY reports that it is talking. The consumer only asks
- * "was there anything in the last quarter of an hour", so a five-second floor
- * loses nothing and keeps a chatty harness from calling out per chunk.
- */
-const OUTPUT_ACTIVITY_THROTTLE_MS = 5_000;
-
-/**
  * Dependencies the PTY core needs from its host process.
  */
 export type PtyCoreDeps = {
@@ -211,10 +205,16 @@ export type PtyCoreDeps = {
    * This Session's harness is still talking (issue 243). Not a status and not
    * a signal — just the fact that bytes arrived, which is what tells a turn
    * that is genuinely running from one that ended without saying so. Throttled
-   * to at most one call per {@link OUTPUT_ACTIVITY_THROTTLE_MS} per PTY, so a
-   * harness redrawing its spinner does not cost a callback per chunk.
+   * to at most one call per five seconds per PTY (`OUTPUT_ACTIVITY_WINDOW_MS`),
+   * so a harness redrawing its spinner does not cost a callback per chunk.
+   *
+   * `kind` is what those bytes were (issue 391): `output` if the burst put
+   * something new on screen, `redraw` if it repainted what was already there.
+   * A harness whose hooks are not arriving paints its spinner forever, so
+   * "bytes arrived" on its own can never end a turn — see
+   * `pty-output-activity.ts` and the two rules in `core-session-backstop.ts`.
    */
-  onSessionOutputActivity?: (info: { taskId: string }) => void;
+  onSessionOutputActivity?: (info: { taskId: string; kind: PtyOutputActivityKind }) => void;
 };
 
 /** Event emitted by the Core for a PTY — `data` (output) or `exit`. */
@@ -709,18 +709,21 @@ export class PtyCore {
     // reports once. Re-armed as soon as it is no longer being shown.
     let interruptReported = false;
     let hookReviewReported = false;
-    // Last time this PTY's output was reported as activity (issue 243).
-    let activityReportedAt = 0;
+    // What this PTY's output has been saying, throttled and classified
+    // (issues 243 and 391).
+    const outputActivity = new PtyOutputActivityWatcher();
     const watchOutput = plan.mode === "agent" && !opts.shell && !opts.shellSession;
     proc.onData((data: string) => {
       releaseSpawnHold();
       if (watchOutput) {
-        if (p.taskId && Date.now() - activityReportedAt > OUTPUT_ACTIVITY_THROTTLE_MS) {
-          activityReportedAt = Date.now();
-          try {
-            this.deps.onSessionOutputActivity?.({ taskId: p.taskId });
-          } catch (err) {
-            log.warn("pty.output-activity.failed", { error: String(err) });
+        if (p.taskId) {
+          const kind = outputActivity.push(data, Date.now());
+          if (kind) {
+            try {
+              this.deps.onSessionOutputActivity?.({ taskId: p.taskId, kind });
+            } catch (err) {
+              log.warn("pty.output-activity.failed", { error: String(err) });
+            }
           }
         }
         const interrupted = hasClaudeInterruptPrompt(data);

--- a/packages/core/src/pty-output-activity.ts
+++ b/packages/core/src/pty-output-activity.ts
@@ -9,6 +9,13 @@
 // as the process lives. Those bytes never stop, so "fifteen minutes with no
 // output" never arrives, and the card claims `running` forever.
 //
+// Both are in scope, on different clocks. A harness this Core has never had a
+// hook from is read from its screen straight away; one whose hooks arrive is
+// deferred to while a tool call could still plausibly be running, and read
+// from its screen after that — see `HOOK_DEFERENCE_MS` in
+// `core-session-backstop.ts`. What this file must never do is let either wait
+// forever.
+//
 // So the bytes have to be read rather than counted. Not parsed — a TUI frame
 // is cursor moves and colour, and every harness draws a different one — but
 // reduced to the question the backstop actually asks: *did anything new appear
@@ -111,8 +118,18 @@ const MAX_REMEMBERED_CHARS = 16 * 1024;
  */
 const MIN_WORD_LENGTH = 3;
 
-/** Cap on the words compared per burst, so a huge paste stays cheap. */
-const MAX_WORDS_PER_BURST = 400;
+/**
+ * How much of a burst is compared, counted in characters from its end.
+ *
+ * Tied to {@link MAX_REMEMBERED_CHARS} on purpose, and that is the whole rule:
+ * compare about as much of the burst as was remembered of the screen. A scan
+ * shallower than the memory hides novelty painted above a static footer (the
+ * mirror of the front-first scan the review of PR 455 found); a scan deeper
+ * than the memory reports the part it cannot remember as new, which would
+ * leave a full-viewport repaint reading as work forever. The margin keeps the
+ * scan inside the memory even when the two disagree by a word.
+ */
+const MAX_SCANNED_CHARS = MAX_REMEMBERED_CHARS - 1024;
 
 // OSC (`ESC ] … BEL` / `ESC ] … ESC \`), CSI (`ESC [ … final`), and the
 // two-byte escapes. Ordered widest-first: an OSC payload can contain what
@@ -131,15 +148,29 @@ const CONTROL_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 // Glyphs a spinner cycles through, and the rules a frame is drawn with:
 // braille, block elements, geometric shapes, box drawing, dingbats, bullets.
 const FRAME_GLYPH_PATTERN = /[\u2022\u00b7\u2500-\u25ff\u2700-\u27bf\u2800-\u28ff]/g;
-// The subset of those that a spinner actually cycles: braille and dingbats.
-// Box drawing is a border and says nothing about whether a line is a clock.
-const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2700-\u27bf\u25d0-\u25d3\u25e2-\u25e5]/;
 /**
- * An elapsed-time counter on a line: `12s`, `1m 12s`, `2h`, `0:42`, `1:02:03`.
- * Deliberately narrow — a unit letter must end the token, so `900 MB` and
- * `3.1 MB/s` are sizes and rates, which are content, not clocks.
+ * The glyphs a spinner actually cycles through: braille frames, the sparkle
+ * and asterisk set, and the circle-fill and circle-quadrant frames.
+ *
+ * Narrowed after the review of PR 455 found the whole Dingbats block in here:
+ * `✔ 43 passed` and `❯ step 43 of 900` are a status mark and a prompt, not
+ * spinner frames, and a line marked as a clock loses the digits that are its
+ * only changing content. Box drawing is a border and is not here either — it
+ * says nothing about whether a line is counting.
  */
-const ELAPSED_PATTERN = /\d+\s*[hms]\b|\d+:\d{2}/;
+const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2731-\u273d\u25d0-\u25d3\u25e2-\u25e5\u25f0-\u25f7]/;
+/**
+ * An elapsed-time counter on a line: `12s`, `1m 12s`, `2h`.
+ *
+ * A unit letter is required, and it must end the token. That keeps `900 MB`
+ * and `3.1 MB/s` — sizes and rates, which are content — off this pattern, and
+ * it is also why `0:42` is not here: `\d+:\d{2}` matches the wall-clock stamp
+ * a build prints in front of every line (`[12:34:07] Compiled 43 files`), and
+ * calling that a clock loses the count beside it (review of PR 455). A colon
+ * counter with no spinner glyph beside it is left as content, which is the
+ * direction that fails safe.
+ */
+const ELAPSED_PATTERN = /\d+\s*[hms]\b/;
 
 /**
  * Did this burst erase or move anything, or did it only append?
@@ -149,6 +180,9 @@ const ELAPSED_PATTERN = /\d+\s*[hms]\b|\d+:\d{2}/;
  * has none of those — it scrolled the screen, so it is new by construction.
  * Exported for the tests.
  */
+/** An erase of the whole display (or its scrollback), which leaves it blank. */
+const ERASE_DISPLAY_PATTERN = /\x1b\[[0-3]?J/;
+
 export function repaintsInPlace(text: string): boolean {
   return (
     /\r(?!\n)/.test(text) ||
@@ -186,75 +220,133 @@ export function normalizePtyOutput(text: string): string {
  * were — and `null` in between, which is the throttle the PTY data path needs.
  */
 export class PtyOutputActivityWatcher {
-  private pending = "";
+  /**
+   * Chunks since the last report, oldest first, and their total length. A list
+   * rather than one growing string: the cap is enforced by dropping whole
+   * chunks off the front, so a chatty PTY never re-copies the whole buffer per
+   * chunk on the Core's hottest path.
+   */
+  private readonly pending: string[] = [];
+  private pendingChars = 0;
   private reportedAt = 0;
   private repaintedLast = false;
   private readonly remembered: string[] = [];
+  /** {@link remembered} as a word set, rebuilt when it changes. */
+  private rememberedSet: Set<string> | null = null;
 
   /**
    * Take a chunk. Returns the kind when the window has elapsed and this burst
    * is being reported, or `null` while it is still being accumulated.
    */
   push(chunk: string, now: number): PtyOutputActivityKind | null {
-    this.pending += chunk;
-    if (this.pending.length > MAX_PENDING_CHARS) {
-      this.pending = this.pending.slice(-MAX_PENDING_CHARS);
+    this.pending.push(chunk);
+    this.pendingChars += chunk.length;
+    // Keep the tail, because that is where a TUI puts what is new. One chunk
+    // always survives, however large it is on its own.
+    while (this.pendingChars > MAX_PENDING_CHARS && this.pending.length > 1) {
+      this.pendingChars -= this.pending.shift()?.length ?? 0;
     }
     if (now - this.reportedAt <= OUTPUT_ACTIVITY_WINDOW_MS) return null;
     this.reportedAt = now;
-    const burst = this.pending;
-    this.pending = "";
+    const burst = this.pending.join("");
+    this.pending.length = 0;
+    this.pendingChars = 0;
     return this.classify(burst);
   }
 
   private classify(burst: string): PtyOutputActivityKind {
+    // Read and re-arm before anything can return: a burst of pure cursor
+    // movement is still a repaint, and leaving the flag stale would deny the
+    // *next* burst the appended-text path that makes new output new by
+    // construction (review of PR 455).
+    const repainted = repaintsInPlace(burst);
+    const wasRepainting = this.repaintedLast;
+    this.repaintedLast = repainted;
+
     const normalized = normalizePtyOutput(burst);
     // A burst that reduces to nothing is pure cursor movement — a repaint of
-    // the same characters, or of none.
-    if (!normalized) return "redraw";
+    // the same characters, or of none. If it wiped the display and put nothing
+    // in its place, the screen is now blank: what was on it is not "already on
+    // screen" any more, and the next line to arrive is new (review of PR 455).
+    if (!normalized) {
+      if (ERASE_DISPLAY_PATTERN.test(burst)) this.forgetScreen();
+      return "redraw";
+    }
     // Nothing was erased, so nothing was replaced: this text scrolled onto the
     // screen and is new whatever it says. The exception is a screen that was
     // being repainted a moment ago — then a burst with no controls of its own
     // is the tail of a frame whose head arrived in the last burst, not a line
     // of appended output.
-    const repainted = repaintsInPlace(burst);
-    const wasRepainting = this.repaintedLast;
-    this.repaintedLast = repainted;
     if (!repainted && !wasRepainting) {
       this.remember(normalized);
       return "output";
     }
-    const onScreen = ` ${this.remembered.join(" ")} `;
+
     const words = normalized.split(" ");
-    let novel = false;
-    // From the end: a TUI paints what is new at the bottom, and `push` keeps
-    // the tail of an oversized burst, so the front is the wrong end to cap.
-    let scanned = 0;
-    for (let i = words.length - 1; i >= 0 && scanned < MAX_WORDS_PER_BURST; i -= 1) {
-      const word = words[i];
-      // Fragments are what a burst boundary inside a word leaves behind, and
-      // they say nothing either way — but a short number is a count, not a
-      // fragment.
-      if (word.length < MIN_WORD_LENGTH && !/\d/.test(word)) continue;
-      scanned += 1;
-      // A number is matched whole. `40` is a substring of `(400)` and a
-      // count that reads as already-seen is a live turn read as idle; a word
-      // is matched loosely on purpose, so a split `Think`/`ing` still is.
-      const numeric = /\d/.test(word) && !/[A-Za-z]/.test(word);
-      if (numeric ? onScreen.includes(` ${word} `) : onScreen.includes(word)) continue;
-      novel = true;
-      break;
-    }
+    const novel = this.hasNewWord(words);
     this.remember(normalized);
     return novel ? "output" : "redraw";
   }
 
+  /**
+   * Does this burst carry a word the screen did not already have?
+   *
+   * Scanned from the end, where a TUI puts what is new and where `push` keeps
+   * the bytes of an oversized burst. The remembered words are a set, so the
+   * scan is a hash lookup per word rather than a substring search, so it can
+   * run as deep as the memory it is comparing against — deep enough to find a
+   * new line painted above a static footer (review of PR 455). The substring
+   * fallback is what tolerates a burst boundary inside a word — `Think` and
+   * `ing` are both inside a remembered `Thinking` — and only a word the set
+   * missed pays for it.
+   */
+  private hasNewWord(words: string[]): boolean {
+    const onScreen = ` ${this.remembered.join(" ")} `;
+    const onScreenWords = this.rememberedWords();
+    let scanned = 0;
+    for (let i = words.length - 1; i >= 0 && scanned < MAX_SCANNED_CHARS; i -= 1) {
+      const word = words[i];
+      scanned += word.length + 1;
+      // Fragments are what a burst boundary inside a word leaves behind, and
+      // they say nothing either way — but a short number is a count, not a
+      // fragment.
+      const numeric = /\d/.test(word) && !/[A-Za-z]/.test(word);
+      if (word.length < MIN_WORD_LENGTH && !numeric) continue;
+      if (onScreenWords.has(word)) continue;
+      // A number is matched whole. `40` is a substring of `(400)`, and a count
+      // that reads as already-seen is a live turn read as idle.
+      if (!numeric && onScreen.includes(word)) continue;
+      return true;
+    }
+    return false;
+  }
+
+  /** The remembered bursts' words, built once per burst and cached. */
+  private rememberedWords(): Set<string> {
+    if (!this.rememberedSet) {
+      this.rememberedSet = new Set(this.remembered.join(" ").split(" "));
+    }
+    return this.rememberedSet;
+  }
+
+  /** The screen was wiped; nothing that was on it counts as being on it. */
+  private forgetScreen(): void {
+    this.remembered.length = 0;
+    this.rememberedSet = null;
+  }
+
   private remember(normalized: string): void {
-    this.remembered.push(
-      normalized.length > MAX_REMEMBERED_CHARS
-        ? normalized.slice(-MAX_REMEMBERED_CHARS)
-        : normalized,
-    );
+    this.rememberedSet = null;
+    let kept = normalized;
+    if (kept.length > MAX_REMEMBERED_CHARS) {
+      kept = kept.slice(-MAX_REMEMBERED_CHARS);
+      // Start at a whole word: a slice through the middle of one leaves a
+      // fragment that matches nothing, and the scan would read the word it
+      // cut in half as new.
+      const firstSpace = kept.indexOf(" ");
+      if (firstSpace > 0) kept = kept.slice(firstSpace + 1);
+    }
+    this.remembered.push(kept);
     while (this.remembered.length > REMEMBERED_BURSTS) this.remembered.shift();
   }
 }

--- a/packages/core/src/pty-output-activity.ts
+++ b/packages/core/src/pty-output-activity.ts
@@ -17,13 +17,28 @@
 //
 // ─── How a repaint is told from real output ───
 //
-// Each burst of output is normalised the way a reader would skim it: escape
-// sequences and control bytes dropped, spinner glyphs dropped, **digits
-// dropped** (the counter is the one thing a spinner frame changes), whitespace
-// collapsed. What is left is the frame's words. The burst counts as real
-// output when it carries a word the last {@link REMEMBERED_BURSTS} bursts do
-// not already contain, and as a redraw when every word in it was already on
-// screen a moment ago.
+// Three tests, in the order they are cheapest to be sure of.
+//
+// **Did the burst erase anything?** A repaint is defined by what it destroys:
+// a carriage return, an erase-line or erase-display, a cursor jump. Text that
+// only appends — a log line, a diff, a row of pytest dots — destroys nothing
+// and scrolls the screen, so it is new by construction and is `output` without
+// looking at a single word. This is the test that keeps appended progress from
+// reading as a spinner (review of PR 455, finding 2).
+//
+// **Do the digits belong to a clock?** Digits are how a counter changes, so
+// they cannot count as new content — but only where they are a counter. They
+// are dropped from a *line* that carries a spinner glyph or an elapsed-time
+// pattern (`1m 12s`, `0:42`), and kept everywhere else, so `Downloading 41.2
+// MB / 900 MB`, `Compiled 41 files` and `Tests 41 passed` stay the changing
+// content they are while `⠹ Working (1m 12s)` reduces to its words.
+//
+// **Is any word new?** What survives — escapes, control bytes and spinner
+// glyphs dropped, whitespace collapsed — is the frame's words. The burst is
+// `output` when it carries a word the last {@link REMEMBERED_BURSTS} bursts do
+// not already contain, and `redraw` when every word in it was already on
+// screen a moment ago. The scan runs from the **end** of the burst, where a
+// TUI puts what is new (review of PR 455, finding 3).
 //
 // The memory is deliberately short — about ten seconds of screen, not the
 // whole turn. A harness that reads the same file twice in a turn, or prints a
@@ -38,19 +53,24 @@
 //
 // ─── What this cannot tell apart ───
 //
-// Two shapes of real output read as repaints, and both are stated here rather
-// than discovered later. Output that differs from the burst before it only in
-// its digits — `Compiled 41 files`, then `Compiled 42 files`, second after
-// second, with nothing else on screen — is indistinguishable from a counter,
-// because that is what it is. And a turn whose tool prints nothing at all is
-// indistinguishable from a turn that ended.
+// Three limits, stated here rather than discovered later.
 //
-// Both matter only for a harness whose hooks are *also* not arriving: a hook
-// is real activity whatever it says, so Claude Code with its hooks installed
-// is never judged on bytes alone. And the cost is the same trade the
-// fifteen-minute window already made, which this only shortens: the row is
-// settled early, nothing is killed, no process is touched, and the next hook
-// or the next new thing on screen puts the row back on `running`.
+// A turn whose tool prints **nothing at all** is indistinguishable from a turn
+// that ended. A progress line that is **both** spinner-prefixed and
+// digits-only — `⠹ 41.2 MB / 900 MB` on one line, with nothing else changing —
+// has its digits dropped as a clock and reads as a repaint. And the whole rule
+// depends on the spinner phrase being **static**: a harness whose spinner
+// rotates its gerund (`✻ Herding… / Simmering… / Pondering…`, Claude Code's
+// shape) puts a new word on screen every rotation, so it produces `output`
+// bursts while idle and the caller's idle rule never fires for it. That is
+// deliberate — this file is for the Codex-shaped TUI #391 names, and a rule
+// that never fires is safe in a way that a wrong finish is not.
+//
+// None of these is load-bearing on its own: the caller narrows further (it
+// wants two consecutive idle sweeps, and it ignores this signal entirely for a
+// harness whose hooks are arriving), and a `finished` it wrote for a Session
+// that was only idle here is taken back by the next `output` burst — see
+// `core-session-backstop.ts`.
 
 /** What a burst of PTY output was: something new on screen, or a repaint. */
 export type PtyOutputActivityKind = "output" | "redraw";
@@ -75,10 +95,20 @@ const MAX_PENDING_CHARS = 64 * 1024;
  */
 const REMEMBERED_BURSTS = 2;
 
-/** Cap on the words kept per remembered burst. A frame is far smaller. */
-const MAX_REMEMBERED_CHARS = 4 * 1024;
+/**
+ * Cap on the words kept per remembered burst. Sized to hold a full-viewport
+ * repaint — a wide screen is some fifteen thousand characters — because a
+ * memory shorter than the burst it is compared against reports the difference
+ * between them as new content.
+ */
+const MAX_REMEMBERED_CHARS = 16 * 1024;
 
-/** Words shorter than this are noise once digits and glyphs are gone. */
+/**
+ * Words shorter than this are noise once glyphs are gone — unless they carry a
+ * digit. A digit that survived normalisation is content, not a clock (the
+ * clock's were dropped with its line), and `41` → `42` is the whole of what
+ * changes in `Compiled 41 files`.
+ */
 const MIN_WORD_LENGTH = 3;
 
 /** Cap on the words compared per burst, so a huge paste stays cheap. */
@@ -88,29 +118,66 @@ const MAX_WORDS_PER_BURST = 400;
 // two-byte escapes. Ordered widest-first: an OSC payload can contain what
 // looks like a CSI.
 const OSC_PATTERN = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// Colour and style, which sit *inside* a line and often inside a word: they
+// vanish without leaving a gap, so a coloured spinner keeps its clock on the
+// same line as its glyph and a colour reset does not split a word in two.
+const SGR_PATTERN = /\x1b\[[0-9;:]*m/g;
+// Everything else a CSI does is layout — a jump, an erase, a scroll — so it
+// ends the line it is in.
 const CSI_PATTERN = /\x1b\[[0-9;:?<>=!]*[ -/]*[@-~]/g;
 const ESCAPE_PATTERN = /\x1b[\s\S]?/g;
-// Control bytes, tab and newline included: line breaks are layout, not words.
-const CONTROL_PATTERN = /[\x00-\x1f\x7f]/g;
+// Control bytes other than the line breaks, which become line boundaries.
+const CONTROL_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 // Glyphs a spinner cycles through, and the rules a frame is drawn with:
 // braille, block elements, geometric shapes, box drawing, dingbats, bullets.
 const FRAME_GLYPH_PATTERN = /[\u2022\u00b7\u2500-\u25ff\u2700-\u27bf\u2800-\u28ff]/g;
+// The subset of those that a spinner actually cycles: braille and dingbats.
+// Box drawing is a border and says nothing about whether a line is a clock.
+const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2700-\u27bf\u25d0-\u25d3\u25e2-\u25e5]/;
+/**
+ * An elapsed-time counter on a line: `12s`, `1m 12s`, `2h`, `0:42`, `1:02:03`.
+ * Deliberately narrow — a unit letter must end the token, so `900 MB` and
+ * `3.1 MB/s` are sizes and rates, which are content, not clocks.
+ */
+const ELAPSED_PATTERN = /\d+\s*[hms]\b|\d+:\d{2}/;
+
+/**
+ * Did this burst erase or move anything, or did it only append?
+ *
+ * A repaint destroys: a bare carriage return, an erase (`ESC [ … J/K`), a
+ * cursor move or jump (`ESC [ … A-H`), a screen switch. Text that only appends
+ * has none of those — it scrolled the screen, so it is new by construction.
+ * Exported for the tests.
+ */
+export function repaintsInPlace(text: string): boolean {
+  return (
+    /\r(?!\n)/.test(text) ||
+    /\x1b\[[0-9;?]*[JKABCDEFGHfd]/.test(text) ||
+    /\x1b\[\?(?:47|1047|1049)[hl]/.test(text) ||
+    /\x1b[78M]/.test(text)
+  );
+}
 
 /**
  * Reduce a burst of PTY output to the words on screen: no escapes, no control
- * bytes, no spinner glyphs, **no digits**, single-spaced. Exported for the
- * tests, which are the only readers that care what the reduction looks like.
+ * bytes, no spinner glyphs, single-spaced — and no digits *on a line that is
+ * carrying a clock*, which is the only place a digit is a counter rather than
+ * content. Exported for the tests, which are the only readers that care what
+ * the reduction looks like.
  */
 export function normalizePtyOutput(text: string): string {
-  return text
+  const plain = text
     .replace(OSC_PATTERN, " ")
-    .replace(CSI_PATTERN, " ")
+    .replace(SGR_PATTERN, "")
+    .replace(CSI_PATTERN, "\n")
     .replace(ESCAPE_PATTERN, " ")
-    .replace(CONTROL_PATTERN, " ")
-    .replace(FRAME_GLYPH_PATTERN, " ")
-    .replace(/\d/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+    .replace(CONTROL_PATTERN, " ");
+  const lines = plain.split(/[\r\n]+/).map((line) => {
+    const isClock = SPINNER_GLYPH_PATTERN.test(line) || ELAPSED_PATTERN.test(line);
+    const words = line.replace(FRAME_GLYPH_PATTERN, " ");
+    return isClock ? words.replace(/\d/g, "") : words;
+  });
+  return lines.join(" ").replace(/\s+/g, " ").trim();
 }
 
 /**
@@ -121,6 +188,7 @@ export function normalizePtyOutput(text: string): string {
 export class PtyOutputActivityWatcher {
   private pending = "";
   private reportedAt = 0;
+  private repaintedLast = false;
   private readonly remembered: string[] = [];
 
   /**
@@ -144,15 +212,36 @@ export class PtyOutputActivityWatcher {
     // A burst that reduces to nothing is pure cursor movement — a repaint of
     // the same characters, or of none.
     if (!normalized) return "redraw";
-    const onScreen = this.remembered.join(" ");
+    // Nothing was erased, so nothing was replaced: this text scrolled onto the
+    // screen and is new whatever it says. The exception is a screen that was
+    // being repainted a moment ago — then a burst with no controls of its own
+    // is the tail of a frame whose head arrived in the last burst, not a line
+    // of appended output.
+    const repainted = repaintsInPlace(burst);
+    const wasRepainting = this.repaintedLast;
+    this.repaintedLast = repainted;
+    if (!repainted && !wasRepainting) {
+      this.remember(normalized);
+      return "output";
+    }
+    const onScreen = ` ${this.remembered.join(" ")} `;
     const words = normalized.split(" ");
     let novel = false;
-    for (let i = 0; i < words.length && i < MAX_WORDS_PER_BURST; i += 1) {
+    // From the end: a TUI paints what is new at the bottom, and `push` keeps
+    // the tail of an oversized burst, so the front is the wrong end to cap.
+    let scanned = 0;
+    for (let i = words.length - 1; i >= 0 && scanned < MAX_WORDS_PER_BURST; i -= 1) {
       const word = words[i];
       // Fragments are what a burst boundary inside a word leaves behind, and
-      // they say nothing either way.
-      if (word.length < MIN_WORD_LENGTH) continue;
-      if (onScreen.includes(word)) continue;
+      // they say nothing either way — but a short number is a count, not a
+      // fragment.
+      if (word.length < MIN_WORD_LENGTH && !/\d/.test(word)) continue;
+      scanned += 1;
+      // A number is matched whole. `40` is a substring of `(400)` and a
+      // count that reads as already-seen is a live turn read as idle; a word
+      // is matched loosely on purpose, so a split `Think`/`ing` still is.
+      const numeric = /\d/.test(word) && !/[A-Za-z]/.test(word);
+      if (numeric ? onScreen.includes(` ${word} `) : onScreen.includes(word)) continue;
       novel = true;
       break;
     }

--- a/packages/core/src/pty-output-activity.ts
+++ b/packages/core/src/pty-output-activity.ts
@@ -173,7 +173,10 @@ const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2731-\u273d\u25d0-\u25d3\u25e2-\u
  * direction that fails safe.
  *
  * Global, because what it matches is what gets dropped: a duration is removed
- * as a *token*, not as a licence to drop every digit on its line. `✔ 43 passed
+ * as a *token*, not as a licence to drop every digit on its line. Being global
+ * it carries a `lastIndex`, so it is for `replace` only — never `test`, which
+ * would answer differently every other call. Its neighbour above is
+ * deliberately not global for that reason. `✔ 43 passed
  * in 12.3s` and `Compiled 41 files in 3.2s` are the standard build-progress
  * shapes, and their counts are the only thing changing — taking those with the
  * elapsed time settles a live build (review of PR 455, round 3).

--- a/packages/core/src/pty-output-activity.ts
+++ b/packages/core/src/pty-output-activity.ts
@@ -1,0 +1,171 @@
+// Telling a harness that is working from one that is only painting (issue 391).
+//
+// The quiet-Session backstop reads PTY output as proof that a turn is still
+// running, and for a harness with working hooks that is nearly free: bytes and
+// hooks agree. The failure this file exists for is the pair that disagree —
+// Codex before its hooks have been reviewed with `/hooks`, or any harness
+// whose terminal `Stop` was the POST that dropped. Both leave a TUI on screen
+// that keeps repainting its spinner and its elapsed-time counter for as long
+// as the process lives. Those bytes never stop, so "fifteen minutes with no
+// output" never arrives, and the card claims `running` forever.
+//
+// So the bytes have to be read rather than counted. Not parsed — a TUI frame
+// is cursor moves and colour, and every harness draws a different one — but
+// reduced to the question the backstop actually asks: *did anything new appear
+// on that screen?* A repaint of the same frame with a bigger number in it did
+// not; a tool result, a diff, a line of assistant prose did.
+//
+// ─── How a repaint is told from real output ───
+//
+// Each burst of output is normalised the way a reader would skim it: escape
+// sequences and control bytes dropped, spinner glyphs dropped, **digits
+// dropped** (the counter is the one thing a spinner frame changes), whitespace
+// collapsed. What is left is the frame's words. The burst counts as real
+// output when it carries a word the last {@link REMEMBERED_BURSTS} bursts do
+// not already contain, and as a redraw when every word in it was already on
+// screen a moment ago.
+//
+// The memory is deliberately short — about ten seconds of screen, not the
+// whole turn. A harness that reads the same file twice in a turn, or prints a
+// heading it printed five minutes ago, is working; only a screen that is
+// *still* showing what it was showing seconds ago is idle. Comparing against
+// everything ever printed would call that harness idle and settle it.
+//
+// The substring test — rather than a set of whole words — is deliberate: a
+// burst boundary can fall inside a word, and `Think` + `ing` must not read as
+// two new words every second. Both are substrings of a `Thinking` already
+// remembered, so a split frame stays a redraw.
+//
+// ─── What this cannot tell apart ───
+//
+// Two shapes of real output read as repaints, and both are stated here rather
+// than discovered later. Output that differs from the burst before it only in
+// its digits — `Compiled 41 files`, then `Compiled 42 files`, second after
+// second, with nothing else on screen — is indistinguishable from a counter,
+// because that is what it is. And a turn whose tool prints nothing at all is
+// indistinguishable from a turn that ended.
+//
+// Both matter only for a harness whose hooks are *also* not arriving: a hook
+// is real activity whatever it says, so Claude Code with its hooks installed
+// is never judged on bytes alone. And the cost is the same trade the
+// fifteen-minute window already made, which this only shortens: the row is
+// settled early, nothing is killed, no process is touched, and the next hook
+// or the next new thing on screen puts the row back on `running`.
+
+/** What a burst of PTY output was: something new on screen, or a repaint. */
+export type PtyOutputActivityKind = "output" | "redraw";
+
+/**
+ * How often a talking PTY reports that it is talking. The consumer only asks
+ * "was there anything new in the last few minutes", so a five-second floor
+ * loses nothing and keeps a chatty harness from calling out per chunk. Also
+ * the window whose bytes are classified together — a frame split across
+ * chunks is one burst here, not two.
+ */
+export const OUTPUT_ACTIVITY_WINDOW_MS = 5_000;
+
+/** Cap on the bytes held between reports. A frame is far smaller than this. */
+const MAX_PENDING_CHARS = 64 * 1024;
+
+/**
+ * How many reported bursts count as "already on screen". Two, which is about
+ * ten seconds: long enough that a frame split across a burst boundary still
+ * finds its other half, short enough that output repeated a minute later is
+ * read as the new work it is.
+ */
+const REMEMBERED_BURSTS = 2;
+
+/** Cap on the words kept per remembered burst. A frame is far smaller. */
+const MAX_REMEMBERED_CHARS = 4 * 1024;
+
+/** Words shorter than this are noise once digits and glyphs are gone. */
+const MIN_WORD_LENGTH = 3;
+
+/** Cap on the words compared per burst, so a huge paste stays cheap. */
+const MAX_WORDS_PER_BURST = 400;
+
+// OSC (`ESC ] … BEL` / `ESC ] … ESC \`), CSI (`ESC [ … final`), and the
+// two-byte escapes. Ordered widest-first: an OSC payload can contain what
+// looks like a CSI.
+const OSC_PATTERN = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+const CSI_PATTERN = /\x1b\[[0-9;:?<>=!]*[ -/]*[@-~]/g;
+const ESCAPE_PATTERN = /\x1b[\s\S]?/g;
+// Control bytes, tab and newline included: line breaks are layout, not words.
+const CONTROL_PATTERN = /[\x00-\x1f\x7f]/g;
+// Glyphs a spinner cycles through, and the rules a frame is drawn with:
+// braille, block elements, geometric shapes, box drawing, dingbats, bullets.
+const FRAME_GLYPH_PATTERN = /[\u2022\u00b7\u2500-\u25ff\u2700-\u27bf\u2800-\u28ff]/g;
+
+/**
+ * Reduce a burst of PTY output to the words on screen: no escapes, no control
+ * bytes, no spinner glyphs, **no digits**, single-spaced. Exported for the
+ * tests, which are the only readers that care what the reduction looks like.
+ */
+export function normalizePtyOutput(text: string): string {
+  return text
+    .replace(OSC_PATTERN, " ")
+    .replace(CSI_PATTERN, " ")
+    .replace(ESCAPE_PATTERN, " ")
+    .replace(CONTROL_PATTERN, " ")
+    .replace(FRAME_GLYPH_PATTERN, " ")
+    .replace(/\d/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * One per agent PTY. Fed every chunk; answers at most once per
+ * {@link OUTPUT_ACTIVITY_WINDOW_MS} with what the bytes since the last answer
+ * were — and `null` in between, which is the throttle the PTY data path needs.
+ */
+export class PtyOutputActivityWatcher {
+  private pending = "";
+  private reportedAt = 0;
+  private readonly remembered: string[] = [];
+
+  /**
+   * Take a chunk. Returns the kind when the window has elapsed and this burst
+   * is being reported, or `null` while it is still being accumulated.
+   */
+  push(chunk: string, now: number): PtyOutputActivityKind | null {
+    this.pending += chunk;
+    if (this.pending.length > MAX_PENDING_CHARS) {
+      this.pending = this.pending.slice(-MAX_PENDING_CHARS);
+    }
+    if (now - this.reportedAt <= OUTPUT_ACTIVITY_WINDOW_MS) return null;
+    this.reportedAt = now;
+    const burst = this.pending;
+    this.pending = "";
+    return this.classify(burst);
+  }
+
+  private classify(burst: string): PtyOutputActivityKind {
+    const normalized = normalizePtyOutput(burst);
+    // A burst that reduces to nothing is pure cursor movement — a repaint of
+    // the same characters, or of none.
+    if (!normalized) return "redraw";
+    const onScreen = this.remembered.join(" ");
+    const words = normalized.split(" ");
+    let novel = false;
+    for (let i = 0; i < words.length && i < MAX_WORDS_PER_BURST; i += 1) {
+      const word = words[i];
+      // Fragments are what a burst boundary inside a word leaves behind, and
+      // they say nothing either way.
+      if (word.length < MIN_WORD_LENGTH) continue;
+      if (onScreen.includes(word)) continue;
+      novel = true;
+      break;
+    }
+    this.remember(normalized);
+    return novel ? "output" : "redraw";
+  }
+
+  private remember(normalized: string): void {
+    this.remembered.push(
+      normalized.length > MAX_REMEMBERED_CHARS
+        ? normalized.slice(-MAX_REMEMBERED_CHARS)
+        : normalized,
+    );
+    while (this.remembered.length > REMEMBERED_BURSTS) this.remembered.shift();
+  }
+}

--- a/packages/core/src/pty-output-activity.ts
+++ b/packages/core/src/pty-output-activity.ts
@@ -34,11 +34,12 @@
 // reading as a spinner (review of PR 455, finding 2).
 //
 // **Do the digits belong to a clock?** Digits are how a counter changes, so
-// they cannot count as new content — but only where they are a counter. They
-// are dropped from a *line* that carries a spinner glyph or an elapsed-time
-// pattern (`1m 12s`, `0:42`), and kept everywhere else, so `Downloading 41.2
-// MB / 900 MB`, `Compiled 41 files` and `Tests 41 passed` stay the changing
-// content they are while `⠹ Working (1m 12s)` reduces to its words.
+// they cannot count as new content — but only where they are a counter. Every
+// digit goes from a line a *spinner* is drawing, because the whole line is a
+// frame; everywhere else only the duration token itself goes (`12.3s`,
+// `1m 12s`). So `⠹ Working (1m 12s)` reduces to its words, while `Downloading
+// 41.2 MB / 900 MB`, `Compiled 41 files in 3.2s` and `✔ 43 passed in 12.3s`
+// keep the counts that are the only thing changing on them.
 //
 // **Is any word new?** What survives — escapes, control bytes and spinner
 // glyphs dropped, whitespace collapsed — is the frame's words. The burst is
@@ -74,9 +75,10 @@
 // that never fires is safe in a way that a wrong finish is not.
 //
 // None of these is load-bearing on its own: the caller narrows further (it
-// wants two consecutive idle sweeps, and it ignores this signal entirely for a
-// harness whose hooks are arriving), and a `finished` it wrote for a Session
-// that was only idle here is taken back by the next `output` burst — see
+// wants two consecutive idle sweeps, and it stands down while a hooked
+// harness's hooks are still speaking for it — for a bounded time, after which
+// it reads the screen anyway), and a `finished` it wrote for a Session that was
+// only idle here is taken back by the next `output` burst — see
 // `core-session-backstop.ts`.
 
 /** What a burst of PTY output was: something new on screen, or a repaint. */
@@ -160,7 +162,7 @@ const FRAME_GLYPH_PATTERN = /[\u2022\u00b7\u2500-\u25ff\u2700-\u27bf\u2800-\u28f
  */
 const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2731-\u273d\u25d0-\u25d3\u25e2-\u25e5\u25f0-\u25f7]/;
 /**
- * An elapsed-time counter on a line: `12s`, `1m 12s`, `2h`.
+ * An elapsed-time counter: `12s`, `1m 12s`, `12.3s`, `2h`.
  *
  * A unit letter is required, and it must end the token. That keeps `900 MB`
  * and `3.1 MB/s` — sizes and rates, which are content — off this pattern, and
@@ -169,8 +171,14 @@ const SPINNER_GLYPH_PATTERN = /[\u2800-\u28ff\u2731-\u273d\u25d0-\u25d3\u25e2-\u
  * calling that a clock loses the count beside it (review of PR 455). A colon
  * counter with no spinner glyph beside it is left as content, which is the
  * direction that fails safe.
+ *
+ * Global, because what it matches is what gets dropped: a duration is removed
+ * as a *token*, not as a licence to drop every digit on its line. `✔ 43 passed
+ * in 12.3s` and `Compiled 41 files in 3.2s` are the standard build-progress
+ * shapes, and their counts are the only thing changing — taking those with the
+ * elapsed time settles a live build (review of PR 455, round 3).
  */
-const ELAPSED_PATTERN = /\d+\s*[hms]\b/;
+const ELAPSED_PATTERN = /\d+(?:[.,]\d+)?\s*[hms]\b/g;
 
 /**
  * Did this burst erase or move anything, or did it only append?
@@ -207,9 +215,14 @@ export function normalizePtyOutput(text: string): string {
     .replace(ESCAPE_PATTERN, " ")
     .replace(CONTROL_PATTERN, " ");
   const lines = plain.split(/[\r\n]+/).map((line) => {
-    const isClock = SPINNER_GLYPH_PATTERN.test(line) || ELAPSED_PATTERN.test(line);
+    // A line a spinner is drawing is a frame, and every number on it is part
+    // of the frame — the elapsed time, the token count, the context percentage.
+    // A line without one is content, and only the duration token on it is a
+    // clock; the count beside it is what changes when work happens.
     const words = line.replace(FRAME_GLYPH_PATTERN, " ");
-    return isClock ? words.replace(/\d/g, "") : words;
+    return SPINNER_GLYPH_PATTERN.test(line)
+      ? words.replace(/\d/g, "")
+      : words.replace(ELAPSED_PATTERN, " ");
   });
   return lines.join(" ").replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
Hunt F5 (#391). A harness that is idle but still painting a clock or a spinner keeps its card on `running`
indefinitely: `pty-manager.ts` reported every five seconds of PTY output as activity, and `core-session-backstop.ts`
skipped any Session that had not been quiet for fifteen minutes. Together they mean the case that most needs a
backstop — Codex before its hooks have been reviewed with `/hooks`, or any harness whose terminal `Stop` was the POST
that dropped — never reaches one, because the redraws never stop.

Both routes the ticket offers are taken, because neither works alone: idle redraws stop counting as work, **and**
there is a finish-class rule that does not wait for fifteen quiet minutes of zero bytes.

## How a redraw is told from real output

New `packages/core/src/pty-output-activity.ts`. Each five-second burst of output is asked three questions:

1. **Did it erase anything?** A burst with no carriage return, erase, cursor jump or screen switch only appended — it
   scrolled the screen — so it is `output` by construction. That is pytest's dots and a plain log stream. (A
   control-free burst following a repainting one is the tail of a frame, and still goes through the word test. A
   burst that erases the display and puts nothing in its place empties the memory: the screen is blank.)
2. **Do the digits belong to a clock?** Every digit is dropped from a line a **spinner** is drawing, because the
   whole line is a frame (clock, token count, context percentage). On every other line only the **duration token**
   itself is dropped (`12.3s`, `1m 12s`) — never the rest of the line's digits. So `Downloading 41.2 MB / 900 MB`,
   `Compiled 41 files in 3.2s`, `✔ 43 passed in 12.3s`, `[1,234 / 5,678] Compiling …; 45s` and
   `[12:34:07] Compiled 43 files` all keep the counts that are their only changing content.
3. **Is any word new?** The burst is `output` when it carries a word the last two bursts (~10 s of screen) do not
   contain. The scan runs from the end of the burst, as deep as the memory it is compared against; numbers are
   matched whole, words loosely (so a `Think`/`ing` split is not two new words a second).

## The two rules

A `running` Session settles on whichever fires first:

| Rule | Fires when | Window |
| --- | --- | --- |
| Quiet (unchanged) | nothing at all — no hook, no byte of any kind | 15 minutes |
| Idle (new) | bytes still arriving (heard within 2 minutes), nothing new on screen, no hook, and hooks are not currently speaking for the Session | 8 minutes, confirmed by 2 consecutive sweeps |

The idle rule is narrowed three ways: it never touches a row this Core has only read from the database; it **defers
to hooks for 15 minutes** after the last one when the Session has printed something since (a single `Bash` call emits
no hook until it completes) and then reads the screen anyway, so a dropped `Stop` on a hooked harness settles rather
than never; and it asks twice. Measured from the last new thing on screen: **~9–10 minutes** for a harness that has
never sent a hook, and **~16–17 minutes** for a hooked harness whose `Stop` dropped — the floor of that family
rather than its ceiling, since the deference restarts from each hook, so a harness whose last hook lands 13 minutes
into a silent stretch settles at ~22 minutes.

## The finish comes back

A `finished` written by the **idle rule** is marked, and the next `output`-class burst returns the row to `running`
within half an hour (`session-backstop.reopened`). No hook reopens anything — a post-turn helper healing a finished
card is the bug #385 closed — and nothing but the idle rule is ever marked, so an operator's finish, a hook's finish
and the quiet rule's finish are never taken back. What ends the claim is **anyone else writing the row**: the settle
records the row's `updatedAt` and the reopen requires it unchanged, which is how a real `Stop`'s `finished`-over-
`finished` is distinguished from the rule's own. A hook the pipeline wrote nothing for (`SubagentStart`,
`SubagentStop`, an unmatched `PostToolUse`) decides nothing and leaves the recovery armed, which matters because
`PostToolUse` is installed unmatched and fires on every tool call.

What a wrong idle settle still costs, stated rather than argued away: it emits `session:finished` (the operator's
toast, and the signal `actana session wait` unblocks on) and clears the tracked subagent set. The reopen restores the
status; it cannot un-send a notification or restore that set, which expires on its own. Three costs are tracked as
their own issues rather than fixed here: the missing counter-signal for `actana session wait` and the flapping this
can produce (**#464**), a harness parked on an unmatched approval dialog being settled like any idle screen
(**#469**), and a correct idle finish being reopened by the echo of an operator typing into the composer
(**#475**).

Documented limits of the classifier: a turn whose tool prints nothing at all is indistinguishable from one that
ended; a line that is both spinner-prefixed and nothing but numbers reads as a clock; and a harness whose spinner
rotates its gerund (`✻ Herding… / Simmering…`) never produces a long enough run of redraws for the rule to fire at
all — deliberate, and pinned by a test.

## Tests

`packages/core/src/__tests__/pty-output-activity.test.ts` (29) and `core-session-backstop.test.ts` (30), including
the reviewer's twelve-minute burst shapes (downloads, compile counts, test tallies, dot progress, timestamped and
check-marked lines all `output`; the Codex spinner still 1 `output` / 143 `redraw`), bursts past both size caps, the
reopen in seven variations, the deference bound in both directions, and both acceptance criteria driven end to end
with the real classifier in the loop.

`pnpm -C packages/core run test`: 60 files, 973 tests, green. `pnpm lint` 0 errors; `tsc --noEmit` clean.

## Scope

Base is `fix/operator-pins-sessions-drop-cli`, not `main` and not `beta/0.4.5`. Draft on purpose. The Esc-mid-turn
work in `pty-manager.ts` is #392 and is not here; Codex `Stop` itself is #290. Nothing under
`packages/shared/src/harness-hook-pipeline.ts` (#390), `packages/panel/src/server/panel-link/router.ts` (#388) or
`active-group.ts` (#384) is touched.

Refs #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxJtcyJQan1tEPLgW4XdRN

