### PR TITLE
fix(panel): a returning page reads the Session's current status

### DIFF
--- a/packages/panel/src/lib/__tests__/server-events-reconnect.test.tsx
+++ b/packages/panel/src/lib/__tests__/server-events-reconnect.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+//
+// The SSE channel after a gap (issue 484, symptom W2 — suspect 2).
+//
+// `/api/events` is fire-and-forget: the server keeps no event log, sends no
+// `id:` lines, and the client sends no `Last-Event-ID`. So a `task:updated`
+// emitted while the socket is down is not delayed, it is gone — a backgrounded
+// tab whose connection a browser or proxy reaped comes back believing whatever
+// it last heard, which for a Session that finished in the gap is `running`.
+//
+// The channel cannot replay. What it can do is say that a gap happened, so the
+// queries it feeds are re-read instead of trusted — the same bargain
+// `useCoreLiveQueries` already makes for a dropped core-link. That is what
+// these tests pin: the announcement, its once-per-gap shape, and the
+// invalidation it drives.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const SSE_RECONNECT_DELAY_MS = 1500;
+
+/** Every EventSource the module has opened, oldest first. */
+const opened: FakeEventSource[] = [];
+
+class FakeEventSource {
+  onopen: (() => void) | null = null;
+  onmessage: ((msg: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(readonly url: string) {
+    opened.push(this);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  /** The stream drops, the way a reaped connection does. */
+  drop(): void {
+    this.onerror?.();
+  }
+}
+
+const {
+  __resetServerEventsForTests,
+  useServerEvents,
+  useServerEventsReconnect,
+} = await import("~/lib/use-events");
+const { useEventStreamReconcile } = await import("~/lib/use-event-stream-reconcile");
+
+/** Stable identities: `useServerEvents` re-subscribes when its handler changes,
+ *  and a fresh closure per render would tear the shared socket down and back up
+ *  between renders, which is not the thing under test. */
+function noop(): void {}
+
+function wrapperFor(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+/** Drive the module's own backoff to the next connection attempt. */
+async function waitOutBackoff(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(SSE_RECONNECT_DELAY_MS);
+    await Promise.resolve();
+  });
+}
+
+describe("a reconnected SSE stream reconciles the gap it left (issue 484)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    opened.length = 0;
+    __resetServerEventsForTests();
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+  afterEach(() => {
+    __resetServerEventsForTests();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("says nothing on the first connection — that is not a gap", async () => {
+    const reconnected = vi.fn();
+    renderHook(() => {
+      useServerEvents(noop);
+      useServerEventsReconnect(reconnected);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(opened).toHaveLength(1);
+    opened[0]!.onopen?.();
+    expect(reconnected).not.toHaveBeenCalled();
+  });
+
+  it("announces the reconnection that follows a drop, once", async () => {
+    const reconnected = vi.fn();
+    renderHook(() => {
+      useServerEvents(noop);
+      useServerEventsReconnect(reconnected);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const first = opened[0]!;
+    first.onopen?.();
+
+    first.drop();
+    expect(first.closed).toBe(true);
+    await waitOutBackoff();
+
+    expect(opened).toHaveLength(2);
+    const second = opened[1]!;
+    act(() => second.onopen?.());
+    expect(reconnected).toHaveBeenCalledTimes(1);
+
+    // The events that follow are ordinary traffic, not further gaps.
+    act(() => second.onmessage?.({ data: JSON.stringify({ type: "task:updated" }) }));
+    expect(reconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces on the first frame when the implementation fires no onopen", async () => {
+    const reconnected = vi.fn();
+    renderHook(() => {
+      useServerEvents(noop);
+      useServerEventsReconnect(reconnected);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    opened[0]!.onmessage?.({ data: JSON.stringify({ type: "hello", at: 1 }) });
+    opened[0]!.drop();
+    await waitOutBackoff();
+
+    act(() => opened[1]!.onmessage?.({ data: JSON.stringify({ type: "hello", at: 2 }) }));
+    expect(reconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads the projects, groups and archived buckets on the way back", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { staleTime: 30_000, refetchOnWindowFocus: false } },
+    });
+    const invalidate = vi.spyOn(client, "invalidateQueries").mockResolvedValue(undefined);
+    renderHook(
+      () => {
+        useServerEvents(noop);
+        useEventStreamReconcile();
+      },
+      { wrapper: wrapperFor(client) },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    opened[0]!.onopen?.();
+    expect(invalidate).not.toHaveBeenCalled();
+
+    opened[0]!.drop();
+    await waitOutBackoff();
+    act(() => opened[1]!.onopen?.());
+
+    const keys = invalidate.mock.calls.map(([filters]) => filters?.queryKey);
+    // `["projects"]` is a prefix: it reaches the list, every project row and
+    // every task bucket beneath them. The archived buckets sit outside that
+    // tree by design (ADR 0019), so they are named separately.
+    expect(keys).toContainEqual(["projects"]);
+    expect(keys).toContainEqual(["groups"]);
+    expect(keys).toContainEqual(["core-archived-tasks"]);
+  });
+
+  it("tells a subscriber nothing once it has unsubscribed", async () => {
+    const reconnected = vi.fn();
+    const view = renderHook(
+      ({ subscribed }: { subscribed: boolean }) => {
+        useServerEvents(noop);
+        useServerEventsReconnect(subscribed ? reconnected : noop);
+      },
+      { initialProps: { subscribed: true } },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    opened[0]!.onopen?.();
+    view.rerender({ subscribed: false });
+
+    opened[0]!.drop();
+    await waitOutBackoff();
+    act(() => opened[1]!.onopen?.());
+    expect(reconnected).not.toHaveBeenCalled();
+  });
+});

--- a/packages/panel/src/lib/use-event-stream-reconcile.ts
+++ b/packages/panel/src/lib/use-event-stream-reconcile.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useServerEventsReconnect } from "~/lib/use-events";
+import { queryKeys } from "~/queries";
+
+/**
+ * Re-read what the Panel's SSE stream feeds, every time that stream comes back
+ * after dropping.
+ *
+ * The stream is fire-and-forget: no cursor, no `Last-Event-ID`, no replay
+ * buffer behind `/api/events`. A Session that finishes while the socket is
+ * down — a backgrounded tab whose connection the browser or a proxy reaped, a
+ * Panel restart, a sleeping laptop — emits its `task:updated` into a stream
+ * nobody is reading, and nothing ever mentions it again. The row keeps the last
+ * status this tab happened to hear (issue 484, symptom W2).
+ *
+ * Nothing here tries to recover the missed events. It marks what they would
+ * have touched as stale, which is the same bargain `useCoreLiveQueries` makes
+ * for a dropped core-link: after a gap, ask again rather than trust the screen.
+ *
+ * `["projects"]` is a prefix, not an exact key, so one invalidation reaches the
+ * projects list, every project row (Panel-owned and Core-tagged alike) and
+ * every task-list bucket under them — see `queryKeys` and `tasksCacheKey`. The
+ * archived buckets sit deliberately outside that tree, so they are named.
+ */
+export function useEventStreamReconcile(): void {
+  const queryClient = useQueryClient();
+  useServerEventsReconnect(
+    useCallback(() => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.groups });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.coreArchivedTasksAll });
+    }, [queryClient]),
+  );
+}

--- a/packages/panel/src/lib/use-events.ts
+++ b/packages/panel/src/lib/use-events.ts
@@ -14,9 +14,27 @@ const SSE_RECONNECT_DELAY_MS = 1500;
 type Listener = (e: ServerEvent) => void;
 
 const listeners = new Set<Listener>();
+/**
+ * Told when the stream comes back up after it went down — see
+ * {@link useServerEventsReconnect}. A separate set from `listeners` on purpose:
+ * these subscribers reconcile state, they are not a reason to hold a socket
+ * open, so they never start a connection and never keep one alive.
+ */
+const reconnectListeners = new Set<() => void>();
 let source: EventSource | null = null;
 let connecting = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Has the stream been down since the last time it was up?
+ *
+ * The server keeps no event log and sends no `id:` lines, so there is no
+ * cursor to resume from and nothing to replay: whatever it emitted while this
+ * tab was disconnected is gone for good. What the tab CAN know is that a gap
+ * happened, and that is what this flag carries to the reconnect subscribers,
+ * who re-read rather than trust what is on screen. Set on error, cleared on
+ * the open that follows — so a first connection is not mistaken for a gap.
+ */
+let streamWasLost = false;
 
 function scheduleReconnect(): void {
   if (reconnectTimer !== null || listeners.size === 0) return;
@@ -24,6 +42,20 @@ function scheduleReconnect(): void {
     reconnectTimer = null;
     void connect();
   }, SSE_RECONNECT_DELAY_MS);
+}
+
+function announceReconnect(): void {
+  if (!streamWasLost) return;
+  streamWasLost = false;
+  // Snapshot: a subscriber that unsubscribes while being told must not mutate
+  // the set mid-iteration, and one that throws must not silence the rest.
+  for (const listener of [...reconnectListeners]) {
+    try {
+      listener();
+    } catch {
+      /* swallow */
+    }
+  }
 }
 
 async function connect(): Promise<void> {
@@ -38,6 +70,9 @@ async function connect(): Promise<void> {
   const es = new EventSource("/api/events");
   source = es;
   connecting = false;
+  es.onopen = () => {
+    announceReconnect();
+  };
   es.onmessage = (msg) => {
     let data: ServerEvent;
     try {
@@ -45,6 +80,11 @@ async function connect(): Promise<void> {
     } catch {
       return;
     }
+    // A message is proof the stream is up. Some EventSource implementations
+    // (and every stub a test writes) deliver the server's opening frame
+    // without firing `onopen`, and a gap that is never announced is a gap
+    // nothing reconciles.
+    announceReconnect();
     // Snapshot so a listener that (un)subscribes during dispatch can't mutate
     // the set mid-iteration; isolate a throwing listener from the rest.
     for (const listener of [...listeners]) {
@@ -58,6 +98,8 @@ async function connect(): Promise<void> {
   es.onerror = () => {
     es.close();
     if (source === es) source = null;
+    // Everything the server emits from here until the next open is lost.
+    streamWasLost = true;
     scheduleReconnect();
   };
 }
@@ -81,4 +123,39 @@ export function useServerEvents(onEvent: (e: ServerEvent) => void) {
       closeIfIdle();
     };
   }, [onEvent]);
+}
+
+/**
+ * Called once each time the shared stream comes back after dropping.
+ *
+ * A dropped SSE connection is a hole in this tab's knowledge, not a pause: a
+ * Session that finishes while the socket is down emits its `task:updated` into
+ * a stream nobody is reading, and no replay brings it back (issue 484). The
+ * subscriber's job is therefore to re-read whatever the stream feeds, exactly
+ * as `useCoreLiveQueries` already does for the core-link's own reconnects.
+ *
+ * Subscribing does not open or hold the stream — only {@link useServerEvents}
+ * does that — so a tab with nothing listening for events is told nothing.
+ */
+export function useServerEventsReconnect(onReconnect: () => void) {
+  useEffect(() => {
+    reconnectListeners.add(onReconnect);
+    return () => {
+      reconnectListeners.delete(onReconnect);
+    };
+  }, [onReconnect]);
+}
+
+/** Test-only: drop every subscriber and forget the connection's history. */
+export function __resetServerEventsForTests(): void {
+  listeners.clear();
+  reconnectListeners.clear();
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  source?.close();
+  source = null;
+  connecting = false;
+  streamWasLost = false;
 }

--- a/packages/panel/src/queries/__tests__/return-to-project-refetch.test.tsx
+++ b/packages/panel/src/queries/__tests__/return-to-project-refetch.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+//
+// Coming back to a project shows what is true now (issue 484, symptom W2).
+//
+// A Session that finished while the operator was on another page read
+// `running` on return, and only a browser refresh corrected it. The Core was
+// right the whole time — `actana session ls` said `finished` — so this is
+// entirely about what the Panel's cache is willing to ask again for.
+//
+// Three suspects were named on the ticket. Two of them are tested here, in the
+// shape that actually failed:
+//
+//   1. The client defaults in `src/router.tsx` — `staleTime: 30_000` (:198)
+//      with `refetchOnWindowFocus: false` (:200). `refetchOnMount` defaults to
+//      refetching only a STALE query, so a remount inside those 30 seconds is
+//      served the cached, pre-finish list; and a refocus never asks at all.
+//      This is the one that enforces the bug, and the first two tests are it.
+//   3. The scope-cancel guard from #381, which cancels an in-flight project
+//      read when the last viewer leaves. It is NOT a cause — a cancel reverts
+//      the query to its pre-fetch state, invalidation included, so the return
+//      path still refetches — and the last test pins that down so the guard is
+//      not blamed (or "fixed") again.
+//
+// Suspect 2, the replay-less SSE channel, is a different transport and has its
+// own suite: `src/lib/__tests__/server-events-reconnect.test.tsx`.
+//
+// Every client here is built with `router.tsx`'s exact defaults; a test that
+// relaxed them would prove nothing about the app.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { CoreLinkTaskSnapshot } from "@actana/sdk/core-link-frames";
+
+const CORE_ID = "core-a";
+const PROJECT_ID = "project-1";
+
+const h = vi.hoisted(() => ({
+  /** What the Core would answer right now. Mutated by the tests. */
+  status: "running",
+  listTasksCalls: 0,
+  /** One entry per held `listTasks`, oldest first, while `hold` is set. */
+  inFlight: [] as { settle: () => void }[],
+  hold: false,
+}));
+
+vi.mock("~/lib/panel-bridge", () => ({
+  getPanelBridge: () => ({
+    watchCore: () => () => {},
+    onEvent: () => () => {},
+    onConnectionChange: () => () => {},
+    listTasks: async () => {
+      h.listTasksCalls += 1;
+      if (h.hold) await new Promise<void>((resolve) => h.inFlight.push({ settle: resolve }));
+      return { tasks: [snapshot(h.status)], archivedCount: 0 };
+    },
+  }),
+}));
+
+const { useTasks, tasksCacheKey } = await import("~/queries");
+const { __resetProjectScopesForTests } = await import("~/lib/visible-project-scope");
+
+function snapshot(status: string): CoreLinkTaskSnapshot {
+  return {
+    taskId: "task-1",
+    projectId: PROJECT_ID,
+    title: "task-1",
+    titleManuallySet: false,
+    claudeSessionId: null,
+    agent: "claude-code",
+    status,
+    pinned: false,
+    archived: false,
+    icon: null,
+    updatedAt: Date.now(),
+  } as unknown as CoreLinkTaskSnapshot;
+}
+
+/** Exactly the client `getRouter()` builds — see `src/router.tsx`. */
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+function wrapperFor(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const renderBoard = (wrapper: ReturnType<typeof wrapperFor>) =>
+  renderHook(() => useTasks(PROJECT_ID, { coreId: CORE_ID }), { wrapper });
+
+/** Let a mount-triggered refetch start, run and paint. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+}
+
+describe("returning to a project reads the Session's current status (issue 484)", () => {
+  beforeEach(() => {
+    __resetProjectScopesForTests();
+    h.status = "running";
+    h.listTasksCalls = 0;
+    h.inFlight = [];
+    h.hold = false;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the finish after a remount well inside the 30s stale window", async () => {
+    const client = makeClient();
+    const wrapper = wrapperFor(client);
+
+    const board = renderBoard(wrapper);
+    await waitFor(() => expect(board.result.current.data?.[0]?.status).toBe("running"));
+    // The operator walks away. Nothing on screen is reading this project now.
+    board.unmount();
+
+    // The Session finishes on the Core. No route is mounted to hear it, and
+    // the Panel is not even watching this Core any more.
+    h.status = "finished";
+
+    // Back within seconds — the window in which the cached answer used to win.
+    const again = renderBoard(wrapper);
+    await settle();
+
+    expect(again.result.current.data?.[0]?.status).toBe("finished");
+    expect(h.listTasksCalls).toBe(2);
+  });
+
+  it("re-reads when the tab is refocused, with the client default off", async () => {
+    const client = makeClient();
+    const board = renderBoard(wrapperFor(client));
+    await waitFor(() => expect(board.result.current.data?.[0]?.status).toBe("running"));
+    expect(h.listTasksCalls).toBe(1);
+
+    // Backgrounded, finished while hidden, refocused. The tab never unmounted,
+    // so nothing above the query gets a chance to ask on its behalf.
+    h.status = "finished";
+    await act(async () => {
+      window.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("focus"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    await waitFor(() => expect(board.result.current.data?.[0]?.status).toBe("finished"));
+    expect(h.listTasksCalls).toBeGreaterThan(1);
+  });
+
+  it("still re-reads when the leave cancelled a read in flight (#381 is not the cause)", async () => {
+    const client = makeClient();
+    const wrapper = wrapperFor(client);
+    const board = renderBoard(wrapper);
+    await waitFor(() => expect(board.result.current.data?.[0]?.status).toBe("running"));
+
+    // A Core event lands, its refetch is still in flight, and the operator
+    // leaves — which is precisely when the scope guard cancels.
+    h.hold = true;
+    await act(async () => {
+      void client.invalidateQueries({ queryKey: tasksCacheKey(PROJECT_ID, CORE_ID) });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await waitFor(() => expect(h.inFlight.length).toBe(1));
+    board.unmount();
+    // The cancelled read's promise still resolves; the panel link has nothing
+    // to abort. React-query drops the answer.
+    await act(async () => {
+      for (const held of h.inFlight) held.settle();
+      h.inFlight = [];
+      h.hold = false;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    h.status = "finished";
+    const again = renderBoard(wrapper);
+    await settle();
+
+    expect(again.result.current.data?.[0]?.status).toBe("finished");
+  });
+});

--- a/packages/panel/src/queries/index.ts
+++ b/packages/panel/src/queries/index.ts
@@ -27,6 +27,8 @@ export const queryKeys = {
   // `useCoreArchivedTaskCount`).
   coreArchivedTasks: (projectId: string, coreId: string) =>
     ["core-archived-tasks", coreId, projectId] as const,
+  /** Prefix over every Core's archived bucket, for a blanket invalidation. */
+  coreArchivedTasksAll: ["core-archived-tasks"] as const,
   coreArchivedTaskCount: (projectId: string, coreId: string) =>
     ["core-archived-task-count", coreId, projectId] as const,
   settings: ["settings"] as const,
@@ -40,6 +42,35 @@ export const queryKeys = {
   updateCheck: ["update-check"] as const,
 };
 
+/**
+ * What every project-scoped read asks of react-query, on top of the client
+ * defaults in `router.tsx`.
+ *
+ * The defaults are `staleTime: 30_000` with `refetchOnWindowFocus: false`
+ * (`src/router.tsx:198` and `:200`), and together they are what leaves a
+ * finished Session reading `running` (issue 484, symptom W2). Navigating away
+ * unmounts the board; navigating back mounts it again, and `refetchOnMount`'s
+ * default only refetches a query it considers STALE — so a return inside the
+ * 30s window is served the cached, pre-finish list and never asks the Core.
+ * Refocusing the tab does not ask either, because focus refetching is off.
+ * Nothing else covers the gap: the Core's events only reach this tab while the
+ * route that subscribes to them is mounted, which is exactly what it was not.
+ *
+ * `"always"` on both, and only here. Freshness matters for the rows the
+ * operator is looking at — a Session's status is a live fact about a machine,
+ * not a cached page — and it does not matter equally for usage rollups or the
+ * update check, which set their own long `staleTime` and are left alone. The
+ * global default stays as it is for everything else.
+ *
+ * Cost is a list read on mount and on focus, against a Core that is already
+ * asked for this same list on every `pty:` event while a Session runs (see
+ * `useCoreLiveQueries`).
+ */
+const PROJECT_SCOPED_FRESHNESS = {
+  refetchOnMount: "always",
+  refetchOnWindowFocus: "always",
+} as const;
+
 export const projectsQueryOptions = () =>
   queryOptions({
     queryKey: queryKeys.projects,
@@ -50,6 +81,7 @@ export const projectsQueryOptions = () =>
 export const projectQueryOptions = (id: string, opts?: { coreId?: string | null }) => {
   const coreId = opts?.coreId ?? null;
   return queryOptions({
+    ...PROJECT_SCOPED_FRESHNESS,
     // A Core's rows get their own cache bucket; the Panel's own rows keep the
     // untagged key so existing invalidations don't need to thread coreId
     // through.
@@ -150,6 +182,7 @@ export const tasksQueryOptions = (
 ) => {
   const coreId = opts?.coreId ?? null;
   return queryOptions({
+    ...PROJECT_SCOPED_FRESHNESS,
     // See `tasksCacheKey` — same rule, shared with the optimistic-task
     // helpers so writes land in the same bucket the query reads from.
     queryKey: tasksCacheKey(projectId, coreId),
@@ -206,6 +239,7 @@ export const archivedTasksQueryOptions = (
   opts: { coreId: string; enabled: boolean },
 ) =>
   queryOptions({
+    ...PROJECT_SCOPED_FRESHNESS,
     queryKey: queryKeys.coreArchivedTasks(projectId, opts.coreId),
     queryFn: async () => {
       const bridge = getPanelBridge();

--- a/packages/panel/src/routes/__root.tsx
+++ b/packages/panel/src/routes/__root.tsx
@@ -79,6 +79,7 @@ import { SessionNotificationsButton } from "~/components/views/SessionNotificati
 import { Toaster } from "sonner";
 import { MC_TOAST_CLASS_NAMES, MC_TOAST_CLOSE_ICON } from "~/lib/mc-toast";
 import { useSessionFinishNotifications } from "~/lib/use-session-finish-notifications";
+import { useEventStreamReconcile } from "~/lib/use-event-stream-reconcile";
 import {
   clearAppNotification,
   clearAppNotifications,
@@ -257,6 +258,11 @@ function Shell() {
   // Window idle: freezes decorative per-frame animations while the window is
   // blurred/hidden (see src/lib/window-idle.ts).
   useWindowIdleController();
+  // The Panel's SSE stream has no replay: a drop is a hole in what this tab
+  // knows, not a pause (issue 484). Re-read on the way back rather than trust
+  // rows last heard about before the gap. Mounted here, once, for the whole
+  // shell — the stream is shared, and so is everything it feeds.
+  useEventStreamReconcile();
   const { data: settings } = useSettings();
   const { data: projects } = useProjects();
   // The rail draws its badges from the Panel's own rows PLUS every Core's pins


### PR DESCRIPTION
## What this is

Symptom **W2**: a Session that finishes while the operator is looking at
another page still reads `running` when they navigate back, and only a full
browser refresh corrects it. The Core is right the whole time — `actana session
ls` says `finished` for the same Session at the same moment.

`packages/panel` only. Nothing under `packages/core` is touched.

## Root cause

**`packages/panel/src/router.tsx:198` — `staleTime: 30_000` on the query
client's defaults.**

Navigating away unmounts the project route, which is the only thing holding
`useTasks`. Navigating back mounts it again, and react-query's default
`refetchOnMount: true` refetches only a query it considers **stale**. Inside
those 30 seconds the query is fresh by that definition, so the observer
subscribes to the cached, pre-finish list and no read ever reaches the Core.
The row keeps the last status this tab happened to hear.

**`packages/panel/src/router.tsx:200` — `refetchOnWindowFocus: false`** is the
second half of the same cause, and the one that owns AC 2: a tab that is
backgrounded while the Session finishes and then refocused never asks either,
whatever the staleness.

Nothing else covers the gap. `useCoreLiveQueries` — the hook that turns a
Core's events into invalidations — is mounted at
`packages/panel/src/routes/projects.$id.tsx:278`, inside the very route that is
unmounted, and it watches only the project whose page is open. While the
operator is away, this tab is not even watching that Core.

**`packages/panel/src/lib/use-events.ts:58` (pre-change) — `es.onerror`** is a
real second contributor, and the one AC 3 names. The handler shut the socket
and opened a fresh `EventSource` with no cursor, no `Last-Event-ID` and no
invalidation, and the server behind it
(`packages/panel/src/server/controllers/events.controller.ts:16`) writes no
`id:` lines and keeps no event log. An event emitted during the gap was not
delayed, it was gone.

### Suspect 3 is not a cause

The scope-cancel guard from #381 (`useScopedToVisibleProject`,
`packages/panel/src/queries/index.ts:368`) cancels an in-flight project read
when the last viewer leaves. It does **not** block the return path, and this
was confirmed by running it rather than reasoned about: `cancelQueries` with
`revert: true` restores the query's pre-fetch state — `isInvalidated` included
— so a cancelled read leaves the query stale and the next mount refetches. The
third test in `return-to-project-refetch.test.tsx` holds a read open, leaves
mid-flight, comes back, and asserts the fresh status arrives, so the guard is
not blamed (or "fixed") the next time this area is touched.

## The fix

1. **`packages/panel/src/queries/index.ts`** — the three project-scoped reads
   (the project row, its task list, its archived rows) take
   `refetchOnMount: "always"` and `refetchOnWindowFocus: "always"` via a shared
   `PROJECT_SCOPED_FRESHNESS`. Deliberately narrow: the client defaults stay as
   they are for usage rollups, provider usage and the update check, which set
   their own long staleness and should keep it. A Session's status is a live
   fact about a machine, not a cached page.

   The cost is one list read on mount and on focus, against a Core that is
   already asked for that same list on every `pty:` event while a Session runs.

2. **`packages/panel/src/lib/use-events.ts`** — the shared stream now tracks
   whether it has been down since it was last up, and announces the open that
   follows a drop. Only that one: a first connection is not a gap. Reconnect
   subscribers live in their own set, so they never open or hold a socket.

3. **`packages/panel/src/lib/use-event-stream-reconcile.ts`** (new) turns that
   announcement into an invalidation of the `["projects"]` tree (which by
   prefix reaches the list, every project row and every task bucket beneath
   them) plus groups and the archived buckets that sit outside that tree by
   design (ADR 0019). Mounted once in the shell
   (`packages/panel/src/routes/__root.tsx:265`) because the stream is shared
   and so is everything it feeds. This is the same bargain
   `useCoreLiveQueries` already makes for a dropped core-link.

Nothing tries to recover the missed events — the channel never recorded them.
It re-reads instead of trusting the screen.

## Tests

- `packages/panel/src/queries/__tests__/return-to-project-refetch.test.tsx` —
  three cases, each built on a client with `router.tsx`'s exact defaults: a
  remount well inside the 30s window shows the finish; a refocus re-reads with
  the client default off; and the #381 cancel path still refetches on return.
  The first two fail on this branch with the `PROJECT_SCOPED_FRESHNESS` spread
  removed, which is how they were checked for vacuity.
- `packages/panel/src/lib/__tests__/server-events-reconnect.test.tsx` — five
  cases: the first connection announces nothing; a drop-then-open announces
  once; a stream that fires no `onopen` still announces on its first frame; the
  reconnect drives the three invalidations; and an unsubscribed listener is
  told nothing.

Full `packages/panel` suite: 168 files, 1783 tests, green. `pnpm typecheck`
clean across the workspace. `pnpm lint` reports no error or warning from any
file in this change.

Refs #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLqzv97JwsmdFEFigxsbiT
