### PR TITLE
fix(panel): group filter must not drop the ring on the open project

### DIFF
--- a/packages/panel/src/components/views/ProjectBar.tsx
+++ b/packages/panel/src/components/views/ProjectBar.tsx
@@ -33,6 +33,7 @@ import {
   clusterPinnedByGroup,
   getGroupRailCluster,
   usesDirectRailProjectShortcuts,
+  type RailCluster,
 } from "~/lib/rail-projects";
 import { shouldFlashPinnedProjectLogo } from "./project-bar-activity";
 import { getPinnedProjectStatusDots } from "./project-bar-status-dots";
@@ -200,30 +201,60 @@ export const ProjectBar = memo(function ProjectBar({
   // scoped rail has to be able to put that project back on screen when the
   // active group would otherwise hide it (#378).
   const activeId = useMemo(() => pathname.match(/^\/projects\/([^/]+)/)?.[1], [pathname]);
-  const railClusters = useMemo(() => {
-    if (!groupScoped) return clusterPinnedByGroup(sortedPinned, orderedGroups);
+  // The clusters the rail draws, plus the name of the workspace it is drawing.
+  // The label travels WITH the clusters because it can no longer be read back
+  // off them: since #378 appends a cluster, `railClusters[0]` is the active
+  // group's cluster only when that group has projects, and guessing wrong made
+  // the rail's landmark announce the group that owns the OTHER project.
+  const rail = useMemo((): { clusters: RailCluster<ProjectWithCounts>[]; label: string } => {
+    if (!groupScoped) {
+      return {
+        clusters: clusterPinnedByGroup(sortedPinned, orderedGroups),
+        label: "Pinned projects",
+      };
+    }
     const cluster = getGroupRailCluster(projects ?? [], orderedGroups, activeGroup);
     const scoped = cluster.projects.length > 0 ? [cluster] : [];
+    // `getGroupRailCluster` names the active group even when it is empty, which
+    // is exactly the case the rail used to have no name for.
+    const label = cluster.label;
     // #378: opening a project in group A and switching the GroupSwitcher to B
     // left the page on A while the rail showed B with no ring — the rail
     // claiming nothing was open while the operator was plainly inside a
     // project. The filter still decides which pins are *workable*; the project
-    // you are on keeps a tile regardless, in a trailing cluster of its own
-    // named after the group that does own it, so the ring has somewhere to sit.
+    // you are on keeps a tile in a trailing cluster of its own, named after the
+    // group that does own it, so the ring has somewhere to sit.
     // Nothing here navigates: the URL stays on the open project.
+    //
+    // Scope, stated exactly: this holds for a group-scoped rail — group → group
+    // and group → Ungrouped. It does NOT hold for group → All, which returns
+    // above: All is the pinned rail, so an unpinned project opened from a
+    // group's workspace still loses its tile there. Same symptom, same gesture,
+    // deliberately not fixed here — see #474. Extending it is not a one-liner:
+    // in All `showClusterLabels` is true, so a synthetic cluster would render a
+    // real `data-cluster-header` / `data-group-handle`, entering the drag row
+    // snapshot and the group-handle list, and taking a group digit that
+    // `__root.tsx` (which resolves chords from the untouched `getRailClusters`)
+    // knows nothing about. That is a design change, not a branch.
     const open = activeId ? (projects ?? []).find((p) => p.id === activeId) : undefined;
-    if (!open || cluster.projects.some((p) => p.id === open.id)) return scoped;
+    if (!open || cluster.projects.some((p) => p.id === open.id)) {
+      return { clusters: scoped, label };
+    }
     const owner = orderedGroups.find((g) => g.id === open.groupId);
-    return [
-      ...scoped,
-      {
-        key: OFF_GROUP_CLUSTER_KEY,
-        label: owner?.name ?? "Ungrouped",
-        color: owner?.color ?? null,
-        projects: [open],
-      },
-    ];
+    return {
+      clusters: [
+        ...scoped,
+        {
+          key: OFF_GROUP_CLUSTER_KEY,
+          label: owner?.name ?? "Ungrouped",
+          color: owner?.color ?? null,
+          projects: [open],
+        },
+      ],
+      label,
+    };
   }, [activeGroup, activeId, groupScoped, orderedGroups, sortedPinned, projects]);
+  const railClusters = rail.clusters;
   const visible = useMemo(() => railClusters.flatMap((c) => c.projects), [railClusters]);
   const visibleById = useMemo(
     () => new Map(visible.map((project) => [project.id, project])),
@@ -809,7 +840,13 @@ export const ProjectBar = memo(function ProjectBar({
     });
   }
   const flatIndexById = new Map(visible.map((project, index) => [project.id, index]));
-  const railLabel = groupScoped ? (railClusters[0]?.label ?? "Group") : "Pinned projects";
+  // Named after the ACTIVE group, never after whatever cluster happens to be
+  // first: with an empty active group the off-group tile is index 0, and
+  // reading the label off it had the `role="navigation"` landmark announcing
+  // "Alpha group projects" while the GroupSwitcher read "Empty group" (#378
+  // review). The rail asserting something false about grouping is the very
+  // thing this PR is fixing; the accessibility surface counts too.
+  const railLabel = rail.label;
 
   const menuProject = menu ? visibleById.get(menu.id) ?? null : null;
 

--- a/packages/panel/src/components/views/ProjectBar.tsx
+++ b/packages/panel/src/components/views/ProjectBar.tsx
@@ -38,6 +38,10 @@ import { shouldFlashPinnedProjectLogo } from "./project-bar-activity";
 import { getPinnedProjectStatusDots } from "./project-bar-status-dots";
 
 const HOTKEY_LIMIT = PINNED_SLOT_COUNT;
+// Cluster key of the trailing tile the scoped rail keeps for the project the
+// route is actually on when the active group hides it (#378). It is a
+// selection affordance only: no chord, no reorder, no drop slot.
+const OFF_GROUP_CLUSTER_KEY = "mc-off-group";
 const DRAG_THRESHOLD_PX = 4;
 
 const ITEM_WIDTH = 58;
@@ -192,11 +196,34 @@ export const ProjectBar = memo(function ProjectBar({
     for (const group of groups) if (!seen.has(group.id)) out.push(group);
     return out;
   }, [groupDragOrder, groups]);
+  // Which project the route is on, read before the clusters are built: a
+  // scoped rail has to be able to put that project back on screen when the
+  // active group would otherwise hide it (#378).
+  const activeId = useMemo(() => pathname.match(/^\/projects\/([^/]+)/)?.[1], [pathname]);
   const railClusters = useMemo(() => {
     if (!groupScoped) return clusterPinnedByGroup(sortedPinned, orderedGroups);
     const cluster = getGroupRailCluster(projects ?? [], orderedGroups, activeGroup);
-    return cluster.projects.length > 0 ? [cluster] : [];
-  }, [activeGroup, groupScoped, orderedGroups, sortedPinned, projects]);
+    const scoped = cluster.projects.length > 0 ? [cluster] : [];
+    // #378: opening a project in group A and switching the GroupSwitcher to B
+    // left the page on A while the rail showed B with no ring — the rail
+    // claiming nothing was open while the operator was plainly inside a
+    // project. The filter still decides which pins are *workable*; the project
+    // you are on keeps a tile regardless, in a trailing cluster of its own
+    // named after the group that does own it, so the ring has somewhere to sit.
+    // Nothing here navigates: the URL stays on the open project.
+    const open = activeId ? (projects ?? []).find((p) => p.id === activeId) : undefined;
+    if (!open || cluster.projects.some((p) => p.id === open.id)) return scoped;
+    const owner = orderedGroups.find((g) => g.id === open.groupId);
+    return [
+      ...scoped,
+      {
+        key: OFF_GROUP_CLUSTER_KEY,
+        label: owner?.name ?? "Ungrouped",
+        color: owner?.color ?? null,
+        projects: [open],
+      },
+    ];
+  }, [activeGroup, activeId, groupScoped, orderedGroups, sortedPinned, projects]);
   const visible = useMemo(() => railClusters.flatMap((c) => c.projects), [railClusters]);
   const visibleById = useMemo(
     () => new Map(visible.map((project) => [project.id, project])),
@@ -233,7 +260,12 @@ export const ProjectBar = memo(function ProjectBar({
   // rail). In group-workspace mode that's the group's pinned subset — the
   // alphabetical unpinned tail is not reorderable — and persistProjectOrder
   // splices the subset back into the global pinned order.
-  pinnedIdsRef.current = visible
+  // The off-group tile (#378) is an affordance, not part of this rail's order:
+  // counting it would splice a project the active group does not contain into
+  // the persisted pinned order on the next keyboard reorder.
+  pinnedIdsRef.current = railClusters
+    .filter((cluster) => cluster.key !== OFF_GROUP_CLUSTER_KEY)
+    .flatMap((cluster) => cluster.projects)
     .filter((project) => project.pinned)
     .map((project) => project.id);
   const closeMenu = useCallback(() => setMenu(null), []);
@@ -719,9 +751,11 @@ export const ProjectBar = memo(function ProjectBar({
   // headers are stable project drop targets. The scoped rail still disappears
   // when the selected group has no projects because there is nothing to move
   // into it from that isolated view.
+  // when the selected group has no projects because there is nothing to move
+  // into it from that isolated view — unless the open project is parked there
+  // as the off-group affordance, which is the whole point of it (#378).
   if (railClusters.length === 0) return null;
 
-  const activeId = pathname.match(/^\/projects\/([^/]+)/)?.[1];
   const activeIndex = visible.findIndex((p) => p.id === activeId);
 
   // Group-number labels only earn their space when a real group exists. With
@@ -1064,11 +1098,14 @@ export const ProjectBar = memo(function ProjectBar({
           {cluster.projects.map((project, projectIndex) => {
         const idx = flatIndexById.get(project.id)!;
         const isActive = idx === activeIndex;
+        // The open-but-filtered-out project (#378). It shows and it rings; it
+        // does not take a chord, a reorder or a drop.
+        const isOffGroup = cluster.key === OFF_GROUP_CLUSTER_KEY;
         // Project numbers restart per cluster when group chords are visible;
         // the no-groups rail has one flat cluster, so these are direct slots.
         const projectNumber = projectIndex + 1;
         const groupNumber = clusterIndex + 1;
-        const hotkey = projectNumber <= HOTKEY_LIMIT ? projectNumber : null;
+        const hotkey = !isOffGroup && projectNumber <= HOTKEY_LIMIT ? projectNumber : null;
         const chordHint = directProjectShortcuts
           ? pinnedSlotBinding(projectNumber)
           : `${pinnedSlotBinding(groupNumber)} ${projectNumber}`;
@@ -1095,7 +1132,10 @@ export const ProjectBar = memo(function ProjectBar({
             : null;
         const tooltip = [
           hotkey ? `${project.name} (${chordHint})` : project.name,
-          project.pinned ? "Drag or press Shift+Arrow Up/Down to reorder pinned projects" : null,
+          isOffGroup ? "Open now — outside the active group" : null,
+          !isOffGroup && project.pinned
+            ? "Drag or press Shift+Arrow Up/Down to reorder pinned projects"
+            : null,
           needsInputLabel,
           runningLabel,
           finishedLabel,
@@ -1123,16 +1163,19 @@ export const ProjectBar = memo(function ProjectBar({
           <button
             key={project.id}
             type="button"
-            data-pinned-item={project.pinned ? true : undefined}
+            data-pinned-item={!isOffGroup && project.pinned ? true : undefined}
+            data-off-group={isOffGroup ? true : undefined}
             data-cluster-id={cluster.key}
             data-project-id={project.id}
             title={tooltip}
             aria-label={tooltip}
-            aria-keyshortcuts={project.pinned ? "Shift+ArrowUp Shift+ArrowDown" : undefined}
+            aria-keyshortcuts={
+              !isOffGroup && project.pinned ? "Shift+ArrowUp Shift+ArrowDown" : undefined
+            }
             onPointerDown={(e) => {
               // Only pinned tiles reorder — the group workspace's alphabetical
               // unpinned tail has a computed order with nothing to drag.
-              if (project.pinned) startProjectPointerDrag(project.id, e);
+              if (!isOffGroup && project.pinned) startProjectPointerDrag(project.id, e);
             }}
             onDragStart={(e) => e.preventDefault()}
             // Drop a file from the desktop onto a Project's tile and it goes to
@@ -1179,7 +1222,7 @@ export const ProjectBar = memo(function ProjectBar({
               showHoverLabel(project.name, e);
             }}
             onKeyDown={(e) => {
-              if (!project.pinned) return;
+              if (isOffGroup || !project.pinned) return;
               if (!e.shiftKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
               e.preventDefault();
               movePinnedProjectByKeyboard(project.id, e.key === "ArrowUp" ? -1 : 1);
@@ -1214,14 +1257,16 @@ export const ProjectBar = memo(function ProjectBar({
               zIndex: isDragging ? 6 : isActive ? 3 : clusterDragging ? 5 : 1,
               cursor: clusterDragging
                 ? "grabbing"
-                : !project.pinned
+                : isOffGroup || !project.pinned
                   ? "pointer"
                   : reorderSaving
                     ? "default"
                     : isDragging
                       ? "grabbing"
                       : "grab",
-              opacity: isDragging ? 0.92 : 1,
+              // Dimmed, but ringed: "you are here, and here is not in this
+              // group" reads at a glance without a second badge (#378).
+              opacity: isDragging ? 0.92 : isOffGroup ? 0.72 : 1,
               transform: `translateY(${tileOffset}px)`,
               boxShadow: isDragging
                 ? "0 0 0 2px color-mix(in srgb, var(--accent) 70%, white), 0 10px 24px -10px rgba(0, 0, 0, 0.6)"

--- a/packages/panel/src/components/views/ProjectBar.tsx
+++ b/packages/panel/src/components/views/ProjectBar.tsx
@@ -750,8 +750,6 @@ export const ProjectBar = memo(function ProjectBar({
   // In All mode, real groups remain useful even without pinned projects: their
   // headers are stable project drop targets. The scoped rail still disappears
   // when the selected group has no projects because there is nothing to move
-  // into it from that isolated view.
-  // when the selected group has no projects because there is nothing to move
   // into it from that isolated view — unless the open project is parked there
   // as the off-group affordance, which is the whole point of it (#378).
   if (railClusters.length === 0) return null;

--- a/packages/panel/src/components/views/__tests__/project-bar-group-filter-ring.test.tsx
+++ b/packages/panel/src/components/views/__tests__/project-bar-group-filter-ring.test.tsx
@@ -1,0 +1,301 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSyncExternalStore } from "react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { ProjectWithCounts } from "~/shared/projects";
+import type { Group } from "~/db/schema";
+
+// Issue 378. The scoped rail is the active group's workspace, and it drew the
+// selection ring only for a tile inside that workspace. So opening a project in
+// group A and then switching the GroupSwitcher to B left the page sitting on A
+// while the rail showed B's pins with no ring anywhere — the rail asserting
+// that nothing was open while the operator was plainly inside a project, with
+// no way back to it except remembering which group it lived in.
+//
+// The two things this suite pins down are exactly the issue's acceptance
+// criteria: the rail keeps a visible selection affordance for the project you
+// are on, and nothing navigates — the URL still matches that project.
+//
+// The group switch is driven through a real subscribable store rather than a
+// re-render with new props, because that is the shape of the bug: ProjectBar is
+// memoised on `coreId`, so a group switch reaches it only through its own hook
+// subscriptions.
+
+const invalidateQueries = vi.fn(async () => {});
+
+const GROUP_A: Group = { id: "g_alpha", name: "Alpha group", color: "#ff8800" } as Group;
+const GROUP_B: Group = { id: "g_beta", name: "Beta group", color: "#0088ff" } as Group;
+const GROUP_EMPTY: Group = { id: "g_empty", name: "Empty group", color: "#00ff88" } as Group;
+
+/** The GroupSwitcher's selection, as a store the rail can subscribe to. */
+const activeGroupStore = {
+  value: GROUP_A.id as string,
+  listeners: new Set<() => void>(),
+  set(next: string) {
+    activeGroupStore.value = next;
+    for (const listener of activeGroupStore.listeners) listener();
+  },
+  subscribe(listener: () => void) {
+    activeGroupStore.listeners.add(listener);
+    return () => activeGroupStore.listeners.delete(listener);
+  },
+  snapshot: () => activeGroupStore.value,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries, setQueryData: vi.fn() }),
+}));
+vi.mock("~/queries", () => ({
+  useProjects: () => ({ data: panelProjects }),
+  useGroups: () => ({ data: groups }),
+  useSettings: () => ({ data: undefined }),
+  queryKeys: { projects: ["projects"], groups: ["groups"], project: (id: string) => ["project", id] },
+}));
+vi.mock("~/lib/use-fleet", () => ({
+  useCores: () => ({ cores: [] }),
+  useRemotePinnedProjects: () => ({ projects: [], refresh: vi.fn() }),
+}));
+vi.mock("~/lib/use-events", () => ({ useServerEvents: () => {} }));
+vi.mock("~/lib/keybindings/store", () => ({
+  useBinding: () => ({ mods: [], key: "" }),
+}));
+vi.mock("~/lib/active-group", async () => {
+  const actual = await vi.importActual<typeof import("~/shared/ui-preferences")>(
+    "~/shared/ui-preferences",
+  );
+  return {
+    ACTIVE_GROUP_ALL: actual.ACTIVE_GROUP_ALL,
+    ACTIVE_GROUP_UNGROUPED: actual.ACTIVE_GROUP_UNGROUPED,
+    useActiveGroup: () => ({
+      activeGroup: useSyncExternalStore(
+        activeGroupStore.subscribe,
+        activeGroupStore.snapshot,
+        activeGroupStore.snapshot,
+      ),
+      setActiveGroup: (next: string) => activeGroupStore.set(next),
+      groups,
+    }),
+  };
+});
+vi.mock("~/lib/api", () => ({
+  api: {
+    getKeybindings: async () => ({ bindings: {} }),
+    listProjectPresentation: async () => ({ presentation: [] }),
+  },
+}));
+
+const {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+  Outlet,
+} = await import("@tanstack/react-router");
+const { ProjectBar } = await import("../ProjectBar");
+
+function makeProject(
+  over: Partial<ProjectWithCounts> & Pick<ProjectWithCounts, "id" | "name">,
+): ProjectWithCounts {
+  return {
+    path: `/srv/${over.id}`,
+    icon: "folder",
+    iconColor: "#88aaff",
+    imagePath: null,
+    groupId: null,
+    pinned: true,
+    pinnedOrder: 0,
+    launchUrl: null,
+    rememberHarnessSettings: false,
+    savedHarness: null,
+    savedSkipPermissions: false,
+    savedBareSession: false,
+    defaultGridView: false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    coreId: null,
+    taskCounts: {
+      ready: 0,
+      running: 0,
+      "needs-input": 0,
+      interrupted: 0,
+      finished: 0,
+      terminated: 0,
+      disconnected: 0,
+      total: 0,
+      activeNonDone: 0,
+    },
+    ...over,
+  };
+}
+
+const PROJECT_A = makeProject({
+  id: "p_alpha",
+  name: "Alpha",
+  groupId: GROUP_A.id,
+  pinnedOrder: 0,
+});
+const PROJECT_B = makeProject({
+  id: "p_beta",
+  name: "Beta",
+  groupId: GROUP_B.id,
+  pinnedOrder: 1,
+});
+
+let panelProjects: ProjectWithCounts[] = [];
+let groups: Group[] = [];
+
+function buildRouter() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <ProjectBar />
+        <Outlet />
+      </>
+    ),
+  });
+  const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/", component: () => null });
+  const projectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/projects/$id",
+    component: () => null,
+    validateSearch: (search: Record<string, unknown>) => ({
+      coreId: typeof search.coreId === "string" ? search.coreId : undefined,
+    }),
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, projectRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+}
+
+async function mountRail() {
+  panelProjects = [PROJECT_A, PROJECT_B];
+  groups = [GROUP_A, GROUP_B, GROUP_EMPTY];
+  const router = buildRouter();
+  const view = render(<RouterProvider router={router as never} />);
+  await settle();
+  return { router, view };
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Drive the GroupSwitcher the way the operator does — nothing else changes. */
+async function switchGroupTo(id: string) {
+  await act(async () => {
+    activeGroupStore.set(id);
+  });
+  await settle();
+}
+
+/** The project the accent ring currently sits on, or null when it is hidden. */
+function ringOn(container: HTMLElement): string | null {
+  return container.querySelector("[data-active-project-id]")?.getAttribute("data-active-project-id") ?? null;
+}
+
+function tile(container: HTMLElement, id: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-project-id="${id}"]`);
+  if (!el) throw new Error(`no rail tile for ${id}`);
+  return el;
+}
+
+function tileOrNull(container: HTMLElement, id: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-project-id="${id}"]`);
+}
+
+afterEach(() => {
+  cleanup();
+  panelProjects = [];
+  groups = [];
+  activeGroupStore.value = GROUP_A.id;
+  activeGroupStore.listeners.clear();
+  vi.clearAllMocks();
+});
+
+describe("ProjectBar selection across a group switch", () => {
+  it("keeps the ring on the open project when the active group hides it, and stays on its URL", async () => {
+    const { router, view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
+    expect(ringOn(container)).toBe(PROJECT_A.id);
+
+    await switchGroupTo(GROUP_B.id);
+
+    // Acceptance 2: nothing navigated. The page is still the project the
+    // operator opened.
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
+    // Acceptance 1: the rail does not pretend nothing is selected — the open
+    // project still has a tile, and the ring is still on it.
+    expect(tileOrNull(container, PROJECT_A.id)).not.toBeNull();
+    expect(ringOn(container)).toBe(PROJECT_A.id);
+    // ...and the switch really did happen: B's own pin is what the rail is
+    // scoped to now.
+    expect(tileOrNull(container, PROJECT_B.id)).not.toBeNull();
+    expect(tile(container, PROJECT_A.id).dataset.offGroup).toBe("true");
+    expect(tile(container, PROJECT_B.id).dataset.offGroup).toBeUndefined();
+  });
+
+  it("keeps the affordance even when the group switched to is empty", async () => {
+    const { router, view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+
+    // An empty group used to collapse the whole rail to nothing, which is the
+    // same lie in a louder form: no rail, no ring, page still on the project.
+    await switchGroupTo(GROUP_EMPTY.id);
+
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
+    expect(ringOn(container)).toBe(PROJECT_A.id);
+    expect(tile(container, PROJECT_A.id).dataset.offGroup).toBe("true");
+  });
+
+  it("gives the off-group tile no chord badge, no drag slot and no reorder", async () => {
+    const { view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+    // In its own group the tile is an ordinary pin: chord badge, drop slot.
+    expect(tile(container, PROJECT_A.id).dataset.pinnedItem).toBe("true");
+    expect(tile(container, PROJECT_A.id).querySelector(".mc-project-hotkey-badge")).not.toBeNull();
+
+    await switchGroupTo(GROUP_B.id);
+
+    // As the off-group affordance it must claim none of that: the chords and
+    // the persisted pinned order belong to the group actually being shown, and
+    // B's own pin keeps digit 1.
+    const off = tile(container, PROJECT_A.id);
+    expect(off.dataset.pinnedItem).toBeUndefined();
+    expect(off.querySelector(".mc-project-hotkey-badge")).toBeNull();
+    expect(off.getAttribute("aria-keyshortcuts")).toBeNull();
+    expect(
+      tile(container, PROJECT_B.id).querySelector(".mc-project-hotkey-badge")?.textContent,
+    ).toBe("1");
+  });
+
+  it("folds the tile back into the ordinary rail when its own group is active again", async () => {
+    const { router, view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+    await switchGroupTo(GROUP_B.id);
+    await switchGroupTo(GROUP_A.id);
+
+    expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
+    expect(ringOn(container)).toBe(PROJECT_A.id);
+    expect(container.querySelectorAll(`[data-project-id="${PROJECT_A.id}"]`)).toHaveLength(1);
+    expect(tile(container, PROJECT_A.id).dataset.offGroup).toBeUndefined();
+    expect(tileOrNull(container, PROJECT_B.id)).toBeNull();
+  });
+});

--- a/packages/panel/src/components/views/__tests__/project-bar-group-filter-ring.test.tsx
+++ b/packages/panel/src/components/views/__tests__/project-bar-group-filter-ring.test.tsx
@@ -208,6 +208,16 @@ function tileOrNull(container: HTMLElement, id: string): HTMLElement | null {
   return container.querySelector<HTMLElement>(`[data-project-id="${id}"]`);
 }
 
+/** Every tile the rail is currently drawing for one project. */
+function tilesFor(container: HTMLElement, id: string): NodeListOf<HTMLElement> {
+  return container.querySelectorAll<HTMLElement>(`[data-project-id="${id}"]`);
+}
+
+/** The accessible name of the rail's `role="navigation"` landmark. */
+function railName(container: HTMLElement): string | null {
+  return container.querySelector(".mc-project-rail")?.getAttribute("aria-label") ?? null;
+}
+
 afterEach(() => {
   cleanup();
   panelProjects = [];
@@ -241,6 +251,13 @@ describe("ProjectBar selection across a group switch", () => {
     expect(tileOrNull(container, PROJECT_B.id)).not.toBeNull();
     expect(tile(container, PROJECT_A.id).dataset.offGroup).toBe("true");
     expect(tile(container, PROJECT_B.id).dataset.offGroup).toBeUndefined();
+    // Exactly one tile, never two. The off-group cluster is appended only when
+    // the scoped cluster does not already hold the project, and both lists are
+    // derived from the same `projects` array — so a second tile would mean the
+    // guard had gone wrong, and the ring's `data-active-project-id` would no
+    // longer name one place on screen.
+    expect(tilesFor(container, PROJECT_A.id)).toHaveLength(1);
+    expect(container.querySelectorAll("[data-off-group]")).toHaveLength(1);
   });
 
   it("keeps the affordance even when the group switched to is empty", async () => {
@@ -257,6 +274,30 @@ describe("ProjectBar selection across a group switch", () => {
     expect(router.state.location.pathname).toBe(`/projects/${PROJECT_A.id}`);
     expect(ringOn(container)).toBe(PROJECT_A.id);
     expect(tile(container, PROJECT_A.id).dataset.offGroup).toBe("true");
+    expect(tilesFor(container, PROJECT_A.id)).toHaveLength(1);
+  });
+
+  it("names the rail after the active group, not after the off-group tile", async () => {
+    const { view } = await mountRail();
+    const container = view.container;
+
+    fireEvent.click(tile(container, PROJECT_A.id));
+    await settle();
+    expect(railName(container)).toBe(`${GROUP_A.name} projects`);
+
+    // A destination that still has pins of its own: the landmark follows the
+    // switcher, and the appended tile does not get a say.
+    await switchGroupTo(GROUP_B.id);
+    expect(railName(container)).toBe(`${GROUP_B.name} projects`);
+
+    // The case that made this a regression rather than a nicety. With an empty
+    // active group the off-group cluster is the ONLY cluster, so a label read
+    // off `railClusters[0]` announced "Alpha group projects" while the
+    // GroupSwitcher read "Empty group" — the rail asserting something false
+    // about grouping, which is the whole of #378, on the a11y surface.
+    await switchGroupTo(GROUP_EMPTY.id);
+    expect(railName(container)).toBe(`${GROUP_EMPTY.name} projects`);
+    expect(railName(container)).not.toContain(GROUP_A.name);
   });
 
   it("gives the off-group tile no chord badge, no drag slot and no reorder", async () => {


### PR DESCRIPTION
Closes #378 (S6). Base is `fix/operator-pins-sessions-drop-cli`, cut from `9b71076` — the merged #376 ring change is already underneath this.

## The bug

Open a project in group A, switch the GroupSwitcher to B. The page stays on A; the rail shows B with no selection ring. The scoped rail drew its overlay only when `activeId` was in the group-scoped visible list, so the filter took the ring away with the pin — the rail claiming nothing was open while the operator was plainly inside a project, and no tile left to get back to it.

## The fix

`ProjectBar.tsx` only. The project the route is on always keeps a tile: when the active group hides it, the scoped rail appends a trailing cluster of its own — named and coloured after the group that actually owns the project — and the ring lands there. The tile is dimmed to `0.72` so "you are here, and here is not in this group" reads at a glance without a second badge, and the divider above it separates it from the group's real workspace.

Nothing navigates. The URL still matches the open project; the filter decides which pins are *workable*, not which project you are in.

The rail also no longer collapses to nothing when the group switched to is empty — that was the same lie in a louder form (no rail, no ring, page still on the project).

The off-group tile is an affordance, not a member of this rail, so it deliberately claims none of a pin's powers:

- no chord badge — the digits belong to the group being shown, and `__root.tsx` resolves chords from `getRailClusters`, which this change does not touch, so badges and hotkeys stay in agreement (#379's invariant)
- no `data-pinned-item`, so it is not a drop slot in the frozen drag geometry
- no pointer drag, no `Shift+Arrow` reorder, and it is excluded from the pinned ids `persistProjectOrder` writes — counting it would splice a project from another group into the stored pinned order

## Tests

New: `packages/panel/src/components/views/__tests__/project-bar-group-filter-ring.test.tsx` — a real TanStack router plus a subscribable active-group store, because a group switch reaches this memoised component only through its own hook subscriptions. Four cases: ring and URL survive the switch; the empty-group case; the off-group tile takes no chord/drag/reorder; the tile folds back into the ordinary rail when its group is active again.

Verified red on the parent commit: three of the four fail without the `ProjectBar.tsx` change (the fourth is the same-group control, green either way).

Green locally: the new suite (4), the #376 ring suite `project-bar-active-ring.test.tsx` (3), `rail-projects` (7), `project-bar-status-dots`, `project-bar-activity`, `project-picker-switch`. `tsc --noEmit` clean; `eslint` clean on both files (two pre-existing unused-import warnings in `ProjectBar.tsx` are untouched).

## Scope

`ProjectBar.tsx` + one new test file. #382's mixed-rail pin reorder is a later round and is not taken here. No `use-fleet.ts`, `shared/projects.ts`, `projects.$id.tsx`, `terminal-store.tsx`, `TerminalPane.tsx`, `__root.tsx`, `active-group.ts` or `user-terminal-store.tsx`; no `packages/core`, `packages/shared` or `packages/cli`.

Draft on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URh1dmYL7MDE9ZV1326cXj
