### PR TITLE
fix: send --wait fails fast rather than waiting for a turn it never started

### DIFF
--- a/.agents/skills/actana-sessions/SKILL.md
+++ b/.agents/skills/actana-sessions/SKILL.md
@@ -97,10 +97,10 @@ a file**, and the contract below is how you get one.
 
 The object also carries `taskId` (the Session's id — this is what every other
 verb takes), `harness`, `project`, `status`, `exited`, and `reportsTurnStart`.
-`--wait-timeout <seconds>` bounds the wait; without it the wait has no deadline
-of its own. A timeout is this side giving up, not a verdict about the Session:
-the Session is still running on the Core and can still be listed, read and
-stopped.
+`--wait-timeout <seconds>` bounds the wait; without it `start --wait` has no
+deadline of its own (`send --wait` does — see the loop below). A timeout is this
+side giving up, not a verdict about the Session: the Session is still running on
+the Core and can still be listed, read and stopped.
 
 While a Session is alive — which is what the `live` field on its
 `actana session ls --json` row tells you, and the only thing that does — you can
@@ -153,17 +153,25 @@ Three things to know before you build on it:
    the Session to settle *first*, then send.
 2. **A `send` presses Enter for you, and `--no-enter` is how you stop it.** The
    text goes first and the carriage return follows as its own separate write.
-   `--no-enter` sends no return, so that send starts no turn — and a `--wait`
-   after it is not waiting for your text: on an idle Session nothing ends, and
-   on a busy one it resolves on the turn that was *already* running. Both are
-   #405's. `--enter` is still accepted and does nothing on a send that carries
-   text, so an older script that passes it keeps working; on a send with no text
-   it still means a bare carriage return and nothing else.
+   `--no-enter` sends no return, so that send starts no turn — and it **cannot
+   be combined with `--wait`**, which is refused as a usage error: a send that
+   submits nothing has no turn to await. Type with `--no-enter`, then
+   `actana session wait` once a turn is actually running. `--enter` is still
+   accepted and does nothing on a send that carries text, so an older script
+   that passes it keeps working; on a send with no text it still means a bare
+   carriage return and nothing else.
 3. **A timeout is this side giving up, not a status.** `--wait-timeout
-   <seconds>` bounds the wait; without it there is no deadline, because a turn
-   takes as long as the work takes. On expiry you get a message saying the wait
-   gave up and a non-zero exit — the Session is still running on the Core, and
-   `session logs`, another `session wait` and `session kill` all still work.
+   <seconds>` bounds the wait. `session wait` has no deadline unless you set
+   one, because a turn takes as long as the work takes; **`send --wait` defaults
+   to 900 seconds**, because it is the one wait for a turn that has not started
+   yet and a carriage return that lands on a dialog rather than a composer
+   starts none at all. `--wait-timeout 0` waits with no deadline. On expiry you
+   get a message saying the wait gave up and a non-zero exit — the Session is
+   still running on the Core, and `session logs`, another `session wait` and
+   `session kill` all still work. When the wait gave up having heard nothing at
+   all about the Session since your text went in, the message says so: no turn
+   ended and none was seen to start, and the text was delivered — read the
+   screen with `session logs` rather than sending it again.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/.agents/skills/actana-sessions/SKILL.md
+++ b/.agents/skills/actana-sessions/SKILL.md
@@ -125,10 +125,15 @@ A Session is a conversation, not a single question. The whole loop:
 
 ```bash
 ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
-actana session wait "$ID" --json --wait-timeout 900     # block until it settles
-actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 900
-actana session send "$ID" "<next>" --wait --json
+actana session wait "$ID" --json --wait-timeout 1800    # block until it settles
+actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 1800
+actana session send "$ID" "<next>" --wait --json --wait-timeout 1800
 ```
+
+Every line carries the same budget on purpose: 1800 seconds is what `await.sh`
+gives a round, and a loop whose steps disagree about how long a turn may take
+gives up in the middle of one. Pass it explicitly rather than leaning on a
+default — `send --wait` has one (1020 seconds) and the other two do not.
 
 **`actana session wait <id>` blocks until the Core reports the Session settled**
 — `finished`, `needs-input`, `interrupted`, `terminated` or `disconnected`,
@@ -144,7 +149,7 @@ object** `start --wait --json` prints — same keys, same `screen` — so one pa
 reads all three verbs. Two of those keys are `null` on a Session you attached to
 rather than started: `command` and `reportsTurnStart` are answers to a spawn.
 
-Three things to know before you build on it:
+Four things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -163,15 +168,22 @@ Three things to know before you build on it:
 3. **A timeout is this side giving up, not a status.** `--wait-timeout
    <seconds>` bounds the wait. `session wait` has no deadline unless you set
    one, because a turn takes as long as the work takes; **`send --wait` defaults
-   to 900 seconds**, because it is the one wait for a turn that has not started
+   to 1020 seconds**, because it is the one wait for a turn that has not started
    yet and a carriage return that lands on a dialog rather than a composer
    starts none at all. `--wait-timeout 0` waits with no deadline. On expiry you
    get a message saying the wait gave up and a non-zero exit — the Session is
-   still running on the Core, and `session logs`, another `session wait` and
-   `session kill` all still work. When the wait gave up having heard nothing at
-   all about the Session since your text went in, the message says so: no turn
-   ended and none was seen to start, and the text was delivered — read the
-   screen with `session logs` rather than sending it again.
+   still running on the Core, and `session logs` and `session kill` still work.
+   When no turn end was reported since your text went in, the message says so
+   and names both readings: the text may have started no turn, or a turn may
+   still be running on a Harness that reports nothing until it ends. The text
+   was delivered either way — read the screen with `session logs` rather than
+   sending it again.
+4. **Do not answer that timeout with `session wait`.** It is uncursored: it
+   answers from the status the Session is parked at, so on a turn that never
+   started it returns **at once, with the status from before your text, and
+   exits zero** — which reads as a completed turn and is not one. To carry on
+   waiting, follow the log from the delivery instead:
+   `actana events tail --since <event id>`, the id the timeout message names.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ routing around it.
 | [0030](adr/0030-the-panel-is-a-dumb-pipe-for-file-bytes.md) | The Panel is a dumb pipe for file bytes, and it is the end that holds the credentials |
 | [0031](adr/0031-the-product-ships-one-skill.md) | The product ships one skill, and installs it into the operator's home — **PROPOSED**, amends 0006 |
 | [0032](adr/0032-one-actana-cli.md) | There is one `actana`, and it is both the Core manager and the client — supersedes #265 §6 and 0031 D8's two-binaries premise |
-| [0033](adr/0033-turn-end-is-the-one-mandatory-harness-signal.md) | Turn-end reporting is the one mandatory harness signal; turn-start, auto-mode flags and resume ids may never gate a feature |
+| [0033](adr/0033-turn-end-is-the-one-mandatory-harness-signal.md) | Turn-end reporting is the one mandatory harness signal; turn-start, auto-mode flags and resume ids may never gate a feature — D5 (#405) gives `send --wait` a default deadline, amending D4 |
 | [0035](adr/0035-a-second-skill-for-the-sub-agent-role.md) | A second skill for the sub-agent role, and it is eager — **PROPOSED**, depends on 0031 |
 | [0036](adr/0036-the-beta-release-channel.md) | The beta release channel: a beta installs like a release, and the ref is the channel — **PROPOSED**, amends 0016 (D28, D29, D34, D35) and 0023 (D8, D9) |
 | [0037](adr/0037-one-version-per-line.md) | One version per line: where a version string is written, and what is authoritative — **PROPOSED**, amends 0023 (D3, D7), the two clauses 0036 §G left open |

--- a/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
+++ b/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
@@ -53,6 +53,29 @@ stream**. #191 deleted a flat quiet-output timer that did exactly that and
 wait with no `--wait-timeout` has no deadline; one with a deadline reports, on
 expiry, that *this side gave up* — never a status the Core did not send.
 
+**D5 — `send --wait` carries a default deadline; the other waits do not**
+(amends D4, #405). `session wait` and `session start --wait` wait for a turn
+that is already under way, and the only thing a default deadline could cut short
+there is honest work — so they keep D4's "no deadline unless the caller sets
+one" exactly. `send --wait` is the one wait for a turn *it* has to start, and a
+carriage return that lands on a dialog rather than a composer starts none: the
+Core then has nothing to report, the status the Session is parked at was seeded
+from the Task row and carries event id 0, and a delivery cursor can never be
+satisfied by it. The wait is correct, silent and permanent. **900 seconds** is
+the default, matching the bound the orchestration skill already tells callers to
+pass, and `--wait-timeout 0` removes it.
+
+This does not weaken D4 or reintroduce what #191 deleted. Nothing new is
+inferred: the deadline is the caller's own clock, and what it reports on expiry
+is still that this side gave up. What it adds is a **fact off the event log** in
+the message — whether the Core reported anything at all about the Session after
+the delivery event — so an operator can tell a slow harness from a return that
+was swallowed. That comparison is two event ids, not a reading of the screen.
+
+A send that submits nothing at all (`--no-enter`) is refused with `--wait`
+rather than bounded: it has no turn to await, so there is nothing for a deadline
+to be about.
+
 ## Consequences
 
 Adding a family is still adding a row, and now the row has a bar to clear. A

--- a/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
+++ b/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
@@ -61,16 +61,32 @@ one" exactly. `send --wait` is the one wait for a turn *it* has to start, and a
 carriage return that lands on a dialog rather than a composer starts none: the
 Core then has nothing to report, the status the Session is parked at was seeded
 from the Task row and carries event id 0, and a delivery cursor can never be
-satisfied by it. The wait is correct, silent and permanent. **900 seconds** is
-the default, matching the bound the orchestration skill already tells callers to
-pass, and `--wait-timeout 0` removes it.
+satisfied by it. The wait is correct, silent and permanent. **1020 seconds** is
+the default and `--wait-timeout 0` removes it. Seventeen minutes rather than
+fifteen so that it cannot tie with the Core's own quiet backstop
+(`QUIET_SETTLE_MS`, fifteen minutes, swept once a minute): where the Core has an
+answer it should be the one to give it, and this deadline should only ever fire
+where the Core has none — which is #405's case exactly, because the backstop
+skips a Session that is not `running`.
 
 This does not weaken D4 or reintroduce what #191 deleted. Nothing new is
 inferred: the deadline is the caller's own clock, and what it reports on expiry
 is still that this side gave up. What it adds is a **fact off the event log** in
-the message — whether the Core reported anything at all about the Session after
-the delivery event — so an operator can tell a slow harness from a return that
-was swallowed. That comparison is two event ids, not a reading of the screen.
+the message — whether a status was reported for the Session at an event id above
+the delivery's — so the operator is told which question is still open. It does
+**not** claim to have told a swallowed return apart from a harness that reports
+nothing mid-turn: half the families in `HOOK_FAMILIES` look identical in that
+silence, and separating them would mean consulting `reportsTurnStart` (D2 forbids
+it) or reading the byte stream (D4 forbids it). The message names both readings
+and sends the reader to the screen. That comparison is two event ids, not a
+reading of the screen.
+
+The remedy the message offers is cursored for the same reason. `session wait` is
+**not** it: that verb answers from the status a Session is parked at, so on a
+turn that never started it returns at once with the status from before the write
+and exits zero — a false completion, which is the failure #405 exists to remove.
+`events tail --since <delivery id>` follows the log from the write and can only
+report what came after it.
 
 A send that submits nothing at all (`--no-enter`) is refused with `--wait`
 rather than bounded: it has no turn to await, so there is nothing for a deadline

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -742,8 +742,11 @@ describe("actana session send", () => {
     expect(calls).toEqual([{ text: "carry on", enter: true }]);
     // And it carries a deadline the operator did not have to know to ask for
     // (#405): the return can land on a dialog rather than a composer, in which
-    // case no turn starts and nothing will ever end this wait.
-    expect(deadlines).toEqual([900_000]);
+    // case no turn starts and nothing will ever end this wait. Seventeen
+    // minutes, which is past the Core's own fifteen-minute quiet backstop and
+    // the minute its sweep can add — where the Core has an answer it gets to
+    // give it, and this only fires where it has none.
+    expect(deadlines).toEqual([1_020_000]);
   });
 
   it("refuses --no-enter with --wait rather than waiting for a turn it did not start", async () => {
@@ -792,6 +795,58 @@ describe("actana session send", () => {
     expect(deadlines).toEqual([30_000, undefined]);
   });
 
+  it("takes --wait-timeout 0 as no deadline on the other verbs that accept it", async () => {
+    await withRegisteredCore();
+    // The "one spelling, one meaning" claim rested on the shared parser alone
+    // (#486 review, coverage). Asserted here on the two other verbs a `0` can
+    // reach: they had no default to opt out of, so `0` must be accepted and
+    // must mean the same thing rather than being refused as it once was.
+    const deadlines: Array<number | undefined> = [];
+    const settle = () =>
+      fakeStartedSession({
+        wait: async (waitOpts) => {
+          deadlines.push(waitOpts.timeoutMs);
+          return { status: "finished", exited: false };
+        },
+      });
+
+    const started = await cli().run(["session", "start", "web", "go", "--wait", "--wait-timeout", "0"], {
+      sessions: fakeSessionGateway({ start: async () => settle() }),
+    });
+    expect(started.code, started.err.join("\n")).toBe(EXIT_OK);
+
+    const waited = await cli().run(["session", "wait", "task_1", "--wait-timeout", "0"], {
+      sessions: fakeSessionGateway({ wait: async () => settle() }),
+    });
+    expect(waited.code, waited.err.join("\n")).toBe(EXIT_OK);
+
+    expect(deadlines).toEqual([undefined, undefined]);
+
+    // And the discontinuity stops at zero: a negative is still a refusal, and a
+    // positive that rounds below a millisecond is still a deadline rather than
+    // an unbounded wait.
+    const negative = await cli().run(["session", "wait", "task_1", "--wait-timeout", "-1"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(negative.code).toBe(EXIT_USAGE);
+    expect(negative.err.join("\n")).toContain("wants a number of seconds");
+
+    const tiny: Array<number | undefined> = [];
+    const rounded = await cli().run(["session", "wait", "task_1", "--wait-timeout", "0.0001"], {
+      sessions: fakeSessionGateway({
+        wait: async () =>
+          fakeStartedSession({
+            wait: async (waitOpts) => {
+              tiny.push(waitOpts.timeoutMs);
+              return { status: "finished", exited: false };
+            },
+          }),
+      }),
+    });
+    expect(rounded.code, rounded.err.join("\n")).toBe(EXIT_OK);
+    expect(tiny).toEqual([1]);
+  });
+
   it("reports a send wait that heard nothing as this side giving up", async () => {
     await withRegisteredCore();
     // The dialog case, end to end: the SDK's deadline expires having heard no
@@ -818,11 +873,59 @@ describe("actana session send", () => {
     const payload = JSON.parse(run.out.join("\n"));
     expect(payload.waited).toBe(true);
     expect(payload.status).toBeUndefined();
+    // The message names both readings rather than diagnosing one: a return that
+    // submitted nothing, or a harness that reports nothing until a turn ends.
     expect(payload.error).toContain("lands on a dialog rather than a composer");
-    expect(run.err.join("\n")).toContain("the Core reported nothing about it");
+    expect(payload.error).toContain("still running on a harness that reports nothing");
+    expect(run.err.join("\n")).toContain("no turn end was reported");
     // The next step is the CLI's to name, and it is named only on this shape of
-    // timeout: read the screen, or keep waiting — never "send it again".
+    // timeout: read the screen, or follow the log **from the delivery**.
     expect(run.err.join("\n")).toContain("`actana session logs task_1` shows what is on screen");
+    expect(run.err.join("\n")).toContain("`actana events tail --since 42`");
+    // **And it warns off `session wait`.** That verb is uncursored: in this
+    // exact state it answers at once with the status from before the send and
+    // exits zero, which reads as a completed turn. Recommending it would put
+    // #405's false completion back one layer up.
+    expect(run.err.join("\n")).toContain("Not `session wait`");
+    expect(run.err.join("\n")).toContain("exits zero");
+  });
+
+  it("does not offer the uncursored wait as the next step after any timeout", async () => {
+    await withRegisteredCore();
+    // #486 review, the blocking finding. `start --wait` waits uncursored, so its
+    // timeout carries `afterEventId: 0` and the generic wording — the
+    // write-specific advice must not be appended under it, and the `session
+    // wait` warning has nothing to warn about there.
+    const started = await cli().run(["session", "start", "web", "go", "--wait", "--wait-timeout", "1"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              throw new CoreSessionTurnTimeoutError({
+                taskId: "task_1",
+                timeoutMs: 1000,
+                afterEventId: 0,
+                lastStatus: "running",
+                reportedSinceDelivery: false,
+              });
+            },
+          }),
+      }),
+    });
+    expect(started.code).toBe(EXIT_FAILURE);
+    expect(started.err.join("\n")).toContain("was still running after 1000ms");
+    expect(started.err.join("\n")).not.toContain("events tail --since");
+    expect(started.err.join("\n")).not.toContain("no turn end was reported");
+  });
+
+  it("keeps the help's next step off `session wait` too", async () => {
+    const help = await cli().run(["session", "--help"]);
+    const text = help.out.join("\n");
+    // The prose and the runtime message have to agree, because an operator
+    // reads whichever they reach first.
+    expect(text).toContain("`wait` is not how you resume that wait");
+    expect(text).toContain("returns at once with the status from *before* your text and exits zero");
+    expect(text).toContain("actana events tail --since <event id>");
   });
 
   it("says in its help what submits, what does not, and what each is not", async () => {

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -23,6 +23,7 @@ import {
   type SessionRow,
   type StartedSession,
 } from "../session-gateway.ts";
+import { CoreSessionTurnTimeoutError } from "@actana/sdk/core-session.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 
 let fixture: CliFixture | null = null;
@@ -717,51 +718,111 @@ describe("actana session send", () => {
     expect(run.err.join("\n")).toContain("contradict each other");
   });
 
-  it("submits a follow-up sent with --wait, and warns when --no-enter left no turn", async () => {
+  it("submits a follow-up sent with --wait, and bounds the wait it did not start", async () => {
     await withRegisteredCore();
     const calls: Array<{ text: string; enter: boolean | undefined }> = [];
+    const deadlines: Array<number | undefined> = [];
     const outcome = { status: "finished", exited: true, exitCode: 0 } as const;
     const run = await cli().run(["session", "send", "task_1", "carry on", "--wait"], {
       sessions: fakeSessionGateway({
         sendAndWait: async (_taskId, text, opts) => {
           calls.push({ text, enter: opts?.enter });
-          return fakeStartedSession({ wait: async () => outcome });
+          return fakeStartedSession({
+            wait: async (waitOpts) => {
+              deadlines.push(waitOpts.timeoutMs);
+              return outcome;
+            },
+          });
         },
       }),
     });
     expect(run.code, run.err.join("\n")).toBe(EXIT_OK);
-    // #405 is the hang; this is only that the wait path takes the same default
-    // the plain path does, so the turn it waits for is one that actually starts.
+    // The wait path takes the same default the plain path does, so the turn it
+    // waits for is one that actually starts.
     expect(calls).toEqual([{ text: "carry on", enter: true }]);
+    // And it carries a deadline the operator did not have to know to ask for
+    // (#405): the return can land on a dialog rather than a composer, in which
+    // case no turn starts and nothing will ever end this wait.
+    expect(deadlines).toEqual([900_000]);
+  });
 
-    calls.length = 0;
-    const typed = await cli().run(["session", "send", "task_1", "carry on", "--wait", "--no-enter"], {
+  it("refuses --no-enter with --wait rather than waiting for a turn it did not start", async () => {
+    await withRegisteredCore();
+    // #405, the first acceptance criterion. Nothing is dialled — the fixture's
+    // gateway throws if it is — so the refusal lands before a byte is written,
+    // which is what makes it a usage error rather than a failed send.
+    const run = await cli().run(["session", "send", "task_1", "carry on", "--no-enter", "--wait"], {
+      sessions: fakeSessionGateway(),
+    });
+    expect(run.code).toBe(EXIT_USAGE);
+    expect(run.err.join("\n")).toContain("--no-enter starts no turn");
+    // It names both ways out, because an operator who typed this wanted one of
+    // them: submit and wait, or type now and wait separately.
+    expect(run.err.join("\n")).toContain("actana session wait");
+  });
+
+  it("lets --wait-timeout replace the send deadline, and 0 remove it", async () => {
+    await withRegisteredCore();
+    const deadlines: Array<number | undefined> = [];
+    const gateway = () =>
+      fakeSessionGateway({
+        sendAndWait: async () =>
+          fakeStartedSession({
+            wait: async (waitOpts) => {
+              deadlines.push(waitOpts.timeoutMs);
+              return { status: "finished", exited: false };
+            },
+          }),
+      });
+
+    const bounded = await cli().run(
+      ["session", "send", "task_1", "carry on", "--wait", "--wait-timeout", "30"],
+      { sessions: gateway() },
+    );
+    expect(bounded.code, bounded.err.join("\n")).toBe(EXIT_OK);
+
+    // `0` is the opt-out, spelled out: the old unbounded wait, for a caller that
+    // knows its turn is long and would rather hang than be given up on.
+    const unbounded = await cli().run(
+      ["session", "send", "task_1", "carry on", "--wait", "--wait-timeout", "0"],
+      { sessions: gateway() },
+    );
+    expect(unbounded.code, unbounded.err.join("\n")).toBe(EXIT_OK);
+
+    expect(deadlines).toEqual([30_000, undefined]);
+  });
+
+  it("reports a send wait that heard nothing as this side giving up", async () => {
+    await withRegisteredCore();
+    // The dialog case, end to end: the SDK's deadline expires having heard no
+    // status since the delivery, and what reaches the operator is that message
+    // — with the exit code that says the wait did not succeed, and no status
+    // the Core never sent.
+    const run = await cli().run(["session", "send", "task_1", "carry on", "--wait", "--json"], {
       sessions: fakeSessionGateway({
-        sendAndWait: async (_taskId, text, opts) => {
-          calls.push({ text, enter: opts?.enter });
-          return fakeStartedSession({ wait: async () => outcome });
-        },
+        sendAndWait: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              throw new CoreSessionTurnTimeoutError({
+                taskId: "task_1",
+                timeoutMs: 900_000,
+                afterEventId: 42,
+                lastStatus: "needs-input",
+                reportedSinceDelivery: false,
+              });
+            },
+          }),
       }),
     });
-    expect(calls).toEqual([{ text: "carry on", enter: false }]);
-    expect(typed.err.join("\n")).toContain("started no turn");
-
-    // And stderr is the **only** signal on this path. The wait's document is
-    // `start --wait --json`'s key set, which #289 requires one parser to read
-    // across all three verbs, so it gains no `submitted` field — the help text
-    // names that exception rather than the document growing a key.
-    const asJson = await cli().run(
-      ["session", "send", "task_1", "carry on", "--wait", "--no-enter", "--json"],
-      {
-        sessions: fakeSessionGateway({
-          sendAndWait: async () => fakeStartedSession({ wait: async () => outcome }),
-        }),
-      },
-    );
-    const document = JSON.parse(asJson.out.join("\n"));
-    expect(document.submitted).toBeUndefined();
-    expect(document.enter).toBeUndefined();
-    expect(asJson.err.join("\n")).toContain("started no turn");
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.waited).toBe(true);
+    expect(payload.status).toBeUndefined();
+    expect(payload.error).toContain("lands on a dialog rather than a composer");
+    expect(run.err.join("\n")).toContain("the Core reported nothing about it");
+    // The next step is the CLI's to name, and it is named only on this shape of
+    // timeout: read the screen, or keep waiting — never "send it again".
+    expect(run.err.join("\n")).toContain("`actana session logs task_1` shows what is on screen");
   });
 
   it("says in its help what submits, what does not, and what each is not", async () => {
@@ -779,10 +840,16 @@ describe("actana session send", () => {
     //    Core's, not this path's.
     expect(text).toContain("Separate is necessary and not sufficient");
     expect(text).toContain("150 ms later, absorbed anyway");
-    // 3. `--wait` after `--no-enter` is not "nothing to await": it hangs on an
-    //    idle Session and answers the *running* turn on a busy one.
-    expect(text).toContain("A `--wait` after it is not waiting");
-    expect(text).toContain("resolves on *that* turn's end and reports it as this send's");
+    // 3. `--wait` after `--no-enter` was the hang and the lie #405 is about,
+    //    and the help now says the pair is refused rather than describing what
+    //    it does to you.
+    expect(text).toContain("It cannot be combined with");
+    expect(text).toContain("refused before anything is written (#405)");
+    // ...and the deadline that verb carries, which is the other half of #405:
+    // a return that lands on a dialog starts no turn, so an unbounded default
+    // there is a wait nothing can end.
+    expect(text).toContain("`send --wait` is the exception");
+    expect(text).toContain("`--wait-timeout 0` waits with no\n  deadline");
     // 4. `submitted` is on the plain document only, never the wait's (#289).
     expect(text).toContain("**not** on the `--wait` document");
   });

--- a/packages/cli/src/orchestration-skill-payload.ts
+++ b/packages/cli/src/orchestration-skill-payload.ts
@@ -173,10 +173,15 @@ A Session is a conversation, not a single question. The whole loop:
 
 \`\`\`bash
 ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
-actana session wait "$ID" --json --wait-timeout 900     # block until it settles
-actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 900
-actana session send "$ID" "<next>" --wait --json
+actana session wait "$ID" --json --wait-timeout 1800    # block until it settles
+actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 1800
+actana session send "$ID" "<next>" --wait --json --wait-timeout 1800
 \`\`\`
+
+Every line carries the same budget on purpose: 1800 seconds is what \`await.sh\`
+gives a round, and a loop whose steps disagree about how long a turn may take
+gives up in the middle of one. Pass it explicitly rather than leaning on a
+default — \`send --wait\` has one (1020 seconds) and the other two do not.
 
 **\`actana session wait <id>\` blocks until the Core reports the Session settled**
 — \`finished\`, \`needs-input\`, \`interrupted\`, \`terminated\` or \`disconnected\`,
@@ -192,7 +197,7 @@ object** \`start --wait --json\` prints — same keys, same \`screen\` — so on
 reads all three verbs. Two of those keys are \`null\` on a Session you attached to
 rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
 
-Three things to know before you build on it:
+Four things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -211,15 +216,22 @@ Three things to know before you build on it:
 3. **A timeout is this side giving up, not a status.** \`--wait-timeout
    <seconds>\` bounds the wait. \`session wait\` has no deadline unless you set
    one, because a turn takes as long as the work takes; **\`send --wait\` defaults
-   to 900 seconds**, because it is the one wait for a turn that has not started
+   to 1020 seconds**, because it is the one wait for a turn that has not started
    yet and a carriage return that lands on a dialog rather than a composer
    starts none at all. \`--wait-timeout 0\` waits with no deadline. On expiry you
    get a message saying the wait gave up and a non-zero exit — the Session is
-   still running on the Core, and \`session logs\`, another \`session wait\` and
-   \`session kill\` all still work. When the wait gave up having heard nothing at
-   all about the Session since your text went in, the message says so: no turn
-   ended and none was seen to start, and the text was delivered — read the
-   screen with \`session logs\` rather than sending it again.
+   still running on the Core, and \`session logs\` and \`session kill\` still work.
+   When no turn end was reported since your text went in, the message says so
+   and names both readings: the text may have started no turn, or a turn may
+   still be running on a Harness that reports nothing until it ends. The text
+   was delivered either way — read the screen with \`session logs\` rather than
+   sending it again.
+4. **Do not answer that timeout with \`session wait\`.** It is uncursored: it
+   answers from the status the Session is parked at, so on a turn that never
+   started it returns **at once, with the status from before your text, and
+   exits zero** — which reads as a completed turn and is not one. To carry on
+   waiting, follow the log from the delivery instead:
+   \`actana events tail --since <event id>\`, the id the timeout message names.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/packages/cli/src/orchestration-skill-payload.ts
+++ b/packages/cli/src/orchestration-skill-payload.ts
@@ -145,10 +145,10 @@ a file**, and the contract below is how you get one.
 
 The object also carries \`taskId\` (the Session's id — this is what every other
 verb takes), \`harness\`, \`project\`, \`status\`, \`exited\`, and \`reportsTurnStart\`.
-\`--wait-timeout <seconds>\` bounds the wait; without it the wait has no deadline
-of its own. A timeout is this side giving up, not a verdict about the Session:
-the Session is still running on the Core and can still be listed, read and
-stopped.
+\`--wait-timeout <seconds>\` bounds the wait; without it \`start --wait\` has no
+deadline of its own (\`send --wait\` does — see the loop below). A timeout is this
+side giving up, not a verdict about the Session: the Session is still running on
+the Core and can still be listed, read and stopped.
 
 While a Session is alive — which is what the \`live\` field on its
 \`actana session ls --json\` row tells you, and the only thing that does — you can
@@ -201,17 +201,25 @@ Three things to know before you build on it:
    the Session to settle *first*, then send.
 2. **A \`send\` presses Enter for you, and \`--no-enter\` is how you stop it.** The
    text goes first and the carriage return follows as its own separate write.
-   \`--no-enter\` sends no return, so that send starts no turn — and a \`--wait\`
-   after it is not waiting for your text: on an idle Session nothing ends, and
-   on a busy one it resolves on the turn that was *already* running. Both are
-   #405's. \`--enter\` is still accepted and does nothing on a send that carries
-   text, so an older script that passes it keeps working; on a send with no text
-   it still means a bare carriage return and nothing else.
+   \`--no-enter\` sends no return, so that send starts no turn — and it **cannot
+   be combined with \`--wait\`**, which is refused as a usage error: a send that
+   submits nothing has no turn to await. Type with \`--no-enter\`, then
+   \`actana session wait\` once a turn is actually running. \`--enter\` is still
+   accepted and does nothing on a send that carries text, so an older script
+   that passes it keeps working; on a send with no text it still means a bare
+   carriage return and nothing else.
 3. **A timeout is this side giving up, not a status.** \`--wait-timeout
-   <seconds>\` bounds the wait; without it there is no deadline, because a turn
-   takes as long as the work takes. On expiry you get a message saying the wait
-   gave up and a non-zero exit — the Session is still running on the Core, and
-   \`session logs\`, another \`session wait\` and \`session kill\` all still work.
+   <seconds>\` bounds the wait. \`session wait\` has no deadline unless you set
+   one, because a turn takes as long as the work takes; **\`send --wait\` defaults
+   to 900 seconds**, because it is the one wait for a turn that has not started
+   yet and a carriage return that lands on a dialog rather than a composer
+   starts none at all. \`--wait-timeout 0\` waits with no deadline. On expiry you
+   get a message saying the wait gave up and a non-zero exit — the Session is
+   still running on the Core, and \`session logs\`, another \`session wait\` and
+   \`session kill\` all still work. When the wait gave up having heard nothing at
+   all about the Session since your text went in, the message says so: no turn
+   ended and none was seen to start, and the text was delivered — read the
+   screen with \`session logs\` rather than sending it again.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -90,18 +90,27 @@ const UNHAPPY_STATUSES: ReadonlySet<string> = new Set(["terminated", "disconnect
  * cursor, and the wait is correct, silent and permanent. A deadline is what
  * turns that into an answer.
  *
- * 900 seconds because that is the bound the orchestration payload already tells
- * callers to pass (`orchestration-skill-payload.ts`), so the default agrees with
- * the documented habit rather than competing with it. It is generous on purpose:
- * a turn takes as long as the work takes, and this side cannot tell a slow
- * harness from a swallowed return — a harness that reports no turn start (half
- * the families in `HOOK_FAMILIES`) looks identical either way, and guessing from
- * the byte stream is what #191 deleted.
+ * **Seventeen minutes, and the number is chosen against the Core rather than
+ * from taste.** The Core's own backstop settles a `running` Session it has heard
+ * nothing from after fifteen minutes of silence (`QUIET_SETTLE_MS` in
+ * `core-session-backstop.ts`), and its sweep runs once a minute, so that settle
+ * can land as late as sixteen. A deadline at fifteen would tie with it and
+ * scheduling would decide which of the two answered; at seventeen the Core's
+ * mechanism wins, and a caller waiting on a wedged harness gets a **status**
+ * rather than this side giving up. It is also comfortably above the 900 seconds
+ * the orchestration skill tells callers to pass, so the default never cuts short
+ * a wait the skill's own budget expects to finish.
+ *
+ * None of that helps #405's own case — the backstop skips a Session that is not
+ * `running`, and a dialog leaves one parked at `needs-input` or `finished` — so
+ * there the deadline is still the only thing that ends the wait. That is what it
+ * is for; the tie-break above is about not stealing the answer in the case where
+ * the Core does have one.
  *
  * `--wait-timeout <s>` replaces it and `--wait-timeout 0` removes it, for a
  * caller that wants the old unbounded wait back.
  */
-const SEND_WAIT_DEFAULT_TIMEOUT_S = 900;
+const SEND_WAIT_DEFAULT_TIMEOUT_S = 1020;
 
 export const SESSION_HELP = `actana session — the Sessions running on a Core
 
@@ -180,10 +189,17 @@ Awaiting a turn
   ${SEND_WAIT_DEFAULT_TIMEOUT_S} seconds.** It is the one wait for a turn that has
   not started yet, and a carriage return that lands on a dialog rather than a
   composer starts none at all — so the Core has nothing to report and the wait
-  would never end (#405). When it runs out having heard nothing about the Session
-  since the text went in, it says exactly that, and it says the text was
+  would never end (#405). When it runs out with no turn end reported since the
+  text went in, it says so, names both readings — a return that submitted nothing,
+  or a harness that reports nothing until a turn ends — and says the text was
   delivered so you do not send it twice. \`--wait-timeout 0\` waits with no
   deadline.
+
+  **\`wait\` is not how you resume that wait.** It is uncursored: it answers from
+  the status the Session is parked at, so on a Session whose turn never started it
+  returns at once with the status from *before* your text and exits zero. To carry
+  on waiting for the turn a send started, follow the log from the delivery instead
+  — \`actana events tail --since <event id>\`, the id the timeout message names.
 
 Sending text, and what submits it
   \`send <session> <text>\` **presses Enter** — that is, the text goes out and a
@@ -443,14 +459,42 @@ async function awaitTurn(
     deps.err(`actana session: ${message}`);
     // What to type next, added here rather than in the SDK: the library states
     // the fact, and the command that has an `actana` on the path says what to do
-    // with it (#405). Only on the wait that heard **nothing** since the write —
-    // the shape of a return that started no turn — because the other kind ran
-    // out on a harness that is working, where "keep waiting" is the obvious move
-    // and "read the screen" is the advice for a different problem.
-    if (err instanceof CoreSessionTurnTimeoutError && !err.reportedSinceDelivery) {
+    // with it (#405).
+    //
+    // **Gated on the same two facts the message itself is** — a delivery cursor,
+    // and nothing heard since it. `start --wait`, `resume --wait` and `session
+    // wait` all wait uncursored, so their expiry gets the generic "was still
+    // <status>" wording, and advice about a write that never happened would sit
+    // under it contradicting it.
+    //
+    // **And it must not offer `session wait`** (#486 review). That verb is
+    // uncursored by design: it answers from the status the Session is already
+    // parked at (`sessionWait` below; `settledSince(0)` in the SDK). In *this*
+    // state — nothing reported since the write, the Session still on the
+    // `needs-input` or `finished` it carried before it — `session wait` returns
+    // immediately, prints that status and exits **zero**. An operator would read
+    // that as the turn completing, and an orchestrating agent reading the exit
+    // code would record it as a finished turn. That is the false completion
+    // #405 exists to remove, and recommending it here would have reintroduced
+    // the bug one layer up.
+    //
+    // What is offered instead is cursored and cannot lie: `events tail --since`
+    // the delivery's own event id follows the log from the write, so it prints
+    // what the Core reports next and nothing that came before. The error carries
+    // that id, which is why the line can name it.
+    if (
+      err instanceof CoreSessionTurnTimeoutError &&
+      err.afterEventId > 0 &&
+      !err.reportedSinceDelivery
+    ) {
       deps.err(
-        `\`actana session logs ${session.taskId}\` shows what is on screen, and ` +
-          `\`actana session wait ${session.taskId}\` keeps waiting for the turn.`,
+        `actana session send: no turn end was reported after the text went in. ` +
+          `\`actana session logs ${session.taskId}\` shows what is on screen — a dialog waiting ` +
+          `for an answer looks like one there, and so does a harness still working. To keep ` +
+          `waiting, follow the log from the delivery: ` +
+          `\`actana events tail --since ${err.afterEventId}\`. Not \`session wait\`: that verb ` +
+          `answers at once with the status this Session was already parked at and exits zero, ` +
+          `which is last turn's answer, not this one's.`,
       );
     }
     return EXIT_FAILURE;
@@ -997,8 +1041,20 @@ function misusedFlag(args: ParsedArgs, accepted: readonly string[]): string | nu
  * **`0` is no deadline, spelled out** (#405). It is the opt-out from the default
  * `send --wait` carries, and it is accepted on every verb that takes the flag so
  * that one spelling means one thing: a caller that writes `--wait-timeout 0` is
- * asking to wait as long as the work takes. Anything else non-numeric or
- * negative is still a refusal rather than a silently ignored instruction.
+ * asking to wait as long as the work takes. Anything non-numeric or negative is
+ * still a refusal rather than a silently ignored instruction.
+ *
+ * **This is a behaviour change on every verb, and worth knowing before you
+ * compute one** (#486 review). `0` used to be `EXIT_USAGE`, so a script writing
+ * `--wait-timeout $(( deadline - $(date +%s) ))` was told its budget had run out
+ * and now waits instead. `-1` is still a refusal, so the discontinuity is at
+ * exactly one value; a script that computes a budget should clamp it to a
+ * positive number itself, because "no time left" and "no deadline" are opposite
+ * instructions and only the caller knows which it meant.
+ *
+ * Only an exact `0` opts out. A positive number that rounds below a millisecond
+ * is a deadline the caller asked for, and it clamps to 1 ms rather than becoming
+ * an unbounded wait — the one direction a rounding error must never take.
  */
 function waitTimeoutMs(
   args: ParsedArgs,
@@ -1012,10 +1068,11 @@ function waitTimeoutMs(
   if (!Number.isFinite(seconds) || seconds < 0) {
     return { ms: null, error: `--wait-timeout wants a number of seconds, not "${args.waitTimeout}"` };
   }
-  // Zero, and anything that rounds to no milliseconds at all, is the opt-out
-  // rather than a deadline that expires before the write lands.
-  const ms = Math.round(seconds * 1000);
-  return { ms: ms > 0 ? ms : null };
+  // Exactly zero is the opt-out. Anything above it is a deadline that was asked
+  // for, floored at a millisecond so a small number cannot round its way into an
+  // unbounded wait — that is the one direction this must never round.
+  if (seconds === 0) return { ms: null };
+  return { ms: Math.max(1, Math.round(seconds * 1000)) };
 }
 
 /**

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -50,6 +50,7 @@ import { resolveCore } from "./core-resolution.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { isKnownHarness, KNOWN_HARNESSES } from "./session-gateway.ts";
 import { runSessionAttach } from "./session-attach.ts";
+import { CoreSessionTurnTimeoutError } from "@actana/sdk/core-session.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { RegistryPaths } from "./blob-registry.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -75,6 +76,33 @@ const SESSION_TIMEOUT_MS = 30_000;
  */
 const UNHAPPY_STATUSES: ReadonlySet<string> = new Set(["terminated", "disconnected"]);
 
+/**
+ * The deadline `actana session send --wait` carries when the operator named none
+ * (#405).
+ *
+ * **Only this verb.** `session wait` and `start --wait` have no default and are
+ * not given one: both wait for a turn that is already under way, so the only
+ * thing a default could cut short there is honest work (ADR 0033 D4, D5). A `send`
+ * is different in the one way that matters — it is waiting for a turn *it* has
+ * to start, and a carriage return that lands on a dialog rather than a composer
+ * starts none. The Core then has nothing to report, the seeded status the
+ * Session is parked at carries event id 0 and can never satisfy the delivery
+ * cursor, and the wait is correct, silent and permanent. A deadline is what
+ * turns that into an answer.
+ *
+ * 900 seconds because that is the bound the orchestration payload already tells
+ * callers to pass (`orchestration-skill-payload.ts`), so the default agrees with
+ * the documented habit rather than competing with it. It is generous on purpose:
+ * a turn takes as long as the work takes, and this side cannot tell a slow
+ * harness from a swallowed return — a harness that reports no turn start (half
+ * the families in `HOOK_FAMILIES`) looks identical either way, and guessing from
+ * the byte stream is what #191 deleted.
+ *
+ * `--wait-timeout <s>` replaces it and `--wait-timeout 0` removes it, for a
+ * caller that wants the old unbounded wait back.
+ */
+const SEND_WAIT_DEFAULT_TIMEOUT_S = 900;
+
 export const SESSION_HELP = `actana session — the Sessions running on a Core
 
 Usage
@@ -92,7 +120,8 @@ Flags
   --json              machine-readable output. Only JSON reaches stdout.
   --wait              start/resume: block until the Core reports it settled
                       send: block until the turn that text starts has ended
-  --wait-timeout <s>  give up waiting after this many seconds, and say so
+  --wait-timeout <s>  give up waiting after this many seconds, and say so.
+                      0 means no deadline. send --wait defaults to ${SEND_WAIT_DEFAULT_TIMEOUT_S}
   --harness <name>    start: ${KNOWN_HARNESSES.join(", ")}
   --cwd <path>        start: a directory on the Core, inside the Project
   --title <text>      start: what the Session is called in \`ls\`
@@ -144,8 +173,17 @@ Awaiting a turn
   can tell those apart, and nothing here guesses.
 
   A harness that reports nothing at all runs out the \`--wait-timeout\` and the
-  message says this side gave up — never a status the Core did not send. Without
-  \`--wait-timeout\` there is no deadline: a turn takes as long as the work takes.
+  message says this side gave up — never a status the Core did not send. \`wait\`
+  has no deadline unless you set one: a turn takes as long as the work takes.
+
+  **\`send --wait\` is the exception, and it defaults to
+  ${SEND_WAIT_DEFAULT_TIMEOUT_S} seconds.** It is the one wait for a turn that has
+  not started yet, and a carriage return that lands on a dialog rather than a
+  composer starts none at all — so the Core has nothing to report and the wait
+  would never end (#405). When it runs out having heard nothing about the Session
+  since the text went in, it says exactly that, and it says the text was
+  delivered so you do not send it twice. \`--wait-timeout 0\` waits with no
+  deadline.
 
 Sending text, and what submits it
   \`send <session> <text>\` **presses Enter** — that is, the text goes out and a
@@ -165,11 +203,11 @@ Sending text, and what submits it
   \`--no-enter\` is the opt-out, for typing without submitting: filling a
   composer, or answering a numbered dialog before the return that confirms it.
   It says so on the way out, every time, because a send that started no turn is
-  the failure this default exists to end. **A \`--wait\` after it is not waiting
-  for your text.** On an idle Session no turn ends, so the wait runs out the
-  \`--wait-timeout\` — or, with none given, does not return. On a Session already
-  mid-turn it resolves on *that* turn's end and reports it as this send's, for a
-  turn this send did not start. Both are #405's and neither is fixed here.
+  the failure this default exists to end. **It cannot be combined with
+  \`--wait\`**, which is refused before anything is written (#405): a send that
+  submits nothing has no turn to await, so the wait would either never end or
+  end on a turn some earlier send started and report it as this one's. Type with
+  \`--no-enter\`, then \`actana session wait\` when a turn is actually running.
 
   \`--json\` on a plain send says all of this in fields: \`enter\` is the return
   that was **asked** for, \`submitted\` is the return that was **accepted**, and
@@ -403,6 +441,18 @@ async function awaitTurn(
     const message = messageOf(err);
     if (args.json) deps.out(formatJson({ ...startedFields(session), waited: true, error: message }));
     deps.err(`actana session: ${message}`);
+    // What to type next, added here rather than in the SDK: the library states
+    // the fact, and the command that has an `actana` on the path says what to do
+    // with it (#405). Only on the wait that heard **nothing** since the write —
+    // the shape of a return that started no turn — because the other kind ran
+    // out on a harness that is working, where "keep waiting" is the obvious move
+    // and "read the screen" is the advice for a different problem.
+    if (err instanceof CoreSessionTurnTimeoutError && !err.reportedSinceDelivery) {
+      deps.err(
+        `\`actana session logs ${session.taskId}\` shows what is on screen, and ` +
+          `\`actana session wait ${session.taskId}\` keeps waiting for the turn.`,
+      );
+    }
     return EXIT_FAILURE;
   }
 
@@ -663,6 +713,22 @@ async function sessionSend(
     return usage(deps, "send", "--enter and --no-enter contradict each other — pass one");
   }
 
+  // **A send that submits nothing has nothing to wait for** (#405). `--no-enter`
+  // sends no carriage return, so no turn starts, and the wait paired with it is
+  // not waiting for this send: on an idle Session nothing ever ends it, and on a
+  // Session that was already mid-turn it ends on *that* turn and reports it as
+  // this send's. One hangs and one lies, and neither is a reading this command
+  // can pick between — so the pair is refused here, before a byte is written,
+  // rather than carried out and warned about afterwards.
+  if (args.noEnter && args.wait) {
+    return usage(
+      deps,
+      "send",
+      "--no-enter starts no turn, so --wait would have nothing to wait for — drop --no-enter to " +
+        "submit and wait, or drop --wait and run `actana session wait` when the turn is under way",
+    );
+  }
+
   const [taskId, ...words] = rest;
   if (taskId === undefined) {
     return usage(deps, "send", "a session id is required — `actana session send <session> <text>`");
@@ -705,17 +771,26 @@ async function sessionSend(
       // write with. The alternative — send, then attach, then wait — is the
       // design the issue's landmine is about: the attach would find a Session
       // sitting at a settled status and answer with last turn's outcome.
+      // Always with the return: `--no-enter --wait` was refused above, so a
+      // wait on this path is always a wait for a turn this send actually asked
+      // for. `submit` is read anyway rather than assumed, so the two halves of
+      // that decision cannot drift apart.
       const andReturn = submit ? " and a carriage return" : "";
-      deps.verbose(`sending ${text.length} characters to session ${taskId}${andReturn}, then waiting`);
+      // The deadline this verb carries when the operator named none (#405). The
+      // wait itself is the SDK's and counts nothing here; this only decides how
+      // long the CLI is willing to sit on it.
+      const deadlineMs =
+        args.waitTimeout === null ? SEND_WAIT_DEFAULT_TIMEOUT_S * 1000 : timeout.ms;
+      deps.verbose(
+        `sending ${text.length} characters to session ${taskId}${andReturn}, then waiting` +
+          (deadlineMs === null ? " with no deadline" : ` up to ${Math.round(deadlineMs / 1000)}s`),
+      );
       const session = await gateway.sendAndWait(taskId, text, { enter: submit });
       deps.err(`Sent ${text.length} characters to session ${taskId}${andReturn}.`);
       // Stderr is the *only* signal on this path, and deliberately: the wait's
       // document is `start --wait --json`'s key set and nothing else, because
-      // #289 requires one parser to read all three verbs. A `submitted` field
-      // here would buy this warning a machine-readable form at the price of
-      // that, so the help text names the exception instead.
-      if (!submit) deps.err(NOT_SUBMITTED_WARNING(taskId));
-      return awaitAttachedTurn(deps, args, session, timeout.ms);
+      // #289 requires one parser to read all three verbs (#289 B).
+      return awaitAttachedTurn(deps, args, session, deadlineMs);
     }
 
     // One call, one PTY resolution, both writes (#204 review). The command has
@@ -913,11 +988,17 @@ function misusedFlag(args: ParsedArgs, accepted: readonly string[]): string | nu
 }
 
 /**
- * `--wait-timeout <seconds>`, in milliseconds.
+ * `--wait-timeout <seconds>`, in milliseconds. `null` is "no deadline".
  *
  * Only with `--wait`, because on its own it is an instruction that cannot be
  * carried out — and a deadline somebody believes they set is worse than no
  * deadline at all. The wait it bounds is the SDK's; nothing here counts time.
+ *
+ * **`0` is no deadline, spelled out** (#405). It is the opt-out from the default
+ * `send --wait` carries, and it is accepted on every verb that takes the flag so
+ * that one spelling means one thing: a caller that writes `--wait-timeout 0` is
+ * asking to wait as long as the work takes. Anything else non-numeric or
+ * negative is still a refusal rather than a silently ignored instruction.
  */
 function waitTimeoutMs(
   args: ParsedArgs,
@@ -927,11 +1008,14 @@ function waitTimeoutMs(
   // `waiting` is for the one verb that *is* a wait: `session wait` takes no
   // `--wait` (the verb says it), so its deadline cannot be gated on the flag.
   if (!waiting) return { ms: null, error: "--wait-timeout only means something with --wait" };
-  const seconds = Number(args.waitTimeout);
-  if (!Number.isFinite(seconds) || seconds <= 0) {
+  const seconds = args.waitTimeout.trim() === "" ? Number.NaN : Number(args.waitTimeout);
+  if (!Number.isFinite(seconds) || seconds < 0) {
     return { ms: null, error: `--wait-timeout wants a number of seconds, not "${args.waitTimeout}"` };
   }
-  return { ms: Math.round(seconds * 1000) };
+  // Zero, and anything that rounds to no milliseconds at all, is the opt-out
+  // rather than a deadline that expires before the write lands.
+  const ms = Math.round(seconds * 1000);
+  return { ms: ms > 0 ? ms : null };
 }
 
 /**

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -37,6 +37,7 @@ import {
   CoreSession,
   CoreSessionAttachError,
   CoreSessionStartError,
+  CoreSessionTurnTimeoutError,
   HARNESS_LAUNCH_COMMANDS,
   STATUS_READ_RETRIES,
   STATUS_READ_RETRY_MS,
@@ -961,19 +962,82 @@ describe("attaching to a Session that is already running (#289)", () => {
     await expect(idle).resolves.toMatchObject({ exited: true, exitCode: 3 });
   });
 
+  it("unblocks on the turn a delivered carriage return started", async () => {
+    // #405's second acceptance criterion, at the layer that implements it:
+    // `send --enter --wait` is a text write, a return write, and a wait counting
+    // from the **later** stamp — the turn starts at the return, not at the text.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const text = await session.deliver("run the tests");
+    const submit = await session.deliver("\r");
+    expect(submit.deliveryEventId).toBeGreaterThan(text.deliveryEventId);
+
+    const idle = session.waitForTurnEnd({ afterEventId: submit.deliveryEventId });
+    r.tasks.setStatus(taskId, "finished");
+
+    await expect(idle).resolves.toEqual({ status: "finished", exited: false });
+  });
+
   it("gives up on the caller's deadline and says what it was still doing", async () => {
     // The honest degradation (#289 D): a harness that reports nothing runs the
     // deadline out, and what is reported is that this side gave up — never a
     // status the Core did not send, and never a turn inferred from the bytes.
+    //
+    // This is the *working* half: the Core reported something after the
+    // delivery, so the wait was waiting on a harness that is doing something,
+    // and the wording that has said so since #289 is kept.
     rig = startRig();
     const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+    r.tasks.setStatus(taskId, "running");
+    await vi.waitFor(() => expect(session!.status()).toBe("running"));
+
+    const err = await session
+      .waitForTurnEnd({ afterEventId: deliveryEventId, timeoutMs: 30 })
+      .catch((thrown: unknown) => thrown);
+    expect(err).toBeInstanceOf(CoreSessionTurnTimeoutError);
+    expect((err as CoreSessionTurnTimeoutError).reportedSinceDelivery).toBe(true);
+    expect((err as Error).message).toMatch(/still running/);
+  });
+
+  it("names a deadline that heard nothing at all as a turn that never started", async () => {
+    // **The seeded-status landmine, made loud** (#405). A status seeded from the
+    // Task row carries event id 0, so it can never satisfy a delivery cursor —
+    // which is correct, and which is why a Session parked at a dialog that ate
+    // the carriage return has nothing that will ever end this wait. The
+    // comparison that cannot be satisfied is reported rather than sat on: the
+    // error says the Core reported nothing since the write, names the dialog,
+    // and says the text was delivered so it is not sent twice.
+    rig = startRig();
+    const taskId = await runningSession("needs-input");
 
     session = await CoreSession.attach(rig.client, { taskId });
-    const { deliveryEventId } = await session.deliver("carry on");
+    // Seeded, not learned: this is the state the cursor can never be answered by.
+    expect(session.status()).toBe("needs-input");
+    const { deliveryEventId } = await session.deliver("2\r");
+    expect(deliveryEventId).toBeGreaterThan(0);
 
-    await expect(
-      session.waitForTurnEnd({ afterEventId: deliveryEventId, timeoutMs: 30 }),
-    ).rejects.toThrow(/still finished/);
+    const err = await session
+      .waitForTurnEnd({ afterEventId: deliveryEventId, timeoutMs: 30 })
+      .catch((thrown: unknown) => thrown);
+
+    expect(err).toBeInstanceOf(CoreSessionTurnTimeoutError);
+    const timeout = err as CoreSessionTurnTimeoutError;
+    expect(timeout.reportedSinceDelivery).toBe(false);
+    expect(timeout.afterEventId).toBe(deliveryEventId);
+    expect(timeout.lastStatus).toBe("needs-input");
+    // Never "still needs-input": that reads as a harness the Core is reporting
+    // on, and the whole point is that it has reported nothing.
+    expect(timeout.message).not.toMatch(/still needs-input/);
+    expect(timeout.message).toMatch(/reported nothing about it/);
+    expect(timeout.message).toMatch(/dialog rather than a composer/);
+    expect(timeout.message).toContain("The text was delivered");
   });
 });
 

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -1006,14 +1006,18 @@ describe("attaching to a Session that is already running (#289)", () => {
     expect((err as Error).message).toMatch(/still running/);
   });
 
-  it("names a deadline that heard nothing at all as a turn that never started", async () => {
+  it("names a deadline with no reported turn end as the open question it is", async () => {
     // **The seeded-status landmine, made loud** (#405). A status seeded from the
     // Task row carries event id 0, so it can never satisfy a delivery cursor —
     // which is correct, and which is why a Session parked at a dialog that ate
     // the carriage return has nothing that will ever end this wait. The
-    // comparison that cannot be satisfied is reported rather than sat on: the
-    // error says the Core reported nothing since the write, names the dialog,
-    // and says the text was delivered so it is not sent twice.
+    // comparison that cannot be satisfied is reported rather than sat on.
+    //
+    // What the message may **not** do is diagnose (#486 review): `codex` and
+    // `cursor-cli` report nothing between a turn's start and its end, so this
+    // same silence is what a working harness looks like on half the families in
+    // the table. It names both readings, sends the reader to the screen, and
+    // says the text was delivered so it is not sent twice.
     rig = startRig();
     const taskId = await runningSession("needs-input");
 
@@ -1035,8 +1039,11 @@ describe("attaching to a Session that is already running (#289)", () => {
     // Never "still needs-input": that reads as a harness the Core is reporting
     // on, and the whole point is that it has reported nothing.
     expect(timeout.message).not.toMatch(/still needs-input/);
-    expect(timeout.message).toMatch(/reported nothing about it/);
+    expect(timeout.message).toMatch(/no turn end was reported/);
+    // Both readings, neither chosen.
     expect(timeout.message).toMatch(/dialog rather than a composer/);
+    expect(timeout.message).toMatch(/reports nothing until it ends/);
+    expect(timeout.message).toMatch(/cannot tell those apart/);
     expect(timeout.message).toContain("The text was delivered");
   });
 });

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -343,7 +343,8 @@ export class CoreSessionTurnTimeoutError extends Error {
   /** The last status the Core reported, or null when it has reported none. */
   readonly lastStatus: string | null;
   /**
-   * Did the Core report **anything** about this Session after `afterEventId`?
+   * Did the Core report a status for this Session **at an event id above**
+   * `afterEventId`?
    *
    * False is the loud half of the seeded-status invariant: a status seeded from
    * the Task row carries event id 0 and can never satisfy a real cursor, so a
@@ -351,6 +352,17 @@ export class CoreSessionTurnTimeoutError extends Error {
    * sit on that comparison forever. It is a fact off the event log — the id the
    * last status was learned at, against the id the delivery was stamped with —
    * and not an inference from the screen.
+   *
+   * **Read the name literally: it is about event ids, not about the Core having
+   * been silent** (#486 review). Only a status carried *by* an event moves
+   * `lastStatusEventId` — a `session:finished`, or a `task:updated` that names
+   * the status it patched. A status this Session learned by *asking*
+   * (`readStatus`, after an event that named none) is recorded with event id 0
+   * on purpose, because a read answers "what is it now" and a wait is asking
+   * "what happened after event N". So `false` means no turn end was *reported
+   * in the log* after the cursor. That is exactly the right thing to gate a wait
+   * on, and it is weaker than "the Core said nothing" for a caller branching on
+   * it.
    */
   readonly reportedSinceDelivery: boolean;
 
@@ -377,9 +389,18 @@ export class CoreSessionTurnTimeoutError extends Error {
  * A wait that heard a status after its cursor and gave up anyway was waiting on
  * a harness that is *working*, and "still finished" is the honest report — the
  * wording every deadline has used since #289. A wait that heard nothing was
- * waiting on a turn that never started, and telling that operator the Session is
- * "still finished" points them at a slow harness when the actual answer is that
- * their carriage return was eaten.
+ * waiting on a turn whose end was never reported, and telling that operator the
+ * Session is "still finished" points them at a slow harness when the answer may
+ * be that their carriage return was eaten.
+ *
+ * **It names both readings and picks neither** (#486 review). `codex` and
+ * `cursor-cli` report nothing between a turn's start and its end, so an ordinary
+ * turn that outruns the caller's deadline produces this same silence on a
+ * harness that is working perfectly. Choosing between the two would mean either
+ * consulting `reportsTurnStart` — which no wait may do (ADR 0033 D2) — or
+ * reading the byte stream, which #191 deleted. The sentence says what is true of
+ * both and sends the reader to the screen, which is the only place the
+ * difference is visible.
  *
  * What is **not** here is what to type next. This is a library: the caller knows
  * whether its user has an `actana` on their path, and the CLI adds that line
@@ -394,10 +415,12 @@ function turnTimeoutMessage(opts: {
 }): string {
   if (opts.afterEventId > 0 && !opts.reportedSinceDelivery) {
     return (
-      `session ${opts.taskId} took the text, but the Core reported nothing about it in the ` +
-      `${opts.timeoutMs}ms after the delivery stamped at event ${opts.afterEventId} — no turn ` +
-      `ended, and none was seen to start. A carriage return that lands on a dialog rather than a ` +
-      `composer submits nothing. The text was delivered either way, so it must not be sent again`
+      `session ${opts.taskId} took the text, but no turn end was reported for it in the ` +
+      `${opts.timeoutMs}ms after the delivery stamped at event ${opts.afterEventId}. Either the ` +
+      `text started no turn — a carriage return that lands on a dialog rather than a composer ` +
+      `submits nothing — or a turn is still running on a harness that reports nothing until it ` +
+      `ends, and this side cannot tell those apart. Read the screen to see which. The text was ` +
+      `delivered either way, so it must not be sent again`
     );
   }
   return `session ${opts.taskId} was still ${opts.lastStatus ?? "unreported"} after ${opts.timeoutMs}ms`;

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -318,6 +318,92 @@ export class CoreSessionAttachError extends Error {
 }
 
 /**
+ * A wait gave up on the deadline its caller set (#405).
+ *
+ * Its own kind because the two ways a wait can run out are two different next
+ * steps for the operator, and a bare `Error` flattens them. The fields say
+ * which one this is without parsing the message: `reportedSinceDelivery` is
+ * `false` when the Core said **nothing at all** about this Session after the
+ * delivery this wait counts from — no turn ended, and no turn was seen to
+ * start. That is what a carriage return landing on a dialog rather than a
+ * composer looks like from here.
+ *
+ * It is still *this side giving up*, never a status (ADR 0033 D4, D5). Nothing here
+ * infers a turn from the byte stream, and a Session that ran the deadline out is
+ * still running on the Core: `session logs`, another `session wait` and
+ * `session kill` all still work.
+ */
+export class CoreSessionTurnTimeoutError extends Error {
+  /** The Session the wait was about. */
+  readonly taskId: string;
+  /** The deadline that expired, in ms — the caller's own, never a default here. */
+  readonly timeoutMs: number;
+  /** The delivery stamp this wait counted from, or 0 for an uncursored wait. */
+  readonly afterEventId: number;
+  /** The last status the Core reported, or null when it has reported none. */
+  readonly lastStatus: string | null;
+  /**
+   * Did the Core report **anything** about this Session after `afterEventId`?
+   *
+   * False is the loud half of the seeded-status invariant: a status seeded from
+   * the Task row carries event id 0 and can never satisfy a real cursor, so a
+   * wait against a Session that is parked and reports nothing would otherwise
+   * sit on that comparison forever. It is a fact off the event log — the id the
+   * last status was learned at, against the id the delivery was stamped with —
+   * and not an inference from the screen.
+   */
+  readonly reportedSinceDelivery: boolean;
+
+  constructor(opts: {
+    taskId: string;
+    timeoutMs: number;
+    afterEventId: number;
+    lastStatus: string | null;
+    reportedSinceDelivery: boolean;
+  }) {
+    super(turnTimeoutMessage(opts));
+    this.name = "CoreSessionTurnTimeoutError";
+    this.taskId = opts.taskId;
+    this.timeoutMs = opts.timeoutMs;
+    this.afterEventId = opts.afterEventId;
+    this.lastStatus = opts.lastStatus;
+    this.reportedSinceDelivery = opts.reportedSinceDelivery;
+  }
+}
+
+/**
+ * What {@link CoreSessionTurnTimeoutError} says, and why there are two of them.
+ *
+ * A wait that heard a status after its cursor and gave up anyway was waiting on
+ * a harness that is *working*, and "still finished" is the honest report — the
+ * wording every deadline has used since #289. A wait that heard nothing was
+ * waiting on a turn that never started, and telling that operator the Session is
+ * "still finished" points them at a slow harness when the actual answer is that
+ * their carriage return was eaten.
+ *
+ * What is **not** here is what to type next. This is a library: the caller knows
+ * whether its user has an `actana` on their path, and the CLI adds that line
+ * itself from the fields above.
+ */
+function turnTimeoutMessage(opts: {
+  taskId: string;
+  timeoutMs: number;
+  afterEventId: number;
+  lastStatus: string | null;
+  reportedSinceDelivery: boolean;
+}): string {
+  if (opts.afterEventId > 0 && !opts.reportedSinceDelivery) {
+    return (
+      `session ${opts.taskId} took the text, but the Core reported nothing about it in the ` +
+      `${opts.timeoutMs}ms after the delivery stamped at event ${opts.afterEventId} — no turn ` +
+      `ended, and none was seen to start. A carriage return that lands on a dialog rather than a ` +
+      `composer submits nothing. The text was delivered either way, so it must not be sent again`
+    );
+  }
+  return `session ${opts.taskId} was still ${opts.lastStatus ?? "unreported"} after ${opts.timeoutMs}ms`;
+}
+
+/**
  * One Session on one Core, driven programmatically.
  *
  * Built by {@link start}. Holds a screen fed from the Session's PTY, the Core's
@@ -873,6 +959,17 @@ export class CoreSession {
    * Nothing here reads the byte stream, and nothing here consults
    * {@link reportsTurnStart}. Turn end is reported by every harness family; turn
    * *start* is not, which is why no wait is keyed on it.
+   *
+   * **A cursored wait can be waiting for a turn that never started** (#405): a
+   * carriage return that lands on a dialog rather than a composer submits
+   * nothing, so the Core has nothing to report and the seeded status the Session
+   * is parked at carries event id 0, which no real cursor can be satisfied by.
+   * That is correct and it is silent, which is the whole complaint. It is
+   * answered here by making the deadline **loud** rather than by guessing at a
+   * turn: expiry rejects with {@link CoreSessionTurnTimeoutError}, whose
+   * `reportedSinceDelivery` says whether the Core reported anything at all after
+   * the write. Bounding the wait is still the caller's — `timeoutMs` is theirs,
+   * and with none this waits as long as the work takes.
    */
   waitForTurnEnd(opts: CoreSessionTurnWaitOptions = {}): Promise<CoreSessionIdle> {
     const afterEventId = opts.afterEventId ?? 0;
@@ -890,12 +987,24 @@ export class CoreSession {
       };
       this.idleWaiters.add(waiter);
       if (opts.timeoutMs && opts.timeoutMs > 0) {
+        const timeoutMs = opts.timeoutMs;
         timer = setTimeout(() => {
           this.idleWaiters.delete(waiter);
+          // **Named rather than bare** (#405). The one thing this deadline knows
+          // that its caller does not is whether the Core reported *anything*
+          // after the delivery: `lastStatusEventId` still at or below the cursor
+          // means no status has been learned since the write, which is the shape
+          // of a return that started no turn. It is a comparison of two event
+          // ids and nothing else — no screen is read, and no turn is inferred
+          // from the bytes (ADR 0033 D4).
           reject(
-            new Error(
-              `session ${this.taskId} was still ${this.lastStatus ?? "unreported"} after ${opts.timeoutMs}ms`,
-            ),
+            new CoreSessionTurnTimeoutError({
+              taskId: this.taskId,
+              timeoutMs,
+              afterEventId,
+              lastStatus: this.lastStatus,
+              reportedSinceDelivery: this.lastStatusEventId > afterEventId,
+            }),
           );
         }, opts.timeoutMs);
       }

--- a/packages/shared/src/orchestration-skill-payload.ts
+++ b/packages/shared/src/orchestration-skill-payload.ts
@@ -173,10 +173,15 @@ A Session is a conversation, not a single question. The whole loop:
 
 \`\`\`bash
 ID=$(actana session start <project> "<first prompt>")   # prints the id, exits
-actana session wait "$ID" --json --wait-timeout 900     # block until it settles
-actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 900
-actana session send "$ID" "<next>" --wait --json
+actana session wait "$ID" --json --wait-timeout 1800    # block until it settles
+actana session send "$ID" "<follow-up>" --wait --json --wait-timeout 1800
+actana session send "$ID" "<next>" --wait --json --wait-timeout 1800
 \`\`\`
+
+Every line carries the same budget on purpose: 1800 seconds is what \`await.sh\`
+gives a round, and a loop whose steps disagree about how long a turn may take
+gives up in the middle of one. Pass it explicitly rather than leaning on a
+default — \`send --wait\` has one (1020 seconds) and the other two do not.
 
 **\`actana session wait <id>\` blocks until the Core reports the Session settled**
 — \`finished\`, \`needs-input\`, \`interrupted\`, \`terminated\` or \`disconnected\`,
@@ -192,7 +197,7 @@ object** \`start --wait --json\` prints — same keys, same \`screen\` — so on
 reads all three verbs. Two of those keys are \`null\` on a Session you attached to
 rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
 
-Three things to know before you build on it:
+Four things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -211,15 +216,22 @@ Three things to know before you build on it:
 3. **A timeout is this side giving up, not a status.** \`--wait-timeout
    <seconds>\` bounds the wait. \`session wait\` has no deadline unless you set
    one, because a turn takes as long as the work takes; **\`send --wait\` defaults
-   to 900 seconds**, because it is the one wait for a turn that has not started
+   to 1020 seconds**, because it is the one wait for a turn that has not started
    yet and a carriage return that lands on a dialog rather than a composer
    starts none at all. \`--wait-timeout 0\` waits with no deadline. On expiry you
    get a message saying the wait gave up and a non-zero exit — the Session is
-   still running on the Core, and \`session logs\`, another \`session wait\` and
-   \`session kill\` all still work. When the wait gave up having heard nothing at
-   all about the Session since your text went in, the message says so: no turn
-   ended and none was seen to start, and the text was delivered — read the
-   screen with \`session logs\` rather than sending it again.
+   still running on the Core, and \`session logs\` and \`session kill\` still work.
+   When no turn end was reported since your text went in, the message says so
+   and names both readings: the text may have started no turn, or a turn may
+   still be running on a Harness that reports nothing until it ends. The text
+   was delivered either way — read the screen with \`session logs\` rather than
+   sending it again.
+4. **Do not answer that timeout with \`session wait\`.** It is uncursored: it
+   answers from the status the Session is parked at, so on a turn that never
+   started it returns **at once, with the status from before your text, and
+   exits zero** — which reads as a completed turn and is not one. To carry on
+   waiting, follow the log from the delivery instead:
+   \`actana events tail --since <event id>\`, the id the timeout message names.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/packages/shared/src/orchestration-skill-payload.ts
+++ b/packages/shared/src/orchestration-skill-payload.ts
@@ -145,10 +145,10 @@ a file**, and the contract below is how you get one.
 
 The object also carries \`taskId\` (the Session's id — this is what every other
 verb takes), \`harness\`, \`project\`, \`status\`, \`exited\`, and \`reportsTurnStart\`.
-\`--wait-timeout <seconds>\` bounds the wait; without it the wait has no deadline
-of its own. A timeout is this side giving up, not a verdict about the Session:
-the Session is still running on the Core and can still be listed, read and
-stopped.
+\`--wait-timeout <seconds>\` bounds the wait; without it \`start --wait\` has no
+deadline of its own (\`send --wait\` does — see the loop below). A timeout is this
+side giving up, not a verdict about the Session: the Session is still running on
+the Core and can still be listed, read and stopped.
 
 While a Session is alive — which is what the \`live\` field on its
 \`actana session ls --json\` row tells you, and the only thing that does — you can
@@ -201,17 +201,25 @@ Three things to know before you build on it:
    the Session to settle *first*, then send.
 2. **A \`send\` presses Enter for you, and \`--no-enter\` is how you stop it.** The
    text goes first and the carriage return follows as its own separate write.
-   \`--no-enter\` sends no return, so that send starts no turn — and a \`--wait\`
-   after it is not waiting for your text: on an idle Session nothing ends, and
-   on a busy one it resolves on the turn that was *already* running. Both are
-   #405's. \`--enter\` is still accepted and does nothing on a send that carries
-   text, so an older script that passes it keeps working; on a send with no text
-   it still means a bare carriage return and nothing else.
+   \`--no-enter\` sends no return, so that send starts no turn — and it **cannot
+   be combined with \`--wait\`**, which is refused as a usage error: a send that
+   submits nothing has no turn to await. Type with \`--no-enter\`, then
+   \`actana session wait\` once a turn is actually running. \`--enter\` is still
+   accepted and does nothing on a send that carries text, so an older script
+   that passes it keeps working; on a send with no text it still means a bare
+   carriage return and nothing else.
 3. **A timeout is this side giving up, not a status.** \`--wait-timeout
-   <seconds>\` bounds the wait; without it there is no deadline, because a turn
-   takes as long as the work takes. On expiry you get a message saying the wait
-   gave up and a non-zero exit — the Session is still running on the Core, and
-   \`session logs\`, another \`session wait\` and \`session kill\` all still work.
+   <seconds>\` bounds the wait. \`session wait\` has no deadline unless you set
+   one, because a turn takes as long as the work takes; **\`send --wait\` defaults
+   to 900 seconds**, because it is the one wait for a turn that has not started
+   yet and a carriage return that lands on a dialog rather than a composer
+   starts none at all. \`--wait-timeout 0\` waits with no deadline. On expiry you
+   get a message saying the wait gave up and a non-zero exit — the Session is
+   still running on the Core, and \`session logs\`, another \`session wait\` and
+   \`session kill\` all still work. When the wait gave up having heard nothing at
+   all about the Session since your text went in, the message says so: no turn
+   ended and none was seen to start, and the text was delivered — read the
+   screen with \`session logs\` rather than sending it again.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.


### PR DESCRIPTION
`actana session send $SID "text" --wait` could wait for ever. The wait counts from the id the Core stamps a delivery with and resolves on the first settling status **after** that id, so a send that starts no turn has nothing that will ever end it:

- `--no-enter` sends no carriage return, so no turn starts;
- a carriage return that lands on a **dialog** rather than a composer submits nothing either.

In both cases the status the Session is parked at was seeded from the Task row and carries **event id 0**, which no real cursor can be satisfied by. That comparison is correct — it is what stops the wait reporting last turn's answer as this turn's — and it is silent and permanent, which is the bug.

## What changed

**1. `--no-enter` with `--wait` is a usage error** (`sessionSend`, `packages/cli/src/session-command.ts`). Refused before a byte is written: a send that submits nothing has no turn to await, and that wait would either never end (idle Session) or end on a turn some earlier send started and report it as this one's (busy Session). One hangs, one lies; neither is a reading the command can pick between.

**2. `send --wait` carries a default deadline of 1020 seconds.** Only that verb. `session wait` and `session start --wait` wait for a turn that is already under way, so a default there could only cut short honest work — they keep "no deadline unless you set one". Seventeen minutes is chosen against the Core rather than from taste: its quiet backstop settles a silent `running` Session at fifteen minutes and sweeps once a minute, so a deadline at fifteen would tie with it and scheduling would pick the winner. At seventeen the Core's mechanism answers first with a real status, and this deadline only ever fires where the Core has none — #405's case, since the backstop skips a Session that is not `running`. `--wait-timeout <s>` replaces it; **`--wait-timeout 0`** removes it (new spelling, accepted on every verb that takes the flag).

**3. The deadline is loud instead of bare.** `waitForTurnEnd` now rejects with a new `CoreSessionTurnTimeoutError` carrying `taskId`, `timeoutMs`, `afterEventId`, `lastStatus` and `reportedSinceDelivery` — the last being whether the Core reported **anything** about the Session after the delivery. That is two event ids compared, not a reading of the screen: nothing is inferred from the byte stream (#191, ADR 0026 D3), and no path consults `reportsTurnStart` (ADR 0033 D2). When it is `false` the message says no turn end was reported and names **both** readings — a return that submitted nothing, or a harness that reports nothing until a turn ends — because `codex` and `cursor-cli` produce that same silence while working; it also says the text was delivered so it is not sent twice. The CLI adds the next step, keeping CLI advice out of a library error: `session logs` to read the screen, `events tail --since <delivery id>` to keep waiting, and an explicit warning **off** `session wait`, which is uncursored and would answer at once with the pre-send status and exit zero.

**4. ADR 0033 gains D5**, amending D4 for the one wait that is not waiting for a turn already running. `docs/README.md`'s index row says so, and the skill payload was regenerated from its authored source.

## Acceptance criteria (issue #405)

1. **`send --wait` without a submitted turn exits with an error rather than hanging** — `--no-enter --wait` is `EXIT_USAGE` before any dial; a submitted return that a dialog eats is bounded by the default deadline and reported as this side giving up, never as a status.
2. **`send --enter --wait` unblocks on turn end when the harness settles** — pinned at both layers: the SDK test writes the text, writes the return, waits from the **later** stamp and resolves when the status lands; the CLI test asserts the wait path still sends the return.

## Files this touches, for the tickets landing beside it

- `packages/sdk/src/core-session.ts` — **the only functions changed are `waitForTurnEnd`** (rejects with the new error) plus the new exported `CoreSessionTurnTimeoutError` and its private `turnTimeoutMessage` helper. `settledSince`, `noteStatus`, `releaseWaiters`, `attach`, `deliver`, `dispose` and `waitForIdle` are untouched, and **no disconnect handler was added to `waitForTurnEnd`** — that is #396, which lands in this file after this PR.
- `packages/core/src/harness-prompt-delivery.ts` — **not touched** (#483 owns it this wave).
- `packages/panel/**` — **not touched** (#484 owns it this wave).
- `packages/cli/src/exit-codes.ts` — unchanged; the timeout reuses `EXIT_FAILURE` and the refusal reuses `EXIT_USAGE`.

## Verification

`pnpm -r typecheck`, `pnpm lint` (0 errors), `pnpm scan:secrets`, and the root, `sdk`, `shared`, `cli` and `core` unit suites all pass locally. Panel is untouched and left to CI.

Refs #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKAxkx64bneadDvmQiwwKz

