### PR TITLE
fix(panel): archived Core session click attaches

### DIFF
--- a/packages/panel/src/lib/__tests__/active-session-memory.test.ts
+++ b/packages/panel/src/lib/__tests__/active-session-memory.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeSessionWentAway,
+  rememberActiveSession,
+  type LastActiveSession,
+} from "../active-session-memory";
+import type { Task } from "~/db/schema";
+
+const SCOPE = "p1";
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return { id, projectId: "p1", status: "ready", archived: false, ...over } as Task;
+}
+
+describe("rememberActiveSession", () => {
+  it("flags an archived Core row, which lives outside the active task list", () => {
+    const remembered = rememberActiveSession("t-archived", SCOPE, {
+      tasks: [task("t-live")],
+      archivedTasks: [task("t-archived", { archived: true })],
+      previous: null,
+    });
+
+    expect(remembered).toEqual({ projectId: SCOPE, taskId: "t-archived", archived: true });
+  });
+
+  it("flags a Panel-owned archived row, which carries the flag in the task list", () => {
+    const remembered = rememberActiveSession("t-archived", SCOPE, {
+      tasks: [task("t-live"), task("t-archived", { archived: true })],
+      archivedTasks: [],
+      previous: null,
+    });
+
+    expect(remembered.archived).toBe(true);
+  });
+
+  it("leaves a live row unflagged", () => {
+    const remembered = rememberActiveSession("t-live", SCOPE, {
+      tasks: [task("t-live")],
+      archivedTasks: [task("t-archived", { archived: true })],
+      previous: null,
+    });
+
+    expect(remembered).toEqual({ projectId: SCOPE, taskId: "t-live", archived: false });
+  });
+
+  it("keeps the archived verdict when a refetch drops the row from both lists", () => {
+    const previous: LastActiveSession = { projectId: SCOPE, taskId: "t-archived", archived: true };
+
+    const remembered = rememberActiveSession("t-archived", SCOPE, {
+      tasks: [task("t-live")],
+      archivedTasks: [],
+      previous,
+    });
+
+    expect(remembered.archived).toBe(true);
+  });
+
+  it("does not carry an archived verdict across a different id or scope", () => {
+    const previous: LastActiveSession = { projectId: SCOPE, taskId: "t-archived", archived: true };
+
+    expect(
+      rememberActiveSession("t-live", SCOPE, { tasks: [], archivedTasks: [], previous }).archived,
+    ).toBe(false);
+    expect(
+      rememberActiveSession("t-archived", "p2", { tasks: [], archivedTasks: [], previous }).archived,
+    ).toBe(false);
+  });
+});
+
+describe("activeSessionWentAway", () => {
+  it("reads a deselected archived row as a deselect, not a deletion", () => {
+    // Closing the panel on an archived Core session used to force-open an
+    // unrelated live one, with no coreId, onto a pane that never spawns.
+    const previous: LastActiveSession = { projectId: SCOPE, taskId: "t-archived", archived: true };
+
+    expect(activeSessionWentAway(previous, SCOPE, [task("t-live")])).toBe(false);
+  });
+
+  it("still reads a live row that left the visible list as a deletion", () => {
+    const previous: LastActiveSession = { projectId: SCOPE, taskId: "t-gone", archived: false };
+
+    expect(activeSessionWentAway(previous, SCOPE, [task("t-live")])).toBe(true);
+  });
+
+  it("reads a live row still on screen as a deselect", () => {
+    const previous: LastActiveSession = { projectId: SCOPE, taskId: "t-live", archived: false };
+
+    expect(activeSessionWentAway(previous, SCOPE, [task("t-live")])).toBe(false);
+  });
+
+  it("says nothing about a memory belonging to another scope", () => {
+    const previous: LastActiveSession = { projectId: "p2", taskId: "t-gone", archived: false };
+
+    expect(activeSessionWentAway(previous, SCOPE, [task("t-live")])).toBe(false);
+  });
+});

--- a/packages/panel/src/lib/__tests__/open-clicked-session.test.ts
+++ b/packages/panel/src/lib/__tests__/open-clicked-session.test.ts
@@ -50,8 +50,11 @@ describe("openClickedSession", () => {
 
   it("prefers the active row when both lists carry the id (Panel-owned project)", () => {
     const terminals = openerStub();
-    const fromTasks = task("t1", { archived: true });
-    const fromArchived = task("t1", { archived: true });
+    // Distinct `title`s, and an identity assertion on the argument: two
+    // structurally equal fixtures would pass whichever object the helper picked,
+    // leaving the tasks-first order the fix depends on untested.
+    const fromTasks = task("t1", { archived: true, title: "from tasks" });
+    const fromArchived = task("t1", { archived: true, title: "from archivedTasks" });
 
     openClickedSession("t1", {
       tasks: [fromTasks],
@@ -61,7 +64,12 @@ describe("openClickedSession", () => {
       terminals,
     });
 
-    expect(terminals.openSession).toHaveBeenCalledWith(project, fromTasks, { coreId: null });
+    expect(terminals.openSession.mock.calls[0]?.[1]).toBe(fromTasks);
+    expect(terminals.openSession).toHaveBeenCalledWith(
+      project,
+      expect.objectContaining({ title: "from tasks" }),
+      { coreId: null },
+    );
   });
 
   it("opens nothing for an id in neither list", () => {

--- a/packages/panel/src/lib/__tests__/open-clicked-session.test.ts
+++ b/packages/panel/src/lib/__tests__/open-clicked-session.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { openClickedSession } from "../open-clicked-session";
+import type { Task } from "~/db/schema";
+import type { ScopedProject } from "~/lib/scoped-project";
+
+const project = { id: "p1", path: "/work" } as ScopedProject;
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return { id, projectId: "p1", status: "ready", archived: false, ...over } as Task;
+}
+
+function openerStub() {
+  return { openSession: vi.fn(), focusGridSession: vi.fn() };
+}
+
+describe("openClickedSession", () => {
+  it("opens an archived Core row, which lives outside the active task list", () => {
+    const terminals = openerStub();
+    const archived = task("t-archived", { archived: true });
+
+    const opened = openClickedSession("t-archived", {
+      tasks: [task("t-active")],
+      archivedTasks: [archived],
+      project,
+      coreId: "core-a",
+      terminals,
+    });
+
+    expect(opened).toBe(true);
+    expect(terminals.openSession).toHaveBeenCalledWith(project, archived, { coreId: "core-a" });
+    expect(terminals.focusGridSession).toHaveBeenCalledWith("t-archived");
+  });
+
+  it("still opens an active row out of the task list, unchanged", () => {
+    const terminals = openerStub();
+    const active = task("t-active");
+
+    const opened = openClickedSession("t-active", {
+      tasks: [active],
+      archivedTasks: [task("t-archived", { archived: true })],
+      project,
+      coreId: "core-a",
+      terminals,
+    });
+
+    expect(opened).toBe(true);
+    expect(terminals.openSession).toHaveBeenCalledWith(project, active, { coreId: "core-a" });
+    expect(terminals.focusGridSession).toHaveBeenCalledWith("t-active");
+  });
+
+  it("prefers the active row when both lists carry the id (Panel-owned project)", () => {
+    const terminals = openerStub();
+    const fromTasks = task("t1", { archived: true });
+    const fromArchived = task("t1", { archived: true });
+
+    openClickedSession("t1", {
+      tasks: [fromTasks],
+      archivedTasks: [fromArchived],
+      project,
+      coreId: null,
+      terminals,
+    });
+
+    expect(terminals.openSession).toHaveBeenCalledWith(project, fromTasks, { coreId: null });
+  });
+
+  it("opens nothing for an id in neither list", () => {
+    const terminals = openerStub();
+
+    const opened = openClickedSession("gone", {
+      tasks: [task("t-active")],
+      archivedTasks: [task("t-archived", { archived: true })],
+      project,
+      coreId: "core-a",
+      terminals,
+    });
+
+    expect(opened).toBe(false);
+    expect(terminals.openSession).not.toHaveBeenCalled();
+    expect(terminals.focusGridSession).not.toHaveBeenCalled();
+  });
+
+  it("opens nothing before the project path is ready", () => {
+    const terminals = openerStub();
+
+    const opened = openClickedSession("t-archived", {
+      tasks: [],
+      archivedTasks: [task("t-archived", { archived: true })],
+      project: null,
+      coreId: "core-a",
+      terminals,
+    });
+
+    expect(opened).toBe(false);
+    expect(terminals.openSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/panel/src/lib/active-session-memory.ts
+++ b/packages/panel/src/lib/active-session-memory.ts
@@ -1,0 +1,66 @@
+import type { Task } from "~/db/schema";
+
+/** What the board remembers about the session that was last active in a scope. */
+export type LastActiveSession = {
+  projectId: string;
+  taskId: string;
+  /** Whether that row was archived while it held the active slot. */
+  archived: boolean;
+};
+
+type RememberDeps = {
+  /** The project's active task list — a Panel-owned project's archived rows live here too. */
+  tasks: readonly Task[];
+  /** The rows the Archived view is showing. For a Core these are absent from `tasks` (ADR 0019). */
+  archivedTasks: readonly Task[];
+  /** What was remembered before, so an established `archived` verdict is not forgotten. */
+  previous: LastActiveSession | null;
+};
+
+/**
+ * Remember the session holding a scope's active slot, and whether it is archived.
+ *
+ * The flag is worked out here, while the row is active and the list it came from
+ * is loaded, rather than at deselect time: a Core's archived rows are fetched
+ * only while the Archived view is open (ADR 0019), so a later read of
+ * `archivedTasks` can no longer answer the question. Once an id is known to be
+ * archived it stays archived for as long as it holds the slot — a refetch that
+ * drops the row must not un-know it.
+ */
+export function rememberActiveSession(
+  taskId: string,
+  projectId: string,
+  deps: RememberDeps,
+): LastActiveSession {
+  const { tasks, archivedTasks, previous } = deps;
+  const alreadyKnown =
+    previous !== null &&
+    previous.projectId === projectId &&
+    previous.taskId === taskId &&
+    previous.archived;
+  const archived =
+    alreadyKnown ||
+    archivedTasks.some((t) => t.id === taskId) ||
+    (tasks.find((t) => t.id === taskId)?.archived ?? false);
+  return { projectId, taskId, archived };
+}
+
+/**
+ * Did the remembered session go away, or did the operator just deselect it?
+ *
+ * The board force-opens a replacement only for the first. The check is "is it
+ * still on screen", and an archived row never is — it is not in the active list
+ * by construction — so before the archived flag existed a deselect on one read
+ * as a deletion and yanked the operator into an unrelated live session (issue
+ * 397 review §5.1; on a Core that session is opened without a `coreId` and its
+ * pane never spawns). An archived row leaving the slot is always a deselect.
+ */
+export function activeSessionWentAway(
+  previous: LastActiveSession,
+  projectId: string,
+  visibleTasks: readonly Task[],
+): boolean {
+  if (previous.projectId !== projectId) return false;
+  if (previous.archived) return false;
+  return !visibleTasks.some((t) => t.id === previous.taskId);
+}

--- a/packages/panel/src/lib/open-clicked-session.ts
+++ b/packages/panel/src/lib/open-clicked-session.ts
@@ -1,0 +1,50 @@
+import type { Task } from "~/db/schema";
+import type { ScopedProject } from "~/lib/scoped-project";
+
+/** The slice of the terminal store a session card click needs. */
+type SessionOpener = {
+  openSession: (
+    project: ScopedProject,
+    task: Task,
+    opts?: { ptyId?: string | null; coreId?: string | null },
+  ) => void;
+  focusGridSession: (taskId: string, opts?: { flash?: boolean }) => void;
+};
+
+type OpenClickedSessionDeps = {
+  /** The project's active task list — a Panel-owned project's archived rows live here too. */
+  tasks: readonly Task[];
+  /** The rows the Archived view is showing. For a Core these are absent from `tasks` (ADR 0019). */
+  archivedTasks: readonly Task[];
+  project: ScopedProject | null;
+  coreId: string | null;
+  terminals: SessionOpener;
+};
+
+/**
+ * Open (or reattach) the session behind a card click, from either list.
+ *
+ * Where the clicked row can be found differs by owner (ADR 0019). A Panel-owned
+ * project's task list already carries its archived rows, so one lookup covers
+ * both views. A Core keeps its archived rows in their own list, so a click on an
+ * archived card resolved against `tasks` alone finds nothing and the card — and
+ * its Reply button, which routes here too — does nothing at all (issue 397).
+ * Falling back to the archived rows resolves those the same way active ones are
+ * resolved. Active rows still resolve out of `tasks` first, so their behaviour
+ * is untouched.
+ *
+ * Returns whether a session was opened.
+ */
+export function openClickedSession(taskId: string, deps: OpenClickedSessionDeps): boolean {
+  const { tasks, archivedTasks, project, coreId, terminals } = deps;
+  const task = tasks.find((t) => t.id === taskId) ?? archivedTasks.find((t) => t.id === taskId);
+  if (!task || !project) return false;
+  terminals.openSession(project, task, { coreId });
+  // Move the caret into the session's terminal so the user can type right
+  // away. Switching to an already-built (cached) surface reattaches without
+  // focusing, so without this the card click selects the session but leaves
+  // the terminal blurred until a second manual click. TerminalPanel consumes
+  // this request and re-asserts focus across the pane remount.
+  terminals.focusGridSession(taskId);
+  return true;
+}

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -29,6 +29,11 @@ import { dragCarriesFiles, useProjectFilesAvailability } from "~/lib/use-project
 import { takeProjectFileDrop } from "~/lib/pending-file-drop";
 import { archiveOpenSession, invalidateSessionQueries } from "~/lib/archive-session";
 import { openClickedSession } from "~/lib/open-clicked-session";
+import {
+  activeSessionWentAway,
+  rememberActiveSession,
+  type LastActiveSession,
+} from "~/lib/active-session-memory";
 import { consumeProjectOnboardIntent, type ProjectOnboardIntent } from "~/lib/project-onboard-intent";
 import { useHideableMenu } from "~/lib/hideable-elements";
 import { DEFAULT_HEADER_BUTTON_VISIBILITY } from "~/shared/header-buttons";
@@ -532,7 +537,7 @@ function ProjectPage() {
   // Scope the ref to {projectId, taskId} so the route component being reused
   // across project switches doesn't make a stale ref look like a deletion in
   // the new project (which would auto-open a session there).
-  const lastActiveRef = useRef<{ projectId: string; taskId: string } | null>(null);
+  const lastActiveRef = useRef<LastActiveSession | null>(null);
   const activeTaskId = terminals.activeTaskIdFor(selectedScopeKey);
   const lastHiddenSessionRef = useRef<{ projectId: string; taskId: string } | null>(null);
   const archiveSessionRef = useRef<(taskId: string) => void>(() => undefined);
@@ -545,19 +550,41 @@ function ProjectPage() {
     window.addEventListener(ARCHIVE_ACTIVE_SESSION_EVENT, onArchiveRequest);
     return () => window.removeEventListener(ARCHIVE_ACTIVE_SESSION_EVENT, onArchiveRequest);
   }, []);
+  // Tell "the active session was deleted" from "the operator deselected it":
+  // only the first hands the scope a replacement session. `archivedTasks` joins
+  // the inputs because an archived row is never in the visible list, so without
+  // it every deselect on one reads as a deletion — see `active-session-memory`.
   useEffect(() => {
     if (activeTaskId !== null) {
-      lastActiveRef.current = { projectId: selectedScopeKey, taskId: activeTaskId };
+      lastActiveRef.current = rememberActiveSession(activeTaskId, selectedScopeKey, {
+        tasks,
+        archivedTasks,
+        previous: lastActiveRef.current,
+      });
       return;
     }
     const prev = lastActiveRef.current;
     if (!prev || prev.projectId !== selectedScopeKey || !terminalProject) return;
     const visible = tasks.filter((t) => !t.archived);
-    if (visible.some((t) => t.id === prev.taskId)) return;
+    if (!activeSessionWentAway(prev, selectedScopeKey, visible)) {
+      // An archived row leaving the slot is always a deselect, and it can never
+      // turn up in `visible` later — forget it instead of re-deciding it every
+      // time the task list moves. A live row still on screen is kept, so its
+      // deletion while deselected is still caught.
+      if (prev.archived) lastActiveRef.current = null;
+      return;
+    }
     lastActiveRef.current = null;
     const next = pickByPriority(visible);
     if (next) toggleTerminalSession(terminalProject, next);
-  }, [activeTaskId, tasks, terminalProject, toggleTerminalSession, selectedScopeKey]);
+  }, [
+    activeTaskId,
+    tasks,
+    archivedTasks,
+    terminalProject,
+    toggleTerminalSession,
+    selectedScopeKey,
+  ]);
 
   // Rehydrate after reload: if a persisted activeTaskId resolves to an
   // existing task for this project, materialize a session entry so the panel

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -28,6 +28,7 @@ import { filesFromDrop, type DroppedFile } from "~/lib/core-files";
 import { dragCarriesFiles, useProjectFilesAvailability } from "~/lib/use-project-files";
 import { takeProjectFileDrop } from "~/lib/pending-file-drop";
 import { archiveOpenSession, invalidateSessionQueries } from "~/lib/archive-session";
+import { openClickedSession } from "~/lib/open-clicked-session";
 import { consumeProjectOnboardIntent, type ProjectOnboardIntent } from "~/lib/project-onboard-intent";
 import { useHideableMenu } from "~/lib/hideable-elements";
 import { DEFAULT_HEADER_BUTTON_VISIBILITY } from "~/shared/header-buttons";
@@ -1373,15 +1374,13 @@ function ProjectPage() {
   // hide the panel — only the session panel close button (or terminal.close
   // hotkey) deselects.
   const selectTerminal = (taskId: string) => {
-    const task = tasks.find((t) => t.id === taskId);
-    if (!task || !terminalProject) return;
-    terminals.openSession(terminalProject, task, { coreId });
-    // Move the caret into the session's terminal so the user can type right
-    // away. Switching to an already-built (cached) surface reattaches without
-    // focusing, so without this the card click selects the session but leaves
-    // the terminal blurred until a second manual click. TerminalPanel consumes
-    // this request and re-asserts focus across the pane remount.
-    terminals.focusGridSession(taskId);
+    openClickedSession(taskId, {
+      tasks,
+      archivedTasks,
+      project: terminalProject,
+      coreId,
+      terminals,
+    });
   };
 
   const toggleSessionPinned = async (taskId: string) => {


### PR DESCRIPTION
Fixes the G1 hunt finding in #397.

## What the operator saw

Core project → Archived → click a card, or its **Reply** button. Nothing opened.

## Why

`selectTerminal` in `packages/panel/src/routes/projects.$id.tsx` resolved the clicked id
against the active `tasks` list only:

```ts
const task = tasks.find((t) => t.id === taskId);
if (!task || !terminalProject) return;
```

Where the clicked row can be found differs by owner (ADR 0019). A Panel-owned project's task
list already carries its archived rows, so that one lookup covers both views. A Core does not:
its archived rows live in their own list (`useArchivedTasks`), fetched over their own frame only
once the Archived view is open. So on a Core the lookup missed, the handler returned early, and
a row plainly on screen would not open. The Reply button routes through the same handler
(`TaskCard` calls `selectTask()`), so it was dead for the same reason.

## The change

The click path moves into a new `~/lib/open-clicked-session` helper, which falls back to the
archived rows when the active list has no match. Active rows still resolve out of `tasks`
first, so their behaviour is unchanged; archived rows now resolve the same way and open or
reattach like any other session.

Scope is deliberately just the open path. The restore-into-cache path, the remember-settings
write, and the board `onDrop` in this same file are untouched — they belong to #399, #398
and #401, which land on this file in later rounds.

## Tests

New `packages/panel/src/lib/__tests__/open-clicked-session.test.ts` (5 cases):

- an archived Core row, present only in `archivedTasks`, opens with the right task and `coreId`
- an active row still opens out of `tasks`, unchanged
- when both lists carry the id (Panel-owned project), the active row wins
- an id in neither list opens nothing
- nothing opens before the project path is ready

`packages/panel` typecheck is clean and ESLint reports no new problems on the touched files.
The two failures in `cores-settings-pairing.test.tsx` seen locally are pre-existing on the base
commit (verified by stashing this change) and unrelated to this route.

Base is `fix/operator-pins-sessions-drop-cli`, not `main` and not `beta/0.4.5`.

Refs #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGk52AU9uCPWGvaePaGaf7
