### PR TITLE
fix(panel): do not drop a finish that lands mid fleet refresh

### DIFF
--- a/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
+++ b/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
@@ -171,7 +171,7 @@ describe("useFleetTasks — a finish that lands during an in-flight refresh", ()
       "task:updated",
       "task:updated",
       "session:finished",
-      "pty:exited",
+      "pty:exit",
       "task:updated",
       "session:finished",
     ]) {
@@ -186,6 +186,53 @@ describe("useFleetTasks — a finish that lands during an in-flight refresh", ()
 
     // One trailing pass for the whole burst, and nothing behind it.
     expect(h.listTasksCalls).toBe(3);
+    expect(h.inFlight).toHaveLength(0);
+  });
+
+  it("does not drop a finish that lands inside the trailing pass itself", async () => {
+    // The loop is a `do…while`, not a single trailing pass, and this is the
+    // only case that can tell those apart. Rewriting `run` to "settle, then at
+    // most one extra read" passes every other test in this file while quietly
+    // re-narrowing #389 to the second event — so this case is what stops that
+    // refactor at CI rather than in an operator's Fleet view.
+    h.tasks = [task("task-1", "running"), task("task-2", "running")];
+    const { result } = renderHook(() => useFleetTasks());
+
+    await waitForRead(1);
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.fleet.rows).toHaveLength(2));
+
+    // Read 2 opens, and the first Session finishes inside it.
+    await emit("task:updated");
+    await waitForRead(2);
+    h.tasks = [task("task-1", "finished"), task("task-2", "running")];
+    await emit("session:finished");
+
+    // Read 2 answers with the pre-finish snapshot, which arms the trailing
+    // pass — read 3.
+    await settleOldestRead();
+    await waitFor(() => expect(h.listTasksCalls).toBe(3));
+
+    // The second Session finishes while *that trailing pass* is in flight.
+    // A single-trailing-pass implementation has nowhere left to put this.
+    h.tasks = [task("task-1", "finished"), task("task-2", "finished")];
+    await emit("session:finished");
+
+    // Read 3 answers with a snapshot that predates the second finish...
+    await settleOldestRead();
+    // ...so a fourth read has to follow it.
+    await waitFor(() => expect(h.listTasksCalls).toBe(4));
+    await settleOldestRead();
+
+    await waitFor(() =>
+      expect(result.current.fleet.rows.map((row) => [row.taskId, row.status]).sort()).toEqual([
+        ["task-1", "finished"],
+        ["task-2", "finished"],
+      ]),
+    );
+    // Four reads and no more: mount, the event, and one trailing pass for each
+    // of the two bursts — not one per event, and not one left running.
+    expect(h.listTasksCalls).toBe(4);
     expect(h.inFlight).toHaveLength(0);
   });
 

--- a/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
+++ b/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
@@ -1,0 +1,302 @@
+// @vitest-environment jsdom
+//
+// The Fleet fan-out and the finish that lands while it is in flight (#389).
+//
+// The hook used to return early whenever a refresh was already running, so a
+// `session:finished` arriving mid-fan-out was dropped: the answers already in
+// flight predate the finish, nothing re-read them, and the row stayed running
+// until the 15s poll. These tests hold a fan-out open on purpose, land the
+// finish inside that window, and then count the reads.
+//
+// Nothing here advances a timer. `FLEET_POLL_MS` and `CORES_POLL_MS` are both
+// 15s and each test finishes in milliseconds, so every read a test observes is
+// an event-driven one — which is exactly the claim under test.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { CoreLinkTaskSnapshot } from "@actana/sdk/core-link-frames";
+import { mergeFleetTasks } from "~/shared/fleet-merge";
+
+const CORE_ID = "core-a";
+const PROJECT_ID = "project-1";
+
+const h = vi.hoisted(() => ({
+  /** Every `onEvent` subscriber currently mounted. */
+  eventHandlers: new Set<(msg: { coreId: string; event: { kind: string } }) => void>(),
+  /** One entry per in-flight `listTasks`, oldest first. */
+  inFlight: [] as { settle: () => void }[],
+  listTasksCalls: 0,
+  listProjectsCalls: 0,
+  /** What the Core would answer *right now*. Mutated by the tests. */
+  tasks: [] as CoreLinkTaskSnapshot[],
+  pinned: true,
+}));
+
+function task(taskId: string, status: string): CoreLinkTaskSnapshot {
+  return {
+    taskId,
+    projectId: PROJECT_ID,
+    title: taskId,
+    titleManuallySet: false,
+    claudeSessionId: null,
+    agent: "claude-code",
+    status,
+    pinned: false,
+    archived: false,
+    icon: null,
+    updatedAt: 1_000,
+  };
+}
+
+vi.mock("~/lib/api", () => ({
+  api: {
+    listCores: async () => ({
+      cores: [
+        {
+          id: CORE_ID,
+          endpoint: "wss://core-a:4100",
+          label: "Warehouse VM",
+          lastEventId: 0,
+          createdAt: 0,
+          updatedAt: 0,
+          dial: { coreId: CORE_ID, state: "connected", lastSeenAt: 1_000 },
+        },
+      ],
+    }),
+    listProjectPresentation: async () => ({ presentation: [] }),
+  },
+}));
+
+// One bridge object for the whole suite, exactly as `getPanelBridge` memoizes
+// the real one: the hooks key their effects on its identity.
+const bridge = {
+  isConnected: () => true,
+  watchCore: () => () => {},
+  onEvent: (cb: (msg: { coreId: string; event: { kind: string } }) => void) => {
+    h.eventHandlers.add(cb);
+    return () => h.eventHandlers.delete(cb);
+  },
+  onDialStatus: () => () => {},
+  onConnectionChange: () => () => {},
+  listProjects: async () => {
+    h.listProjectsCalls++;
+    return [
+      {
+        projectId: PROJECT_ID,
+        name: "Control",
+        path: "/srv/control",
+        icon: "CO",
+        iconColor: "#888888",
+        pinned: h.pinned,
+        rememberHarnessSettings: false,
+        savedHarness: null,
+        savedSkipPermissions: false,
+        savedBareSession: false,
+        defaultGridView: false,
+        updatedAt: 1_000,
+      },
+    ];
+  },
+  // Held open until the test says so: the whole bug lives in this window.
+  listTasks: () => {
+    h.listTasksCalls++;
+    const snapshot = () => ({ tasks: [...h.tasks], archivedCount: 0 });
+    return new Promise<{ tasks: CoreLinkTaskSnapshot[]; archivedCount: number }>((resolve) => {
+      h.inFlight.push({ settle: () => resolve(snapshot()) });
+    });
+  },
+};
+
+vi.mock("~/lib/panel-bridge", () => ({ getPanelBridge: () => bridge }));
+
+const { useFleetTasks, useRemotePinnedProjects } = await import("~/lib/use-fleet");
+const { fleetProjectKey, taskCountsByFleetProject } = await import("~/shared/projects");
+
+/** Let the oldest held `listTasks` answer, with the Core's current rows. */
+async function settleOldestRead(): Promise<void> {
+  const call = h.inFlight.shift();
+  if (!call) throw new Error("no listTasks in flight");
+  await act(async () => {
+    call.settle();
+    // Two turns: the fan-out's `Promise.all`, then the state it sets.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** A Core event, as the panel link delivers it. */
+async function emit(kind: string): Promise<void> {
+  await act(async () => {
+    for (const cb of [...h.eventHandlers]) cb({ coreId: CORE_ID, event: { kind } });
+    await Promise.resolve();
+  });
+}
+
+/** Wait until the fan-out the hook starts on mount is the one in flight. */
+async function waitForRead(n: number): Promise<void> {
+  await waitFor(() => expect(h.listTasksCalls).toBeGreaterThanOrEqual(n));
+}
+
+beforeEach(() => {
+  h.eventHandlers.clear();
+  h.inFlight = [];
+  h.listTasksCalls = 0;
+  h.listProjectsCalls = 0;
+  h.tasks = [task("task-1", "running")];
+  h.pinned = true;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useFleetTasks — a finish that lands during an in-flight refresh", () => {
+  it("shows the finish after that refresh, without waiting for the 15s poll", async () => {
+    const { result } = renderHook(() => useFleetTasks());
+
+    // First fan-out: the Session is running.
+    await waitForRead(1);
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.fleet.rows).toHaveLength(1));
+    expect(result.current.fleet.rows[0]?.status).toBe("running");
+
+    // A task event opens a second fan-out and we hold it open.
+    await emit("task:updated");
+    await waitForRead(2);
+
+    // The Session finishes *inside* that window. The read already in flight
+    // was launched before it, so its answer cannot carry the finish.
+    h.tasks = [task("task-1", "finished")];
+    await emit("session:finished");
+
+    // The stale answer lands first — this is the state the old code settled on.
+    await settleOldestRead();
+
+    // ...and the dropped event has to have re-armed the fan-out.
+    await waitFor(() => expect(h.listTasksCalls).toBe(3));
+    await settleOldestRead();
+
+    await waitFor(() => expect(result.current.fleet.rows[0]?.status).toBe("finished"));
+    // Three reads: mount, the event, and the trailing re-run. No poll tick.
+    expect(h.listTasksCalls).toBe(3);
+  });
+
+  it("re-runs exactly once for a burst of events landing in one refresh", async () => {
+    const { result } = renderHook(() => useFleetTasks());
+
+    await waitForRead(1);
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.fleet.rows).toHaveLength(1));
+
+    await emit("task:updated");
+    await waitForRead(2);
+
+    // Six more events while that one read is in flight — a burst, not six
+    // refreshes. Coalescing them is the other half of the fix.
+    h.tasks = [task("task-1", "finished")];
+    for (const kind of [
+      "task:updated",
+      "task:updated",
+      "session:finished",
+      "pty:exited",
+      "task:updated",
+      "session:finished",
+    ]) {
+      await emit(kind);
+    }
+    expect(h.listTasksCalls).toBe(2);
+
+    await settleOldestRead();
+    await waitFor(() => expect(h.listTasksCalls).toBe(3));
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.fleet.rows[0]?.status).toBe("finished"));
+
+    // One trailing pass for the whole burst, and nothing behind it.
+    expect(h.listTasksCalls).toBe(3);
+    expect(h.inFlight).toHaveLength(0);
+  });
+
+  it("settles after the trailing pass instead of re-reading forever", async () => {
+    const { result } = renderHook(() => useFleetTasks());
+
+    await waitForRead(1);
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.fleet.rows).toHaveLength(1));
+
+    await emit("task:updated");
+    await waitForRead(2);
+    await emit("session:finished");
+    await settleOldestRead();
+
+    // The trailing pass runs and then stops. A coalescing loop that cleared
+    // its flag *after* the read instead of before would keep re-reading here.
+    await waitFor(() => expect(h.listTasksCalls).toBe(3));
+    await settleOldestRead();
+    expect(h.listTasksCalls).toBe(3);
+  });
+});
+
+describe("useRemotePinnedProjects — pin activity dots", () => {
+  it("counts a pinned project from the same settled fan-out the row came from", async () => {
+    const { result } = renderHook(() => useRemotePinnedProjects());
+
+    await waitForRead(1);
+    await settleOldestRead();
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
+    // Running work lights the dot: the counts are the fan-out's, not zeroes.
+    await waitFor(() => expect(result.current.projects[0]?.taskCounts.running).toBe(1));
+    expect(result.current.projects[0]?.taskCounts.activeNonDone).toBe(1);
+
+    // The same mid-refresh finish, seen from the rail.
+    await emit("task:updated");
+    await waitForRead(2);
+    h.tasks = [task("task-1", "finished")];
+    await emit("session:finished");
+    await settleOldestRead();
+    await waitFor(() => expect(h.listTasksCalls).toBe(3));
+    await settleOldestRead();
+
+    await waitFor(() => expect(result.current.projects[0]?.taskCounts.finished).toBe(1));
+    const counts = result.current.projects[0]!.taskCounts;
+    expect(counts.running).toBe(0);
+    expect(counts.activeNonDone).toBe(0);
+    expect(counts.total).toBe(1);
+  });
+});
+
+describe("taskCountsByFleetProject", () => {
+  it("tallies exactly the rows mergeFleetTasks settled on", () => {
+    const rows = mergeFleetTasks([
+      {
+        coreId: CORE_ID,
+        coreLabel: "Warehouse VM",
+        ok: true,
+        lastSeenAt: 1_000,
+        tasks: [
+          task("task-1", "finished"),
+          task("task-2", "running"),
+          task("task-3", "needs-input"),
+          { ...task("task-4", "running"), archived: true },
+        ],
+      },
+    ]).rows;
+
+    const counts = taskCountsByFleetProject(rows);
+    const forProject = counts.get(fleetProjectKey(CORE_ID, PROJECT_ID));
+
+    // The archived row is not in `rows`, so it is not in the counts either.
+    expect(forProject?.total).toBe(rows.length);
+    expect(forProject?.finished).toBe(1);
+    expect(forProject?.running).toBe(1);
+    expect(forProject?.["needs-input"]).toBe(1);
+    expect(forProject?.activeNonDone).toBe(2);
+  });
+
+  it("keys by Core so two Cores sharing a project id do not merge", () => {
+    const counts = taskCountsByFleetProject([
+      { coreId: "core-a", projectId: PROJECT_ID, status: "running" },
+      { coreId: "core-b", projectId: PROJECT_ID, status: "running" },
+    ]);
+    expect(counts.get(fleetProjectKey("core-a", PROJECT_ID))?.running).toBe(1);
+    expect(counts.get(fleetProjectKey("core-b", PROJECT_ID))?.running).toBe(1);
+  });
+});

--- a/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
+++ b/packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx
@@ -14,7 +14,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { CoreLinkTaskSnapshot } from "@actana/sdk/core-link-frames";
-import { mergeFleetTasks } from "~/shared/fleet-merge";
 
 const CORE_ID = "core-a";
 const PROJECT_ID = "project-1";
@@ -25,10 +24,8 @@ const h = vi.hoisted(() => ({
   /** One entry per in-flight `listTasks`, oldest first. */
   inFlight: [] as { settle: () => void }[],
   listTasksCalls: 0,
-  listProjectsCalls: 0,
   /** What the Core would answer *right now*. Mutated by the tests. */
   tasks: [] as CoreLinkTaskSnapshot[],
-  pinned: true,
 }));
 
 function task(taskId: string, status: string): CoreLinkTaskSnapshot {
@@ -62,7 +59,6 @@ vi.mock("~/lib/api", () => ({
         },
       ],
     }),
-    listProjectPresentation: async () => ({ presentation: [] }),
   },
 }));
 
@@ -77,25 +73,6 @@ const bridge = {
   },
   onDialStatus: () => () => {},
   onConnectionChange: () => () => {},
-  listProjects: async () => {
-    h.listProjectsCalls++;
-    return [
-      {
-        projectId: PROJECT_ID,
-        name: "Control",
-        path: "/srv/control",
-        icon: "CO",
-        iconColor: "#888888",
-        pinned: h.pinned,
-        rememberHarnessSettings: false,
-        savedHarness: null,
-        savedSkipPermissions: false,
-        savedBareSession: false,
-        defaultGridView: false,
-        updatedAt: 1_000,
-      },
-    ];
-  },
   // Held open until the test says so: the whole bug lives in this window.
   listTasks: () => {
     h.listTasksCalls++;
@@ -108,8 +85,7 @@ const bridge = {
 
 vi.mock("~/lib/panel-bridge", () => ({ getPanelBridge: () => bridge }));
 
-const { useFleetTasks, useRemotePinnedProjects } = await import("~/lib/use-fleet");
-const { fleetProjectKey, taskCountsByFleetProject } = await import("~/shared/projects");
+const { useFleetTasks } = await import("~/lib/use-fleet");
 
 /** Let the oldest held `listTasks` answer, with the Core's current rows. */
 async function settleOldestRead(): Promise<void> {
@@ -140,9 +116,7 @@ beforeEach(() => {
   h.eventHandlers.clear();
   h.inFlight = [];
   h.listTasksCalls = 0;
-  h.listProjectsCalls = 0;
   h.tasks = [task("task-1", "running")];
-  h.pinned = true;
 });
 
 afterEach(() => {
@@ -232,71 +206,5 @@ describe("useFleetTasks — a finish that lands during an in-flight refresh", ()
     await waitFor(() => expect(h.listTasksCalls).toBe(3));
     await settleOldestRead();
     expect(h.listTasksCalls).toBe(3);
-  });
-});
-
-describe("useRemotePinnedProjects — pin activity dots", () => {
-  it("counts a pinned project from the same settled fan-out the row came from", async () => {
-    const { result } = renderHook(() => useRemotePinnedProjects());
-
-    await waitForRead(1);
-    await settleOldestRead();
-    await waitFor(() => expect(result.current.projects).toHaveLength(1));
-    // Running work lights the dot: the counts are the fan-out's, not zeroes.
-    await waitFor(() => expect(result.current.projects[0]?.taskCounts.running).toBe(1));
-    expect(result.current.projects[0]?.taskCounts.activeNonDone).toBe(1);
-
-    // The same mid-refresh finish, seen from the rail.
-    await emit("task:updated");
-    await waitForRead(2);
-    h.tasks = [task("task-1", "finished")];
-    await emit("session:finished");
-    await settleOldestRead();
-    await waitFor(() => expect(h.listTasksCalls).toBe(3));
-    await settleOldestRead();
-
-    await waitFor(() => expect(result.current.projects[0]?.taskCounts.finished).toBe(1));
-    const counts = result.current.projects[0]!.taskCounts;
-    expect(counts.running).toBe(0);
-    expect(counts.activeNonDone).toBe(0);
-    expect(counts.total).toBe(1);
-  });
-});
-
-describe("taskCountsByFleetProject", () => {
-  it("tallies exactly the rows mergeFleetTasks settled on", () => {
-    const rows = mergeFleetTasks([
-      {
-        coreId: CORE_ID,
-        coreLabel: "Warehouse VM",
-        ok: true,
-        lastSeenAt: 1_000,
-        tasks: [
-          task("task-1", "finished"),
-          task("task-2", "running"),
-          task("task-3", "needs-input"),
-          { ...task("task-4", "running"), archived: true },
-        ],
-      },
-    ]).rows;
-
-    const counts = taskCountsByFleetProject(rows);
-    const forProject = counts.get(fleetProjectKey(CORE_ID, PROJECT_ID));
-
-    // The archived row is not in `rows`, so it is not in the counts either.
-    expect(forProject?.total).toBe(rows.length);
-    expect(forProject?.finished).toBe(1);
-    expect(forProject?.running).toBe(1);
-    expect(forProject?.["needs-input"]).toBe(1);
-    expect(forProject?.activeNonDone).toBe(2);
-  });
-
-  it("keys by Core so two Cores sharing a project id do not merge", () => {
-    const counts = taskCountsByFleetProject([
-      { coreId: "core-a", projectId: PROJECT_ID, status: "running" },
-      { coreId: "core-b", projectId: PROJECT_ID, status: "running" },
-    ]);
-    expect(counts.get(fleetProjectKey("core-a", PROJECT_ID))?.running).toBe(1);
-    expect(counts.get(fleetProjectKey("core-b", PROJECT_ID))?.running).toBe(1);
   });
 });

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -7,11 +7,8 @@ import type { Harness } from "@actana/shared/domain";
 import { coreOrder, type CoreWithDial } from "~/shared/cores";
 import { subscribeCoreProjectEvents } from "~/lib/subscribe-core-project-events";
 import {
-  emptyTaskCounts,
-  fleetProjectKey,
   projectPresentationById,
   projectRowFromSnapshot,
-  taskCountsByFleetProject,
   type ProjectWithCounts,
 } from "~/shared/projects";
 import type { ProjectPresentation } from "~/db/schema";
@@ -392,23 +389,17 @@ export function useCoreTasks(
  * remembers — and it re-reads when a Core says a pin changed, so two Panels on
  * one Core agree.
  *
- * Each row's `taskCounts` — the rail's activity dot — is joined on from the
- * Fleet fan-out's settled rows rather than counted separately, so the dot and
- * the Fleet row for the same project are two readings of one snapshot and
- * cannot disagree (#389).
+ * The rail's activity dot is `taskCounts`, and a Core-owned pin has no Panel
+ * row to count, so every dot here is dark. That is issue #377's, and PR #457
+ * derives them from Core task snapshots on top of the coalescing loop below —
+ * at which point they settle correctly mid-refresh for free (#389 acceptance 2).
  */
 export function useRemotePinnedProjects(): {
   projects: ProjectWithCounts[];
   refresh: () => void;
 } {
   const bridge = getPanelBridge();
-  // The rail's activity dot is `taskCounts`, and a Core-owned pin has no Panel
-  // row to count — so the counts come from the same *kind* of read the Fleet
-  // row does, settled together, rather than from a separate tally that can
-  // disagree with the row it stands for (#389). This is a second `useFleetTasks`
-  // instance, so a page showing both the rail and Fleet fans out twice; the
-  // alternative is a dot that is dark whatever the Core is doing.
-  const { fleet, cores } = useFleetTasks();
+  const { cores } = useCores();
   const [pinned, setPinned] = useState<ProjectWithCounts[]>([]);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const refresh = useCallback(() => setRefreshNonce((n) => n + 1), []);
@@ -471,19 +462,6 @@ export function useRemotePinnedProjects(): {
     };
   }, [bridge, coreIds]);
 
-  // Join the pins onto the fleet's counts. `projectRowFromSnapshot` has no
-  // answer for task counts — a project snapshot carries no tasks — so without
-  // this every Core-owned pin renders a permanently dark dot, and the one
-  // event that would have lit it is the one the refresh used to drop.
-  const projects = useMemo(() => {
-    const counts = taskCountsByFleetProject(fleet.rows);
-    return pinned.map((project) => ({
-      ...project,
-      taskCounts:
-        counts.get(fleetProjectKey(project.coreId ?? "", project.id)) ?? emptyTaskCounts(),
-    }));
-  }, [pinned, fleet.rows]);
-
-  return { projects, refresh };
+  return { projects: pinned, refresh };
 }
 

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -7,8 +7,11 @@ import type { Harness } from "@actana/shared/domain";
 import { coreOrder, type CoreWithDial } from "~/shared/cores";
 import { subscribeCoreProjectEvents } from "~/lib/subscribe-core-project-events";
 import {
+  emptyTaskCounts,
+  fleetProjectKey,
   projectPresentationById,
   projectRowFromSnapshot,
+  taskCountsByFleetProject,
   type ProjectWithCounts,
 } from "~/shared/projects";
 import type { ProjectPresentation } from "~/db/schema";
@@ -116,6 +119,10 @@ export function useFleetTasks(): {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const refreshing = useRef(false);
+  // An event arrived while a fan-out was in flight and its finish is not in
+  // that fan-out's answers. Set by the dropped call, read by the loop that
+  // owns the refresh — see `run` below.
+  const pending = useRef(false);
   const coresRef = useRef<CoreWithDial[]>(cores);
   coresRef.current = cores;
   // Which Cores exist, and whether each is reachable — the two things a change
@@ -127,9 +134,10 @@ export function useFleetTasks(): {
   );
   const coreIds = useMemo(() => cores.map((c) => c.id).join(","), [cores]);
 
-  const run = useCallback(async () => {
-    if (!bridge || refreshing.current) return;
-    refreshing.current = true;
+  const fanOut = useCallback(async (): Promise<boolean> => {
+    // Unreachable through `run`, which guards the same thing; false is the
+    // safe answer either way — no link, nothing to re-read.
+    if (!bridge) return false;
     try {
       const results = await Promise.all(
         coresRef.current.map(async (core): Promise<CoreFanOutResult> => {
@@ -158,13 +166,42 @@ export function useFleetTasks(): {
       );
       setFleet(mergeFleetTasks(results));
       setError(null);
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      return false;
     } finally {
       setLoading(false);
-      refreshing.current = false;
     }
   }, [bridge]);
+
+  const run = useCallback(async () => {
+    if (!bridge) return;
+    if (refreshing.current) {
+      // The fan-out in flight was launched *before* this event, so its answers
+      // cannot contain what the event announced — a `session:finished` that
+      // lands here used to be dropped outright, leaving the row running until
+      // the 15s poll or the next event (#389). Remember it instead.
+      pending.current = true;
+      return;
+    }
+    refreshing.current = true;
+    try {
+      do {
+        // Cleared before the read, not after: anything that arrives while this
+        // very pass is in flight has to survive into the next one.
+        pending.current = false;
+        // One trailing pass per burst, not one per event: every event landing
+        // during a pass sets the same flag, and the loop reads it once.
+        // A failed pass stops the loop rather than spinning on the error —
+        // whatever arrived during it is picked up by the next event or poll.
+        if (!(await fanOut())) break;
+      } while (pending.current);
+    } finally {
+      refreshing.current = false;
+      pending.current = false;
+    }
+  }, [bridge, fanOut]);
 
   // Watch every Core so its task events reach this tab, and refetch when one
   // lands. This is what "without refresh" means: an agent finishing on a VM
@@ -354,13 +391,22 @@ export function useCoreTasks(
  * Core fact, so this is a live read per Core rather than anything the Panel
  * remembers — and it re-reads when a Core says a pin changed, so two Panels on
  * one Core agree.
+ *
+ * Each row's `taskCounts` — the rail's activity dot — is joined on from the
+ * Fleet fan-out's settled rows rather than counted separately, so the dot and
+ * the Fleet row for the same project are two readings of one snapshot and
+ * cannot disagree (#389).
  */
 export function useRemotePinnedProjects(): {
   projects: ProjectWithCounts[];
   refresh: () => void;
 } {
   const bridge = getPanelBridge();
-  const { cores } = useCores();
+  // The same fan-out the Fleet view renders, not a second one: the rail's
+  // activity dot is `taskCounts`, a Core-owned pin has no Panel row to count,
+  // and a dot counted from a different read is a dot that can disagree with
+  // the row it stands for. One settled snapshot feeds both (#389).
+  const { fleet, cores } = useFleetTasks();
   const [pinned, setPinned] = useState<ProjectWithCounts[]>([]);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const refresh = useCallback(() => setRefreshNonce((n) => n + 1), []);
@@ -423,6 +469,19 @@ export function useRemotePinnedProjects(): {
     };
   }, [bridge, coreIds]);
 
-  return { projects: pinned, refresh };
+  // Join the pins onto the fleet's counts. `projectRowFromSnapshot` has no
+  // answer for task counts — a project snapshot carries no tasks — so without
+  // this every Core-owned pin renders a permanently dark dot, and the one
+  // event that would have lit it is the one the refresh used to drop.
+  const projects = useMemo(() => {
+    const counts = taskCountsByFleetProject(fleet.rows);
+    return pinned.map((project) => ({
+      ...project,
+      taskCounts:
+        counts.get(fleetProjectKey(project.coreId ?? "", project.id)) ?? emptyTaskCounts(),
+    }));
+  }, [pinned, fleet.rows]);
+
+  return { projects, refresh };
 }
 

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -42,6 +42,30 @@ function emptyFleet(): FleetMergeResult {
 }
 
 /**
+ * Structural equality for the plain, JSON-shaped values a fan-out settles on.
+ *
+ * Task and project snapshots are flat records of scalars, one optional nested
+ * `lock` deep, held in arrays — so a recursive own-key walk is the whole of it,
+ * and it is bounded by the same row count `mergeFleetTasks` just paid for.
+ * Nothing here needs to handle a Date, a Map or a cycle, and it must not
+ * pretend to: it is used only to answer "did this read change anything".
+ */
+function sameSnapshot(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const left = a as Record<string, unknown>;
+  const right = b as Record<string, unknown>;
+  const keys = Object.keys(left);
+  if (keys.length !== Object.keys(right).length) return false;
+  for (const key of keys) {
+    if (!Object.hasOwn(right, key)) return false;
+    if (!sameSnapshot(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+/**
  * "Nothing filed yet", shared by identity so a re-read that finds no filing
  * doesn't re-join every row. Read-only — nothing ever writes into it.
  */
@@ -161,7 +185,12 @@ export function useFleetTasks(): {
           }
         }),
       );
-      setFleet(mergeFleetTasks(results));
+      // Keep the previous object when the fan-out settled on the same answer.
+      // `fleet.rows` is a dependency of memos and effects several layers up,
+      // and a fresh array on every event would tear those down for nothing —
+      // the merge is already O(rows), so comparing it costs the same order.
+      const merged = mergeFleetTasks(results);
+      setFleet((prev) => (sameSnapshot(prev, merged) ? prev : merged));
       setError(null);
       return true;
     } catch (err) {
@@ -190,13 +219,14 @@ export function useFleetTasks(): {
         pending.current = false;
         // One trailing pass per burst, not one per event: every event landing
         // during a pass sets the same flag, and the loop reads it once.
-        // A failed pass stops the loop rather than spinning on the error —
-        // whatever arrived during it is picked up by the next event or poll.
+        // A failed pass stops the loop rather than spinning on the error, and
+        // leaves `pending` exactly as the burst left it — clearing it here
+        // would drop the backlog on the error path, which is #389 again in
+        // miniature. The next event or the poll picks it up.
         if (!(await fanOut())) break;
       } while (pending.current);
     } finally {
       refreshing.current = false;
-      pending.current = false;
     }
   }, [bridge, fanOut]);
 

--- a/packages/panel/src/lib/use-fleet.ts
+++ b/packages/panel/src/lib/use-fleet.ts
@@ -402,10 +402,12 @@ export function useRemotePinnedProjects(): {
   refresh: () => void;
 } {
   const bridge = getPanelBridge();
-  // The same fan-out the Fleet view renders, not a second one: the rail's
-  // activity dot is `taskCounts`, a Core-owned pin has no Panel row to count,
-  // and a dot counted from a different read is a dot that can disagree with
-  // the row it stands for. One settled snapshot feeds both (#389).
+  // The rail's activity dot is `taskCounts`, and a Core-owned pin has no Panel
+  // row to count — so the counts come from the same *kind* of read the Fleet
+  // row does, settled together, rather than from a separate tally that can
+  // disagree with the row it stands for (#389). This is a second `useFleetTasks`
+  // instance, so a page showing both the rail and Fleet fans out twice; the
+  // alternative is a dot that is dark whatever the Core is doing.
   const { fleet, cores } = useFleetTasks();
   const [pinned, setPinned] = useState<ProjectWithCounts[]>([]);
   const [refreshNonce, setRefreshNonce] = useState(0);

--- a/packages/panel/src/shared/projects.ts
+++ b/packages/panel/src/shared/projects.ts
@@ -1,5 +1,5 @@
 import type { CoreLinkProjectSnapshot } from "@actana/sdk/core-link-frames";
-import { TASK_STATUSES, type Harness } from "@actana/shared/domain";
+import { isActiveStatus, isTaskStatus, TASK_STATUSES, type Harness } from "@actana/shared/domain";
 import type { Project, ProjectPresentation, TaskStatus } from "~/db/schema";
 
 export type ProjectWithCounts = Project & {
@@ -50,6 +50,64 @@ export function projectSettingsFromSnapshot(
   };
 }
 
+/** The count block every {@link ProjectWithCounts} carries. */
+export type ProjectTaskCounts = ProjectWithCounts["taskCounts"];
+
+/**
+ * A count block with every status at zero — "this project has no active work",
+ * as opposed to "nobody has counted yet". The Panel's own rows are counted
+ * server-side; this is what a row built from a Core snapshot starts as, and
+ * what a project the fleet fan-out returned no rows for settles at.
+ */
+export function emptyTaskCounts(): ProjectTaskCounts {
+  return {
+    ...(Object.fromEntries(TASK_STATUSES.map((s) => [s, 0])) as Record<TaskStatus, number>),
+    total: 0,
+    activeNonDone: 0,
+  };
+}
+
+/** How a fleet row is addressed per project: project ids are only Core-unique. */
+export function fleetProjectKey(coreId: string, projectId: string): string {
+  return `${coreId}/${projectId}`;
+}
+
+/**
+ * Per-project counts derived from the Fleet fan-out's own rows, keyed by
+ * {@link fleetProjectKey}.
+ *
+ * The pin rail draws an activity dot from `taskCounts`, and a Core-owned pin
+ * has no Panel database row to count — so the counts have to come from the
+ * same `tasksList` answer the Fleet row came from. Deriving them here rather
+ * than from a second read is what makes a dot and its row agree by
+ * construction: one snapshot in, both readings out (#389 acceptance 2).
+ *
+ * The arithmetic mirrors the server's own `decorate()` — archived rows are
+ * already dropped by `mergeFleetTasks`, `total` is the rows counted, and
+ * `activeNonDone` is the active-but-unfinished subset — so a Core-owned
+ * project and a Panel-owned one light the same dot for the same work.
+ */
+export function taskCountsByFleetProject(
+  rows: readonly { coreId: string; projectId: string; status: string }[],
+): Map<string, ProjectTaskCounts> {
+  const byProject = new Map<string, ProjectTaskCounts>();
+  for (const row of rows) {
+    const key = fleetProjectKey(row.coreId, row.projectId);
+    let counts = byProject.get(key);
+    if (!counts) {
+      counts = emptyTaskCounts();
+      byProject.set(key, counts);
+    }
+    counts.total++;
+    // A Core may name a status this Panel does not model; it still counts
+    // toward `total` but has no bucket of its own to land in.
+    if (!isTaskStatus(row.status)) continue;
+    counts[row.status]++;
+    if (isActiveStatus(row.status) && row.status !== "finished") counts.activeNonDone++;
+  }
+  return byProject;
+}
+
 /**
  * A Core's project snapshot as the row every project surface renders.
  *
@@ -86,11 +144,7 @@ export function projectRowFromSnapshot(
     ...projectSettingsFromSnapshot(snapshot),
     createdAt: snapshot.updatedAt,
     updatedAt: snapshot.updatedAt,
-    taskCounts: {
-      ...(Object.fromEntries(TASK_STATUSES.map((s) => [s, 0])) as Record<TaskStatus, number>),
-      total: 0,
-      activeNonDone: 0,
-    },
+    taskCounts: emptyTaskCounts(),
     preview: null,
     githubUrl: null,
     repoKey: null,

--- a/packages/panel/src/shared/projects.ts
+++ b/packages/panel/src/shared/projects.ts
@@ -1,5 +1,5 @@
 import type { CoreLinkProjectSnapshot } from "@actana/sdk/core-link-frames";
-import { isActiveStatus, isTaskStatus, TASK_STATUSES, type Harness } from "@actana/shared/domain";
+import { TASK_STATUSES, type Harness } from "@actana/shared/domain";
 import type { Project, ProjectPresentation, TaskStatus } from "~/db/schema";
 
 export type ProjectWithCounts = Project & {
@@ -50,64 +50,6 @@ export function projectSettingsFromSnapshot(
   };
 }
 
-/** The count block every {@link ProjectWithCounts} carries. */
-export type ProjectTaskCounts = ProjectWithCounts["taskCounts"];
-
-/**
- * A count block with every status at zero — "this project has no active work",
- * as opposed to "nobody has counted yet". The Panel's own rows are counted
- * server-side; this is what a row built from a Core snapshot starts as, and
- * what a project the fleet fan-out returned no rows for settles at.
- */
-export function emptyTaskCounts(): ProjectTaskCounts {
-  return {
-    ...(Object.fromEntries(TASK_STATUSES.map((s) => [s, 0])) as Record<TaskStatus, number>),
-    total: 0,
-    activeNonDone: 0,
-  };
-}
-
-/** How a fleet row is addressed per project: project ids are only Core-unique. */
-export function fleetProjectKey(coreId: string, projectId: string): string {
-  return `${coreId}/${projectId}`;
-}
-
-/**
- * Per-project counts derived from the Fleet fan-out's own rows, keyed by
- * {@link fleetProjectKey}.
- *
- * The pin rail draws an activity dot from `taskCounts`, and a Core-owned pin
- * has no Panel database row to count — so the counts have to come from the
- * same `tasksList` answer the Fleet row came from. Deriving them here rather
- * than from a second read is what makes a dot and its row agree by
- * construction: one snapshot in, both readings out (#389 acceptance 2).
- *
- * The arithmetic mirrors the server's own `decorate()` — archived rows are
- * already dropped by `mergeFleetTasks`, `total` is the rows counted, and
- * `activeNonDone` is the active-but-unfinished subset — so a Core-owned
- * project and a Panel-owned one light the same dot for the same work.
- */
-export function taskCountsByFleetProject(
-  rows: readonly { coreId: string; projectId: string; status: string }[],
-): Map<string, ProjectTaskCounts> {
-  const byProject = new Map<string, ProjectTaskCounts>();
-  for (const row of rows) {
-    const key = fleetProjectKey(row.coreId, row.projectId);
-    let counts = byProject.get(key);
-    if (!counts) {
-      counts = emptyTaskCounts();
-      byProject.set(key, counts);
-    }
-    counts.total++;
-    // A Core may name a status this Panel does not model; it still counts
-    // toward `total` but has no bucket of its own to land in.
-    if (!isTaskStatus(row.status)) continue;
-    counts[row.status]++;
-    if (isActiveStatus(row.status) && row.status !== "finished") counts.activeNonDone++;
-  }
-  return byProject;
-}
-
 /**
  * A Core's project snapshot as the row every project surface renders.
  *
@@ -144,7 +86,11 @@ export function projectRowFromSnapshot(
     ...projectSettingsFromSnapshot(snapshot),
     createdAt: snapshot.updatedAt,
     updatedAt: snapshot.updatedAt,
-    taskCounts: emptyTaskCounts(),
+    taskCounts: {
+      ...(Object.fromEntries(TASK_STATUSES.map((s) => [s, 0])) as Record<TaskStatus, number>),
+      total: 0,
+      activeNonDone: 0,
+    },
     preview: null,
     githubUrl: null,
     repoKey: null,


### PR DESCRIPTION
Refs #389 (F3). **Scope narrowed after review:** this PR is now the coalescing loop and nothing else.

## What was wrong

`useFleetTasks` guarded its fan-out with `if (!bridge || refreshing.current) return;`. Any `session:finished` or
`task:updated(finished)` that arrived while a `tasksList` fan-out was in flight hit that early return and was
dropped. The reads already in flight were launched *before* the finish, so their answers cannot carry it, and
nothing re-read them — the row stayed `running` until the 15s poll or until some later event happened along.

## The fix — `packages/panel/src/lib/use-fleet.ts`

- The refresh owns a coalescing loop instead of a bare guard. An event landing during a pass sets a `pending`
  flag rather than returning; the loop reads that flag when the pass settles and runs one trailing pass per
  burst, however many events the burst contained.
- The flag is cleared *before* each read, not after, so an event landing inside the trailing pass survives into
  the next one — no finish is ever dropped, including one that lands inside a trailing pass.
- A failed pass breaks the loop rather than spinning on the error, and **leaves `pending` as the burst left it**
  so the backlog is picked up by the next event or the poll (review finding 6).
- `setFleet` keeps the previous object when the merge settles on the same answer, so `fleet.rows` no longer
  churns identity on every event and the memos and effects keyed on it upstream stop tearing down for nothing
  (review finding 5).

## Acceptance

**Acceptance 1** — *a finish landing mid-refresh is visible after that refresh without waiting for the 15s poll*
— is met here and is what this PR is.

**Acceptance 2** — *pin activity dots for that project match the settled row* — is **not claimed by this PR.**
An earlier revision of #456 derived the dots here; review found that is #377's fix and that **PR #457 already
carries it**, rewriting the same `projectRowFromSnapshot` count block (`git merge-tree` conflicts on
`packages/panel/src/shared/projects.ts`). By orchestrator decision on merge order, **#456 keeps only the
coalescing loop and #457 wires the counts in `use-fleet.ts` after #456 merges.** That half is fully reverted
here — `shared/projects.ts` is byte-identical to the base branch and `useRemotePinnedProjects` is back to its
own `useCores` returning `pinned` unjoined.

Acceptance 2 is then **satisfied by construction**: a Core-owned pin currently has no count source at all, so
once #457 derives the dots from Core task snapshots on top of this loop, they settle through the very fan-out
this loop stops dropping — the mid-refresh finish reaches the dot for the same reason it now reaches the row.

The **unreachable-Core case** the review raised (an offline Core's pins falling through to zeroed counts and
reading as "finished" rather than "not counted") goes with the dot: it is a property of the derivation, not of
the loop, so **it belongs to #457**, which has `fleet.offlineCores` available to key off. Nothing in this PR
can produce it — no pin here has counts to zero.

## Tests — `packages/panel/src/lib/__tests__/use-fleet-refresh.test.tsx`

The mocked bridge parks every `listTasks` call and the test decides when each answers, which is what lets an
event land strictly inside a pass. Four cases:

1. a finish landing mid-refresh is visible once that refresh settles (3 reads exactly)
2. a burst of six events inside one pass produces exactly one trailing read and nothing behind it
3. **a finish landing inside the trailing pass itself is not dropped** — emits during read 3, asserts a fourth
   read and that both Sessions settle `finished` (review finding 3)
4. the loop settles after the trailing pass instead of re-reading forever

No test advances a timer. Both polls are 15s and each case finishes in milliseconds, so every read observed is
event-driven, and the exact read counts are the proof the 15s poll is not what fixed the row.

**Three mutations of `run()` now fail, each on all four cases or on the case written for it:**

| Mutation | Result |
| --- | --- |
| the original `if (refreshing.current) return;` guard | 4 of 4 fail |
| clear `pending` *after* the read instead of before | 4 of 4 fail |
| `do…while` → settle-then-at-most-one-extra-read | case 3 fails |

The third is the one review finding 3 called out as passing the previous suite.

`pnpm test` in `packages/panel`: 148 files, 1597 tests, green. Repo `pnpm typecheck` clean; `pnpm lint` 0 errors
(the one warning in `use-fleet.ts` is the pre-existing unused `Harness` import, untouched here). commitlint run
locally over `e68c354..HEAD` the way CI runs it: 0 problems.

## Scope

Touches `packages/panel/src/lib/use-fleet.ts` and the new test file **only**. `packages/panel/src/shared/projects.ts`
is back to base contents verbatim. The #383 picker Core-snapshot work in the same file is a later wave and is
**not** taken here. Base is `fix/operator-pins-sessions-drop-cli`, not `main` and not `beta/0.4.5`. Draft on
purpose. The revert was landed as a new commit; nothing pushed has been force-pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NasX2s8dYACnTAyhrLWhgv
