### PR TITLE
fix(cli): events tail --kind must print matching history

### DIFF
--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -555,24 +555,27 @@ describe("actana events tail", () => {
     );
     await settle();
 
-    core.emitEvent({ eventId: 1, kind: "session:finished", taskId: "t-old" });
+    core.emitEvent({ eventId: 1, kind: "session:finished", taskId: "t-oldest" });
     core.emitEvent({ eventId: 2, kind: "task:updated" });
-    core.emitEvent({ eventId: 3, kind: "session:finished", taskId: "t-mid" });
+    core.emitEvent({ eventId: 3, kind: "session:finished", taskId: "t-old" });
     core.emitReplayed(3);
     await settle();
     // The ring survives the re-ask: it is one walk, however many tails it takes.
     expect(core.subscribes).toContain(3);
 
-    core.emitEvent({ eventId: 4, kind: "session:finished", taskId: "t-new" });
-    core.emitReplayed(4);
+    core.emitEvent({ eventId: 4, kind: "session:finished", taskId: "t-mid" });
+    core.emitEvent({ eventId: 5, kind: "session:finished", taskId: "t-new" });
+    core.emitReplayed(5);
     await settle();
-    core.emitReplayed(4);
+    core.emitReplayed(5);
 
     const result = await run;
     expect(result.code).toBe(EXIT_OK);
-    // #3 and #4 — in the order the Core appended them, and not #1, which is the
-    // one a run that printed on the way past would have answered with.
-    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([3, 4]);
+    // #4 and #5 — in the order the Core appended them, and not #1, which is the
+    // one a run that printed on the way past would have answered with. Four
+    // matches through a ring of two also turns its write index over twice,
+    // which is where a rotation that read from the wrong slot shows up.
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([4, 5]);
     expect(result.out.map((line) => JSON.parse(line).taskId)).toEqual(["t-mid", "t-new"]);
   });
 
@@ -638,6 +641,124 @@ describe("actana events tail", () => {
     const result = await run;
     expect(result.code).toBe(EXIT_OK);
     expect(JSON.parse(result.out[0]!).eventId).toBe(3);
+  });
+
+  it("does not answer a bounded --kind run from a tip it could only approximate", async () => {
+    // Round-2 review, blocking. The last hiding place of round-1's finding 1.
+    // `tipFrom` hands back its approximation as an ordinary number after
+    // MAX_TIP_ROUNDS, so a walk that took it as the tip flushed its ring and
+    // exited 0 — with whatever matches it happened to see, which on a Core
+    // racing ahead of the reader are the oldest in the log. Everything a script
+    // can observe, exit code and stdout, was then indistinguishable from a
+    // correct answer, and stderr said the run was "carrying on" after it had
+    // exited.
+    //
+    // `event-tip.ts` names this caller by hand: a caller that ends on the
+    // number says so in its own words and decides that an approximation is not
+    // a finished read.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "1"],
+      { connect: core.connect },
+    );
+    await settle();
+
+    // A stale finish first, then a Core that keeps the hunt asking past the
+    // round it gives up on. MAX_TIP_ROUNDS is 200 and lives in `event-tip.ts`.
+    core.emitEvent({ eventId: 1, kind: "session:finished", taskId: "t-stale" });
+    for (let round = 2; round <= 202; round += 1) {
+      core.emitEvent({ eventId: round, kind: "task:updated" });
+      core.emitReplayed(round);
+    }
+
+    const result = await run;
+    // Not a 0, and not the stale finish presented as the answer.
+    expect(
+      result.code,
+      "a bounded --kind run answered from an approximate tip and called it a success",
+    ).toBe(EXIT_FAILURE);
+    const said = result.err.join("\n");
+    expect(said).toContain("appended events faster than they could be read");
+    expect(said).toContain("did not finish");
+    // The sentence written for a run that really is about to follow, which this
+    // one is not: it has exited.
+    expect(said).not.toContain("carrying on");
+    // What it held still goes out — a short read is reported by its status, not
+    // by withholding what it read (#439) — and the sentence counts it.
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([1]);
+    expect(said).toContain("1 of them held from an unfinished walk");
+    expect(core.closed).toBe(true);
+  });
+
+  it("still carries on from an approximate tip when the walk is not the answer", async () => {
+    // The other half of the split, and why the fix above is narrower than
+    // `--limit`. A run with a ceiling but no `--kind` prints nothing on the
+    // walk: its ceiling is spent on live events, so an approximate tip costs it
+    // a short replay rather than its answer. It really is "a first run about to
+    // follow", which is the caller `event-tip.ts` wrote its default sentence
+    // for — so it keeps that sentence and keeps following.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(["events", "tail", "--json", "--limit", "1"], { connect: core.connect });
+    await settle();
+
+    // The hunt gives up on the round after the last one it will take, so 201
+    // rounds of non-empty tail is where it settles and printing switches on.
+    for (let round = 1; round <= 201; round += 1) {
+      core.emitEvent({ eventId: round, kind: "task:updated" });
+      core.emitReplayed(round);
+    }
+    await settle();
+
+    // Still following, and told why in the words `event-tip.ts` chose.
+    core.emitEvent({ eventId: 202, kind: "session:finished" });
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([202]);
+    expect(result.err.join("\n")).toContain("carrying on from");
+  });
+
+  it("streams --kind matches as they arrive when there is no --limit", async () => {
+    // Round-2 review, should-fix: the `recent === null` branch of the walk had
+    // no test, and it is what the help paragraph advertises. Without a ceiling
+    // there is no n to choose between, every match is going to be printed
+    // anyway, so they go out as they go past rather than into a ring.
+    //
+    // Deliberately never awaited: a tail with no --limit is a follow and has no
+    // ending, which is the whole point of the case. Nothing is armed either —
+    // the 30s deadline belongs to bounded runs — so there is no timer to leak.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const printed: string[] = [];
+    void cli().run(["events", "tail", "--json", "--kind", "session:finished"], {
+      connect: core.connect,
+      onOut: (line) => printed.push(line),
+    });
+    await settle();
+
+    core.emitEvent({ eventId: 1, kind: "session:finished", taskId: "t-1" });
+    core.emitEvent({ eventId: 2, kind: "task:updated" });
+    core.emitEvent({ eventId: 3, kind: "session:finished", taskId: "t-2" });
+    await settle();
+
+    // Both matches, in order, while the walk is still going — no ring, no wait
+    // for the tip. The unasked-for kind in the middle stays quiet, as ever.
+    expect(printed.map((line) => JSON.parse(line).eventId)).toEqual([1, 3]);
+
+    core.emitReplayed(3);
+    await settle();
+    core.emitReplayed(3);
+    await settle();
+
+    // …and then it follows, which is what a tail with no ceiling does.
+    core.emitEvent({ eventId: 4, kind: "task:updated" });
+    core.emitEvent({ eventId: 5, kind: "session:finished", taskId: "t-3" });
+    await settle();
+    expect(printed.map((line) => JSON.parse(line).eventId)).toEqual([1, 3, 5]);
   });
 
   it("stops timing the Core once it has said where its log ends", async () => {

--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -503,11 +503,7 @@ describe("actana events tail", () => {
     // walking to the tip — and the finish it was typed to find is already in
     // that tail. Counting it and moving on was the defect: nothing on stdout,
     // and then a wait for a second `session:finished` that nobody was going to
-    // produce. On `HEAD~1` this case does not fail an assertion, it hangs.
-    //
-    // No marker is sent here on purpose. The run ends on its ceiling, in the
-    // middle of the walk, which is what "prints one and exits" has to mean for
-    // an operator whose Core has nothing further to say.
+    // produce. On the parent this case does not fail an assertion, it hangs.
     await withRegisteredCore();
     const core = fakeCore({});
 
@@ -521,16 +517,94 @@ describe("actana events tail", () => {
     core.emitEvent({ eventId: 1, kind: "task:created" });
     core.emitEvent({ eventId: 2, kind: "session:finished", taskId: "t-1" });
     core.emitEvent({ eventId: 3, kind: "task:updated" });
+    await settle();
+
+    // Nothing yet, and that is the point of the round-1 review's finding: which
+    // match is the newest is not knowable until the log has an end, so the walk
+    // holds rather than prints. A run that answered here would be answering
+    // with the oldest match the Core still holds.
+    expect(printed).toEqual([]);
+
+    core.emitReplayed(3);
+    await settle();
+    // A receipt, not the tip — the walk carries on and keeps holding.
+    expect(core.subscribes).toContain(3);
+    expect(printed).toEqual([]);
+
+    core.emitReplayed(3);
 
     const result = await run;
     expect(result.code).toBe(EXIT_OK);
     expect(result.out).toHaveLength(1);
     expect(JSON.parse(result.out[0]!)).toMatchObject({ eventId: 2, kind: "session:finished" });
-    // Printed as it went past, not gathered up at the end of the walk: the
-    // cursor advances per delivered event, so a line that waits for the end of
-    // the tail is a line a Ctrl-C can lose.
-    expect(printed).toHaveLength(1);
     expect(core.closed).toBe(true);
+  });
+
+  it("holds the newest --limit matches of the walk, not the first it finds", async () => {
+    // Round-1 review, blocking finding 1, at this suite's level. A first run
+    // walks the whole retained log, so "the first match" and "the match the
+    // operator just watched happen" are the same event only on a Core with no
+    // history. Three finishes go past, spread over two rounds of a capped
+    // replay, and `--limit 2` must answer with the last two.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "2"],
+      { connect: core.connect },
+    );
+    await settle();
+
+    core.emitEvent({ eventId: 1, kind: "session:finished", taskId: "t-old" });
+    core.emitEvent({ eventId: 2, kind: "task:updated" });
+    core.emitEvent({ eventId: 3, kind: "session:finished", taskId: "t-mid" });
+    core.emitReplayed(3);
+    await settle();
+    // The ring survives the re-ask: it is one walk, however many tails it takes.
+    expect(core.subscribes).toContain(3);
+
+    core.emitEvent({ eventId: 4, kind: "session:finished", taskId: "t-new" });
+    core.emitReplayed(4);
+    await settle();
+    core.emitReplayed(4);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    // #3 and #4 — in the order the Core appended them, and not #1, which is the
+    // one a run that printed on the way past would have answered with.
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([3, 4]);
+    expect(result.out.map((line) => JSON.parse(line).taskId)).toEqual(["t-mid", "t-new"]);
+  });
+
+  it("hands over what the walk was holding when the Core stops answering", async () => {
+    // The deadline is this side giving up, and #439 settled what that looks
+    // like: what was read goes to stdout, the reason to stderr, and the exit is
+    // non-zero because a read cut off partway is not a read that finished. A
+    // walk that is holding matches has read them — the cursor has already moved
+    // past them — so dropping them on the way out would lose them for every
+    // later run to buy nothing.
+    vi.useFakeTimers();
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const run = cli().run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "3"],
+      { connect: core.connect },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    core.emitEvent({ eventId: 1, kind: "session:finished" });
+    core.emitEvent({ eventId: 2, kind: "task:updated" });
+    // …and then nothing: no marker, no further event, no end of the log.
+    await vi.advanceTimersByTimeAsync(SUBSCRIBE_ANSWER_MS + 1);
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_FAILURE);
+    expect(result.out.map((line) => JSON.parse(line).eventId)).toEqual([1]);
+    const said = result.err.join("\n");
+    expect(said).toContain("stopped answering");
+    expect(said).toContain("held from an unfinished walk");
+    expect(said).toContain("did not finish");
   });
 
   it("still prints none of the kinds a first run was not asked for", async () => {

--- a/packages/cli/src/__tests__/events-command.test.ts
+++ b/packages/cli/src/__tests__/events-command.test.ts
@@ -474,8 +474,9 @@ describe("actana events tail", () => {
     // operator asked for still finished, and has nothing left to wait for —
     // reading `printed` here would hang exactly where #402 hung, one flag over.
     //
-    // The first-run half of the kind filter — history skipped while the cursor
-    // advances past it — is #403 and is not touched here.
+    // This is the run *with* a cursor. The first-run half of the filter — where
+    // a named kind is printed out of the walk to the tip — is #403 and is the
+    // two cases below.
     await withRegisteredCore();
     const core = fakeCore({});
 
@@ -495,6 +496,74 @@ describe("actana events tail", () => {
     expect(result.code).toBe(EXIT_OK);
     expect(result.out).toEqual([]);
     expect(core.closed).toBe(true);
+  });
+
+  it("prints a --kind match out of a first run's tail, and ends on it", async () => {
+    // #403, frame for frame. No stored cursor and no --since, so this run is
+    // walking to the tip — and the finish it was typed to find is already in
+    // that tail. Counting it and moving on was the defect: nothing on stdout,
+    // and then a wait for a second `session:finished` that nobody was going to
+    // produce. On `HEAD~1` this case does not fail an assertion, it hangs.
+    //
+    // No marker is sent here on purpose. The run ends on its ceiling, in the
+    // middle of the walk, which is what "prints one and exits" has to mean for
+    // an operator whose Core has nothing further to say.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const printed: string[] = [];
+    const run = cli().run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "1"],
+      { connect: core.connect, onOut: (line) => printed.push(line) },
+    );
+    await settle();
+
+    core.emitEvent({ eventId: 1, kind: "task:created" });
+    core.emitEvent({ eventId: 2, kind: "session:finished", taskId: "t-1" });
+    core.emitEvent({ eventId: 3, kind: "task:updated" });
+
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.out).toHaveLength(1);
+    expect(JSON.parse(result.out[0]!)).toMatchObject({ eventId: 2, kind: "session:finished" });
+    // Printed as it went past, not gathered up at the end of the walk: the
+    // cursor advances per delivered event, so a line that waits for the end of
+    // the tail is a line a Ctrl-C can lose.
+    expect(printed).toHaveLength(1);
+    expect(core.closed).toBe(true);
+  });
+
+  it("still prints none of the kinds a first run was not asked for", async () => {
+    // The guard on #403's narrowing. The replay storm is a history nobody asked
+    // for, and it is still suppressed exactly as it was — what changed is that
+    // naming a kind counts as asking for it. Everything else in the tail stays
+    // as quiet on a first run as it has always been.
+    await withRegisteredCore();
+    const core = fakeCore({});
+
+    const printed: string[] = [];
+    const run = cli().run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "1"],
+      { connect: core.connect, onOut: (line) => printed.push(line) },
+    );
+    await settle();
+
+    core.emitEvent({ eventId: 1, kind: "task:created" });
+    core.emitEvent({ eventId: 2, kind: "task:updated" });
+    core.emitReplayed(2);
+    await settle();
+    // A receipt, not the tip: the walk carries on from #2 (`event-tip.ts`).
+    expect(core.subscribes).toContain(2);
+    core.emitReplayed(2);
+    await settle();
+
+    // Two events of history, no finish among them, and nothing on stdout.
+    expect(printed).toEqual([]);
+
+    core.emitEvent({ eventId: 3, kind: "session:finished" });
+    const result = await run;
+    expect(result.code).toBe(EXIT_OK);
+    expect(JSON.parse(result.out[0]!).eventId).toBe(3);
   });
 
   it("stops timing the Core once it has said where its log ends", async () => {

--- a/packages/cli/src/__tests__/events-tail-cursor.test.ts
+++ b/packages/cli/src/__tests__/events-tail-cursor.test.ts
@@ -292,6 +292,94 @@ describe("actana events tail, across a Core restart", () => {
     expect(log.tailReads).toBeGreaterThan(1);
   }, 60_000);
 
+  it("prints the finish already in the log on a first --kind run, and exits", async () => {
+    // #403's first criterion, against the Core that produces it and the cursor
+    // file a real run writes. This is the command an operator types after a
+    // session has finished, on a machine that has never followed this Core: no
+    // stored cursor, no --since, and the answer already in the log. It used to
+    // print nothing and never exit.
+    const log = arrayEventLog();
+    const port = await freePort();
+    const core = await coreOn(port, log);
+    fixture = makeCliFixture();
+    registerCore(fixture.paths, "inproc", core.blobText);
+
+    log.push("session:started");
+    log.push("task:created");
+    log.push("session:finished");
+    log.push("task:updated");
+
+    const result = await fixture.run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "1"],
+      { connect: connectCore },
+    );
+
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+    // One event, and the one that was asked for. The three around it are the
+    // history nobody asked for and are still not printed.
+    expect(idsOf(result.out)).toEqual([3]);
+  }, 60_000);
+
+  it("never lets the cursor pass a --kind match the operator was not shown", async () => {
+    // #403's second criterion: Ctrl-C must not persist a cursor past unseen
+    // matching events. The old walk counted the finish, let the durable client
+    // advance and persist the cursor past it, and printed nothing — so the
+    // operator killing the hung command lost that event for every later run
+    // too, silently and with nothing in the log to notice.
+    //
+    // There is no signal handler to raise here (`events tail` takes the default
+    // disposition on purpose), so the interrupt is modelled where it actually
+    // bites: the cursor on disk is sampled while the run is still walking, and
+    // whatever moment that sample lands in is a moment a Ctrl-C could have
+    // landed in. The finish must already be on stdout by then.
+    const log = arrayEventLog();
+    for (let i = 0; i < 21; i += 1) log.push("task:updated"); // #1 – #21
+    log.push("session:finished"); // #22
+    for (let i = 0; i < 8; i += 1) log.push("task:updated"); // #23 – #30
+
+    const port = await freePort();
+    const core = await coreOn(port, log);
+    fixture = makeCliFixture();
+    registerCore(fixture.paths, "inproc", core.blobText);
+
+    const printed: string[] = [];
+    // `--limit 2` against a log holding one finish: the ceiling cannot be
+    // reached on history, so the run is still going at the moment the sample
+    // below is taken — which is what makes it an interrupt rather than an exit.
+    const tail = fixture.run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "2"],
+      { connect: connectCore, onOut: (line) => printed.push(line) },
+    );
+
+    const dir = cursorsDir(fixture.paths);
+    const cursor = (): number => {
+      if (!existsSync(dir)) return 0;
+      const [file] = readdirSync(dir);
+      if (file === undefined) return 0;
+      const raw = readFileSync(path.join(dir, file), "utf8").trim();
+      return raw === "" ? 0 : Number(raw);
+    };
+
+    await waitFor(() => cursor() >= 22, "the cursor never reached the finish");
+    expect(
+      idsOf(printed),
+      "the cursor stood past a session:finished that had never been printed",
+    ).toContain(22);
+
+    // And it does walk on past it — which is exactly why the printing has to
+    // happen on the way. The finish is behind the cursor now and unreachable to
+    // every later run; the only reason it is not lost is that it has been seen.
+    await waitFor(() => cursor() >= 30, "the walk never reached the end of the history");
+    expect(idsOf(printed)).toEqual([22]);
+
+    // A second finish, live, so the run ends on its ceiling rather than
+    // following for the rest of the suite.
+    log.push("session:finished");
+    const result = await tail;
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+    expect(idsOf(result.out)).toEqual([22, 31]);
+  }, 60_000);
+
   it("leaves the stored cursor alone when --since asks for a one-off rewind", async () => {
     const log = arrayEventLog();
     const port = await freePort();

--- a/packages/cli/src/__tests__/events-tail-cursor.test.ts
+++ b/packages/cli/src/__tests__/events-tail-cursor.test.ts
@@ -320,21 +320,20 @@ describe("actana events tail, across a Core restart", () => {
     expect(idsOf(result.out)).toEqual([3]);
   }, 60_000);
 
-  it("never lets the cursor pass a --kind match the operator was not shown", async () => {
-    // #403's second criterion: Ctrl-C must not persist a cursor past unseen
-    // matching events. The old walk counted the finish, let the durable client
-    // advance and persist the cursor past it, and printed nothing — so the
-    // operator killing the hung command lost that event for every later run
-    // too, silently and with nothing in the log to notice.
-    //
-    // There is no signal handler to raise here (`events tail` takes the default
-    // disposition on purpose), so the interrupt is modelled where it actually
-    // bites: the cursor on disk is sampled while the run is still walking, and
-    // whatever moment that sample lands in is a moment a Ctrl-C could have
-    // landed in. The finish must already be on stdout by then.
+  it("answers a bounded first --kind run with the newest match, not the oldest", async () => {
+    // Round-1 review, blocking finding 1, with the reviewer's own log. A first
+    // run has no cursor, so it subscribes from #0 and its walk covers the whole
+    // retained log — nothing prunes the store. A run that printed matches as
+    // they went past therefore answered with the *earliest* finish the Core
+    // still held: `#3`, possibly weeks old and carrying a different taskId,
+    // returned with exit 0 for a question about the session that just finished
+    // at `#22`. A visible hang is a better failure than a confident wrong
+    // answer, which is why this is the finding that blocked the round.
     const log = arrayEventLog();
-    for (let i = 0; i < 21; i += 1) log.push("task:updated"); // #1 – #21
-    log.push("session:finished"); // #22
+    for (let i = 0; i < 2; i += 1) log.push("task:updated"); // #1 – #2
+    log.push("session:finished", '{"taskId":"t-old"}'); // #3, weeks ago
+    for (let i = 0; i < 18; i += 1) log.push("task:updated"); // #4 – #21
+    log.push("session:finished", '{"taskId":"t-now"}'); // #22, just watched
     for (let i = 0; i < 8; i += 1) log.push("task:updated"); // #23 – #30
 
     const port = await freePort();
@@ -342,42 +341,68 @@ describe("actana events tail, across a Core restart", () => {
     fixture = makeCliFixture();
     registerCore(fixture.paths, "inproc", core.blobText);
 
-    const printed: string[] = [];
-    // `--limit 2` against a log holding one finish: the ceiling cannot be
-    // reached on history, so the run is still going at the moment the sample
-    // below is taken — which is what makes it an interrupt rather than an exit.
-    const tail = fixture.run(
-      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "2"],
-      { connect: connectCore, onOut: (line) => printed.push(line) },
+    const result = await fixture.run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "1"],
+      { connect: connectCore },
     );
 
-    const dir = cursorsDir(fixture.paths);
-    const cursor = (): number => {
-      if (!existsSync(dir)) return 0;
-      const [file] = readdirSync(dir);
-      if (file === undefined) return 0;
-      const raw = readFileSync(path.join(dir, file), "utf8").trim();
-      return raw === "" ? 0 : Number(raw);
-    };
-
-    await waitFor(() => cursor() >= 22, "the cursor never reached the finish");
-    expect(
-      idsOf(printed),
-      "the cursor stood past a session:finished that had never been printed",
-    ).toContain(22);
-
-    // And it does walk on past it — which is exactly why the printing has to
-    // happen on the way. The finish is behind the cursor now and unreachable to
-    // every later run; the only reason it is not lost is that it has been seen.
-    await waitFor(() => cursor() >= 30, "the walk never reached the end of the history");
-    expect(idsOf(printed)).toEqual([22]);
-
-    // A second finish, live, so the run ends on its ceiling rather than
-    // following for the rest of the suite.
-    log.push("session:finished");
-    const result = await tail;
     expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
-    expect(idsOf(result.out)).toEqual([22, 31]);
+    // One line, and the finish the operator actually watched happen.
+    expect(idsOf(result.out)).toEqual([22]);
+    expect(JSON.parse(result.out[0]!).payload).toContain("t-now");
+  }, 60_000);
+
+  it("delivers --kind matches exactly once and in order across a capped replay", async () => {
+    // The case the round-1 review asked for by name, and its own numbers. The
+    // Core streams at most `EVENT_TAIL_LIMIT` (1000) events per tail and closes
+    // with a marker reporting the last id it *sent*, so a 1500-event log takes
+    // three rounds to walk — and the ring holding the newest matches has to
+    // survive every re-ask. A repeat here is a replay storm through the filter;
+    // a gap is a match dropped at a round boundary.
+    const log = arrayEventLog();
+    for (let i = 1; i <= 1_500; i += 1) {
+      log.push(i === 500 || i === 1_200 || i === 1_450 ? "session:finished" : "task:updated");
+    }
+
+    const port = await freePort();
+    const core = await coreOn(port, log);
+    fixture = makeCliFixture();
+    registerCore(fixture.paths, "inproc", core.blobText);
+
+    const result = await fixture.run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "3"],
+      { connect: connectCore },
+    );
+
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+    expect(idsOf(result.out)).toEqual([500, 1_200, 1_450]);
+    // More than one tail read, so this really did cross the cap rather than fit
+    // inside a single replay that happened to be big enough.
+    expect(log.tailReads).toBeGreaterThan(1);
+  }, 60_000);
+
+  it("keeps only the newest --limit matches when the walk crosses the cap", async () => {
+    // The same shape, asked a narrower question. `--limit 2` against three
+    // finishes spread across three rounds is where a ring that resets per tail,
+    // or one that keeps the first n it meets, gives a different and wrong
+    // answer — `[500, 1200]` instead of the two most recent.
+    const log = arrayEventLog();
+    for (let i = 1; i <= 1_500; i += 1) {
+      log.push(i === 500 || i === 1_200 || i === 1_450 ? "session:finished" : "task:updated");
+    }
+
+    const port = await freePort();
+    const core = await coreOn(port, log);
+    fixture = makeCliFixture();
+    registerCore(fixture.paths, "inproc", core.blobText);
+
+    const result = await fixture.run(
+      ["events", "tail", "--json", "--kind", "session:finished", "--limit", "2"],
+      { connect: connectCore },
+    );
+
+    expect(result.code, result.err.join("\n")).toBe(EXIT_OK);
+    expect(idsOf(result.out)).toEqual([1_200, 1_450]);
   }, 60_000);
 
   it("leaves the stored cursor alone when --since asks for a one-off rewind", async () => {

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -29,6 +29,18 @@
 //     the loop that closes it; this file feeds it the two frames and keeps
 //     quiet until it says the log has an end.
 //
+//     **`--kind` is the one thing that speaks during that walk**, and that is
+//     #403. The storm the silence prevents is a history nobody asked for; naming
+//     kinds is asking for them. After a session has finished,
+//     `--kind session:finished --limit 1` walked past the very event it was
+//     typed to find, printed nothing, and waited for a second finish that was
+//     never coming — and the cursor, which the durable client advances and
+//     persists per event delivered, had moved past that finish, so Ctrl-C put it
+//     out of the next run's reach too. So a named kind is printed out of this
+//     tail as it goes past; every other kind stays as quiet as it has always
+//     been. The decision is the flag the operator typed and never the state of
+//     the log, so the command means one thing on every Core.
+//
 //   • **Where the cursor lives.** `FileCursorStorage`, so the second run of a
 //     command picks up where the first left off. A reconnect *within* a run is
 //     already covered by the in-memory cursor; a restart is not, and a CLI is
@@ -135,6 +147,10 @@ Where it starts
   Each Core gets a cursor under the config directory, so a second run carries on
   from where the first stopped. With no cursor and no --since, a tail starts at
   the end of the log — like \`tail -f\`, not like \`cat\`.
+
+  --kind is the exception: naming kinds is asking for them, so a first run prints
+  the ones already in the log before it goes on following. Everything else in
+  that history stays unprinted, as it would have been anyway.
 
   --since does not move the stored cursor: a one-off rewind leaves the
   follow-along stream where it was.
@@ -336,6 +352,20 @@ async function eventsTail(
       stopTiming();
     };
 
+    /**
+     * One event onto stdout, with the ceiling checked behind it.
+     *
+     * Both walks print through here — the run reading the history past its
+     * cursor, and the first run's walk to the tip once `--kind` has named what
+     * it is walking for (#403). One formatter and one ceiling, so "at most n"
+     * cannot come to mean two things on the two sides of the printing switch.
+     */
+    const emit = (event: CoreLinkEvent) => {
+      deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
+      printed += 1;
+      if (limit.value !== null && printed >= limit.value) finish(EXIT_OK);
+    };
+
     const offEvent = client.onEvent(({ event }) => {
       // Everything reaching here is already past the cursor and already deduped
       // — that is the durable client's contract, and it is what makes a
@@ -348,6 +378,19 @@ async function eventsTail(
         // (`event-tip.ts`).
         tip.saw(event.eventId);
         waitForAnswer();
+        // …except for the kinds the operator named. The argument is in the
+        // header (#403): the storm this silence prevents is a history nobody
+        // asked for, and `--kind` is the asking.
+        //
+        // Printed *here*, as the event goes past, rather than gathered up and
+        // replayed once the tip is known — which is what keeps the cursor
+        // honest. `DurableCoreClient.deliverEvent` advances and persists the
+        // cursor per event delivered, so a Ctrl-C leaves it at the last event
+        // this side was handed; every match up to that event has already been
+        // on stdout, and the cursor cannot come to rest beyond a match the
+        // operator was never shown.
+        if (kinds.size === 0 || !kinds.has(event.kind)) return;
+        emit(event);
         return;
       }
       // Counted before the filter, and before the ceiling: this is history the
@@ -359,9 +402,7 @@ async function eventsTail(
         waitForAnswer();
       }
       if (kinds.size > 0 && !kinds.has(event.kind)) return;
-      deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
-      printed += 1;
-      if (limit.value !== null && printed >= limit.value) finish(EXIT_OK);
+      emit(event);
     });
 
     // The marker that closes a replay tail. On a first run it is also how the

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -151,6 +151,51 @@ import type { ParsedArgs } from "./cli-args.ts";
  */
 const SUBSCRIBE_ANSWER_MS = 30_000;
 
+/**
+ * The last `capacity` events handed to it, oldest first, at O(1) per event.
+ *
+ * A rotated write index rather than `push` + `shift`, because the walk this
+ * serves runs the length of a Core's whole retained log: `shift` moves every
+ * held element on every match once the ring is full, which is quadratic in the
+ * log for a wide filter and a large ceiling (`--kind task:updated --limit 5000`
+ * over a hundred thousand events is the shape). The memory is the same either
+ * way — `capacity` events and no more, whatever the log's length.
+ *
+ * {@link MatchRing.drain} empties it, so a second call yields nothing: the
+ * events it held are the caller's now, and a ring that could hand the same
+ * event over twice would be a second chance to print it.
+ */
+type MatchRing = {
+  add: (event: CoreLinkEvent) => void;
+  /** Everything held, oldest first, and the ring emptied. */
+  drain: () => CoreLinkEvent[];
+};
+
+function matchRing(capacity: number): MatchRing {
+  const held: CoreLinkEvent[] = [];
+  // Where the next event goes once `held` is full — the oldest slot, which is
+  // also where a drain has to start reading to give them back in order.
+  let next = 0;
+
+  return {
+    add: (event) => {
+      if (held.length < capacity) {
+        held.push(event);
+        return;
+      }
+      held[next] = event;
+      next = (next + 1) % capacity;
+    },
+    drain: () => {
+      const inOrder =
+        held.length < capacity ? held.slice() : [...held.slice(next), ...held.slice(0, next)];
+      held.length = 0;
+      next = 0;
+      return inOrder;
+    },
+  };
+}
+
 export const EVENTS_HELP = `actana events tail — follow a Core's event log
 
 Usage
@@ -309,21 +354,6 @@ async function eventsTail(
     // `MAX_TIP_ROUNDS`, a run still looking for the tip really does carry on,
     // and a run reading history is about to stop. Same walk, different sentence
     // at the end of it.
-    const tip = trackEventTip(client, deps);
-    // Set when the walk below settled for an approximation rather than reaching
-    // the end of the log. A run that ends here has not read what it was asked
-    // for, whatever its last marker said.
-    let approximate = false;
-    let history =
-      limit.value !== null && fromStart
-        ? trackEventTip(client, deps, {
-            // The number is taken from `tipFrom`'s return where the run ends;
-            // all this needs to record is that it is an approximation.
-            onRoundsExhausted: () => {
-              approximate = true;
-            },
-          })
-        : null;
     /**
      * The last `--limit` matches seen on the walk to the tip, or null when
      * there is no walk to hold them for.
@@ -348,7 +378,61 @@ async function eventsTail(
      */
     const recentCap =
       !fromStart && kinds.size > 0 && limit.value !== null && limit.value > 0 ? limit.value : 0;
-    let recent: CoreLinkEvent[] | null = recentCap > 0 ? [] : null;
+    let recent: MatchRing | null = recentCap > 0 ? matchRing(recentCap) : null;
+
+    /**
+     * Whether the walk to the tip is what produces this run's answer.
+     *
+     * Narrower than `--limit`, deliberately, and this is the divergence the
+     * round-2 review invited an argument for. `event-tip.ts` splits its callers
+     * into "a first run about to follow", for whom its default sentence about
+     * carrying on from an approximate number is true, and a caller that *ends*
+     * on the number, for whom it is a sentence printed after the process has
+     * exited. Which side a run falls on is not `--limit`:
+     *
+     *   • `--limit 5` with no `--kind` still follows. The walk prints nothing,
+     *     the ceiling is spent on live events, and an approximate tip costs it
+     *     a short replay rather than its answer — it really is about to follow,
+     *     so the default sentence stays true and this leaves it alone.
+     *   • `--limit 5 --kind session:finished` ends on the walk. Its answer *is*
+     *     the ring flushed at the tip, so a tip that is not the tip means the
+     *     newest matches were never seen and the run is about to hand back
+     *     stale ones with a 0.
+     *
+     * Which is exactly the ring's own condition, so it is read off the ring.
+     */
+    const tipEndsThisRun = recentCap > 0;
+
+    // Set when the walk to the tip settled for an approximation rather than
+    // reaching the end of the log, on a run whose walk is what produces its
+    // answer. See `tipEndsThisRun` above for why that is narrower than
+    // `--limit`.
+    let tipApproximate = false;
+    const tip = trackEventTip(
+      client,
+      deps,
+      tipEndsThisRun
+        ? {
+            onRoundsExhausted: () => {
+              tipApproximate = true;
+            },
+          }
+        : {},
+    );
+    // Set when the walk below settled for an approximation rather than reaching
+    // the end of the log. A run that ends here has not read what it was asked
+    // for, whatever its last marker said.
+    let approximate = false;
+    let history =
+      limit.value !== null && fromStart
+        ? trackEventTip(client, deps, {
+            // The number is taken from `tipFrom`'s return where the run ends;
+            // all this needs to record is that it is an approximation.
+            onRoundsExhausted: () => {
+              approximate = true;
+            },
+          })
+        : null;
     // Whether the Core still owes this run an answer. `--limit` is the whole of
     // it: a tail with no ceiling is a follow, and a follow has nothing to give
     // up on. Cleared the moment the log's end is known, whichever walk found it.
@@ -386,24 +470,13 @@ async function eventsTail(
       if (!timing || settled) return;
       if (idle !== null) clearTimeout(idle);
       idle = setTimeout(() => {
-        // What the walk was holding goes out before the run does. These are
-        // real matches past this run's cursor, the cursor has already moved
-        // past them, and dropping them would lose them for every later run to
-        // buy nothing. Written rather than emitted: the ceiling cannot be
-        // exceeded by n or fewer events, and this run is ending a failure
-        // whatever it prints — a read cut off partway is not a read that
-        // finished, and #439 settled that the exit code says so, not the
-        // output.
-        const held = recent?.length ?? 0;
-        if (recent !== null) {
-          const rest = recent;
-          recent = null;
-          for (const event of rest) write(event);
-        }
+        // What the walk was holding goes out before the run does — see
+        // `handOverRecent`. The tally is read after the writes, so the sentence
+        // counts what actually reached stdout.
+        const held = handOverRecent();
         deps.err(
           `actana events tail: ${name ?? endpoint} stopped answering the event ` +
-            `subscription; giving up with ${printed} event(s) printed` +
-            `${held > 0 ? `, ${held} of them held from an unfinished walk` : ""}. This read did not finish.`,
+            `subscription; giving up with ${tally(held)}. This read did not finish.`,
         );
         finish(EXIT_FAILURE);
       }, SUBSCRIBE_ANSWER_MS);
@@ -444,19 +517,47 @@ async function eventsTail(
     /**
      * Print what the walk was holding, now that the log's end is known.
      *
-     * Emptied before the first line goes out, so a `finish` reached inside the
+     * Detached before the first line goes out, so a `finish` reached inside the
      * loop cannot leave a second flush behind it, and re-checked against
      * `settled` per event because the ceiling can be reached partway through.
      */
     const flushRecent = () => {
       if (recent === null) return;
-      const held = recent;
+      const held = recent.drain();
       recent = null;
       for (const event of held) {
         if (settled) return;
         emit(event);
       }
     };
+
+    /**
+     * Hand the walk's held matches over on a run that is ending unfinished, and
+     * say how many went out.
+     *
+     * Two endings need this and neither of them is an answer: a Core that
+     * stopped answering `subscribe`, and a tip the hunt could only approximate.
+     * In both the matches are real, they are past this run's cursor, and the
+     * cursor has already moved over them — dropping them would lose them for
+     * every later run to buy nothing, and #439 settled that a partial read is
+     * reported by its exit code rather than by withholding what it read.
+     *
+     * `write` rather than `emit`, so the ceiling cannot turn an ending that
+     * failed into an `EXIT_OK`. It cannot be exceeded either way: a live ring
+     * means the walk printed nothing, so `printed` is 0 and the ring holds at
+     * most n.
+     */
+    const handOverRecent = (): number => {
+      if (recent === null) return 0;
+      const held = recent.drain();
+      recent = null;
+      for (const event of held) write(event);
+      return held.length;
+    };
+
+    /** "…3 event(s) printed, 1 of them held from an unfinished walk". */
+    const tally = (held: number): string =>
+      `${printed} event(s) printed${held > 0 ? `, ${held} of them held from an unfinished walk` : ""}`;
 
     const offEvent = client.onEvent(({ event }) => {
       // Everything reaching here is already past the cursor and already deduped
@@ -493,8 +594,7 @@ async function eventsTail(
           emit(event);
           return;
         }
-        recent.push(event);
-        if (recent.length > recentCap) recent.shift();
+        recent.add(event);
         return;
       }
       // Counted before the filter, and before the ceiling: this is history the
@@ -524,6 +624,28 @@ async function eventsTail(
           waitForAnswer();
           return;
         }
+        // Not the end of the log — the number `event-tip.ts` settled for after
+        // `MAX_TIP_ROUNDS` of a Core appending faster than this side could
+        // drain it, on a run whose answer *is* this walk. Taking it as the tip
+        // would flush the ring and exit 0 with whatever matches this side
+        // happened to see, which on a Core racing ahead are the oldest ones in
+        // the log — the round-1 defect, in its last hiding place. So this run
+        // ends the way the reading side below ends and the way `event-tip.ts`
+        // asks its ending callers to: its own sentence, and a failure.
+        //
+        // What it holds still goes out. It is a short read rather than a wrong
+        // answer once the exit code says so, and the events are past the cursor
+        // either way.
+        if (tipApproximate) {
+          const held = handOverRecent();
+          deps.err(
+            `actana events tail: ${name ?? endpoint} appended events faster than they could be ` +
+              `read; giving up at #${end} with ${tally(held)}. This read did not finish.`,
+          );
+          finish(EXIT_FAILURE);
+          return;
+        }
+
         // The end of the log, found. This run has its answer, so the deadline
         // comes off here as well as in `stopReading` — from here it is a
         // follow, and a follow waits through any amount of quiet.
@@ -555,7 +677,7 @@ async function eventsTail(
       if (approximate) {
         deps.err(
           `actana events tail: ${name ?? endpoint} appended events faster than they could be ` +
-            `read; giving up at #${end} with ${printed} event(s) printed. This read did not finish.`,
+            `read; giving up at #${end} with ${tally(0)}. This read did not finish.`,
         );
         finish(EXIT_FAILURE);
         return;

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -20,8 +20,9 @@
 //     tail starts at the end of the log, the way `tail -f` does. The Core has no
 //     frame that answers "what is your tip", so the tip is learned the way it is
 //     published — subscribe, let the tail stream, read `eventsReplayed` — and
-//     everything up to it is counted, not printed. A first run that printed it
-//     would be the replay storm, produced deliberately.
+//     everything up to it is counted, not printed, bar the one exception two
+//     paragraphs down. A first run that printed it would be the replay storm,
+//     produced deliberately.
 //
 //     One `eventsReplayed` is *not* enough to conclude the log has ended: the
 //     Core caps a replay tail at `EVENT_TAIL_LIMIT` and the marker reports what
@@ -413,8 +414,9 @@ async function eventsTail(
       if (!printing) {
         const end = tip.tipFrom(lastEventId);
         // A capped replay: the rest has been asked for and another marker is
-        // coming. Printing stays off, which is the whole point — this is the
-        // history the operator did not ask to see.
+        // coming. The walk stays where it is, which is the whole point — the
+        // history going past is the history the operator did not ask to see,
+        // and `--kind` has already taken the part of it they did.
         if (end === null) {
           waitForAnswer();
           return;

--- a/packages/cli/src/events-command.ts
+++ b/packages/cli/src/events-command.ts
@@ -35,12 +35,33 @@
 //     kinds is asking for them. After a session has finished,
 //     `--kind session:finished --limit 1` walked past the very event it was
 //     typed to find, printed nothing, and waited for a second finish that was
-//     never coming — and the cursor, which the durable client advances and
-//     persists per event delivered, had moved past that finish, so Ctrl-C put it
-//     out of the next run's reach too. So a named kind is printed out of this
-//     tail as it goes past; every other kind stays as quiet as it has always
-//     been. The decision is the flag the operator typed and never the state of
-//     the log, so the command means one thing on every Core.
+//     never coming. So a named kind is taken out of this tail; every other kind
+//     stays as quiet as it has always been. What decides it is the flag the
+//     operator typed and never the state of the log.
+//
+//     **Which** matches, though, is a second question with a second answer, and
+//     printing them on the way past gets it wrong. This walk covers the whole
+//     retained log — it subscribes from `0`, and nothing prunes the store — so
+//     the first match to go past is the *oldest* one the Core still holds, and
+//     `--limit 1` would answer a question about the session that just finished
+//     with a finish from weeks ago, exit 0, and be believed. Newest needs the
+//     end of the log, and the end of the log needs the walk. So the walk holds
+//     the last n matches it has seen and prints them when the tip is known: n
+//     and no more, whatever the log's length, and the answer is the newest n.
+//
+//     That costs the property the printing bought. A held match is one the
+//     stored cursor has already passed, so an interrupt during the walk loses
+//     it — and the cursor outruns stdout on the ordinary exit path too, because
+//     `DurableCoreClient.deliverEvent` persists before any listener runs and
+//     frames already in flight keep arriving after `finish` has closed the
+//     client. **That is #442, it is not fixed here, and #403 stays open until
+//     it lands.**
+//
+//     Without `--limit` there is no n to choose between, so matches stream as
+//     they arrive: every one of them is going to be printed anyway, and holding
+//     them would buy nothing and cost an unbounded array. What it does cost is
+//     said out loud in the help text — `--kind` bounds *what* is printed, and
+//     only `--limit` bounds *how much*.
 //
 //   • **Where the cursor lives.** `FileCursorStorage`, so the second run of a
 //     command picks up where the first left off. A reconnect *within* a run is
@@ -152,6 +173,14 @@ Where it starts
   --kind is the exception: naming kinds is asking for them, so a first run prints
   the ones already in the log before it goes on following. Everything else in
   that history stays unprinted, as it would have been anyway.
+
+  With --limit n that is the newest n of them, not the first n found: the run
+  reads to the end of the log before it can know which are newest, so it holds
+  the last n it saw and prints them once it does.
+
+  Without --limit it is all of them — every event of those kinds the Core still
+  holds, which on a Core that has been up for weeks is not a short list. --kind
+  bounds what gets printed; --limit is what bounds how much.
 
   --since does not move the stored cursor: a one-off rewind leaves the
   follow-along stream where it was.
@@ -295,6 +324,31 @@ async function eventsTail(
             },
           })
         : null;
+    /**
+     * The last `--limit` matches seen on the walk to the tip, or null when
+     * there is no walk to hold them for.
+     *
+     * A first run's walk covers the **whole retained log** — it subscribes from
+     * `0` because there is no cursor, and nothing prunes `event_log_store`. So
+     * a `--kind` match printed as it goes past is the *oldest* match the Core
+     * still holds, and `--limit 1` after a session finished answers with a
+     * finish from weeks ago, exit 0, and is believed. That is worse than the
+     * hang #403 reports, because the hang was visible; it is the same hazard
+     * `event-tip.ts` argues for `harness install`, where a stale
+     * `harness:installFailed` must not be read as this install's verdict.
+     *
+     * Which match is the newest cannot be known before the walk ends, so the
+     * walk holds the last n it has seen — n and no more, whatever the log's
+     * length — and prints them once the tip is known. Bounded memory, and the
+     * answer is the newest n rather than the oldest.
+     *
+     * Null, and matches stream as they arrive, when there is no n to choose
+     * between them: without `--limit` every match is printed anyway, so holding
+     * them would buy nothing and cost an unbounded array.
+     */
+    const recentCap =
+      !fromStart && kinds.size > 0 && limit.value !== null && limit.value > 0 ? limit.value : 0;
+    let recent: CoreLinkEvent[] | null = recentCap > 0 ? [] : null;
     // Whether the Core still owes this run an answer. `--limit` is the whole of
     // it: a tail with no ceiling is a follow, and a follow has nothing to give
     // up on. Cleared the moment the log's end is known, whichever walk found it.
@@ -332,9 +386,24 @@ async function eventsTail(
       if (!timing || settled) return;
       if (idle !== null) clearTimeout(idle);
       idle = setTimeout(() => {
+        // What the walk was holding goes out before the run does. These are
+        // real matches past this run's cursor, the cursor has already moved
+        // past them, and dropping them would lose them for every later run to
+        // buy nothing. Written rather than emitted: the ceiling cannot be
+        // exceeded by n or fewer events, and this run is ending a failure
+        // whatever it prints — a read cut off partway is not a read that
+        // finished, and #439 settled that the exit code says so, not the
+        // output.
+        const held = recent?.length ?? 0;
+        if (recent !== null) {
+          const rest = recent;
+          recent = null;
+          for (const event of rest) write(event);
+        }
         deps.err(
           `actana events tail: ${name ?? endpoint} stopped answering the event ` +
-            `subscription; giving up with ${printed} event(s) printed. This read did not finish.`,
+            `subscription; giving up with ${printed} event(s) printed` +
+            `${held > 0 ? `, ${held} of them held from an unfinished walk` : ""}. This read did not finish.`,
         );
         finish(EXIT_FAILURE);
       }, SUBSCRIBE_ANSWER_MS);
@@ -353,18 +422,40 @@ async function eventsTail(
       stopTiming();
     };
 
+    /** One event onto stdout. One formatter, wherever the event came from. */
+    const write = (event: CoreLinkEvent) => {
+      deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
+      printed += 1;
+    };
+
     /**
      * One event onto stdout, with the ceiling checked behind it.
      *
-     * Both walks print through here — the run reading the history past its
-     * cursor, and the first run's walk to the tip once `--kind` has named what
-     * it is walking for (#403). One formatter and one ceiling, so "at most n"
-     * cannot come to mean two things on the two sides of the printing switch.
+     * Every path that prints on a run that is still going prints through here,
+     * so "at most n" cannot come to mean two things on the two sides of the
+     * printing switch. The one path that does not is the deadline below, which
+     * is already ending the run and must end it its own way.
      */
     const emit = (event: CoreLinkEvent) => {
-      deps.out(args.json ? formatEventJson(event) : formatEventLine(event));
-      printed += 1;
+      write(event);
       if (limit.value !== null && printed >= limit.value) finish(EXIT_OK);
+    };
+
+    /**
+     * Print what the walk was holding, now that the log's end is known.
+     *
+     * Emptied before the first line goes out, so a `finish` reached inside the
+     * loop cannot leave a second flush behind it, and re-checked against
+     * `settled` per event because the ceiling can be reached partway through.
+     */
+    const flushRecent = () => {
+      if (recent === null) return;
+      const held = recent;
+      recent = null;
+      for (const event of held) {
+        if (settled) return;
+        emit(event);
+      }
     };
 
     const offEvent = client.onEvent(({ event }) => {
@@ -383,15 +474,27 @@ async function eventsTail(
         // header (#403): the storm this silence prevents is a history nobody
         // asked for, and `--kind` is the asking.
         //
-        // Printed *here*, as the event goes past, rather than gathered up and
-        // replayed once the tip is known — which is what keeps the cursor
-        // honest. `DurableCoreClient.deliverEvent` advances and persists the
-        // cursor per event delivered, so a Ctrl-C leaves it at the last event
-        // this side was handed; every match up to that event has already been
-        // on stdout, and the cursor cannot come to rest beyond a match the
-        // operator was never shown.
+        // Held rather than printed when there is a `--limit` to choose between
+        // them, for the reason on `recent`: this walk covers the whole retained
+        // log, so printing on the way past answers with its oldest match.
+        //
+        // The trade is stated rather than hidden. Printing on the way past kept
+        // the stored cursor from outrunning what had been shown, and holding
+        // gives that up: the cursor advances and persists per event delivered,
+        // so an interrupt during the walk loses what the ring is holding. It is
+        // not a property this branch can keep on its own — the cursor outruns
+        // stdout on the ordinary exit path too, because
+        // `DurableCoreClient.deliverEvent` persists before any listener runs and
+        // frames already in flight keep arriving after `finish` has closed the
+        // client. That is #442, it is not fixed here, and #403 stays open until
+        // it lands.
         if (kinds.size === 0 || !kinds.has(event.kind)) return;
-        emit(event);
+        if (recent === null) {
+          emit(event);
+          return;
+        }
+        recent.push(event);
+        if (recent.length > recentCap) recent.shift();
         return;
       }
       // Counted before the filter, and before the ceiling: this is history the
@@ -427,6 +530,8 @@ async function eventsTail(
         stopTiming();
         deps.verbose(`the Core's log ends at #${end}; following from there`);
         printing = true;
+        // The newest matches the walk saw, now that "newest" has a meaning.
+        flushRecent();
         return;
       }
       deps.verbose(`caught up to #${lastEventId}`);


### PR DESCRIPTION
**Refs #403** (hunt `F7`) — deliberately *not* `Fixes`. On top of the merged #439 that fixed #402, building on that
change rather than against it.

> **#403 stays open when this lands.** Its criterion 2 — "Ctrl-C does not persist a cursor past unseen matching
> events" — is not satisfied by this PR and cannot be from here. The stored cursor is advanced and persisted by
> `DurableCoreClient.deliverEvent` before any listener runs, so it outruns stdout on the ordinary exit path as well as
> under an interrupt. That mechanism is **#442**, which must not be fixed in this PR; the exit-path case is filed there
> with numbers. This PR closes #403's criterion 1 and makes the command answer the right question; #403 should be
> closed once #442 lands.

> **Merge or rebase this branch — do not squash it.** The repo's squash message mode is `COMMIT_MESSAGES`, so a squash
> concatenates all four commit bodies into one message with no ordering cue. `d7bfb7d`'s body claims that printing on
> the way past "keeps the cursor honest" and that "an interrupt cannot leave the cursor beyond a match that was never
> shown" — a paragraph `3f1b3bd` exists to retract, and `89383a0` narrows again. A merge or a rebase keeps each
> correction adjacent to the claim it corrects; a squash would land the retracted claim and its retraction side by side
> as if both were current. (Round-2 review nit.)

## What the operator saw

After a session had already finished, `actana events tail --kind session:finished --limit 1` — no `--since` — printed
nothing and never exited. Ctrl-C left the cursor past the finish.

## Why

A first run has no stored cursor, so it is walking to the tip of the log: the Core has no frame that answers "where does
your log end", and the only way to learn it is to subscribe, let the tail stream, and read the `eventsReplayed` markers
until one closes an empty tail (`event-tip.ts`). Everything in that walk was **counted and not printed** — including the
`session:finished` the command was typed to find. The only way out of the printing loop was a *second* finish that
nobody was going to append.

## What changed

`packages/cli/src/events-command.ts`, and its two suites. Nothing else in the tree; no `packages/core`,
`packages/shared`, `packages/panel` or `packages/sdk` file is touched, and neither is `session-command.ts` or
`session-gateway.ts`.

A first run starts at the end of the log because a history nobody asked for is the replay storm. **`--kind` is the
asking**: the operator has named the kinds they came for, so a named kind is taken out of that walk and every other kind
stays as quiet as it has always been. What decides that is the flag the operator typed, never the state of the log.

**Which** matches is a second question, and it is the one round 1 got wrong. A first run's walk covers the whole
retained log — it subscribes from `#0`, and nothing prunes the store — so printing matches as they go past answers with
the *oldest* match the Core still holds. Newest needs the end of the log, and the end of the log needs the walk. So the
walk holds the last `n` matches it has seen and prints them once the tip is known: **`n` and no more, whatever the log's
length, and the answer is the newest `n`.** Without `--limit` there is no `n` to choose between, so matches stream as
they arrive — every one is going to be printed anyway, and holding them would buy nothing and cost an unbounded array.

If the Core goes quiet mid-walk, what is held goes to stdout before the run gives up, with the count named on stderr and
the exit still non-zero — the matches are past the cursor and the cursor has already moved over them, so dropping them
would lose them for every later run to buy nothing.

`EVENTS_HELP` says all of this under *Where it starts*, including that `--kind` bounds *what* is printed and only
`--limit` bounds *how much*; the module header carries the argument.

### The tip the hunt could only approximate

`event-tip.ts` gives up after `MAX_TIP_ROUNDS` against a Core appending faster than this side can drain it, and hands
back its approximation as an ordinary number. A walk that took that for the end of the log flushed its ring and exited
**0** — with the oldest matches in the log, since the Core had raced ahead — while stderr said the run was "carrying on"
after it had exited. `event-tip.ts` names that caller by hand as the one that must not take its default sentence.

So `tip` now carries an `onRoundsExhausted`, and the walk ends the way the reading side already ends: its own sentence
on stderr and a **non-zero exit**, with what the ring holds handed over first through the same path the 30s deadline
uses.

The condition is `recentCap > 0`, not `--limit`. What splits `event-tip.ts`'s two callers is whether the walk *is* the
answer: `--limit 5` with no `--kind` prints nothing on the walk and spends its ceiling on live events, so it really is
"a first run about to follow" and keeps the default sentence; `--limit 5 --kind session:finished` ends on the ring, so
an approximate tip costs it the answer. The reasoning is at `tipEndsThisRun` and both halves are pinned by a test.

The ring's `shift` is now a rotated write index — O(1) per match at the same bounded memory, where the old one moved
every held element on every match once full.

## Deliberately not in scope

- **#441**, the explicit `--follow` / `--no-follow` design. Not taken: this change adds no flag and does not touch what
  `--limit` means for a run that has a cursor.
- **#442**, the cursor running ahead of what was printed. Not taken, and now filed with the exit-path case this PR makes
  reachable. `DurableCoreClient` and the ceiling's `finish` are untouched.

## How it is proven

Against the **real in-process Core**, a real `wss://` link, the real durable client and the real cursor file
(`events-tail-cursor.test.ts`):

- **the newest match, not the oldest** — the reviewer's own log, finishes at `#3` (weeks old, different `taskId`) and
  `#22` (just watched), `--limit 1` → `[22]`. Returns `[3]` on the reviewed head `6c8474f`.
- **the newest across a capped replay** — 1500 events, finishes at `#500`/`#1200`/`#1450`, `--limit 2` → `[1200, 1450]`.
  Returns `[500, 1200]` on `6c8474f`.
- **exactly once and in order across the cap** — the same log, `--limit 3` → `[500, 1200, 1450]`, exit 0. The case the
  review asked for by name.
- **criterion 1** — a finish already in the log, `--kind session:finished --limit 1` on a machine that has never
  followed this Core: one event, the right one, and an exit. Hangs on the parent `31444a9`.

At the **frame level** against a fake Core (`events-command.test.ts`):

- the first-run `--kind` run frame for frame, asserting that **nothing is printed until the tip is known**;
- **the ring across a re-ask** — three finishes over two rounds of a capped replay, `--limit 2` → the last two;
- **the hand-over on a silent Core** — held matches on stdout, `held from an unfinished walk` on stderr, exit non-zero;
- **the guard on the narrowing** — a first run given `--kind session:finished` still prints none of the `task:*` history
  it walks past.

The real-Core interrupt test from round 1 is **removed**: with the ring it asserted something that is no longer true,
and the criterion it covered now belongs to #442. That is stated rather than quietly dropped.

With the fix, `packages/cli` is green — **1204 passed | 3 skipped across 51 files**, including
`events-tail-cursor.test.ts` and `no-prompt-timing.test.ts`. `tsc --noEmit` clean in every package; `eslint packages`
0 errors (45 pre-existing warnings, none in the changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V69DFjnRqF69ojUsYnbt24

