### PR TITLE
fix(panel): the pairing query survives the auth round trip

### DIFF
--- a/packages/panel/src/lib/__tests__/api-401-redirect.test.ts
+++ b/packages/panel/src/lib/__tests__/api-401-redirect.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The third leg of the auth round trip: a session that dies under an open tab.
+ *
+ * `documentAuthRedirect` never sees it — the browser is already on the page and
+ * the next `/api/*` call comes back 401 — so `redirectToLoginOnce` is the only
+ * thing that decides where that operator lands, and it was the one behaviour
+ * changed by #406 with nothing exercising it (#490 review N1).
+ *
+ * It has its own file because `pairing-query-across-auth.test.tsx` mocks
+ * `~/lib/api` wholesale; this suite needs the real module and a stubbed
+ * `fetch` under it.
+ */
+
+/** Where the last `window.location.assign` was pointed, or null. */
+let assigned: string | null = null;
+let realLocation: PropertyDescriptor | undefined;
+
+function browserAt(href: string): void {
+  const url = new URL(href, "http://panel.example.test");
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: url.href,
+      pathname: url.pathname,
+      search: url.search,
+      assign: (target: string) => {
+        assigned = target;
+      },
+    },
+  });
+}
+
+/** Answer every call with one status, so `req` takes the branch under test. */
+function respondWith(status: number): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify({ error: "unauthorized" }), { status })),
+  );
+}
+
+const { api, ApiError } = await import("~/lib/api");
+
+/** Drive one gated call and swallow the `ApiError` the failure raises. */
+async function callTheApi(): Promise<void> {
+  await expect(api.listCores()).rejects.toBeInstanceOf(ApiError);
+}
+
+beforeEach(() => {
+  assigned = null;
+  realLocation = Object.getOwnPropertyDescriptor(window, "location");
+});
+
+afterEach(() => {
+  if (realLocation) Object.defineProperty(window, "location", realLocation);
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("a 401 under an open tab", () => {
+  it("brings the operator back to the step they were on", async () => {
+    respondWith(401);
+    browserAt("/?step=redeem");
+    await callTheApi();
+    expect(assigned).toBe("/login?step=redeem");
+  });
+
+  it("goes to a bare login page when there was nothing to carry", async () => {
+    respondWith(401);
+    browserAt("/");
+    await callTheApi();
+    expect(assigned).toBe("/login");
+  });
+
+  /**
+   * The same narrowing the gate and the two pages apply (#490 review B1): the
+   * expiry happens on `/projects/$id`, the operator is sent to `/login`, and
+   * `coreId` means nothing there or on the `/` they sign in to.
+   */
+  it("leaves a deep route's own parameters behind", async () => {
+    respondWith(401);
+    browserAt("/projects/p1?coreId=core-b");
+    await callTheApi();
+    expect(assigned).toBe("/login");
+  });
+
+  it("stays put when the 401 arrives on the login page itself", async () => {
+    respondWith(401);
+    browserAt("/login?step=redeem");
+    await callTheApi();
+    expect(assigned).toBeNull();
+  });
+
+  it("does not redirect on any other failure", async () => {
+    respondWith(500);
+    browserAt("/?step=redeem");
+    await callTheApi();
+    expect(assigned).toBeNull();
+  });
+});

--- a/packages/panel/src/lib/__tests__/pairing-query-across-auth.test.tsx
+++ b/packages/panel/src/lib/__tests__/pairing-query-across-auth.test.tsx
@@ -187,6 +187,57 @@ describe("creating the Operator", () => {
   });
 });
 
+/**
+ * The carry keeps the query and drops the path, so an unfiltered version lands
+ * a deep route's parameters on a shallower one (#490 review B1).
+ *
+ * `coreId` is the live case. `routes/projects.$id.tsx` is the only route that
+ * declares it, and `__root.tsx` reads it off every route — its selector's own
+ * comment being "Only the /projects/$id route sets `coreId`; every other route
+ * implicitly means the Panel's own rows". Replayed onto `/` after a re-login it
+ * scopes the root route to a remote Core and arms `UserTerminalPanel`'s New
+ * Terminal button, which is disabled on a clean `/` for exactly the reason that
+ * there is no Core to open a shell on.
+ */
+describe("a deep route's parameters", () => {
+  it("do not follow a sign-in home to the root route", async () => {
+    browserAt("/login?coreId=core-b");
+    await signIn();
+    expect(assigned).toBe("/");
+  });
+
+  it("do not follow an Operator create home either", async () => {
+    browserAt("/setup?coreId=core-b");
+    await createOperator();
+    expect(assigned).toBe("/");
+  });
+
+  it("are dropped without taking the pairing query with them", async () => {
+    browserAt("/login?step=redeem&coreId=core-b&label=my-panel");
+    await signIn();
+    const url = new URL(assigned!, "http://x");
+    expect(url.searchParams.get("coreId")).toBeNull();
+    expect(url.searchParams.get("step")).toBe("redeem");
+    expect(url.searchParams.get("label")).toBe("my-panel");
+    expect(firstRunStepFromSearch(url.search)).toBe(REDEEM_STEP);
+  });
+
+  it("survive on the route that owns them", () => {
+    // Not a path this module redirects to today — pinned so the rule reads as
+    // "carried where it means something", not "always deleted".
+    expect(withCarriedQuery("/projects/p1", "?coreId=core-b")).toBe("/projects/p1?coreId=core-b");
+  });
+
+  it("are dropped on every destination the auth round trip uses", () => {
+    for (const destination of ["/", "/login", "/setup"]) {
+      expect(withCarriedQuery(destination, "?coreId=core-b")).toBe(destination);
+      expect(withCarriedQuery(destination, "?step=redeem&coreId=core-b")).toBe(
+        `${destination}?step=redeem`,
+      );
+    }
+  });
+});
+
 describe("withCarriedQuery", () => {
   it("leaves a destination with no query alone", () => {
     expect(withCarriedQuery("/", "")).toBe("/");

--- a/packages/panel/src/lib/__tests__/pairing-query-across-auth.test.tsx
+++ b/packages/panel/src/lib/__tests__/pairing-query-across-auth.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentType } from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+/**
+ * The pairing query survives the auth round trip (#406).
+ *
+ * `deploy/docker-compose.yml` prints `…/?step=redeem`, and an operator opening
+ * it on a fresh Panel is bounced through `/setup` or `/login` before anything
+ * reads it. `FirstRunWizard` picks its starting step out of
+ * `window.location.search` once, at mount — so every hop that rebuilds the URL
+ * from a bare path silently turns that documented link back into step 1.
+ *
+ * Both exits from the round trip are covered here, deliberately. Creating the
+ * Operator and signing in are different pages with different handlers, the
+ * acceptance criterion names both, and fixing either one alone leaves the other
+ * broken for exactly the operator the link was written for: the one arriving at
+ * a Panel that has never been set up.
+ *
+ * The assertion is the landing URL *as the wizard reads it* — `?step=redeem`
+ * put back through `firstRunStepFromSearch` — rather than a string compare, so
+ * this suite fails if the query survives in a shape the wizard cannot parse.
+ *
+ * It lives beside `~/lib/auth-paths` rather than under `src/routes/`, whose
+ * every file the route generator expects to export a `Route`; the two pages are
+ * imported by alias, so the folder makes no difference to what is tested. The
+ * server half of the same round trip is in
+ * `server/__tests__/operator-auth.test.ts`, where the Panel DB harness lives.
+ */
+
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+const api = {
+  login: vi.fn(async (_password: string) => ({ ok: true })),
+  setupOperator: vi.fn(async (_body: { name: string; password: string }) => ({ ok: true })),
+};
+
+vi.mock("~/lib/api", () => ({ api, ApiError }));
+
+const { withCarriedQuery } = await import("~/lib/auth-paths");
+const { FIRST_RUN_STEP_IDS, REDEEM_STEP_LINK, firstRunStepFromSearch } = await import(
+  "~/shared/core-onboarding"
+);
+const loginRoute = await import("~/routes/login");
+const setupRoute = await import("~/routes/setup");
+
+const REDEEM_STEP = FIRST_RUN_STEP_IDS.indexOf("redeem");
+
+/** The page component a route file hands the router, ready to render alone. */
+function pageOf(route: { options: unknown }): ComponentType {
+  const component = (route.options as { component?: ComponentType }).component;
+  if (!component) throw new Error("route has no component");
+  return component;
+}
+
+/** Where the last `window.location.assign` was pointed, or null. */
+let assigned: string | null = null;
+let realLocation: PropertyDescriptor | undefined;
+
+/**
+ * Put the browser on `href` with a `location` that records navigations instead
+ * of performing them. jsdom's own `assign` is unforgeable and does nothing, so
+ * the destination — the whole subject of these tests — is unobservable without
+ * standing in for the object.
+ */
+function browserAt(href: string): void {
+  const url = new URL(href, "http://panel.example.test");
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: url.href,
+      pathname: url.pathname,
+      search: url.search,
+      assign: (target: string) => {
+        assigned = target;
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  assigned = null;
+  realLocation = Object.getOwnPropertyDescriptor(window, "location");
+});
+
+afterEach(() => {
+  cleanup();
+  if (realLocation) Object.defineProperty(window, "location", realLocation);
+  vi.clearAllMocks();
+});
+
+/** Fill a labelled box on the rendered card. */
+function type(label: RegExp, value: string): void {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+async function submit(buttonLabel: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: buttonLabel }));
+  });
+}
+
+async function signIn(): Promise<void> {
+  const LoginPage = pageOf(loginRoute.Route);
+  render(<LoginPage />);
+  type(/^password$/i, "operator-password");
+  await submit("Sign in");
+}
+
+async function createOperator(): Promise<void> {
+  const SetupPage = pageOf(setupRoute.Route);
+  render(<SetupPage />);
+  type(/your name/i, "Operator");
+  type(/^password$/i, "a-long-enough-password");
+  type(/confirm password/i, "a-long-enough-password");
+  await submit("Create Operator");
+}
+
+describe("signing in", () => {
+  it("lands the operator back on the step the compose link asked for", async () => {
+    browserAt(`/login${REDEEM_STEP_LINK}`);
+    await signIn();
+    expect(api.login).toHaveBeenCalledOnce();
+    expect(assigned).not.toBeNull();
+    expect(firstRunStepFromSearch(new URL(assigned!, "http://x").search)).toBe(REDEEM_STEP);
+  });
+
+  it("carries the rest of the pairing query, not just the step", async () => {
+    browserAt("/login?step=redeem&label=my-panel&session=7f2c1a9e");
+    await signIn();
+    const search = new URL(assigned!, "http://x").searchParams;
+    expect(search.get("step")).toBe("redeem");
+    expect(search.get("label")).toBe("my-panel");
+    expect(search.get("session")).toBe("7f2c1a9e");
+  });
+
+  it("still goes to a bare root when there was nothing to carry", async () => {
+    browserAt("/login");
+    await signIn();
+    expect(assigned).toBe("/");
+  });
+});
+
+describe("creating the Operator", () => {
+  it("lands the operator back on the step the compose link asked for", async () => {
+    browserAt(`/setup${REDEEM_STEP_LINK}`);
+    await createOperator();
+    expect(api.setupOperator).toHaveBeenCalledOnce();
+    expect(assigned).not.toBeNull();
+    expect(firstRunStepFromSearch(new URL(assigned!, "http://x").search)).toBe(REDEEM_STEP);
+  });
+
+  it("carries the rest of the pairing query, not just the step", async () => {
+    browserAt("/setup?step=redeem&label=my-panel");
+    await createOperator();
+    const search = new URL(assigned!, "http://x").searchParams;
+    expect(search.get("step")).toBe("redeem");
+    expect(search.get("label")).toBe("my-panel");
+  });
+
+  it("still goes to a bare root when there was nothing to carry", async () => {
+    browserAt("/setup");
+    await createOperator();
+    expect(assigned).toBe("/");
+  });
+
+  it("stays put when the two passwords disagree", async () => {
+    browserAt(`/setup${REDEEM_STEP_LINK}`);
+    const SetupPage = pageOf(setupRoute.Route);
+    render(<SetupPage />);
+    type(/your name/i, "Operator");
+    type(/^password$/i, "a-long-enough-password");
+    type(/confirm password/i, "something-else-entirely");
+    await submit("Create Operator");
+    expect(api.setupOperator).not.toHaveBeenCalled();
+    expect(assigned).toBeNull();
+  });
+});
+
+describe("withCarriedQuery", () => {
+  it("leaves a destination with no query alone", () => {
+    expect(withCarriedQuery("/", "")).toBe("/");
+    expect(withCarriedQuery("/login", "?")).toBe("/login");
+  });
+
+  it("keeps every parameter, in order", () => {
+    expect(withCarriedQuery("/login", "?step=redeem&label=my-panel")).toBe(
+      "/login?step=redeem&label=my-panel",
+    );
+  });
+
+  /**
+   * The value goes into a `Location` header as well as `location.assign`, so a
+   * CR or LF smuggled through the query has to come out escaped rather than
+   * splitting the response.
+   */
+  it("re-encodes a query that would otherwise break a header", () => {
+    const carried = withCarriedQuery("/login", "?step=redeem%0d%0aSet-Cookie:%20x=1");
+    expect(carried).not.toMatch(/[\r\n]/);
+    expect(new URL(carried, "http://x").searchParams.get("step")).toBe(
+      "redeem\r\nSet-Cookie: x=1",
+    );
+  });
+});

--- a/packages/panel/src/lib/api.ts
+++ b/packages/panel/src/lib/api.ts
@@ -4,6 +4,7 @@ import type { ProjectPathStatus, ProjectWithCounts } from "~/shared/projects";
 import type { CoreListResponse, CoreWithDial } from "~/shared/cores";
 import type { CorePairingIdentityResponse } from "~/shared/core-pairing";
 import { DEV_SERVER_ORIGIN } from "~/shared/dev-server";
+import { LOGIN_PATH, isAuthPath, withCarriedQuery } from "~/lib/auth-paths";
 import type { Binding, BindingMap, HotkeyAction } from "~/lib/keybindings/types";
 import type { UsageSummary } from "~/shared/token-usage";
 import type { ClaudeUsageLimits } from "~/shared/claude-usage-limits";
@@ -104,9 +105,12 @@ export class ApiError extends Error {
  */
 function redirectToLoginOnce(): void {
   if (typeof window === "undefined") return;
-  const { pathname } = window.location;
-  if (pathname === "/login" || pathname === "/setup") return;
-  window.location.assign("/login");
+  const { pathname, search } = window.location;
+  if (isAuthPath(pathname)) return;
+  // The third leg of the same round trip `documentAuthRedirect` and the two
+  // auth pages make, so it carries the query for the same reason (#406): an
+  // expiry under an open `/?step=redeem` should come back to `/?step=redeem`.
+  window.location.assign(withCarriedQuery(LOGIN_PATH, search));
 }
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {

--- a/packages/panel/src/lib/auth-paths.ts
+++ b/packages/panel/src/lib/auth-paths.ts
@@ -7,6 +7,38 @@ export function isAuthPath(pathname: string): boolean {
 }
 
 /**
+ * Search parameters that belong to one route and mean nothing on any other,
+ * with the route prefix that owns each.
+ *
+ * `coreId` is the Panel's only one today. `routes/projects.$id.tsx` declares it
+ * in `validateProjectSearch`, and `__root.tsx` reads it off *every* route with
+ * the invariant spelled out above the selector: "Only the /projects/$id route
+ * sets `coreId`; every other route implicitly means the Panel's own rows."
+ *
+ * Carrying it across an expiry would break that invariant rather than restore a
+ * link. A sign-in from `/projects/p1?coreId=core-b` ends on `/`, and `/` with a
+ * `coreId` is a root route scoped to a remote Core: `__root.tsx` hands it to
+ * `UserTerminalPanel`, whose New Terminal button is disabled precisely when
+ * there is no `coreId`, and to the ⌘T binding behind it — so a control that is
+ * inert on a clean `/` would come back live, pointed at a machine the operator
+ * did not navigate to.
+ *
+ * A stray Core scope on a route that should have none is a shape this codebase
+ * has already been burned by: `ProjectBar.tsx` carries a comment saying its
+ * fallback to the bar's `coreId` prop "is gone rather than merely unused",
+ * because it made an operator's own project look Core-owned (#382 review round
+ * 2). Carrying `coreId` home from an expiry would be the same mistake by
+ * another route.
+ *
+ * The pairing query is untouched by this: `step` belongs to no route — the
+ * wizard is rendered by `FirstRunGate` over whatever route the operator landed
+ * on — so nothing here filters it, and nothing here names it either.
+ */
+const ROUTE_SCOPED_PARAMS: readonly { readonly name: string; readonly ownedBy: string }[] = [
+  { name: "coreId", ownedBy: "/projects/" },
+];
+
+/**
  * A destination with the query string the browser arrived with carried onto it.
  *
  * The auth round trip is three hops — the requested page, `/setup` or `/login`,
@@ -27,8 +59,16 @@ export function isAuthPath(pathname: string): boolean {
  * put in a `Location` header as well as in `location.assign`: the value is
  * re-encoded, so a CR or LF smuggled into the incoming query is escaped rather
  * than sent as a header break.
+ *
+ * **A parameter is only carried onto a route it means something on.** The path
+ * is dropped and the query kept, so an unfiltered carry would land a deep
+ * route's parameters on a shallower one — see {@link ROUTE_SCOPED_PARAMS}.
  */
 export function withCarriedQuery(pathname: string, search: string): string {
-  const query = new URLSearchParams(search).toString();
+  const params = new URLSearchParams(search);
+  for (const { name, ownedBy } of ROUTE_SCOPED_PARAMS) {
+    if (!pathname.startsWith(ownedBy)) params.delete(name);
+  }
+  const query = params.toString();
   return query ? `${pathname}?${query}` : pathname;
 }

--- a/packages/panel/src/lib/auth-paths.ts
+++ b/packages/panel/src/lib/auth-paths.ts
@@ -5,3 +5,30 @@ export const SETUP_PATH = "/setup";
 export function isAuthPath(pathname: string): boolean {
   return pathname === LOGIN_PATH || pathname === SETUP_PATH;
 }
+
+/**
+ * A destination with the query string the browser arrived with carried onto it.
+ *
+ * The auth round trip is three hops — the requested page, `/setup` or `/login`,
+ * then back — and every one of them used to be built from a bare path, so a URL
+ * that said anything in its query said nothing by the time the shell mounted.
+ * That is what breaks the documented Compose link: `/?step=redeem` opens the
+ * pairing wizard on the install step, because `FirstRunWizard` reads
+ * `window.location.search` and by then the search is empty (#406).
+ *
+ * The query rides the redirect itself rather than a side channel. There is
+ * nothing to store, nothing to expire, and nothing left behind for the *next*
+ * visit to pick up by mistake: a link opened in one tab cannot decide where a
+ * second tab starts, and an abandoned sign-in leaves no residue.
+ *
+ * **Only the query travels.** The path is always one this module chose, so this
+ * cannot become an open redirect — no origin, no host, no path is taken from
+ * the request. Re-serialising through `URLSearchParams` is what makes it safe to
+ * put in a `Location` header as well as in `location.assign`: the value is
+ * re-encoded, so a CR or LF smuggled into the incoming query is escaped rather
+ * than sent as a header break.
+ */
+export function withCarriedQuery(pathname: string, search: string): string {
+  const query = new URLSearchParams(search).toString();
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/packages/panel/src/routes/login.tsx
+++ b/packages/panel/src/routes/login.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { AuthCard } from "~/components/views/AuthCard";
 import { TextField } from "~/components/ui/TextField";
 import { api, ApiError } from "~/lib/api";
+import { withCarriedQuery } from "~/lib/auth-paths";
 
 // The Panel's only anonymous page once an Operator exists. Reached by every
 // unauthenticated navigation (server/panel-auth.ts:documentAuthRedirect).
@@ -23,7 +24,12 @@ function LoginPage() {
       await api.login(password);
       // A full load rather than a client navigation: the app shell mounts
       // outside this page's tree, and SSR should render it with the new cookie.
-      window.location.assign("/");
+      //
+      // The query goes home with it. `documentAuthRedirect` sent this browser
+      // here carrying whatever it asked with, and a bare `/` here would throw
+      // that away on the last hop of the round trip — which is how a documented
+      // `?step=redeem` link opened the wizard on step 1 (#406).
+      window.location.assign(withCarriedQuery("/", window.location.search));
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "sign-in failed");
       setBusy(false);

--- a/packages/panel/src/routes/setup.tsx
+++ b/packages/panel/src/routes/setup.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { AuthCard } from "~/components/views/AuthCard";
 import { TextField } from "~/components/ui/TextField";
 import { api, ApiError } from "~/lib/api";
+import { withCarriedQuery } from "~/lib/auth-paths";
 import { MIN_PASSWORD_LENGTH } from "~/shared/operator-password";
 
 // First boot: the Panel serves this page, and only this page, until the single
@@ -33,7 +34,10 @@ function SetupPage() {
     setError(null);
     try {
       await api.setupOperator({ name, password });
-      window.location.assign("/");
+      // Carrying the query, for the same reason `login.tsx` does: creating the
+      // Operator is the *other* way out of the auth round trip, and a fix that
+      // survives sign-in but not first-boot is not a fix (#406).
+      window.location.assign(withCarriedQuery("/", window.location.search));
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "setup failed");
       setBusy(false);

--- a/packages/panel/src/server/__tests__/operator-auth.test.ts
+++ b/packages/panel/src/server/__tests__/operator-auth.test.ts
@@ -344,6 +344,27 @@ describe("the served UI", () => {
     });
 
     /**
+     * The gate drops the path and keeps the query, so a deep route's parameters
+     * would otherwise arrive on a shallower one (#490 review B1). `coreId`
+     * belongs to `/projects/$id` alone, and `__root.tsx` reads it off every
+     * route — on `/` it scopes the whole shell to a Core the operator did not
+     * navigate to. A plain reload of an expired session is the path in, so the
+     * gate has to be the place it is stopped, not only the two pages.
+     */
+    it("leaves a deep route's own parameters behind", async () => {
+      await setup();
+      expect(
+        documentAuthRedirect(navigate("/projects/p1?coreId=core-b"))?.headers.get("location"),
+      ).toBe("/login");
+      // …and the pairing query still rides, from the same URL.
+      expect(
+        documentAuthRedirect(navigate("/projects/p1?coreId=core-b&step=redeem"))?.headers.get(
+          "location",
+        ),
+      ).toBe("/login?step=redeem");
+    });
+
+    /**
      * The carried value reaches a response header, so it is re-encoded rather
      * than pasted through: a CR or LF in the query must not be able to end the
      * `Location` line and start one of its own.

--- a/packages/panel/src/server/__tests__/operator-auth.test.ts
+++ b/packages/panel/src/server/__tests__/operator-auth.test.ts
@@ -298,6 +298,65 @@ describe("the served UI", () => {
     // The login page has to be able to load its own JavaScript.
     expect(documentAuthRedirect(request("/assets/index.js"))).toBeNull();
   });
+
+  /**
+   * The gate is the first thing the documented Compose link meets, and for a
+   * long time it was where the link died: `?step=redeem` went in and a bare
+   * `/setup` came out, so the wizard opened on step 1 having been asked for
+   * step 3 (#406). Every hop is checked, because a browser on a fresh Panel
+   * makes two of them before a page renders.
+   */
+  describe("the pairing query", () => {
+    const REDEEM = "?step=redeem";
+
+    it("rides out to setup on first boot", () => {
+      expect(documentAuthRedirect(navigate(`/${REDEEM}`))?.headers.get("location")).toBe(
+        `/setup${REDEEM}`,
+      );
+    });
+
+    it("rides out to login once an Operator exists", async () => {
+      await setup();
+      expect(documentAuthRedirect(navigate(`/${REDEEM}`))?.headers.get("location")).toBe(
+        `/login${REDEEM}`,
+      );
+      // And on the hop that closes setup behind the first Operator.
+      expect(documentAuthRedirect(navigate(`/setup${REDEEM}`))?.headers.get("location")).toBe(
+        `/login${REDEEM}`,
+      );
+    });
+
+    it("rides home again for a browser that is already signed in", async () => {
+      const cookie = sessionCookieFrom(await setup());
+      expect(
+        documentAuthRedirect(navigate(`/login${REDEEM}`, cookie))?.headers.get("location"),
+      ).toBe(`/${REDEEM}`);
+      expect(
+        documentAuthRedirect(navigate(`/setup${REDEEM}`, cookie))?.headers.get("location"),
+      ).toBe(`/${REDEEM}`);
+    });
+
+    it("keeps the rest of the query with it", async () => {
+      await setup();
+      expect(
+        documentAuthRedirect(navigate("/?step=redeem&label=my-panel"))?.headers.get("location"),
+      ).toBe("/login?step=redeem&label=my-panel");
+    });
+
+    /**
+     * The carried value reaches a response header, so it is re-encoded rather
+     * than pasted through: a CR or LF in the query must not be able to end the
+     * `Location` line and start one of its own.
+     */
+    it("cannot smuggle a second header out of the query", async () => {
+      await setup();
+      const location = documentAuthRedirect(
+        navigate("/?step=redeem%0d%0aSet-Cookie:%20stolen=1"),
+      )?.headers.get("location");
+      expect(location).not.toMatch(/[\r\n]/);
+      expect(location).toBe("/login?step=redeem%0D%0ASet-Cookie%3A+stolen%3D1");
+    });
+  });
 });
 
 describe("restart", () => {

--- a/packages/panel/src/server/panel-auth.ts
+++ b/packages/panel/src/server/panel-auth.ts
@@ -1,5 +1,5 @@
 import { jsonError } from "./http-responses";
-import { LOGIN_PATH, SETUP_PATH } from "~/lib/auth-paths";
+import { LOGIN_PATH, SETUP_PATH, withCarriedQuery } from "~/lib/auth-paths";
 import { HTTP_UNAUTHORIZED } from "~/shared/http-status";
 import { operatorExists } from "./services/operator";
 import {
@@ -75,10 +75,19 @@ export function readPanelAuthState(request: Request): PanelAuthState {
   return { needsSetup: false, session: resolvePanelSession(readSessionCookie(request)) };
 }
 
-function redirectTo(pathname: string): Response {
+/**
+ * A 303 to `pathname`, carrying `search` — the query the browser asked with —
+ * onto it.
+ *
+ * Every redirect in this gate passes through here with the incoming query,
+ * because a gate that answers `/?step=redeem` with a bare `/login` has thrown
+ * away the only thing the request said (#406). `withCarriedQuery` re-encodes
+ * the value, so nothing an attacker puts in a query can break the header.
+ */
+function redirectTo(pathname: string, search: string): Response {
   return new Response(null, {
     status: 303,
-    headers: { location: pathname, "cache-control": "no-store" },
+    headers: { location: withCarriedQuery(pathname, search), "cache-control": "no-store" },
   });
 }
 
@@ -94,8 +103,14 @@ function redirectTo(pathname: string): Response {
 export function documentAuthRedirect(request: Request): Response | null {
   if (!request.headers.get("accept")?.includes("text/html")) return null;
   let pathname: string;
+  let search: string;
   try {
-    pathname = new URL(request.url).pathname;
+    const url = new URL(request.url);
+    pathname = url.pathname;
+    // The pairing query travels with the browser through the whole round trip
+    // — out to setup or login and back again — rather than being dropped here
+    // and reconstructed from somewhere else later.
+    search = url.search;
   } catch {
     return null;
   }
@@ -104,14 +119,14 @@ export function documentAuthRedirect(request: Request): Response | null {
   const { needsSetup, session } = readPanelAuthState(request);
   if (pathname === SETUP_PATH) {
     if (needsSetup) return null;
-    return redirectTo(session ? "/" : LOGIN_PATH);
+    return redirectTo(session ? "/" : LOGIN_PATH, search);
   }
   if (pathname === LOGIN_PATH) {
-    if (needsSetup) return redirectTo(SETUP_PATH);
-    return session ? redirectTo("/") : null;
+    if (needsSetup) return redirectTo(SETUP_PATH, search);
+    return session ? redirectTo("/", search) : null;
   }
   if (session) return null;
-  return redirectTo(needsSetup ? SETUP_PATH : LOGIN_PATH);
+  return redirectTo(needsSetup ? SETUP_PATH : LOGIN_PATH, search);
 }
 
 /** The gate every authenticated surface goes through. */


### PR DESCRIPTION
Opening `http://localhost:7420/?step=redeem` — the URL `deploy/docker-compose.yml` prints — and then creating the Operator or
signing in landed the operator on the wizard's **install** step. The pairing query did not survive the auth round trip.

## The destroyers

`FirstRunWizard` reads `window.location.search` once, at mount. Everything between the operator's click and that mount rebuilt
the URL from a bare path, so by the time the wizard looked, there was nothing to read.

| Hop | Before | After |
| --- | --- | --- |
| `server/panel-auth.ts` — `documentAuthRedirect` | `/?step=redeem` → `/setup`, `/login`; and back to `/` | query carried on every 303 |
| `routes/setup.tsx` — Operator create | `window.location.assign("/")` | `assign(withCarriedQuery("/", …))` |
| `routes/login.tsx` — sign-in | `window.location.assign("/")` | `assign(withCarriedQuery("/", …))` |
| `lib/api.ts` — 401 under an open tab | `assign("/login")` | query carried too |

The issue names the first two; the third and fourth are the same round trip's other legs. `api.ts` is included because a session
that expires under an open `/?step=redeem` should come back to `/?step=redeem` — it is one line and the same bug.

**Both exits are fixed, not one.** Creating the Operator and signing in are separate pages with separate handlers, and the
acceptance criterion names both. The first-boot Compose link is aimed precisely at the Panel that has no Operator yet, so a fix
that only survived sign-in would miss the operator it was written for.

## No side channel

The query rides the redirect itself. Nothing is written to `localStorage`, a cookie, or any other store: there is nothing to
expire, nothing for a second tab to inherit, and nothing left behind by an abandoned sign-in. The redirect can simply keep it,
so it keeps it.

New shared helper, `lib/auth-paths.ts` → `withCarriedQuery(pathname, search)`. **Only the query travels** — the path is always
one this code chose, so this cannot become an open redirect. Re-serialising through `URLSearchParams` is what makes the value
safe in a `Location` header as well as in `location.assign`: a CR or LF smuggled through the query comes out percent-encoded
rather than ending the header line. Both suites pin that.

## Is it a regression of #372?

**No — a different one.** #372 is where `?step=` and the Compose link came from, and it is easy to read this as its regression,
but the history says otherwise:

- `git log --diff-filter=A` puts both destroyers — `panel-auth.ts`'s bare `redirectTo` and `login.tsx`'s
  `window.location.assign("/")` — in `c2b8d0d`, the initial commit, 2026-08-03.
- #372 merged 2026-09-01 as `97cd450` and touched **neither file**: `actana-pair.ts`, `FirstRunWizard.tsx`,
  `core-onboarding.ts`, `docker-compose.yml` and their tests, and nothing else.

Nothing that worked before stopped working. The auth gate has never carried a query; #372 shipped the first link whose query
anyone needed to survive, and the two had simply never met. #372's own tests are honest about their scope — they exercise
`firstRunStepFromSearch` and the wizard directly, never through a sign-in — which is exactly the seam this PR repairs.

## Only onto a route it means something on (review B1)

The carry keeps the query and drops the path, so an unfiltered version replays a **deep route's** parameters onto a shallower
one. `coreId` is the live case: `routes/projects.$id.tsx` is the only route that declares it, and `__root.tsx` reads it off
every route under a comment stating the invariant — *"Only the /projects/$id route sets `coreId`; every other route implicitly
means the Panel's own rows."* An expiry on `/projects/p1?coreId=core-b` came home as `/?coreId=core-b`, which scopes the whole
root shell to a Core the operator never navigated to and arms `UserTerminalPanel`'s New Terminal button — disabled on a clean
`/` precisely because there is no Core to open a shell on. #382 round 2 removed a fallback of that shape from `ProjectBar`.

`withCarriedQuery` now drops a parameter whose owning route the destination is not. `ROUTE_SCOPED_PARAMS` names the one the
Panel has today beside the route that owns it, so the rule reads as a fact about `coreId` rather than a list of destinations —
and a parameter still travels onto the route it belongs to (`/projects/p1?coreId=c` keeps it).

The narrowing is in the helper alone: no redirect restructured, no call site changed. The pairing query is untouched — `step`
belongs to no route, so nothing filters it and nothing names it.

## Coverage

Every changed file is covered, and every suite fails on the code before its change (verified by reverting, not asserted):

| Suite | Cases | Reverting | Result |
| --- | --- | --- | --- |
| `server/__tests__/operator-auth.test.ts` | 6 | `panel-auth.ts` | **5 failed / 23 passed** |
| `lib/__tests__/pairing-query-across-auth.test.tsx` | 15 | `login.tsx` + `setup.tsx` | **4 failed / 6 passed** |
| `lib/__tests__/api-401-redirect.test.ts` | 5 | `api.ts` | **1 failed / 4 passed** |
| all three | — | the B1 narrowing | **6 failed / 43 passed** |

The page tests assert the landing URL *as the wizard reads it* (`firstRunStepFromSearch`), not as a string. The B1 narrowing
fails one case per way in: the gate, both auth pages, the 401 leg, and the helper.

`api-401-redirect.test.ts` is new in the second commit and answers review N1 — `lib/api.ts` previously had no test, while this
description implied otherwise. It drives the real client against a stubbed 401: the step survives, a bare route stays bare, a
deep route's parameters do not travel, the login page does not redirect to itself, and a 500 does not redirect at all. It is a
separate file because `pairing-query-across-auth.test.tsx` mocks `~/lib/api` wholesale.

Both page suites live under `lib/__tests__` rather than `src/routes/__tests__` because the route generator warns on any file
under `src/routes/` that does not export a `Route`; the pages are imported by alias, so the folder changes nothing about what
is tested.

## Verification

- `packages/panel` full suite: **167 files, 1801 tests, all passing.**
- `pnpm typecheck` clean across all five workspaces; route generation clean.
- `pnpm lint` — 0 errors; the 43 warnings are pre-existing and none are in a file this PR touches.

## Boundaries

`packages/panel/src/router.tsx` and `lib/use-events.ts` (#484) untouched. Nothing under `packages/core` (#483, #405, #290)
touched. `router.tsx:65` has a fifth bare `assign("/")` — an error-boundary "go home" — left alone as #484's file and not part
of this path. `OperatorSettingsPage`'s sign-out `assign("/login")` is deliberately left bare: leaving is not a round trip.

Refs #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Doi96KzL7VATynvKaE8Up
