### PR TITLE
fix(panel): a drop over a grid session is not a project-root upload

### DIFF
--- a/packages/panel/src/components/views/SessionGrid.tsx
+++ b/packages/panel/src/components/views/SessionGrid.tsx
@@ -52,9 +52,14 @@ const DRAG_THRESHOLD_PX = 4;
 // below) — the resize math needs them to place divider handles precisely.
 const GRID_GAP = 8;
 const GRID_PADDING = 8;
-// Hit area for a divider handle — exactly the cell gap, so the invisible
-// handles (zIndex above the cells) never overhang the terminal surfaces and
-// steal pointerdowns near a cell's inner edge.
+// Hit area for a divider handle — 8px, the cell gap this grid was first laid
+// out with. It is no longer a gap: the shipped Studio look runs gridGap = 0 and
+// gridPad = 0 (see the layout block below), so each handle is an 8px strip
+// centred on a 0-width seam and *does* overhang the terminal surfaces, 4px into
+// each neighbour. That is deliberate — a grabbable divider on a flush layout
+// has to come from somewhere — but it means the handles sit on top of terminal
+// pixels while belonging to no cell, which anything reasoning about "is this
+// point on a session?" has to account for (#401, `board-drop-arbiter.ts`).
 const HANDLE_HIT = GRID_GAP;
 // Cards glide between grid slots on reorder — same timing/easing as the
 // sidebar's pinned-project slide so the two motions feel related.

--- a/packages/panel/src/lib/board-drop-arbiter.test.ts
+++ b/packages/panel/src/lib/board-drop-arbiter.test.ts
@@ -1,25 +1,112 @@
+// @vitest-environment jsdom
+//
+// The arbiter that decides whether a file drop on a Project board belongs to a
+// session or to the board (#401).
+//
+// Real DOM, real `closest`, markup shaped like `SessionGrid`'s: a stub that
+// answers `closest` against the same string the module holds would agree with
+// any selector, and that tautology is exactly what let the divider seam through
+// the first time. The divider case below is the one that decides this file.
 import { describe, expect, it } from "vitest";
 import { dragTargetIsSessionPane } from "./board-drop-arbiter";
 
-/** Stands in for the element a drag event reports as its target. `matches` is
- *  the set of selectors this element (or one of its ancestors) answers to. */
-function targetMatching(...matches: string[]): EventTarget {
-  return {
-    closest: (selector: string) => (matches.includes(selector) ? { tag: selector } : null),
-  } as unknown as EventTarget;
+/**
+ * The board as it renders in grid view — mirroring `projects.$id.tsx` and
+ * `SessionGrid.tsx`:
+ *
+ *   board                      the drop target that uploads to the Project root
+ *     frame                    CardFrame, 8px padding — board space
+ *       header                 the project header strip — board space
+ *       grid                   [data-session-grid], position: relative
+ *         row                  [data-grid-row]
+ *           cell / cell        [data-grid-cell], each holding a terminal
+ *         divider              absolutely positioned child of the *grid*, a
+ *                              sibling of the rows and inside no cell, lying
+ *                              across the seam between the two cells
+ *       hiddenBar              sibling *after* the grid — board space
+ */
+function renderBoard() {
+  const make = (tag: string, attrs: Record<string, string> = {}) => {
+    const el = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    return el;
+  };
+
+  const board = make("div");
+  const frame = make("div");
+  const header = make("div", { class: "mc-project-header" });
+  const grid = make("div", { "data-session-grid": "" });
+  const row = make("div", { "data-grid-row": "0" });
+  const cellA = make("div", { "data-grid-cell": "", "data-task-id": "task-a" });
+  const cellB = make("div", { "data-grid-cell": "", "data-task-id": "task-b" });
+  const terminalA = make("div", { class: "xterm" });
+  const terminalCanvasA = make("canvas");
+  const divider = make("div", { style: "position:absolute;z-index:6" });
+  const hiddenBar = make("div", { "data-hidden-sessions-bar": "" });
+
+  terminalA.append(terminalCanvasA);
+  cellA.append(terminalA);
+  row.append(cellA, cellB);
+  grid.append(row, divider);
+  frame.append(header, grid, hiddenBar);
+  board.append(frame);
+  document.body.append(board);
+
+  return { board, frame, header, grid, row, cellA, cellB, terminalCanvasA, divider, hiddenBar };
 }
 
 describe("dragTargetIsSessionPane", () => {
-  it("claims a drag whose target sits inside a grid cell", () => {
-    expect(dragTargetIsSessionPane({ target: targetMatching("[data-grid-cell]") })).toBe(true);
+  it("claims a drop on the terminal inside a cell", () => {
+    const { terminalCanvasA } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: terminalCanvasA })).toBe(true);
   });
 
-  it("leaves the board's own space to the board", () => {
-    expect(dragTargetIsSessionPane({ target: targetMatching() })).toBe(false);
+  it("claims a drop on a cell itself", () => {
+    const { cellB } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: cellB })).toBe(true);
+  });
+
+  it("claims a drop on a resize divider lying across the seam between two panes", () => {
+    // The regression this file exists for. The divider is a child of the grid
+    // and inside no cell, but it is an 8px strip painted over 4px of each
+    // neighbouring terminal (HANDLE_HIT = 8 with gridGap = 0), so a drop on it
+    // is a drop the operator aimed at a session. `[data-grid-cell]` alone
+    // answers null here and the board would have uploaded to the Project root.
+    const { divider } = renderBoard();
+    expect(divider.closest("[data-grid-cell]")).toBeNull();
+    expect(dragTargetIsSessionPane({ target: divider })).toBe(true);
+  });
+
+  it("claims a drop on the grid container itself", () => {
+    const { grid } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: grid })).toBe(true);
+  });
+
+  it("leaves the project header strip to the board", () => {
+    const { header } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: header })).toBe(false);
+  });
+
+  it("leaves the frame padding around the grid to the board", () => {
+    const { frame } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: frame })).toBe(false);
+  });
+
+  it("leaves the hidden-sessions bar to the board", () => {
+    // It renders as a sibling *after* the grid element, so widening the
+    // selector to the grid container did not swallow it.
+    const { hiddenBar } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: hiddenBar })).toBe(false);
+  });
+
+  it("leaves the board's own surface to the board", () => {
+    const { board } = renderBoard();
+    expect(dragTargetIsSessionPane({ target: board })).toBe(false);
   });
 
   it("treats a target that is not an element as board space", () => {
     expect(dragTargetIsSessionPane({ target: null })).toBe(false);
+    expect(dragTargetIsSessionPane({ target: document.createTextNode("x") })).toBe(false);
     expect(dragTargetIsSessionPane({ target: {} as EventTarget })).toBe(false);
   });
 });

--- a/packages/panel/src/lib/board-drop-arbiter.test.ts
+++ b/packages/panel/src/lib/board-drop-arbiter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { dragTargetIsSessionPane } from "./board-drop-arbiter";
+
+/** Stands in for the element a drag event reports as its target. `matches` is
+ *  the set of selectors this element (or one of its ancestors) answers to. */
+function targetMatching(...matches: string[]): EventTarget {
+  return {
+    closest: (selector: string) => (matches.includes(selector) ? { tag: selector } : null),
+  } as unknown as EventTarget;
+}
+
+describe("dragTargetIsSessionPane", () => {
+  it("claims a drag whose target sits inside a grid cell", () => {
+    expect(dragTargetIsSessionPane({ target: targetMatching("[data-grid-cell]") })).toBe(true);
+  });
+
+  it("leaves the board's own space to the board", () => {
+    expect(dragTargetIsSessionPane({ target: targetMatching() })).toBe(false);
+  });
+
+  it("treats a target that is not an element as board space", () => {
+    expect(dragTargetIsSessionPane({ target: null })).toBe(false);
+    expect(dragTargetIsSessionPane({ target: {} as EventTarget })).toBe(false);
+  });
+});

--- a/packages/panel/src/lib/board-drop-arbiter.ts
+++ b/packages/panel/src/lib/board-drop-arbiter.ts
@@ -8,16 +8,46 @@
 // somewhere the operator did not aim.
 //
 // Nested drop targets need an arbiter, and the only honest arbiter for a
-// pointer gesture is where the pointer was. A grid cell marks itself with
-// `data-grid-cell` (SessionGrid), which is already the repo's way of asking
-// "is this inside a session pane?" — the same attribute the grid's own
-// keyboard navigation walks up to. So the board asks the same question of the
-// drag's target, and stands down when the answer is yes.
+// pointer gesture is where the pointer was. Two markers answer that, and it
+// takes both:
+//
+//   [data-grid-cell]     one session's cell (SessionGrid) — the same attribute
+//                        the grid's own keyboard navigation walks up to.
+//   [data-session-grid]  the grid container itself. Not redundant: the row and
+//                        column resize handles are absolutely-positioned
+//                        children of *this* element, siblings of the row divs
+//                        and inside no cell, at zIndex 6 — above every
+//                        non-expanded cell. Their hit area is HANDLE_HIT = 8px
+//                        while the shipped layout runs gridGap = 0 and
+//                        gridPad = 0, so each one is an 8px strip centred on a
+//                        0-width seam: it lies on top of terminal pixels, 4px
+//                        into each neighbour, full pane height for a column
+//                        divider and full grid width for a row divider. Cell
+//                        alone answers null there, and the board would paint
+//                        itself hot and upload to the Project root 4px from a
+//                        pane edge — #401's exact failure mode, in the one
+//                        place the operator cannot see that they are not on a
+//                        pane.
+//
+// So the whole grid element is session space. With gridGap and gridPad both 0
+// there is no board space left inside it to protect: the board's own space in
+// grid view is the project header strip and the CardFrame's 8px padding, both
+// *outside* the grid element, plus the hidden-sessions bar, which renders as a
+// sibling after it. Those still upload to the Project root, as they should.
 //
 // Single-session view needs nothing here: `TerminalPanel` renders as a sibling
 // of the board in `__root.tsx`, never a descendant, so its drops never reach
 // the board handler in the first place.
-const SESSION_PANE_SELECTOR = "[data-grid-cell]";
+//
+// Known and accepted gap: a menu portalled out of a cell to `document.body`
+// (TerminalPane's session-actions menu) still bubbles to the board through the
+// React tree while its DOM sits outside the grid, so `closest` answers null and
+// a drop on the open menu uploads to the Project root. It takes a menu held
+// open across a drag, and a menu is not a terminal, so it is recorded rather
+// than fixed. A DOM-position arbiter cannot see a React-tree ancestor; closing
+// that would mean a second signal (a dataset marker on the portal, or the
+// menu claiming the drag itself).
+const SESSION_PANE_SELECTOR = "[data-grid-cell], [data-session-grid]";
 
 /** The subset of `Element` this needs — duck-typed so the check is unit
  *  testable without a DOM, and so a non-Element target (a text node, `null`)
@@ -37,8 +67,8 @@ function isClosestCapable(target: unknown): target is ClosestCapable {
  * own space.
  *
  * True means the board must not treat the gesture as a Project-root upload:
- * the operator aimed at a session, and the space between and around the cells
- * is the only part of the board they can aim at when the grid is up.
+ * the operator aimed at a session, or at the grid's own furniture lying across
+ * one.
  */
 export function dragTargetIsSessionPane(event: { target: EventTarget | null }): boolean {
   const target: unknown = event.target;

--- a/packages/panel/src/lib/board-drop-arbiter.ts
+++ b/packages/panel/src/lib/board-drop-arbiter.ts
@@ -1,0 +1,47 @@
+// Which nested drop target owns a file drop on a Project board (#401).
+//
+// A Project's board is itself a drop target: a file dropped anywhere on it
+// uploads to the Project root. In grid view the whole session grid renders
+// *inside* that board, so every drag aimed at a session's terminal also
+// bubbles to the board's handler — and the board, having no idea what the
+// operator was aiming at, uploads to the Project root. The file lands
+// somewhere the operator did not aim.
+//
+// Nested drop targets need an arbiter, and the only honest arbiter for a
+// pointer gesture is where the pointer was. A grid cell marks itself with
+// `data-grid-cell` (SessionGrid), which is already the repo's way of asking
+// "is this inside a session pane?" — the same attribute the grid's own
+// keyboard navigation walks up to. So the board asks the same question of the
+// drag's target, and stands down when the answer is yes.
+//
+// Single-session view needs nothing here: `TerminalPanel` renders as a sibling
+// of the board in `__root.tsx`, never a descendant, so its drops never reach
+// the board handler in the first place.
+const SESSION_PANE_SELECTOR = "[data-grid-cell]";
+
+/** The subset of `Element` this needs — duck-typed so the check is unit
+ *  testable without a DOM, and so a non-Element target (a text node, `null`)
+ *  is simply "not a session pane" rather than a throw. */
+type ClosestCapable = { closest(selector: string): unknown };
+
+function isClosestCapable(target: unknown): target is ClosestCapable {
+  return (
+    typeof target === "object" &&
+    target !== null &&
+    typeof (target as ClosestCapable).closest === "function"
+  );
+}
+
+/**
+ * Whether a drag event landed inside a session pane rather than on the board's
+ * own space.
+ *
+ * True means the board must not treat the gesture as a Project-root upload:
+ * the operator aimed at a session, and the space between and around the cells
+ * is the only part of the board they can aim at when the grid is up.
+ */
+export function dragTargetIsSessionPane(event: { target: EventTarget | null }): boolean {
+  const target: unknown = event.target;
+  if (!isClosestCapable(target)) return false;
+  return target.closest(SESSION_PANE_SELECTOR) != null;
+}

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -25,6 +25,7 @@ import { GridLayoutButton } from "~/components/views/GridLayoutButton";
 import { ProjectFilesPanel } from "~/components/views/ProjectFilesPanel";
 import { SessionGrid } from "~/components/views/SessionGrid";
 import { filesFromDrop, type DroppedFile } from "~/lib/core-files";
+import { dragTargetIsSessionPane } from "~/lib/board-drop-arbiter";
 import { dragCarriesFiles, useProjectFilesAvailability } from "~/lib/use-project-files";
 import { takeProjectFileDrop } from "~/lib/pending-file-drop";
 import { archiveOpenSession, invalidateSessionQueries } from "~/lib/archive-session";
@@ -1842,11 +1843,25 @@ function ProjectPage() {
         // Project on its Core. `dragCarriesFiles` is what keeps this off the
         // Panel's own drags — a project path dragged from the rail into a
         // terminal still belongs to the handler that already understands it.
+        //
+        // And `dragTargetIsSessionPane` is what keeps it off the sessions
+        // (#401). In grid view the grid renders inside this div, so a drag
+        // aimed at a session's terminal bubbles here too; the board answering
+        // it would upload to the Project root, which is not where the operator
+        // was pointing. It still has to `preventDefault` over a cell — leaving
+        // the browser's default alone makes the drop navigate the Panel to the
+        // dropped file — but it says `none`, so the cursor reads no-drop and
+        // the board never paints itself hot for a gesture it will refuse.
         onDragOver={
           filesAvailable
             ? (e) => {
                 if (!dragCarriesFiles(e)) return;
                 e.preventDefault();
+                if (dragTargetIsSessionPane(e)) {
+                  e.dataTransfer.dropEffect = "none";
+                  setFileDropHot(false);
+                  return;
+                }
                 e.dataTransfer.dropEffect = "copy";
                 setFileDropHot(true);
               }
@@ -1857,8 +1872,15 @@ function ProjectPage() {
           filesAvailable
             ? (e) => {
                 if (!dragCarriesFiles(e)) return;
+                // Swallowed before the arbiter runs: whoever the drop belonged
+                // to, the browser's default for a file dropped on a page is to
+                // navigate to it, and that must not happen on either path.
                 e.preventDefault();
                 setFileDropHot(false);
+                // Aimed at a session, so it was never the board's to take
+                // (#401). No upload, no drawer, no toast — refusing quietly is
+                // what the no-drop cursor above already told the operator.
+                if (dragTargetIsSessionPane(e)) return;
                 // Opened first: the upload is about to run, and a progress list
                 // nobody can see is the same as no progress at all.
                 setShowFiles(true);

--- a/packages/panel/src/routes/projects.$id.tsx
+++ b/packages/panel/src/routes/projects.$id.tsx
@@ -1848,10 +1848,20 @@ function ProjectPage() {
         // (#401). In grid view the grid renders inside this div, so a drag
         // aimed at a session's terminal bubbles here too; the board answering
         // it would upload to the Project root, which is not where the operator
-        // was pointing. It still has to `preventDefault` over a cell — leaving
-        // the browser's default alone makes the drop navigate the Panel to the
-        // dropped file — but it says `none`, so the cursor reads no-drop and
-        // the board never paints itself hot for a gesture it will refuse.
+        // was pointing. It still has to `preventDefault` over the grid —
+        // leaving the browser's default alone makes the drop navigate the Panel
+        // to the dropped file — but it says `none`, so the cursor reads no-drop
+        // and the board never paints itself hot for a gesture it will refuse.
+        //
+        // Writing `dropEffect` unconditionally is safe only while nothing
+        // inside the grid handles a file drag. This handler runs last, on the
+        // bubble, so it stomps whatever a nested one set: if a per-session drop
+        // is ever added — an image attached into a grid cell — it will
+        // `preventDefault` and set `copy`, and the `none` below would overwrite
+        // it and suppress that pane's `drop` entirely. The repo's convention
+        // for nested drop targets is the inner one claiming the gesture with
+        // `stopPropagation` (`ProjectFilesPanel.tsx`, #400/#227); a per-session
+        // drop should do the same, and then this branch never runs for it.
         onDragOver={
           filesAvailable
             ? (e) => {

--- a/packages/shared/src/__tests__/core-cert-material.test.ts
+++ b/packages/shared/src/__tests__/core-cert-material.test.ts
@@ -6,6 +6,7 @@ import {
   generateCertMaterial,
   issueServerCert,
   generateClientCsr,
+  randomSerial,
   signClientCsr,
 } from "../core-cert-material";
 
@@ -318,6 +319,26 @@ describe("signing a client CSR against the Core's CA", () => {
     expect(a.serial).not.toBe(b.serial);
     // Positive, per RFC 5280 §4.1.2.2 — the top bit of the first byte is clear.
     expect(parseInt(a.serial.slice(0, 2), 16)).toBeLessThan(0x80);
+    // And the whole 16 bytes came back. A serial minted with a leading zero
+    // byte returns a byte shorter than it went in, because DER writes an
+    // INTEGER minimally and the reader strips the pad — see `randomSerial`.
+    for (const serial of [a.serial, b.serial]) expect(serial).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("never mints a serial the certificate would hand back shortened", () => {
+    // The property, drawn often enough to bite. Signing a certificate per draw
+    // would take minutes; the issuances above already pin that the serial the
+    // certificate reports is the serial `randomSerial` produced, and this pins
+    // that every draw is a serial that survives that round trip: 16 bytes, top
+    // bit of the first clear so the INTEGER is positive, and the first byte
+    // never 0x00 so nothing is stripped off the front of it.
+    for (let i = 0; i < 5000; i++) {
+      const serial = randomSerial();
+      expect(serial).toMatch(/^[0-9a-f]{32}$/);
+      const first = parseInt(serial.slice(0, 2), 16);
+      expect(first).toBeGreaterThan(0x00);
+      expect(first).toBeLessThan(0x80);
+    }
   });
 
   it("mints a client CSR whose private key it hands back and never embeds", async () => {

--- a/packages/shared/src/core-cert-material.ts
+++ b/packages/shared/src/core-cert-material.ts
@@ -538,10 +538,28 @@ async function importCaKey(pem: string): Promise<X509SigningKey> {
   }
 }
 
-/** A positive 16-byte serial, hex-encoded — RFC 5280 §4.1.2.2 wants positive. */
-function randomSerial(): string {
+/**
+ * A positive 16-byte serial, hex-encoded — RFC 5280 §4.1.2.2 wants positive.
+ *
+ * The leading byte is forced into 0x01..0x7f, and the floor matters as much as
+ * the ceiling. The top bit clear is what makes the DER INTEGER positive. The
+ * non-zero is what keeps the serial we minted and the serial the certificate
+ * reports back the same string: DER writes an INTEGER minimally, and
+ * `@peculiar/x509` hands `serialNumber` back with a leading zero byte stripped,
+ * so a serial that began 0x00 came back a byte shorter — and reading as
+ * negative-looking hex if the byte behind it had its own top bit set. That is a
+ * 1-in-256 draw, and the serial is the certificate's name in every later
+ * revocation list and `pair ls` row, so it has to be the same name on both
+ * sides of the issuance every time.
+ *
+ * Exported for the tests, which draw it many times: a single issuance only
+ * meets the bad byte once in 256, which is too rare for a test to rely on and
+ * exactly often enough to redden someone else's pull request.
+ */
+export function randomSerial(): string {
   const bytes = randomBytes(16);
-  bytes[0] = bytes[0]! & 0x7f;
+  const first = bytes[0]! & 0x7f;
+  bytes[0] = first === 0 ? 0x01 : first;
   return bytes.toString("hex");
 }
 


### PR DESCRIPTION
Closes #401 (B7).

## The landmine

In grid view the whole session grid renders **inside** the board `div`, so the board's own `onDrop` wraps it. A file
dropped on a session's terminal bubbled to the board handler, which has no idea what the operator was aiming at and
uploaded to the **project root** — the file landed somewhere nobody pointed at.

## The shape chosen: a target test on the board side, not `e.defaultPrevented`

The task asked whether honouring `e.defaultPrevented` on the board handler — the alternative shape #400 named for this
file — is right here. **It is not**, for two independent reasons:

1. **Nothing in a session pane ever sets it for this gesture.** `wireTerminalFileDrop`
   (`packages/panel/src/lib/terminal-pane-helpers.ts`) `preventDefault`s only for a *project-path* drag from the
   Panel's own rail. Desktop file drags are deliberately ignored there: the browser hands over bytes, not a path on
   the Core's machine (ADR 0010). So on a file drop over a terminal `e.defaultPrevented` is `false`, and a board
   guard reading it would be a no-op — the bug would ship unchanged.
2. **React would blunt it even if something did set it.** `SyntheticEvent` copies `defaultPrevented` from the native
   event *at construction*, so a React descendant calling `preventDefault` during the same root dispatch would not
   show up on the board's event object. Only a native listener firing before React's root listener would, which is
   exactly the case (1) rules out.

`stopPropagation` on the session side — #400's other shape — is also wrong here: it is the drawer's fix (already
merged, `ProjectFilesPanel.tsx`, a different handler and untouched by this PR), and it needs a descendant handler that
*wants* the drop. A session pane does not want a file drop at all; it needs the board to stand down, not to hand the
gesture over.

So the arbiter is **where the pointer was**. New `packages/panel/src/lib/board-drop-arbiter.ts` exports
`dragTargetIsSessionPane(event)`, which walks up from the drag's target to `[data-grid-cell], [data-session-grid]`.

## The discriminator: both markers, and why the grid container is not redundant

`[data-grid-cell]` alone is defeated exactly where the operator cannot see it, and the first round of this PR shipped
that hole ([review finding 3.3a](https://github.com/actana/control/pull/477#discussion_r3923999452)):

`SessionGrid` renders the row and column **resize handles** as absolutely-positioned children of the grid container —
siblings of the row `div`s, inside no cell — at `zIndex: 6`, above every non-expanded cell (`SessionGrid.tsx:2433-2476`;
the only higher value, `8`, is the expanded cell, where `resizeEnabled` is false anyway, `:1774`). Their hit area is
`HANDLE_HIT = GRID_GAP = 8` (`:53`, `:63`) while the shipped Studio layout runs `gridGap = 0; gridPad = 0` (`:836-837`).
So each handle is an **8px strip centred on a 0-width seam**: it lies on top of terminal pixels, 4px into each
neighbour, full pane height for a column divider and full grid width for a row divider. `closest("[data-grid-cell]")`
answers `null` there — so the board painted itself hot, showed the `copy` cursor and uploaded to the project root, 4px
from a pane edge, with feedback that actively invited the drop. AC1's exact failure mode.

`[data-session-grid]` (already on the grid container, `SessionGrid.tsx:2373`) closes it by making the **whole grid
element** session space. Nothing else moves: the hidden-sessions bar renders as a sibling *after* the grid (`:2531`),
and the project header strip and the `CardFrame`'s 8px padding sit outside it. All three still upload to the project
root.

Correcting the justification while I was here: the earlier version of this PR (and of the module comment) claimed "the
gaps around and between the cells" as the board's own space inside the grid. **With `gridGap` and `gridPad` both 0 that
space does not exist**, and the only thing that looks like it — the divider strip — is the one place the operator cannot
tell they are not on a pane. The board's real own space in grid view is entirely *outside* the grid element.

`SessionGrid.tsx:55-57` also carried a stale claim — that the invisible handles "never overhang the terminal surfaces".
True when the gap was 8, false since the flush layout, and the accurate account was already sitting at `:827`. That
comment is now corrected in place, and points at this arbiter.

## What the board does now

- `onDragOver` inside the grid: still `preventDefault` (leaving the browser default alone would make the drop
  **navigate the Panel to the dropped file**), but `dropEffect: "none"` and the hot dashed outline stays off. The
  operator sees a no-drop cursor over a session, and a hot board only where the board really will take the file.
- `onDrop` inside the grid: `preventDefault` first (same reason), then return. No upload, no Files drawer, no pending
  drop.
- Everywhere else on the board — the project header strip, the frame padding, the hidden-sessions bar, the empty-grid
  state and all of single-session view — uploads to the project root exactly as before.

Single-session view needed no change: `TerminalPanel` renders as a *sibling* of the board in `__root.tsx`, never a
descendant, so its drops never reached this handler. That is stated in a comment next to the selector so the next
reader does not go looking for a missing case.

## Recorded, not fixed

- **A portalled menu is still board space** ([3.3c](https://github.com/actana/control/pull/477#issuecomment-5524738131)).
  `TerminalPane.tsx:299` portals the session-actions menu to `document.body` (`:392`). React propagates synthetic
  events along the *React* tree, so a drop on the open menu reaches the board's `onDrop` while its DOM sits outside the
  grid and `closest` answers `null` — it uploads to the project root. It takes a menu held open across a drag, and a
  menu is not a terminal. A DOM-position arbiter cannot see a React-tree ancestor; closing it would need a second
  signal. Commented in `board-drop-arbiter.ts`.
- **`dropEffect` is written unconditionally on the bubble** (reviewer's note on `projects.$id.tsx:1860`). Benign today
  — nothing inside a cell handles a file drag — but a future per-session drop that sets `copy` would have it stomped.
  The repo's convention is the inner target claiming the gesture with `stopPropagation` (`ProjectFilesPanel.tsx`,
  #400/#227). Commented on the handler.
- **With a cell expanded, the refusal covers everything under the header**
  ([3.5](https://github.com/actana/control/pull/477#discussion_r3923999477)) — a feedback gap, not a wrong destination.
  Filed as **#479**, referencing #401 and this PR, rather than carried here.

## One red check that was not this PR's, fixed rather than re-run

`Unit Tests` went red on the head of this branch in a package it does not touch: `packages/shared`,
`core-cert-material` > "gives every issuance its own serial", `expected 240 to be less than 128`. A 1-in-256 draw in
`randomSerial`, not a regression from #401 — the earlier run at `361b6d9` was green with the same code.

`randomSerial` drew 16 bytes and cleared the top bit of the first, which makes the DER INTEGER positive (RFC 5280
§4.1.2.2). Two of the 256 possible first bytes — `0x00` and `0x80` — clear to `0x00`, and the mask is not enough there:
DER writes an INTEGER minimally and `@peculiar/x509` returns `serialNumber` with the leading zero byte **stripped**, so
that issuance reported a 15-byte serial starting at whatever byte sat behind the zero — with its own top bit set half
the time. Confirmed against the library directly: a certificate minted with `00f0aabb…` reports `f0aabb…`, one minted
with `7f0011…` reports it unchanged.

The serial names the certificate in every later revocation list and `pair ls` row, so it has to be the same string on
both sides of the issuance. The leading byte is now forced into `0x01..0x7f` — top bit clear for positive, non-zero so
the encoder has nothing to strip. The test drew the property once per issuance, which is how a one-in-256 bug outlived
every run of it; it now asserts the full 16 bytes came back and draws `randomSerial` 5000 times to pin the bounds
directly. The new test fails against the old body.

Separate commit (`ccda088`), and easy to lift out of this PR if you would rather it rode on its own.

## Scope

- Touched: `packages/panel/src/routes/projects.$id.tsx`, `packages/panel/src/components/views/SessionGrid.tsx`
  (comment only), plus `lib/board-drop-arbiter.ts` and its test. Outside #401 and in its own commit:
  `packages/shared/src/core-cert-material.ts` and its test, for the red check above.
- Not touched: `ProjectFilesPanel.tsx` (#400, already merged — a different handler), `ProjectBar.tsx`, `use-fleet.ts`,
  `shared/projects.ts`, `queries/index.ts`, `visible-project-scope.ts` (#382 / #381).
- Base `fix/operator-pins-sessions-drop-cli` merged in with a plain merge commit (`3fc380c`) after #471, #462 and #472
  landed. No rebase, no force push.

## Verification

- The test suite is rebuilt on **real DOM under `jsdom`**, with markup shaped like `SessionGrid`'s: board → frame →
  header → `[data-session-grid]` → `[data-grid-row]` → `[data-grid-cell]` → `.xterm`, a divider as a sibling of the
  rows inside the grid, and the hidden-sessions bar after it. The old stub answered `closest` against the same literal
  the module holds, so it agreed with any selector — a tautology, and the reason the divider went unnoticed
  ([3.4](https://github.com/actana/control/pull/477#discussion_r3923999471)). 9 tests; **the divider-seam case fails
  against the old `[data-grid-cell]`-only selector**, which is the point of it.
- `pnpm typecheck` — clean.
- `eslint` on the four touched files — **0 errors**; the warnings reported are pre-existing unused-vars. Full
  `pnpm lint` OOMs (exit 137) on this box, which is a local memory ceiling, not a finding; CI runs it.
- Targeted suites green: `board-drop-arbiter` (9), `project-files-panel` (19), `session-grid-layout` +
  `session-grid-tracks` (18).

Draft on purpose, based on `fix/operator-pins-sessions-drop-cli` (not `main`, not the train).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBR3m1VZWiuWVSoRWUEqGU

