### PR TITLE
fix(panel): pin ring follows the route on a same-Core click

### DIFF
--- a/packages/panel/src/components/views/ProjectBar.tsx
+++ b/packages/panel/src/components/views/ProjectBar.tsx
@@ -1,6 +1,6 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
 import { createPortal } from "react-dom";
-import { useRouter } from "@tanstack/react-router";
+import { useRouter, useRouterState } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CircleAlert } from "lucide-react";
 import { toast } from "sonner";
@@ -69,7 +69,12 @@ type RailRow = {
 
 // Memoized: the shell re-renders on route/settings changes, but ProjectBar's
 // only props are stable primitives — it should re-render only when they change
-// or its own query subscriptions move, never just because the shell did.
+// or its own query subscriptions move, never just because the shell did. The
+// highlight ring is the one thing in here that *does* track the route, so it
+// reads the pathname through `useRouterState` (which subscribes) rather than
+// off `useRouter().state` (which does not): without that subscription the memo
+// swallowed the re-render and the ring stayed on the previously clicked pin
+// until an unrelated render moved it (#376).
 export const ProjectBar = memo(function ProjectBar({
   // Pin routes through the coreId-parameterised mutation surface; the
   // remaining projects / order wiring still reads the Panel's own rows,
@@ -81,6 +86,11 @@ export const ProjectBar = memo(function ProjectBar({
   coreId?: string | null;
 }) {
   const router = useRouter();
+  // Subscribed read of the route. `router.state` is a plain snapshot taken at
+  // render time and notifies nobody when it moves, so the ring has to come off
+  // a subscription for a same-Core pin click — which changes only the route —
+  // to repaint the rail in the same frame as the navigation (#376).
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const queryClient = useQueryClient();
   const { data: panelProjects } = useProjects();
   // A Core's pinned projects live on its own Core — pull them via a small
@@ -711,7 +721,7 @@ export const ProjectBar = memo(function ProjectBar({
   // into it from that isolated view.
   if (railClusters.length === 0) return null;
 
-  const activeId = router.state.location.pathname.match(/^\/projects\/([^/]+)/)?.[1];
+  const activeId = pathname.match(/^\/projects\/([^/]+)/)?.[1];
   const activeIndex = visible.findIndex((p) => p.id === activeId);
 
   // Group-number labels only earn their space when a real group exists. With
@@ -796,6 +806,10 @@ export const ProjectBar = memo(function ProjectBar({
       {activeIndex >= 0 && (
         <div
           aria-hidden
+          // The ring is a positioned overlay rather than a border on the tile,
+          // so nothing in the DOM otherwise says which project it sits on.
+          // Naming it makes "the ring is on B" assertable (#376).
+          data-active-project-id={activeProject?.id}
           style={{
             position: "absolute",
             top: PAD_TOP,

--- a/packages/panel/src/components/views/__tests__/project-bar-active-ring.test.tsx
+++ b/packages/panel/src/components/views/__tests__/project-bar-active-ring.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { ProjectWithCounts } from "~/shared/projects";
+
+// Issue 376. The rail is memoised and its only prop is `coreId`, so a click on
+// another pin of the SAME Core changes nothing the memo can see: same props,
+// same query data, only the route moved. Reading the route off `useRouter()`
+// (a plain snapshot that notifies nobody) therefore left the accent ring
+// parked on the previously clicked pin until some unrelated render — a hover,
+// a query refetch — happened to repaint the bar.
+//
+// So this suite drives a REAL TanStack router rather than a stubbed one: the
+// point under test is whether the component subscribes to route state, and a
+// hand-rolled router stub would answer that question for it.
+
+const invalidateQueries = vi.fn(async () => {});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries, setQueryData: vi.fn() }),
+}));
+vi.mock("~/queries", () => ({
+  useProjects: () => ({ data: [] }),
+  useGroups: () => ({ data: [] }),
+  useSettings: () => ({ data: undefined }),
+  queryKeys: { projects: ["projects"], groups: ["groups"], project: (id: string) => ["project", id] },
+}));
+// Both pins come off one Core, which is the shape the bug needs: clicking
+// between them changes only the route.
+vi.mock("~/lib/use-fleet", () => ({
+  useCores: () => ({ cores: [] }),
+  useRemotePinnedProjects: () => ({ projects: remotePinned, refresh: vi.fn() }),
+}));
+vi.mock("~/lib/use-events", () => ({ useServerEvents: () => {} }));
+vi.mock("~/lib/keybindings/store", () => ({
+  useBinding: () => ({ mods: [], key: "" }),
+}));
+vi.mock("~/lib/active-group", async () => {
+  const actual = await vi.importActual<typeof import("~/shared/ui-preferences")>(
+    "~/shared/ui-preferences",
+  );
+  return {
+    ACTIVE_GROUP_ALL: actual.ACTIVE_GROUP_ALL,
+    ACTIVE_GROUP_UNGROUPED: actual.ACTIVE_GROUP_UNGROUPED,
+    useActiveGroup: () => ({
+      activeGroup: actual.ACTIVE_GROUP_ALL,
+      setActiveGroup: vi.fn(),
+      groups: [],
+    }),
+  };
+});
+vi.mock("~/lib/api", () => ({
+  api: {
+    getKeybindings: async () => ({ bindings: {} }),
+    listProjectPresentation: async () => ({ presentation: [] }),
+  },
+}));
+
+const {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+  Outlet,
+} = await import("@tanstack/react-router");
+const { ProjectBar } = await import("../ProjectBar");
+
+const CORE_ID = "core_alpha";
+
+function makeProject(
+  over: Partial<ProjectWithCounts> & Pick<ProjectWithCounts, "id" | "name">,
+): ProjectWithCounts {
+  return {
+    path: `/srv/${over.id}`,
+    icon: "folder",
+    iconColor: "#88aaff",
+    imagePath: null,
+    groupId: null,
+    pinned: true,
+    pinnedOrder: 0,
+    launchUrl: null,
+    rememberHarnessSettings: false,
+    savedHarness: null,
+    savedSkipPermissions: false,
+    savedBareSession: false,
+    defaultGridView: false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    coreId: CORE_ID,
+    taskCounts: {
+      ready: 0,
+      running: 0,
+      "needs-input": 0,
+      interrupted: 0,
+      finished: 0,
+      terminated: 0,
+      disconnected: 0,
+      total: 0,
+      activeNonDone: 0,
+    },
+    ...over,
+  };
+}
+
+const PROJECT_A = makeProject({ id: "p_alpha", name: "Alpha", pinnedOrder: 0 });
+const PROJECT_B = makeProject({ id: "p_beta", name: "Beta", pinnedOrder: 1 });
+
+/** What `useRemotePinnedProjects` hands the bar for the current test. */
+let remotePinned: ProjectWithCounts[] = [];
+
+function buildRouter() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <ProjectBar />
+        <Outlet />
+      </>
+    ),
+  });
+  const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/", component: () => null });
+  const projectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/projects/$id",
+    component: () => null,
+    validateSearch: (search: Record<string, unknown>) => ({
+      coreId: typeof search.coreId === "string" ? search.coreId : undefined,
+    }),
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, projectRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+}
+
+async function mountRail() {
+  remotePinned = [PROJECT_A, PROJECT_B];
+  const router = buildRouter();
+  const view = render(<RouterProvider router={router as never} />);
+  await settle();
+  return { router, view };
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** The project the accent ring currently sits on, or null when it is hidden. */
+function ringOn(container: HTMLElement): string | null {
+  return container.querySelector("[data-active-project-id]")?.getAttribute("data-active-project-id") ?? null;
+}
+
+function tile(container: HTMLElement, id: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-project-id="${id}"]`);
+  if (!el) throw new Error(`no rail tile for ${id}`);
+  return el;
+}
+
+afterEach(() => {
+  cleanup();
+  remotePinned = [];
+  vi.clearAllMocks();
+});
+
+describe("ProjectBar active ring", () => {
+  it("moves to the second pin of the same Core as soon as the URL is that project's route", async () => {
+    const { router, view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
+    expect(ringOn(container)).toBe(PROJECT_A.id);
+
+    // The same-Core click the issue is about: nothing but the route changes,
+    // so no hover and no query refresh gets a chance to repaint the bar.
+    fireEvent.click(tile(container, PROJECT_B.id));
+    await settle();
+
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_B.id}`);
+    // Same assertion point as the URL check above — the ring has to have moved
+    // by the time the route reads as B, not one stray render later.
+    expect(ringOn(container)).toBe(PROJECT_B.id);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("keeps the ring following a plain route change with no click at all", async () => {
+    const { router, view } = await mountRail();
+    const container = view.container;
+
+    // A navigation the rail did not initiate (a hotkey, a link elsewhere in
+    // the shell) has to move the ring too — the subscription, not the click
+    // handler, is what makes that work.
+    await act(async () => {
+      await router.navigate({
+        to: "/projects/$id",
+        params: { id: PROJECT_B.id },
+        search: { coreId: CORE_ID },
+      });
+    });
+    await settle();
+
+    expect(ringOn(container)).toBe(PROJECT_B.id);
+  });
+
+  it("routes a Core pin click with its owning coreId in the search", async () => {
+    const { router, view } = await mountRail();
+
+    fireEvent.click(tile(view.container, PROJECT_B.id));
+    await settle();
+
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_B.id}`);
+    expect(router.state.location.search).toEqual({ coreId: CORE_ID });
+    expect(router.state.location.searchStr).toContain(`coreId=${CORE_ID}`);
+  });
+});


### PR DESCRIPTION
Fixes the S1 rail-highlight bug filed as #376.

## The bug

`ProjectBar` is memoised on its `coreId` prop. Clicking pin A and then pin B **on
the same Core** changes nothing the memo can see — same props, same query data,
only the route moved. The accent ring read that route off
`router.state.location.pathname` via `useRouter()`, and `useRouter()` hands back
a snapshot that notifies nobody when the location changes. So no re-render was
ever scheduled, the memo had nothing to let through, and the ring stayed parked
on A until some unrelated render (a hover label, a query refetch) repainted the
bar.

## The fix

Read the pathname through `useRouterState({ select: s => s.location.pathname })`.
That hook subscribes, so the navigation itself re-renders the rail and the ring
is on B in the same frame the URL becomes B's route. It also covers navigations
the rail did not initiate — a pinned-slot hotkey, a link elsewhere in the shell —
which the click handler alone never would.

`useRouter()` stays for `router.navigate`; the Core-pin click still threads its
owning `coreId` into the search, untouched.

The ring is a positioned overlay rather than a border on the tile, so nothing in
the DOM said which project it sat on. It now carries `data-active-project-id`,
which is what the new suite asserts against — "the ring is on B" instead of
pixel arithmetic on a `translateY`.

## Tests

New `project-bar-active-ring.test.tsx` drives a **real** TanStack router over a
memory history rather than a stub: whether the component subscribes to route
state is the entire question, and a hand-rolled router stub would answer it for
us. Three cases —

- click A then B on one Core: the ring reads B at the same assertion point the
  URL reads `/projects/p_beta`, with no hover and no query invalidation in
  between (the suite asserts `invalidateQueries` was never called);
- a `router.navigate` with no click at all still moves the ring;
- a Core pin click lands `?coreId=core_alpha` in the search.

Reverting the hook fails the first two. All 17 view suites (176 tests) stay
green, and `pnpm typecheck` is clean.

## Scope

`ProjectBar.tsx` is also the file behind #378 (group filter dropping the ring)
and #382 (mixed-rail pin reorder). Both are later waves and neither is touched
here.

Base is `fix/operator-pins-sessions-drop-cli`, not `main`. Draft on purpose.

Refs #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gvCfms9hCR4MFaTNz8QPD
