### PR TITLE
fix: a wait ends when its link to the Core does, and calls the outcome unknown

### DIFF
--- a/.agents/skills/actana-sessions/SKILL.md
+++ b/.agents/skills/actana-sessions/SKILL.md
@@ -149,7 +149,7 @@ object** `start --wait --json` prints — same keys, same `screen` — so one pa
 reads all three verbs. Two of those keys are `null` on a Session you attached to
 rather than started: `command` and `reportsTurnStart` are answers to a spawn.
 
-Four things to know before you build on it:
+Five things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -184,6 +184,17 @@ Four things to know before you build on it:
    exits zero** — which reads as a completed turn and is not one. To carry on
    waiting, follow the log from the delivery instead:
    `actana events tail --since <event id>`, the id the timeout message names.
+5. **A wait whose link to the Core drops ends as *unknown*.** Every wait listens
+   over that link, so a Core that restarts or a connection that is reaped takes
+   the report the wait was waiting for with it. Rather than hang — which is what
+   it used to do, with no deadline of any kind to end it — the command exits
+   non-zero saying **the turn's outcome is unknown**: it may have ended while
+   this side was deaf, and it may still be running. That is not a failed turn
+   and not a finished one, and it is the one case where the Session's status has
+   to be re-read from the Core rather than taken from the wait. Do that once the
+   Core is reachable again — `actana session ls` says whether it is still live,
+   `actana events tail --since <event id>` follows the log from your delivery —
+   and **do not** answer it with `session wait`, for the reason in 4.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ routing around it.
 | [0030](adr/0030-the-panel-is-a-dumb-pipe-for-file-bytes.md) | The Panel is a dumb pipe for file bytes, and it is the end that holds the credentials |
 | [0031](adr/0031-the-product-ships-one-skill.md) | The product ships one skill, and installs it into the operator's home — **PROPOSED**, amends 0006 |
 | [0032](adr/0032-one-actana-cli.md) | There is one `actana`, and it is both the Core manager and the client — supersedes #265 §6 and 0031 D8's two-binaries premise |
-| [0033](adr/0033-turn-end-is-the-one-mandatory-harness-signal.md) | Turn-end reporting is the one mandatory harness signal; turn-start, auto-mode flags and resume ids may never gate a feature — D5 (#405) gives `send --wait` a default deadline, amending D4 |
+| [0033](adr/0033-turn-end-is-the-one-mandatory-harness-signal.md) | Turn-end reporting is the one mandatory harness signal; turn-start, auto-mode flags and resume ids may never gate a feature — D5 (#405) gives `send --wait` a default deadline and D6 (#396) ends a wait whose link dropped as unknown, both amending D4 |
 | [0035](adr/0035-a-second-skill-for-the-sub-agent-role.md) | A second skill for the sub-agent role, and it is eager — **PROPOSED**, depends on 0031 |
 | [0036](adr/0036-the-beta-release-channel.md) | The beta release channel: a beta installs like a release, and the ref is the channel — **PROPOSED**, amends 0016 (D28, D29, D34, D35) and 0023 (D8, D9) |
 | [0037](adr/0037-one-version-per-line.md) | One version per line: where a version string is written, and what is authoritative — **PROPOSED**, amends 0023 (D3, D7), the two clauses 0036 §G left open |

--- a/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
+++ b/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
@@ -92,6 +92,43 @@ A send that submits nothing at all (`--no-enter`) is refused with `--wait`
 rather than bounded: it has no turn to await, so there is nothing for a deadline
 to be about.
 
+**D6 — A lost link ends a wait as *unknown*, and never as an outcome**
+(extends D4, #396). Everything that can end a wait well arrives down the core
+link: the status change a harness's hooks produce, and the process exit behind
+it. A link that drops therefore takes every one of them with it, and the wait
+does not end — it goes quiet. With no `--wait-timeout` there is nothing left in
+the world that can settle it, which is `actana session start … --wait` sitting
+for ever after a Core blip; with one, the operator learns about the drop as a
+deadline, which points them at a slow harness rather than at a dead socket.
+
+So a drop is an ending in its own right, and the class of ending is the whole
+decision. **The wait fails.** Resolving it with the status the Session was last
+seen at is the cheap fix and the forbidden one: it reports a turn as ended on
+the evidence that this side stopped listening, which is a false completion — the
+failure D4 and #405 exist to remove, arriving through the transport instead of
+through the harness. The wait rejects with `CoreSessionLinkLostError`, distinct
+by class from both a resolution (the Core reported a turn ended) and
+`CoreSessionTurnTimeoutError` (this side gave up on its own clock), and its
+message says the outcome is unknown and names both readings — the turn may have
+ended in the silence, and it may still be running.
+
+The wait is not failed on the first blip. A client that reconnects usually
+recovers a drop without the wait noticing: the link returns, the client
+re-subscribes from its cursor, and the Core streams the tail it missed —
+including the status change the wait was waiting for. So a drop starts a
+**grace**, not a deadline: thirty seconds (`CORE_LINK_LOST_GRACE_MS`), which is
+six or more of `DurableCoreClient`'s backoff attempts, cancelled the moment a
+connection comes back, and running only while the link is down. A client that
+does **not** reconnect gets a grace of zero, because a grace is time given to a
+reconnect and a one-shot client — the `actana` CLI's — has none coming; waiting
+it out would be thirty more seconds of the hang.
+
+Nothing here weakens D2 or D4. No screen is read, `reportsTurnStart` is
+consulted nowhere, and the only facts the error carries are that the link went
+and two event ids. The Session itself is untouched by any of it: it is running
+on the Core, which is where its status lives and where the question this error
+leaves open is answered.
+
 ## Consequences
 
 Adding a family is still adding a row, and now the row has a bar to clear. A

--- a/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
+++ b/docs/adr/0033-turn-end-is-the-one-mandatory-harness-signal.md
@@ -117,11 +117,36 @@ recovers a drop without the wait noticing: the link returns, the client
 re-subscribes from its cursor, and the Core streams the tail it missed —
 including the status change the wait was waiting for. So a drop starts a
 **grace**, not a deadline: thirty seconds (`CORE_LINK_LOST_GRACE_MS`), which is
-six or more of `DurableCoreClient`'s backoff attempts, cancelled the moment a
-connection comes back, and running only while the link is down. A client that
-does **not** reconnect gets a grace of zero, because a grace is time given to a
-reconnect and a one-shot client — the `actana` CLI's — has none coming; waiting
-it out would be thirty more seconds of the hang.
+six or more of `DurableCoreClient`'s backoff attempts, and running only while
+the link is down. A client that does **not** reconnect gets a grace of zero,
+because a grace is time given to a reconnect and a one-shot client — the
+`actana` CLI's — has none coming; waiting it out would be thirty more seconds of
+the hang.
+
+Two clauses of that grace are load-bearing, and #492's review found the first
+draft wrong on both. Each was a way for a wait to outlive its link after all,
+which would have left this decision stating something untrue.
+
+**The grace is a cumulative budget, not a fresh allowance per outage.** The
+outages a single wait lives through are summed, and the wait fails once they
+total the grace. Forgiving each flap in full bounds nothing: a Core in a restart
+crash-loop, or a `DurableCoreClient` on its 500 ms–5 s backoff against a flaky
+link, drops and returns indefinitely with no single outage long enough to fire
+anything, and the wait hangs for ever — #396's own bug, reached the long way
+round. Summed, the deaf time a wait can accumulate is bounded, so the wait always
+ends. The error reports both numbers, because they differ: `graceMs` is the
+budget and `downMs` is what was actually spent.
+
+**The grace is forgiven by an *established* connection, not by `ready`.** `ready`
+is the Core's first unsolicited frame and lands before `auth` is answered, so a
+connection the Core is about to refuse for an expired or rotated bearer produces
+one. Nothing can be sent on that connection and no `subscribe` goes out — that
+rides the established signal — so treating `ready` as recovery forgives an outage
+that never ended; with a supervisor dialing again it is a `ready` → `authError` →
+`disconnect` loop that arms and disarms the guard for ever with no events flowing
+at all. `CoreClient.onEstablished` — the Core has said who it is and the link can
+be written to, authenticated where a bearer was configured — is the signal, and
+`onReady` is not.
 
 Nothing here weakens D2 or D4. No screen is read, `reportsTurnStart` is
 consulted nowhere, and the only facts the error carries are that the link went

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -23,7 +23,10 @@ import {
   type SessionRow,
   type StartedSession,
 } from "../session-gateway.ts";
-import { CoreSessionTurnTimeoutError } from "@actana/sdk/core-session.ts";
+import {
+  CoreSessionLinkLostError,
+  CoreSessionTurnTimeoutError,
+} from "@actana/sdk/core-session.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "../exit-codes.ts";
 
 let fixture: CliFixture | null = null;
@@ -943,6 +946,75 @@ describe("actana session send", () => {
     // #405's false completion back one layer up.
     expect(run.err.join("\n")).toContain("Not `session wait`");
     expect(run.err.join("\n")).toContain("exits zero");
+  });
+
+  it("exits non-zero when the link drops mid-wait, and calls the outcome unknown (#396)", async () => {
+    // Issue #396's acceptance criterion, at the layer the operator meets it:
+    // `--wait` against a Core that blips used to leave the command pending for
+    // ever. It now ends — non-zero, with the outcome named as unknown, and
+    // **not** as a status the Core never sent.
+    await withRegisteredCore();
+    const run = await cli().run(["session", "send", "task_1", "carry on", "--wait", "--json"], {
+      sessions: fakeSessionGateway({
+        sendAndWait: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              throw new CoreSessionLinkLostError({
+                taskId: "task_1",
+                afterEventId: 42,
+                lastStatus: "running",
+                reportedSinceDelivery: true,
+                graceMs: 30_000,
+                reason: "socket hang up",
+              });
+            },
+          }),
+      }),
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    const payload = JSON.parse(run.out.join("\n"));
+    expect(payload.waited).toBe(true);
+    // No status key at all: the Core reported none, so the document carries
+    // none. A `--json` caller branching on `status` must not find `running`
+    // here and read it as the turn.
+    expect(payload.status).toBeUndefined();
+    expect(payload.error).toContain("outcome is unknown");
+    expect(payload.error).toContain("not a report that the turn finished");
+    expect(run.err.join("\n")).toContain("the turn's outcome is unknown");
+    // Cursored, so the next step is the log from the delivery — and, as after
+    // #405's timeout, explicitly not `session wait`, which would answer from the
+    // status this Session was parked at before the drop and exit zero.
+    expect(run.err.join("\n")).toContain("`actana events tail --since 42`");
+    expect(run.err.join("\n")).toContain("Not `session wait`");
+  });
+
+  it("points an uncursored wait at the Core rather than at a delivery it never made", async () => {
+    // `start --wait` and `session wait` carry no delivery stamp, so there is no
+    // `--since` to follow and the advice that names one would be a fiction.
+    await withRegisteredCore();
+    const run = await cli().run(["session", "start", "web", "go", "--wait"], {
+      sessions: fakeSessionGateway({
+        start: async () =>
+          fakeStartedSession({
+            wait: async () => {
+              throw new CoreSessionLinkLostError({
+                taskId: "task_1",
+                afterEventId: 0,
+                lastStatus: null,
+                reportedSinceDelivery: false,
+                graceMs: 0,
+                reason: null,
+              });
+            },
+          }),
+      }),
+    });
+
+    expect(run.code).toBe(EXIT_FAILURE);
+    expect(run.err.join("\n")).toContain("the turn's outcome is unknown");
+    expect(run.err.join("\n")).toContain("`actana session ls`");
+    expect(run.err.join("\n")).not.toContain("events tail --since");
   });
 
   it("does not offer the uncursored wait as the next step after any timeout", async () => {

--- a/packages/cli/src/__tests__/session-command.test.ts
+++ b/packages/cli/src/__tests__/session-command.test.ts
@@ -965,6 +965,7 @@ describe("actana session send", () => {
                 lastStatus: "running",
                 reportedSinceDelivery: true,
                 graceMs: 30_000,
+                downMs: 31_200,
                 reason: "socket hang up",
               });
             },
@@ -1004,6 +1005,7 @@ describe("actana session send", () => {
                 lastStatus: null,
                 reportedSinceDelivery: false,
                 graceMs: 0,
+                downMs: 0,
                 reason: null,
               });
             },

--- a/packages/cli/src/orchestration-skill-payload.ts
+++ b/packages/cli/src/orchestration-skill-payload.ts
@@ -197,7 +197,7 @@ object** \`start --wait --json\` prints — same keys, same \`screen\` — so on
 reads all three verbs. Two of those keys are \`null\` on a Session you attached to
 rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
 
-Four things to know before you build on it:
+Five things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -232,6 +232,17 @@ Four things to know before you build on it:
    exits zero** — which reads as a completed turn and is not one. To carry on
    waiting, follow the log from the delivery instead:
    \`actana events tail --since <event id>\`, the id the timeout message names.
+5. **A wait whose link to the Core drops ends as *unknown*.** Every wait listens
+   over that link, so a Core that restarts or a connection that is reaped takes
+   the report the wait was waiting for with it. Rather than hang — which is what
+   it used to do, with no deadline of any kind to end it — the command exits
+   non-zero saying **the turn's outcome is unknown**: it may have ended while
+   this side was deaf, and it may still be running. That is not a failed turn
+   and not a finished one, and it is the one case where the Session's status has
+   to be re-read from the Core rather than taken from the wait. Do that once the
+   Core is reachable again — \`actana session ls\` says whether it is still live,
+   \`actana events tail --since <event id>\` follows the log from your delivery —
+   and **do not** answer it with \`session wait\`, for the reason in 4.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.

--- a/packages/cli/src/session-command.ts
+++ b/packages/cli/src/session-command.ts
@@ -50,7 +50,10 @@ import { resolveCore } from "./core-resolution.ts";
 import { formatJson, formatTable } from "./cli-output.ts";
 import { isKnownHarness, KNOWN_HARNESSES } from "./session-gateway.ts";
 import { runSessionAttach } from "./session-attach.ts";
-import { CoreSessionTurnTimeoutError } from "@actana/sdk/core-session.ts";
+import {
+  CoreSessionLinkLostError,
+  CoreSessionTurnTimeoutError,
+} from "@actana/sdk/core-session.ts";
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from "./exit-codes.ts";
 import type { RegistryPaths } from "./blob-registry.ts";
 import type { ActanaCliDeps } from "./cli-deps.ts";
@@ -460,9 +463,10 @@ async function awaitTurn(
   try {
     outcome = await session.wait(timeoutMs === null ? {} : { timeoutMs });
   } catch (err) {
-    // The only thing that reaches here is the deadline the operator asked for.
-    // It is reported as what it is — this side gave up — rather than as a
-    // status, because the Core never said one.
+    // Two things reach here, and neither is a status: the deadline the operator
+    // asked for (#405), and the link to the Core dropping out from under the
+    // wait (#396). Both are reported as what they are — this side gave up, or
+    // this side went deaf — because the Core never said anything either way.
     const message = messageOf(err);
     if (args.json) deps.out(formatJson({ ...startedFields(session), waited: true, error: message }));
     deps.err(`actana session: ${message}`);
@@ -504,6 +508,33 @@ async function awaitTurn(
           `\`actana events tail --since ${err.afterEventId}\`. Not \`session wait\`: that verb ` +
           `answers at once with the status this Session was already parked at and exits zero, ` +
           `which is last turn's answer, not this one's.`,
+      );
+    }
+    // The lost link's next step (#396), and it is a different one: nothing here
+    // gave up on a clock, so there is no "keep waiting" to offer against a Core
+    // this invocation can no longer reach. What it can say is where the answer
+    // is — the Core, once it is reachable — and, when there is a delivery cursor
+    // to name, the one command that reads the log from the write rather than
+    // from whatever status the row is parked at.
+    //
+    // **`session wait` is warned off here for the same reason it is above.**
+    // After a drop the Session may well be sitting at the status it carried
+    // before this turn, and an uncursored wait would print that and exit zero —
+    // a turn reported as finished on the strength of a network failure, which is
+    // exactly what the SDK refused to do a moment earlier.
+    if (err instanceof CoreSessionLinkLostError) {
+      const followOn =
+        err.afterEventId > 0
+          ? `To pick the wait up where it stopped, follow the log from the delivery: ` +
+            `\`actana events tail --since ${err.afterEventId}\`. Not \`session wait\`: it answers ` +
+            `from the status this Session is parked at and exits zero, which after a drop is as ` +
+            `likely to be last turn's answer as this one's.`
+          : `\`actana session ls\` says whether it is still live, and ` +
+            `\`actana session logs ${session.taskId}\` shows what is on screen.`;
+      deps.err(
+        `actana session: the turn's outcome is unknown — the Core never reported it ending, and ` +
+          `this side stopped listening. The Session is on the Core, not in this process, so it is ` +
+          `still running there. ${followOn}`,
       );
     }
     return EXIT_FAILURE;

--- a/packages/sdk/src/__tests__/core-client.test.ts
+++ b/packages/sdk/src/__tests__/core-client.test.ts
@@ -492,6 +492,46 @@ describe("CoreClient", () => {
     expect(ordered).toEqual(["reclaim", "replay"]);
   });
 
+  it("records a subscribe only when one actually went out (#396)", async () => {
+    // `isSubscribedToEvents()` is read by `CoreSession` to decide whether it
+    // still owes the Core a `subscribe`. It used to be set before the frame was
+    // written, so a subscribe that never made it onto a link answered `true`
+    // anyway — a Session wired to an event stream nobody asked for, hearing no
+    // status ever, with every wait on it one that nothing could end.
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+    });
+
+    // Before the dial there is no writable connection to put a frame on, so the
+    // send fails — and the client must say so rather than remember a subscribe
+    // it never sent.
+    expect(client.subscribeEvents()).toBe(false);
+    expect(client.isSubscribedToEvents()).toBe(false);
+
+    await client.connect();
+
+    expect(client.subscribeEvents()).toBe(true);
+    expect(client.isSubscribedToEvents()).toBe(true);
+    expect(dial.last().client.framesOfType("subscribe")).toHaveLength(1);
+  });
+
+  it("says it will not reconnect, because it will not (#396)", async () => {
+    // The predicate anything deciding how long to wait out a drop reads. A
+    // one-shot client has no supervisor: the socket dying is the end of it, and
+    // a caller that waited for a reconnect here would wait for ever.
+    const core = authenticatingRig();
+    const { client: c, dial } = await connected(core);
+
+    expect(c.willReconnect()).toBe(false);
+    dial.last().server.close();
+    expect(c.isConnected()).toBe(false);
+    expect(c.willReconnect()).toBe(false);
+  });
+
   it("authenticates nothing and is writable at once against a loopback Core", async () => {
     // No `authVerifier` on the Core, no bearer on the client: the trusted
     // loopback shape, where `auth` is a no-op and there is no `authOk` coming.

--- a/packages/sdk/src/__tests__/core-client.test.ts
+++ b/packages/sdk/src/__tests__/core-client.test.ts
@@ -519,6 +519,54 @@ describe("CoreClient", () => {
     expect(dial.last().client.framesOfType("subscribe")).toHaveLength(1);
   });
 
+  it("establishes on an authenticated connection, never on `ready` alone (#396)", async () => {
+    // **#492 review, blocking 2.** `ready` is the Core's first unsolicited frame
+    // and lands before `auth` is answered, so it is not "the link is usable".
+    // Anything that waits out a drop has to disarm on the connection being
+    // *established* — open, and authenticated where a bearer was configured —
+    // or a connection the Core is about to refuse counts as recovery.
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    const order: string[] = [];
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: signBearer({ coreId: "core_x", exp: Date.now() - 1_000 }, SECRET),
+      createSocket: dial.createSocket,
+      connectTimeoutMs: 2_000,
+    });
+    client.onReady(() => order.push("ready"));
+    client.onEstablished(() => order.push("established"));
+    client.onAuthError(() => order.push("authError"));
+    client.onDisconnected(() => order.push("disconnected"));
+
+    await expect(client.connect()).rejects.toBeInstanceOf(CoreLinkAuthError);
+
+    // The Core said who it is, refused the bearer, and hung up. Nothing was ever
+    // writable, so nothing was ever established.
+    expect(order).toEqual(["ready", "authError", "disconnected"]);
+  });
+
+  it("fires established once a bearer has been accepted (#396)", async () => {
+    // The other half: on a connection that does authenticate, `established`
+    // lands — after `ready`, and behind the frames the connection owes the Core.
+    const core = authenticatingRig();
+    const dial = core.dialer();
+    const order: string[] = [];
+    client = new CoreClient({
+      url: "wss://core.test:9444",
+      bearer: bearerFor(),
+      createSocket: dial.createSocket,
+    });
+    client.onReady(() => order.push("ready"));
+    client.onEstablished(() => order.push("established"));
+
+    await client.connect();
+
+    expect(order).toEqual(["ready", "established"]);
+    expect(client.isAuthenticated()).toBe(true);
+    void dial;
+  });
+
   it("says it will not reconnect, because it will not (#396)", async () => {
     // The predicate anything deciding how long to wait out a drop reads. A
     // one-shot client has no supervisor: the socket dying is the end of it, and

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -34,8 +34,10 @@ import type {
 } from "../core-link-frames.ts";
 import { CoreClient } from "../core-client.ts";
 import {
+  CORE_LINK_LOST_GRACE_MS,
   CoreSession,
   CoreSessionAttachError,
+  CoreSessionLinkLostError,
   CoreSessionStartError,
   CoreSessionTurnTimeoutError,
   HARNESS_LAUNCH_COMMANDS,
@@ -165,6 +167,10 @@ type Rig = {
   ptyCore: PtyCore & { emitEvent: (e: PtyCoreEvent) => void };
   tasks: FakeTaskStore;
   eventLog: FakeEventLog;
+  /** Every connection this rig has handed out, in dial order. */
+  pairs: FakeSocketPair[];
+  /** The link dies the way a reaped NAT flow or a restarted Core kills it (#396). */
+  drop: () => void;
   close: () => void;
 };
 
@@ -202,10 +208,12 @@ function startRig(
       ? {}
       : { announceMultiConnection: opts.announceMultiConnection }),
   });
+  const pairs: FakeSocketPair[] = [];
   const client = new CoreClient({
     url: "wss://core.test:9444",
     createSocket: () => {
       const pair = new FakeSocketPair();
+      pairs.push(pair);
       if (opts.afterServerFrame) {
         const send = pair.server.send.bind(pair.server);
         pair.server.send = (data: string) => {
@@ -218,7 +226,15 @@ function startRig(
       return pair.client.asClientSocket();
     },
   });
-  const built: Rig = { client, ptyCore, tasks, eventLog, close: () => server.close() };
+  const built: Rig = {
+    client,
+    ptyCore,
+    tasks,
+    eventLog,
+    pairs,
+    drop: () => pairs[pairs.length - 1]?.server.close(),
+    close: () => server.close(),
+  };
   return built;
 }
 
@@ -1045,6 +1061,215 @@ describe("attaching to a Session that is already running (#289)", () => {
     expect(timeout.message).toMatch(/reports nothing until it ends/);
     expect(timeout.message).toMatch(/cannot tell those apart/);
     expect(timeout.message).toContain("The text was delivered");
+  });
+});
+
+describe("a wait cannot outlive its link (#396)", () => {
+  // The hang this suite is about: every way a wait can end well — a status
+  // change, a process exit — reaches this side down the core link, so a link
+  // that drops takes all of them with it and the wait goes quiet instead of
+  // ending. With no `--wait-timeout` there was nothing left that could ever
+  // settle it, which is the operator's `actana session start … --wait` sitting
+  // for ever after a Core blip.
+  //
+  // What is asserted below is the shape of the fix as much as its presence: the
+  // wait **rejects**. Resolving it with the status the Session was last seen at
+  // would report a turn as ended because a socket died, and a false completion
+  // is the one outcome worse than the hang (ADR 0033 D6).
+
+  async function runningSession(status = "running"): Promise<string> {
+    const r = rig!;
+    await r.client.connect();
+    const created = await r.client.tasksMutate({
+      op: "create",
+      projectId: PROJECT_ID,
+      title: "somebody else's session",
+      agent: "claude-code",
+    });
+    r.tasks.setStatus(created!.taskId, status);
+    return created!.taskId;
+  }
+
+  it("ends a wait that has no deadline at all, rather than hanging on a dead link", async () => {
+    // Issue #396's acceptance criterion, at the layer that implements it. No
+    // `timeoutMs` — which is `session wait` with no `--wait-timeout`, and what
+    // `--wait-timeout 0` opts back into on the one verb that has a default
+    // (#405) — so this rejection is the only thing in the world that will ever
+    // settle this promise.
+    rig = startRig();
+    const taskId = await runningSession("running");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+
+    rig.drop();
+
+    const err = await idle;
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+  });
+
+  it("says the outcome is unknown, and never that the turn ended", async () => {
+    // The distinction the whole train exists to protect. The Session is parked
+    // at `running`, the link dies, and what comes back must not read as a turn
+    // that ended — not in the class, not in the fields, and not in the prose.
+    rig = startRig();
+    const taskId = await runningSession("finished");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+    r.tasks.setStatus(taskId, "running");
+    await vi.waitFor(() => expect(session!.status()).toBe("running"));
+
+    const idle = session
+      .waitForTurnEnd({ afterEventId: deliveryEventId })
+      .catch((thrown: unknown) => thrown);
+    r.drop();
+
+    const err = (await idle) as CoreSessionLinkLostError;
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+    expect(err.name).toBe("CoreSessionLinkLostError");
+    // **Distinguishable from the deadline #405 added**, which is a different
+    // next step: that one is this side giving up on a clock it set, this one is
+    // this side going deaf. A caller branches on the class, not on the wording.
+    expect(err).not.toBeInstanceOf(CoreSessionTurnTimeoutError);
+    // The cursor and the last-known status are carried as context…
+    expect(err.taskId).toBe(taskId);
+    expect(err.afterEventId).toBe(deliveryEventId);
+    expect(err.lastStatus).toBe("running");
+    // …and `running` was learned after the delivery, so the turn was seen to be
+    // under way when the link went. Informative, never settling: a settling
+    // status would have ended the wait instead.
+    expect(err.reportedSinceDelivery).toBe(true);
+    // The sentence that matters.
+    expect(err.message).toMatch(/outcome is unknown/);
+    expect(err.message).toMatch(/not a report that the turn finished/);
+    expect(err.message).toMatch(/may still be running/);
+  });
+
+  it("fails a wait started after the link had already gone", async () => {
+    // The same hang through the other door: nothing drops mid-wait here, the
+    // wait simply begins against a link that is already down. It has exactly as
+    // little chance of hearing a status, so it gets exactly the same ending.
+    rig = startRig();
+    const taskId = await runningSession("running");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    rig.drop();
+
+    await expect(session.waitForIdle()).rejects.toBeInstanceOf(CoreSessionLinkLostError);
+  });
+
+  it("fails at once on a client with no reconnect coming, and names the reason", async () => {
+    // A one-shot `CoreClient` — the `actana` CLI's — does not dial again, so
+    // there is no reconnect for a grace to be time for and the wait fails on the
+    // drop itself. Sitting out thirty seconds first would be thirty seconds of
+    // the hang this fixes.
+    rig = startRig();
+    expect(rig.client.willReconnect()).toBe(false);
+    const taskId = await runningSession("running");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+    rig.drop();
+
+    const err = (await idle) as CoreSessionLinkLostError;
+    expect(err.graceMs).toBe(0);
+    expect(err.message).toMatch(/this client does not reconnect/);
+  });
+
+  it("gives a link that may come back the grace to do it in", async () => {
+    // The other half, and the reason this is not a bare rejection on the first
+    // blip: on a client that reconnects, a drop is usually not even an
+    // interruption — the link returns, the client re-subscribes from its cursor,
+    // and the Core streams the tail it missed. Failing instantly would report a
+    // turn as unobservable while it was being observed again.
+    //
+    // The grace is asked for explicitly here because the default is thirty
+    // seconds and a unit test may not take thirty seconds. That default is
+    // asserted separately, below.
+    rig = startRig();
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, linkLostGraceMs: 60 });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+
+    r.drop();
+    // Still waiting a tick later: the drop alone decides nothing.
+    let settled = false;
+    void idle.then(() => {
+      settled = true;
+    });
+    await new Promise((r2) => setTimeout(r2, 10));
+    expect(settled).toBe(false);
+
+    const err = (await idle) as CoreSessionLinkLostError;
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+    expect(err.graceMs).toBe(60);
+    expect(err.message).toMatch(/still down 60ms later/);
+  });
+
+  it("keeps waiting when the link comes back inside the grace", async () => {
+    // The recovery this grace exists for, and the property that makes it safe to
+    // have one: a link that returns leaves the wait exactly as it was — still
+    // pending, still owed a status by the Core, never resolved and never failed
+    // by anything that happened to the socket.
+    rig = startRig();
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, linkLostGraceMs: 40 });
+    let outcome: unknown = null;
+    void session.waitForIdle().then(
+      (idle) => {
+        outcome = idle;
+      },
+      (err: unknown) => {
+        outcome = err;
+      },
+    );
+
+    r.drop();
+    // A second connection, well inside the grace. `onReady` on the new link is
+    // what disarms it.
+    await r.client.connect();
+    await new Promise((r2) => setTimeout(r2, 120));
+
+    expect(outcome).toBeNull();
+  });
+
+  it("takes its default grace from whether the client reconnects at all", async () => {
+    // The default is not a number this layer picked for everyone: it is thirty
+    // seconds for a client that dials again and zero for one that does not, and
+    // the client is the one that knows which it is.
+    expect(CORE_LINK_LOST_GRACE_MS).toBe(30_000);
+    rig = startRig();
+    const taskId = await runningSession("running");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+    rig.drop();
+
+    // A one-shot client, so zero — and the wait is over long before any
+    // thirty-second grace could have run.
+    expect(((await idle) as CoreSessionLinkLostError).graceMs).toBe(0);
+  });
+
+  it("leaves a turn that really ended ending the wait, drop or no drop", async () => {
+    // The regression guard on the whole of this: nothing above may make a
+    // settled status stop resolving a wait, and a Session whose link never
+    // wobbles must behave exactly as it did before #396.
+    rig = startRig();
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId });
+    const { deliveryEventId } = await session.deliver("carry on");
+    const idle = session.waitForTurnEnd({ afterEventId: deliveryEventId });
+    r.tasks.setStatus(taskId, "finished");
+
+    await expect(idle).resolves.toEqual({ status: "finished", exited: false });
   });
 });
 

--- a/packages/sdk/src/__tests__/core-session.test.ts
+++ b/packages/sdk/src/__tests__/core-session.test.ts
@@ -32,6 +32,8 @@ import type {
   CoreLinkTaskMutation,
   CoreLinkTaskSnapshot,
 } from "../core-link-frames.ts";
+import type { CoreLinkSocket } from "../core-link-socket.ts";
+import { signBearer, verifyBearer } from "@actana/shared/core-link-bearer";
 import { CoreClient } from "../core-client.ts";
 import {
   CORE_LINK_LOST_GRACE_MS,
@@ -46,10 +48,12 @@ import {
 } from "../core-session.ts";
 import {
   FakeEventLog,
+  FakeSocket,
   FakeSocketPair,
   FakeSocketServer,
   makeMockPtyCore,
 } from "./fake-core-link.ts";
+import { CORE_LINK_PROTOCOL_VERSION } from "../core-link-frames.ts";
 
 const ESC = "\u001B";
 const CSI = `${ESC}[`;
@@ -179,6 +183,23 @@ function startRig(
     announceMultiConnection?: boolean;
     spawn?: PtyCore["spawn"];
     /**
+     * Arm the Core's auth gate and give the client a bearer, so a connection is
+     * not usable until `authOk` lands. The remote shape rather than the
+     * loopback one — what #492's blocking 2 is about (`ready` arrives first, and
+     * is not the link coming back).
+     */
+    authVerifier?: (bearer: string) =>
+      | { ok: true; coreId: string; exp: number }
+      | { ok: false; reason: "expired" | "bad-signature" | "malformed" };
+    bearer?: string;
+    /**
+     * Take over a dial. Called with the 0-based dial number; return a socket to
+     * hand the client instead of a connection to this rig's Core, or null to
+     * dial the Core as usual. How a test stages a connection the Core never
+     * accepts.
+     */
+    dial?: (n: number) => CoreLinkSocket | null;
+    /**
      * Called after the server has written a frame, in the same synchronous
      * turn. Node's `ws` emits several `message` events from one socket read, so
      * this is how a test reproduces two frames reaching the client before its
@@ -207,11 +228,16 @@ function startRig(
     ...(opts.announceMultiConnection === undefined
       ? {}
       : { announceMultiConnection: opts.announceMultiConnection }),
+    ...(opts.authVerifier ? { authVerifier: opts.authVerifier } : {}),
   });
   const pairs: FakeSocketPair[] = [];
+  let dials = 0;
   const client = new CoreClient({
     url: "wss://core.test:9444",
+    ...(opts.bearer ? { bearer: opts.bearer } : {}),
     createSocket: () => {
+      const staged = opts.dial?.(dials++) ?? null;
+      if (staged) return staged;
       const pair = new FakeSocketPair();
       pairs.push(pair);
       if (opts.afterServerFrame) {
@@ -1207,7 +1233,8 @@ describe("a wait cannot outlive its link (#396)", () => {
     const err = (await idle) as CoreSessionLinkLostError;
     expect(err).toBeInstanceOf(CoreSessionLinkLostError);
     expect(err.graceMs).toBe(60);
-    expect(err.message).toMatch(/still down 60ms later/);
+    expect(err.downMs).toBeGreaterThanOrEqual(60);
+    expect(err.message).toMatch(/been deaf for \d+ms, past the 60ms/);
   });
 
   it("keeps waiting when the link comes back inside the grace", async () => {
@@ -1256,6 +1283,168 @@ describe("a wait cannot outlive its link (#396)", () => {
     expect(((await idle) as CoreSessionLinkLostError).graceMs).toBe(0);
   });
 
+  /**
+   * Await `p`, but never for longer than `ms` — a regression here is a **hang**,
+   * and a test that hangs takes the suite down with it rather than failing.
+   */
+  async function settledWithin(p: Promise<unknown>, ms: number): Promise<unknown> {
+    const STILL_PENDING = Symbol("still pending");
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const bound = new Promise((resolve) => {
+      timer = setTimeout(() => resolve(STILL_PENDING), ms);
+    });
+    try {
+      const settled = await Promise.race([p, bound]);
+      if (settled === STILL_PENDING) {
+        throw new Error(`the wait was still pending after ${ms}ms — it is hanging`);
+      }
+      return settled;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  it("adds a flapping link's outages up rather than forgiving each one", async () => {
+    // **#492 review, blocking 1.** `onLinkBack` used to clear the grace outright,
+    // so the next drop got a full fresh one and nothing anywhere added up how
+    // long this side had actually been deaf. A link that drops and returns
+    // repeatedly — each outage shorter than the grace — therefore never failed
+    // the wait, however much total time was lost. A Core in a restart crash-loop
+    // and a `DurableCoreClient` on its 500 ms–5 s backoff are exactly that
+    // shape, so this is #396's own bug through a slower door.
+    //
+    // Five outages of ~65 ms against a 100 ms budget, and **no `timeoutMs`** —
+    // the deaf time is what has to end this, because nothing else can.
+    rig = startRig();
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, linkLostGraceMs: 100 });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+
+    for (let flap = 0; flap < 5; flap += 1) {
+      r.drop();
+      await new Promise((res) => setTimeout(res, 65));
+      await r.client.connect().catch(() => {});
+      await new Promise((res) => setTimeout(res, 15));
+    }
+
+    const err = (await settledWithin(idle, 4000)) as CoreSessionLinkLostError;
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+    // The budget is the configured constant; `downMs` is what was actually
+    // spent, and it is the sum across outages rather than the last one alone.
+    expect(err.graceMs).toBe(100);
+    expect(err.downMs).toBeGreaterThanOrEqual(100);
+  });
+
+  it("does not take an unauthenticated `ready` for the link coming back", async () => {
+    // **#492 review, blocking 2.** The disarm hung on `onReady`, and `ready` is
+    // the Core's first unsolicited frame — it lands *before* `auth` is answered.
+    // So a connection the Core is about to refuse, or one that simply never
+    // authenticates, counted as recovery: the guard was disarmed, nothing could
+    // be sent on that connection, no `subscribe` went out, and the wait sat
+    // there with the link permanently unusable and nothing left to end it.
+    //
+    // Staged exactly: dial 0 is this rig's Core with a good bearer; dial 1 is a
+    // socket that opens, says `ready`, and never answers the `auth` behind it.
+    const secret = "core-session-suite-secret-32-byte-x";
+    let bogus: FakeSocket | null = null;
+    rig = startRig({
+      authVerifier: (bearer) => verifyBearer(bearer, secret),
+      bearer: signBearer({ coreId: "core_test", exp: Date.now() + 60_000 }, secret),
+      dial: (n) => {
+        if (n === 0) return null;
+        const socket = new FakeSocket();
+        bogus = socket;
+        queueMicrotask(() => {
+          socket.readyState = 1;
+          socket.emit("open");
+          socket.receive({ type: "ready", version: CORE_LINK_PROTOCOL_VERSION });
+        });
+        return socket.asClientSocket();
+      },
+    });
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, linkLostGraceMs: 120 });
+    const idle = session.waitForIdle().catch((thrown: unknown) => thrown);
+
+    r.drop();
+    void r.client.connect().catch(() => {});
+
+    const err = (await settledWithin(idle, 4000)) as CoreSessionLinkLostError;
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+    expect(err.downMs).toBeGreaterThanOrEqual(120);
+    // The replacement connection really did say `ready` and really did get an
+    // `auth` it never answered — so the case under test is the one described,
+    // not a dial that failed to happen.
+    const staged = bogus as FakeSocket | null;
+    expect(staged?.framesOfType("auth")).toHaveLength(1);
+  });
+
+  it("hands the grace back when the caller's own deadline fires", async () => {
+    // **#492 review, should fix 1.** `notify` and `fail` released the grace; the
+    // `timeoutMs` callback did not. The timer is deliberately not `unref`ed, so
+    // it went on holding the event loop after the wait had settled — and because
+    // `armLinkLostGrace` keeps one timer per Session, the *next* wait inherited
+    // that stale, part-spent one and was failed early against a budget it never
+    // had.
+    rig = startRig();
+    const taskId = await runningSession("running");
+    const r = rig;
+
+    session = await CoreSession.attach(r.client, { taskId, linkLostGraceMs: 300 });
+    r.drop();
+
+    // Wait A gives up on its own clock well inside the grace.
+    await expect(session.waitForIdle({ timeoutMs: 60 })).rejects.toBeInstanceOf(
+      CoreSessionTurnTimeoutError,
+    );
+
+    // Wait B, started fresh, gets the whole budget rather than what was left of
+    // A's — and reports the deaf time it actually sat through.
+    const startedAt = Date.now();
+    const err = (await settledWithin(
+      session.waitForIdle().catch((thrown: unknown) => thrown),
+      4000,
+    )) as CoreSessionLinkLostError;
+    const elapsed = Date.now() - startedAt;
+
+    expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+    expect(err.downMs).toBeGreaterThanOrEqual(300);
+    // Comfortably above the ~240ms A would have left behind.
+    expect(elapsed).toBeGreaterThan(260);
+  });
+
+  it("orphans no deadline timer when a grace of 0 rejects inside the executor", async () => {
+    // **#492 review, should fix 2.** The `linkDown` check ran *before* the
+    // deadline was armed, so on a grace of 0 — the `actana` CLI's one-shot
+    // client — `fail` ran with `timer` still null and the `setTimeout` armed two
+    // lines later was never cleared by anything, `dispose()` included. Harmless
+    // where the process exits; an SDK consumer holds the event loop for the
+    // whole of a seventeen-minute deadline it has already stopped caring about.
+    rig = startRig();
+    const taskId = await runningSession("running");
+
+    session = await CoreSession.attach(rig.client, { taskId });
+    rig.drop();
+    await new Promise((res) => setTimeout(res, 5));
+
+    vi.useFakeTimers();
+    try {
+      const err = await session
+        .waitForIdle({ timeoutMs: 1_020_000 })
+        .catch((thrown: unknown) => thrown);
+      expect(err).toBeInstanceOf(CoreSessionLinkLostError);
+      // Nothing left armed under the fake clock: the deadline went back with the
+      // wait it belonged to.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("leaves a turn that really ended ending the wait, drop or no drop", async () => {
     // The regression guard on the whole of this: nothing above may make a
     // settled status stop resolving a wait, and a Session whose link never
@@ -1291,6 +1480,24 @@ describe("no wait is keyed on a turn's start (#289 A)", () => {
 
     expect(waiting.length).toBeGreaterThan(200);
     expect(waiting).not.toContain("reportsTurnStart");
+  });
+
+  it("mentions it nowhere in the handlers that end a wait on a lost link either", () => {
+    // **#492 review, advisory.** The slice above stops at `// ─── Lifecycle`, and
+    // #396's handlers sit under `// ─── Internals` — so the guard no longer
+    // covered every path that ends a wait, which is the property it exists to
+    // protect. Second slice, same rule.
+    const source = readFileSync(new URL("../core-session.ts", import.meta.url), "utf8");
+    const linkLost = source
+      .slice(source.indexOf("  private onLinkLost("), source.indexOf("  private ingestExit("))
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+
+    expect(linkLost.length).toBeGreaterThan(200);
+    expect(linkLost).not.toContain("reportsTurnStart");
+    // And nothing here reads the screen either (#191, ADR 0026 D3).
+    expect(linkLost).not.toContain("terminal");
+    expect(linkLost).not.toContain("screen");
   });
 });
 

--- a/packages/sdk/src/__tests__/durable-core-client.test.ts
+++ b/packages/sdk/src/__tests__/durable-core-client.test.ts
@@ -269,6 +269,25 @@ describe("DurableCoreClient", () => {
     expect(c.isConnected()).toBe(false);
   });
 
+  it("says a reconnect is coming, and stops saying it once hung up on (#396)", async () => {
+    // The predicate a wait reads to decide whether a drop is worth sitting out.
+    // Not the same question as "is a timer armed right now": between the socket
+    // dying and the backoff firing there is no timer, and the answer is still
+    // yes because this client is what it is. What ends it is `close()` — this
+    // client hanging up, after which nothing is coming.
+    const core = remoteRig();
+    const { client: c, dial } = makeClient(core);
+    await c.connect();
+
+    expect(c.willReconnect()).toBe(true);
+    dial.last().server.close();
+    expect(c.isConnected()).toBe(false);
+    expect(c.willReconnect()).toBe(true);
+
+    c.close();
+    expect(c.willReconnect()).toBe(false);
+  });
+
   it("resumes a restarted client's timeline from the store it was given", async () => {
     const core = remoteRig();
     core.eventLog.appendEvent("task:created", "{}", { taskId: "t1" });

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -619,6 +619,22 @@ export class CoreClient {
   }
 
   /**
+   * Will this client dial again on its own after a link it just lost?
+   *
+   * **False here, and that is the whole of a one-shot client's story**: it has no
+   * supervisor, so a dropped socket is the end of it and nothing above it should
+   * be written to wait one out. {@link DurableCoreClient} overrides it.
+   *
+   * Asked by anything that has to decide how long to keep waiting after a drop —
+   * `CoreSession`'s waits are the first (#396). The alternative was a fixed
+   * grace everywhere, which is either too short to cover a reconnect or long
+   * enough to be a hang on a client that will never have one.
+   */
+  willReconnect(): boolean {
+    return false;
+  }
+
+  /**
    * May this Core be sent frames only a multi-connection Core understands — the
    * Session lock's `claim`, the per-connection PTY subscription, and whatever
    * else lands under ADR 0024?
@@ -1008,8 +1024,16 @@ export class CoreClient {
    */
   subscribeEvents(lastEventId = 0): boolean {
     if (this.closed) return false;
-    this.eventsSubscribed = true;
-    return this.sendNow({ type: "subscribe", reqId: "", lastEventId }, "sub");
+    // Recorded only if the frame actually went out (#396). Setting it first made
+    // `isSubscribedToEvents()` answer true for a subscribe that was never sent —
+    // `sendNow` returns false when there is no writable connection to put it on
+    // — and the caller that consults it, `CoreSession`, reads it to decide
+    // whether it still owes the Core a subscribe. A lie there is a Session
+    // wired to an event stream that was never asked for: no status ever
+    // arrives, and every wait on it is one nothing will end.
+    const sent = this.sendNow({ type: "subscribe", reqId: "", lastEventId }, "sub");
+    if (sent) this.eventsSubscribed = true;
+    return sent;
   }
 
   /**

--- a/packages/sdk/src/core-client.ts
+++ b/packages/sdk/src/core-client.ts
@@ -359,6 +359,7 @@ export class CoreClient {
     (msg: { reason: CoreLinkAuthErrorReason }) => void
   >();
   private readonly disconnectedListeners = new Set<(msg: { error?: string }) => void>();
+  private readonly establishedListeners = new Set<() => void>();
   private readonly reclaimedListeners = new Set<
     (msg: { replaced: boolean; taskIds: string[] }) => void
   >();
@@ -568,6 +569,10 @@ export class CoreClient {
     // tail is delivered ahead of the answers to requests that were waiting.
     this.flushQueue();
     this.settleConnect();
+    // Last, so a listener hears about a connection that has already sent what it
+    // owed the Core — the reclaim, and on a durable client the subscribe that
+    // re-opens the event stream. See {@link onEstablished}.
+    for (const cb of this.establishedListeners) cb();
   }
 
   /** The socket is gone. A one-shot client is done; a durable one reconnects. */
@@ -1071,6 +1076,25 @@ export class CoreClient {
   onAuthError(cb: (msg: { reason: CoreLinkAuthErrorReason }) => void): Unsubscribe {
     this.authErrorListeners.add(cb);
     return () => this.authErrorListeners.delete(cb);
+  }
+
+  /**
+   * Notified when a connection is **established**: the Core has said who it is
+   * and the link can be written to — authenticated, where a bearer was
+   * configured. Fires once per connection, so a reconnect fires it again.
+   *
+   * **This, and not {@link onReady}, is "the link is usable again"** (#396).
+   * `ready` is the Core's first unsolicited frame and lands *before* `auth` is
+   * answered, so a connection the Core is about to refuse for an expired bearer
+   * produces one. A caller that took `ready` as recovery would forgive an outage
+   * that never ended: nothing can be sent on that connection, no `subscribe`
+   * goes out — that rides {@link onConnectionEstablished} — and the next frame
+   * is the `authError` that closes it. Anything waiting on the Core's report
+   * must count the link as down for the whole of that.
+   */
+  onEstablished(cb: () => void): Unsubscribe {
+    this.establishedListeners.add(cb);
+    return () => this.establishedListeners.delete(cb);
   }
 
   /**

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -183,9 +183,9 @@ export const STATUS_READ_RETRY_MS = 250;
  * first blip would report a turn as unobservable while it was being observed
  * again.
  *
- * Thirty seconds because that is several of `DurableCoreClient`'s
- * reconnects: its backoff runs 500 ms, 1 s, 2 s, 4 s and then every 5 s, so a
- * link that is coming back has had six or more attempts by the time this fires.
+ * Thirty seconds because that is several of `DurableCoreClient`'s reconnects:
+ * its backoff runs 500 ms, 1 s, 2 s, 4 s and then every 5 s, so a link that is
+ * coming back has had six or more attempts by the time this fires.
  * A link that has not come back by then is not a blip, and the wait behind it
  * has nothing left to hear.
  *
@@ -469,11 +469,12 @@ function turnTimeoutMessage(opts: {
  * The link to the Core went down while a wait was running, and did not come
  * back (#396).
  *
- * **Its whole reason for existing is that it is not a status.** A wait had three
- * ways to end before this: a settled status, which is the Core reporting a turn
- * ended; a deadline ({@link CoreSessionTurnTimeoutError}), which is this side
- * giving up on a clock it set itself; and — for a link that dropped — nothing at
- * all, which is the bug. The obvious cheap fix is the forbidden one: resolving
+ * **Its whole reason for existing is that it is not a status.** Three things can
+ * stop a wait, and before this only two of them ended it: a settled status,
+ * which is the Core reporting a turn ended; a deadline
+ * ({@link CoreSessionTurnTimeoutError}), which is this side giving up on a clock
+ * it set itself; and a link that dropped, which ended nothing and simply went
+ * quiet — the bug. The obvious cheap fix is the forbidden one: resolving
  * the wait with whatever status the Session was last seen at would report a turn
  * as ended on the evidence that this side stopped listening. That is a false
  * completion, which is the exact failure ADR 0033 exists to remove, so a lost

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -172,6 +172,34 @@ const STATUS_BEARING_EVENT_KINDS: ReadonlySet<string> = new Set([
 export const STATUS_READ_RETRIES = 3;
 export const STATUS_READ_RETRY_MS = 250;
 
+/**
+ * How long a wait goes on waiting after the link to the Core drops, before it
+ * gives up and says the turn's outcome is unknown (#396).
+ *
+ * A drop is not a verdict, and the reason there is a grace at all is that on a
+ * client that reconnects it is usually not even an interruption: the link comes
+ * back, the client re-subscribes from its cursor, and the Core streams the tail
+ * it missed — including the status change that ends this wait. Failing on the
+ * first blip would report a turn as unobservable while it was being observed
+ * again.
+ *
+ * Thirty seconds because that is several of `DurableCoreClient`'s
+ * reconnects: its backoff runs 500 ms, 1 s, 2 s, 4 s and then every 5 s, so a
+ * link that is coming back has had six or more attempts by the time this fires.
+ * A link that has not come back by then is not a blip, and the wait behind it
+ * has nothing left to hear.
+ *
+ * **It is a grace, not a deadline.** It only ever runs while the link is down,
+ * it is cancelled the moment the link returns, and it is not what
+ * {@link CoreSessionWaitOptions.timeoutMs} is — a caller that passed no deadline
+ * still has none while the Core is reachable.
+ *
+ * Zero, which {@link CoreSession.start} and {@link CoreSession.attach} use for a
+ * client that does not reconnect, means the wait fails the instant the link
+ * drops: there is no coming back to wait for.
+ */
+export const CORE_LINK_LOST_GRACE_MS = 30_000;
+
 export type CoreSessionStartOptions = {
   /**
    * The Project to start this Session in. Either this or {@link taskId}: with a
@@ -231,6 +259,15 @@ export type CoreSessionStartOptions = {
    * caller is doing something the check cannot see.
    */
   subscribeToEvents?: boolean;
+  /**
+   * How long a wait on this Session keeps waiting after the link to the Core
+   * drops, before it fails with {@link CoreSessionLinkLostError} (#396).
+   *
+   * Defaults to {@link CORE_LINK_LOST_GRACE_MS} on a client that reconnects and
+   * to **0** on one that does not, because on the second kind there is nothing
+   * to wait for. 0 fails the wait the instant the link goes down.
+   */
+  linkLostGraceMs?: number;
 };
 
 export type CoreSessionAttachOptions = {
@@ -258,6 +295,8 @@ export type CoreSessionAttachOptions = {
    * whose wait outlives the process it is about.
    */
   replay?: boolean;
+  /** As {@link CoreSessionStartOptions.linkLostGraceMs}. */
+  linkLostGraceMs?: number;
 };
 
 /** What a Session settled on. */
@@ -427,6 +466,118 @@ function turnTimeoutMessage(opts: {
 }
 
 /**
+ * The link to the Core went down while a wait was running, and did not come
+ * back (#396).
+ *
+ * **Its whole reason for existing is that it is not a status.** A wait had three
+ * ways to end before this: a settled status, which is the Core reporting a turn
+ * ended; a deadline ({@link CoreSessionTurnTimeoutError}), which is this side
+ * giving up on a clock it set itself; and — for a link that dropped — nothing at
+ * all, which is the bug. The obvious cheap fix is the forbidden one: resolving
+ * the wait with whatever status the Session was last seen at would report a turn
+ * as ended on the evidence that this side stopped listening. That is a false
+ * completion, which is the exact failure ADR 0033 exists to remove, so a lost
+ * link rejects and says what it actually knows — **the outcome is unknown**.
+ *
+ * Distinguishable from both of the other two endings by class, so a caller
+ * branches without parsing prose: a resolution is a turn that ended, a
+ * {@link CoreSessionTurnTimeoutError} is a deadline the caller set, and this is
+ * the link.
+ *
+ * Nothing here reads the byte stream and nothing here consults
+ * `reportsTurnStart` (ADR 0026 D3, ADR 0033 D2). The only facts it carries are
+ * the link going down and two event ids.
+ *
+ * The Session is untouched by any of this. It is running on the Core, which is
+ * where its status lives; reconnecting and asking is what answers the question
+ * this error leaves open.
+ */
+export class CoreSessionLinkLostError extends Error {
+  /** The Session the wait was about. */
+  readonly taskId: string;
+  /** The delivery stamp this wait counted from, or 0 for an uncursored wait. */
+  readonly afterEventId: number;
+  /**
+   * The last status the Core reported before the link went, or null when it had
+   * reported none.
+   *
+   * **Context, never the answer.** It is what was true before the drop, and a
+   * caller that presents it as the turn's outcome has written the false
+   * completion this class exists to prevent.
+   */
+  readonly lastStatus: string | null;
+  /**
+   * Did the Core report a status for this Session at an event id above
+   * {@link afterEventId} before the link went?
+   *
+   * Read exactly as its twin on {@link CoreSessionTurnTimeoutError} is read: two
+   * event ids compared, and only a status carried *by* an event moves the id it
+   * is compared against. `true` here is informative rather than settling — a
+   * settling status would have ended the wait, so what it reports is a turn that
+   * was seen to be *under way* when the link died. `false` means the log said
+   * nothing about this Session after the cursor.
+   */
+  readonly reportedSinceDelivery: boolean;
+  /** How long the wait went on for after the drop before giving up, in ms. */
+  readonly graceMs: number;
+  /** What the transport said about the drop, when it said anything. */
+  readonly reason: string | null;
+
+  constructor(opts: {
+    taskId: string;
+    afterEventId: number;
+    lastStatus: string | null;
+    reportedSinceDelivery: boolean;
+    graceMs: number;
+    reason: string | null;
+  }) {
+    super(linkLostMessage(opts));
+    this.name = "CoreSessionLinkLostError";
+    this.taskId = opts.taskId;
+    this.afterEventId = opts.afterEventId;
+    this.lastStatus = opts.lastStatus;
+    this.reportedSinceDelivery = opts.reportedSinceDelivery;
+    this.graceMs = opts.graceMs;
+    this.reason = opts.reason;
+  }
+}
+
+/**
+ * What {@link CoreSessionLinkLostError} says.
+ *
+ * One sentence for the fact — the link dropped and stayed down — and one for the
+ * consequence, which is the part that has to be unambiguous: the turn's outcome
+ * is **unknown**. It deliberately names both readings and settles neither, for
+ * the same reason the timeout's message does: the turn may have ended in the
+ * silence and it may still be running, and the only place that is known is the
+ * Core this side can no longer hear.
+ *
+ * What is **not** here is what to type next. This is a library; the CLI knows
+ * whether its user has an `actana` on their path and adds that line itself.
+ */
+function linkLostMessage(opts: {
+  taskId: string;
+  lastStatus: string | null;
+  graceMs: number;
+  reason: string | null;
+}): string {
+  const stayedDown =
+    opts.graceMs > 0
+      ? `and was still down ${opts.graceMs}ms later`
+      : "and this client does not reconnect";
+  const because = opts.reason ? ` (${opts.reason})` : "";
+  return (
+    `the link to the Core dropped while waiting for session ${opts.taskId} to end a turn${because}, ` +
+    `${stayedDown}. The turn's outcome is unknown: it may have ended while this side was deaf, and ` +
+    `it may still be running — the Core is where that is known, and nothing here can stand in for ` +
+    `it. This is not a report that the turn finished` +
+    (opts.lastStatus
+      ? `; ${opts.lastStatus} is only what the Core last said before the link went`
+      : "")
+  );
+}
+
+/**
  * One Session on one Core, driven programmatically.
  *
  * Built by {@link start}. Holds a screen fed from the Session's PTY, the Core's
@@ -500,6 +651,11 @@ export class CoreSession {
   private readonly idleWaiters = new Set<{
     afterEventId: number;
     notify: (idle: CoreSessionIdle) => void;
+    /**
+     * End this wait with a failure rather than an outcome — the route a lost
+     * link takes (#396), and the only one that can say "unknown".
+     */
+    fail: (err: Error) => void;
   }>();
 
   /**
@@ -532,6 +688,18 @@ export class CoreSession {
    * greater than nothing, so it can never satisfy a real cursor.
    */
   private lastStatusEventId = 0;
+  /**
+   * How long a wait on this Session survives a dropped link before it fails —
+   * {@link CORE_LINK_LOST_GRACE_MS}, 0 on a client that will not reconnect, or
+   * whatever the caller asked for.
+   */
+  private readonly linkLostGraceMs: number;
+  /** True between the link going down and it coming back. */
+  private linkDown = false;
+  /** What the transport said about the current drop, when it said anything. */
+  private linkLostReason: string | null = null;
+  /** The grace running against the current drop, armed only while one is. */
+  private linkLostTimer: ReturnType<typeof setTimeout> | null = null;
   private exit: { exitCode: number; signal?: number } | null = null;
   private disposed = false;
   /** A status read is in flight; another event arrived while it was. */
@@ -549,6 +717,7 @@ export class CoreSession {
     command: string | null;
     reportsTurnStart: boolean | null;
     terminal: TerminalScreen;
+    linkLostGraceMs: number;
   }) {
     this.client = opts.client;
     this.taskId = opts.taskId;
@@ -557,6 +726,7 @@ export class CoreSession {
     this.command = opts.command;
     this.reportsTurnStart = opts.reportsTurnStart;
     this.terminal = opts.terminal;
+    this.linkLostGraceMs = Math.max(0, opts.linkLostGraceMs);
   }
 
   /**
@@ -644,6 +814,11 @@ export class CoreSession {
       }
       session.onCoreEvent(event);
     });
+    // The link itself, because a wait that cannot hear the Core is a wait
+    // nothing will ever end (#396). Not held like the three above: a drop before
+    // the spawn is answered fails the spawn, which is the `catch` below.
+    const stopDown = client.onDisconnected(({ error }) => session?.onLinkLost(error));
+    const stopUp = client.onReady(() => session?.onLinkBack());
 
     let spawned: { ptyId: string; hooksReportTurnStart: boolean };
     try {
@@ -665,6 +840,8 @@ export class CoreSession {
       stopData();
       stopExit();
       stopEvents();
+      stopDown();
+      stopUp();
       throw new CoreSessionStartError(
         `the Core refused to start a ${opts.harness} Session in ${opts.cwd}: ${
           err instanceof Error ? err.message : String(err)
@@ -682,8 +859,9 @@ export class CoreSession {
       command,
       reportsTurnStart: spawned.hooksReportTurnStart,
       terminal,
+      linkLostGraceMs: linkLostGraceFor(client, opts.linkLostGraceMs),
     });
-    session.unsubscribes.push(stopData, stopExit, stopEvents);
+    session.unsubscribes.push(stopData, stopExit, stopEvents, stopDown, stopUp);
 
     for (const event of heldEvents) session.onCoreEvent(event);
     for (const frame of held) {
@@ -758,6 +936,7 @@ export class CoreSession {
       command: null,
       reportsTurnStart: null,
       terminal,
+      linkLostGraceMs: linkLostGraceFor(client, opts.linkLostGraceMs),
     });
 
     session.unsubscribes.push(
@@ -768,6 +947,12 @@ export class CoreSession {
         if (frame.ptyId === ptyId) session.ingestExit(frame);
       }),
       client.onEvent(({ event }) => session.onCoreEvent(event)),
+      // The link, for the same reason `start` wires it: an attached wait is the
+      // one `session wait` and `send --wait` are built on, and a dropped link
+      // used to leave it pending with nothing left that could ever end it
+      // (#396).
+      client.onDisconnected(({ error }) => session.onLinkLost(error)),
+      client.onReady(() => session.onLinkBack()),
     );
 
     const replay = opts.replay !== false;
@@ -993,6 +1178,23 @@ export class CoreSession {
    * `reportedSinceDelivery` says whether the Core reported anything at all after
    * the write. Bounding the wait is still the caller's — `timeoutMs` is theirs,
    * and with none this waits as long as the work takes.
+   *
+   * **A wait cannot outlive the link it is listening on** (#396). Everything
+   * that ends a wait well — a status change, an exit — reaches this side down
+   * the core link, so a link that drops takes every one of them with it and the
+   * wait goes quiet rather than ending: on a caller with no `timeoutMs`, or on
+   * the `--wait-timeout 0` that removes one, quiet is forever. A drop is
+   * therefore an ending in its own right: the wait keeps going for
+   * {@link CORE_LINK_LOST_GRACE_MS} in case the link comes back — on a client
+   * that reconnects it usually does, and the replay past its cursor carries the
+   * status this wait was missing — and then rejects with
+   * {@link CoreSessionLinkLostError}.
+   *
+   * **It rejects rather than resolving**, and that is the whole of the design:
+   * this side stopped hearing from the Core, which is evidence about the link
+   * and none at all about the turn. Resolving with the last status seen would
+   * report a turn as ended because the network failed, and a false completion is
+   * worse than either a hang or an error (ADR 0033 D6).
    */
   waitForTurnEnd(opts: CoreSessionTurnWaitOptions = {}): Promise<CoreSessionIdle> {
     const afterEventId = opts.afterEventId ?? 0;
@@ -1005,10 +1207,21 @@ export class CoreSession {
         notify: (idle: CoreSessionIdle): void => {
           this.idleWaiters.delete(waiter);
           if (timer) clearTimeout(timer);
+          this.releaseLinkLostGrace();
           resolve(idle);
+        },
+        fail: (err: Error): void => {
+          this.idleWaiters.delete(waiter);
+          if (timer) clearTimeout(timer);
+          this.releaseLinkLostGrace();
+          reject(err);
         },
       };
       this.idleWaiters.add(waiter);
+      // A wait started while the link is already down is the same wait as one
+      // that was running when it went (#396) — it has just as little chance of
+      // hearing anything — so the grace is armed for it too, from here.
+      if (this.linkDown) this.armLinkLostGrace();
       if (opts.timeoutMs && opts.timeoutMs > 0) {
         const timeoutMs = opts.timeoutMs;
         timer = setTimeout(() => {
@@ -1076,6 +1289,10 @@ export class CoreSession {
       clearTimeout(this.statusRetryTimer);
       this.statusRetryTimer = null;
     }
+    if (this.linkLostTimer) {
+      clearTimeout(this.linkLostTimer);
+      this.linkLostTimer = null;
+    }
     // Anyone still waiting is waiting on a report this Session will no longer
     // hear, so they are settled on the way out rather than left pending
     // forever. `kill()` disposes, and `await session.kill()` after starting a
@@ -1104,6 +1321,99 @@ export class CoreSession {
       } catch {
         /* a listener's failure is not this Session's failure */
       }
+    }
+  }
+
+  /**
+   * @internal — the client's link to the Core went down (#396).
+   *
+   * Nothing is decided here. The link being down is a fact about this side, and
+   * the wait it endangers is given {@link linkLostGraceMs} to see whether it
+   * comes back: on a client that reconnects it usually does, and the replay past
+   * its cursor delivers whatever the Core reported in the gap, so the wait ends
+   * on the Core's own report exactly as it would have.
+   */
+  private onLinkLost(reason?: string): void {
+    if (this.disposed || this.linkDown) return;
+    this.linkDown = true;
+    this.linkLostReason = reason ?? null;
+    this.armLinkLostGrace();
+  }
+
+  /**
+   * @internal — a connection came up. Whatever the grace was about is over.
+   *
+   * The wait carries on from here with nothing changed: this restores the state
+   * a wait is supposed to be in, and does not resolve, fail or advance anything.
+   * A turn that ended while the link was down is reported by the replay the
+   * client asks for on its new connection, through the ordinary event path.
+   */
+  private onLinkBack(): void {
+    this.linkDown = false;
+    this.linkLostReason = null;
+    if (this.linkLostTimer) {
+      clearTimeout(this.linkLostTimer);
+      this.linkLostTimer = null;
+    }
+  }
+
+  /**
+   * Start the clock on the current drop, or fail the waiters now if this client
+   * has no reconnect for the clock to be about.
+   *
+   * One timer for the Session rather than one per waiter: the link is a property
+   * of the client, so every wait on this Session went deaf at the same instant
+   * and there is nothing for two clocks to disagree about.
+   *
+   * **Not `unref`ed**, unlike the status-read retry. That retry is a nice-to-have
+   * a finished script may exit through; this one is the only thing left that will
+   * ever settle a pending wait, and a process that exited around it would leave
+   * that promise unsettled — which is the hang this exists to remove, wearing an
+   * exit code of 0.
+   */
+  private armLinkLostGrace(): void {
+    if (this.disposed || !this.linkDown) return;
+    if (this.idleWaiters.size === 0) return;
+    if (this.linkLostGraceMs === 0) {
+      this.failWaitersLinkLost();
+      return;
+    }
+    if (this.linkLostTimer) return;
+    this.linkLostTimer = setTimeout(() => {
+      this.linkLostTimer = null;
+      if (this.disposed || !this.linkDown) return;
+      this.failWaitersLinkLost();
+    }, this.linkLostGraceMs);
+  }
+
+  /** The grace is only ever about a wait; with none left there is nothing to time. */
+  private releaseLinkLostGrace(): void {
+    if (this.idleWaiters.size > 0) return;
+    if (this.linkLostTimer) {
+      clearTimeout(this.linkLostTimer);
+      this.linkLostTimer = null;
+    }
+  }
+
+  /**
+   * End every pending wait as *unknown* — the link went and did not come back.
+   *
+   * `fail`, never `notify`. The waiters are holding cursors and last-known
+   * statuses that would make a plausible-looking resolution, and every one of
+   * them would be a turn reported as ended on the strength of a network failure.
+   */
+  private failWaitersLinkLost(): void {
+    for (const waiter of [...this.idleWaiters]) {
+      waiter.fail(
+        new CoreSessionLinkLostError({
+          taskId: this.taskId,
+          afterEventId: waiter.afterEventId,
+          lastStatus: this.lastStatus,
+          reportedSinceDelivery: this.lastStatusEventId > waiter.afterEventId,
+          graceMs: this.linkLostGraceMs,
+          reason: this.linkLostReason,
+        }),
+      );
     }
   }
 
@@ -1283,6 +1593,22 @@ export class CoreSession {
       if (settled) waiter.notify(settled);
     }
   }
+}
+
+/**
+ * How long a Session's waits survive a dropped link, given what the caller asked
+ * for and what kind of client it handed over (#396).
+ *
+ * The caller's number wins outright, 0 included. With none, the answer comes off
+ * the client: one that dials again gets {@link CORE_LINK_LOST_GRACE_MS} to do
+ * it in, and one that does not gets **0**, because a grace is time given to a
+ * reconnect and a one-shot client has none coming. That is the `actana` CLI's
+ * case — its drop is permanent, and a wait that sat out thirty seconds before
+ * saying so would be thirty seconds of the hang this fixes.
+ */
+function linkLostGraceFor(client: CoreClient, asked: number | undefined): number {
+  if (asked !== undefined) return asked;
+  return client.willReconnect() ? CORE_LINK_LOST_GRACE_MS : 0;
 }
 
 /**

--- a/packages/sdk/src/core-session.ts
+++ b/packages/sdk/src/core-session.ts
@@ -189,10 +189,20 @@ export const STATUS_READ_RETRY_MS = 250;
  * A link that has not come back by then is not a blip, and the wait behind it
  * has nothing left to hear.
  *
- * **It is a grace, not a deadline.** It only ever runs while the link is down,
- * it is cancelled the moment the link returns, and it is not what
+ * **It is a grace, not a deadline.** It runs only while the link is down, it is
+ * paused the moment a usable connection returns, and it is not what
  * {@link CoreSessionWaitOptions.timeoutMs} is — a caller that passed no deadline
  * still has none while the Core is reachable.
+ *
+ * **And it is a budget, spent cumulatively** (#492 review, blocking 1). A link
+ * that drops and comes back does not earn a fresh thirty seconds: the outages a
+ * single wait lives through are added up, and the wait fails once they total
+ * this much. Forgiving each flap in full is how a wait outlives its link the
+ * long way round — a Core in a restart crash-loop, or a `DurableCoreClient` on
+ * its 500 ms–5 s backoff against a flaky link, drops and returns indefinitely
+ * with no single outage long enough to fire anything, and the wait hangs for
+ * ever on exactly the failure #396 exists to remove. Summed, the deaf time a
+ * wait can accumulate is bounded, so it always ends.
  *
  * Zero, which {@link CoreSession.start} and {@link CoreSession.attach} use for a
  * client that does not reconnect, means the wait fails the instant the link
@@ -262,6 +272,9 @@ export type CoreSessionStartOptions = {
   /**
    * How long a wait on this Session keeps waiting after the link to the Core
    * drops, before it fails with {@link CoreSessionLinkLostError} (#396).
+   *
+   * A cumulative budget rather than a per-outage one: the outages a single wait
+   * lives through are summed against it.
    *
    * Defaults to {@link CORE_LINK_LOST_GRACE_MS} on a client that reconnects and
    * to **0** on one that does not, because on the second kind there is nothing
@@ -519,8 +532,25 @@ export class CoreSessionLinkLostError extends Error {
    * nothing about this Session after the cursor.
    */
   readonly reportedSinceDelivery: boolean;
-  /** How long the wait went on for after the drop before giving up, in ms. */
+  /**
+   * The **budget** a dropped link was given to come back in, in ms — the
+   * configured grace, not a measurement.
+   *
+   * 0 on a client that does not reconnect, where the wait fails on the drop
+   * itself because there is nothing coming to wait for.
+   */
   readonly graceMs: number;
+  /**
+   * How long this side was **actually deaf** before the wait gave up, in ms,
+   * summed across every outage the wait lived through.
+   *
+   * The measurement, where {@link graceMs} is the budget (#492 review, should
+   * fix 1). They are not the same number and the difference is the point: a
+   * wait that flapped fails part-way into a later outage, having banked the
+   * earlier ones, so reporting the constant would overstate what this side sat
+   * through. Always at least `graceMs` when `graceMs` is above 0.
+   */
+  readonly downMs: number;
   /** What the transport said about the drop, when it said anything. */
   readonly reason: string | null;
 
@@ -530,6 +560,7 @@ export class CoreSessionLinkLostError extends Error {
     lastStatus: string | null;
     reportedSinceDelivery: boolean;
     graceMs: number;
+    downMs: number;
     reason: string | null;
   }) {
     super(linkLostMessage(opts));
@@ -539,6 +570,7 @@ export class CoreSessionLinkLostError extends Error {
     this.lastStatus = opts.lastStatus;
     this.reportedSinceDelivery = opts.reportedSinceDelivery;
     this.graceMs = opts.graceMs;
+    this.downMs = opts.downMs;
     this.reason = opts.reason;
   }
 }
@@ -560,11 +592,13 @@ function linkLostMessage(opts: {
   taskId: string;
   lastStatus: string | null;
   graceMs: number;
+  downMs: number;
   reason: string | null;
 }): string {
   const stayedDown =
     opts.graceMs > 0
-      ? `and was still down ${opts.graceMs}ms later`
+      ? `and this side has now been deaf for ${opts.downMs}ms, past the ${opts.graceMs}ms a dropped ` +
+        `link is given to come back in`
       : "and this client does not reconnect";
   const because = opts.reason ? ` (${opts.reason})` : "";
   return (
@@ -695,12 +729,22 @@ export class CoreSession {
    * whatever the caller asked for.
    */
   private readonly linkLostGraceMs: number;
-  /** True between the link going down and it coming back. */
+  /** True between the link going down and a usable connection coming back. */
   private linkDown = false;
   /** What the transport said about the current drop, when it said anything. */
   private linkLostReason: string | null = null;
   /** The grace running against the current drop, armed only while one is. */
   private linkLostTimer: ReturnType<typeof setTimeout> | null = null;
+  /** When the outage now running began, or null while the link is usable. */
+  private linkDownSince: number | null = null;
+  /**
+   * Deaf time already banked from earlier outages, for the wait now running.
+   *
+   * The half that makes the grace a **budget** rather than a fresh allowance per
+   * flap (#492 review, blocking 1). Reset when the last waiter goes, because the
+   * budget belongs to a wait and not to the Session.
+   */
+  private linkDownBankedMs = 0;
   private exit: { exitCode: number; signal?: number } | null = null;
   private disposed = false;
   /** A status read is in flight; another event arrived while it was. */
@@ -819,7 +863,7 @@ export class CoreSession {
     // nothing will ever end (#396). Not held like the three above: a drop before
     // the spawn is answered fails the spawn, which is the `catch` below.
     const stopDown = client.onDisconnected(({ error }) => session?.onLinkLost(error));
-    const stopUp = client.onReady(() => session?.onLinkBack());
+    const stopUp = client.onEstablished(() => session?.onLinkBack());
 
     let spawned: { ptyId: string; hooksReportTurnStart: boolean };
     try {
@@ -953,7 +997,7 @@ export class CoreSession {
       // used to leave it pending with nothing left that could ever end it
       // (#396).
       client.onDisconnected(({ error }) => session.onLinkLost(error)),
-      client.onReady(() => session.onLinkBack()),
+      client.onEstablished(() => session.onLinkBack()),
     );
 
     const replay = opts.replay !== false;
@@ -1189,7 +1233,9 @@ export class CoreSession {
    * {@link CORE_LINK_LOST_GRACE_MS} in case the link comes back — on a client
    * that reconnects it usually does, and the replay past its cursor carries the
    * status this wait was missing — and then rejects with
-   * {@link CoreSessionLinkLostError}.
+   * {@link CoreSessionLinkLostError}. That grace is a **cumulative budget**, so
+   * a link that flaps cannot renew it: the deaf time one wait accumulates is
+   * bounded, and the wait therefore always ends.
    *
    * **It rejects rather than resolving**, and that is the whole of the design:
    * this side stopped hearing from the Core, which is evidence about the link
@@ -1219,14 +1265,16 @@ export class CoreSession {
         },
       };
       this.idleWaiters.add(waiter);
-      // A wait started while the link is already down is the same wait as one
-      // that was running when it went (#396) — it has just as little chance of
-      // hearing anything — so the grace is armed for it too, from here.
-      if (this.linkDown) this.armLinkLostGrace();
       if (opts.timeoutMs && opts.timeoutMs > 0) {
         const timeoutMs = opts.timeoutMs;
         timer = setTimeout(() => {
           this.idleWaiters.delete(waiter);
+          // The grace goes back with the waiter (#492 review, should fix 1).
+          // Without this the timer outlives the wait it was about: it is not
+          // `unref`ed, so it holds the event loop for the rest of the grace, and
+          // `armLinkLostGrace`'s "one timer per Session" guard would hand the
+          // next wait on this Session that stale, part-spent one.
+          this.releaseLinkLostGrace();
           // **Named rather than bare** (#405). The one thing this deadline knows
           // that its caller does not is whether the Core reported *anything*
           // after the delivery: `lastStatusEventId` still at or below the cursor
@@ -1245,6 +1293,15 @@ export class CoreSession {
           );
         }, opts.timeoutMs);
       }
+      // **After the deadline is armed, not before** (#492 review, should fix 2).
+      // A wait started while the link is already down is the same wait as one
+      // that was running when it went (#396) — it has just as little chance of
+      // hearing anything — so the grace is armed for it too, from here. On a
+      // grace of 0 that rejects *synchronously*, inside this executor, and a
+      // `fail` that ran with `timer` still null would leave the `setTimeout`
+      // above orphaned: nothing clears it, `dispose()` included, and an SDK
+      // consumer holds the event loop until it fires.
+      if (this.linkDown) this.armLinkLostGrace();
     });
   }
 
@@ -1294,6 +1351,8 @@ export class CoreSession {
       clearTimeout(this.linkLostTimer);
       this.linkLostTimer = null;
     }
+    this.linkDownSince = null;
+    this.linkDownBankedMs = 0;
     // Anyone still waiting is waiting on a report this Session will no longer
     // hear, so they are settled on the way out rather than left pending
     // forever. `kill()` disposes, and `await session.kill()` after starting a
@@ -1329,33 +1388,64 @@ export class CoreSession {
    * @internal — the client's link to the Core went down (#396).
    *
    * Nothing is decided here. The link being down is a fact about this side, and
-   * the wait it endangers is given {@link linkLostGraceMs} to see whether it
-   * comes back: on a client that reconnects it usually does, and the replay past
-   * its cursor delivers whatever the Core reported in the gap, so the wait ends
-   * on the Core's own report exactly as it would have.
+   * the wait it endangers is given what is left of {@link linkLostGraceMs} to
+   * see whether a usable connection comes back: on a client that reconnects one
+   * usually does, and the replay past its cursor delivers whatever the Core
+   * reported in the gap, so the wait ends on the Core's own report exactly as it
+   * would have.
+   *
+   * *What is left of*, because outages already lived through were banked by
+   * {@link onLinkBack} and are spent — see {@link armLinkLostGrace}.
    */
   private onLinkLost(reason?: string): void {
     if (this.disposed || this.linkDown) return;
     this.linkDown = true;
     this.linkLostReason = reason ?? null;
+    this.linkDownSince = Date.now();
     this.armLinkLostGrace();
   }
 
   /**
-   * @internal — a connection came up. Whatever the grace was about is over.
+   * @internal — a connection came up **and is usable**. The outage is over.
    *
-   * The wait carries on from here with nothing changed: this restores the state
-   * a wait is supposed to be in, and does not resolve, fail or advance anything.
-   * A turn that ended while the link was down is reported by the replay the
-   * client asks for on its new connection, through the ordinary event path.
+   * Wired to `onEstablished` rather than to `onReady` (#492 review, blocking 2).
+   * `ready` is the Core's first unsolicited frame and lands before `auth` is
+   * answered, so a connection the Core is about to refuse — an expired or
+   * rotated bearer — produces one. Nothing can be sent on that connection and no
+   * `subscribe` goes out, so counting it as recovery forgives an outage that
+   * never ended; with a supervisor dialing again it is a `ready` → `authError` →
+   * `disconnect` loop that could re-arm and disarm this guard for ever, with no
+   * events flowing at all. `onEstablished` means the Core has said who it is and
+   * the link can be written to, authenticated where a bearer was configured.
+   *
+   * **The outage is banked, not forgiven.** The time this side spent deaf is
+   * added to {@link linkDownBankedMs} and counts against the same budget the
+   * next drop draws on, which is what stops a flapping link renewing its grace
+   * for ever (blocking 1).
+   *
+   * The wait itself carries on with nothing changed: this resolves, fails and
+   * advances nothing. A turn that ended while the link was down is reported by
+   * the replay the client asks for on its new connection, through the ordinary
+   * event path.
    */
   private onLinkBack(): void {
+    if (!this.linkDown) return;
     this.linkDown = false;
     this.linkLostReason = null;
+    if (this.linkDownSince !== null) {
+      this.linkDownBankedMs += Date.now() - this.linkDownSince;
+      this.linkDownSince = null;
+    }
     if (this.linkLostTimer) {
       clearTimeout(this.linkLostTimer);
       this.linkLostTimer = null;
     }
+  }
+
+  /** Deaf time this wait has accumulated: banked outages plus the one running. */
+  private linkDownElapsedMs(): number {
+    const running = this.linkDownSince === null ? 0 : Date.now() - this.linkDownSince;
+    return this.linkDownBankedMs + running;
   }
 
   /**
@@ -1375,7 +1465,11 @@ export class CoreSession {
   private armLinkLostGrace(): void {
     if (this.disposed || !this.linkDown) return;
     if (this.idleWaiters.size === 0) return;
-    if (this.linkLostGraceMs === 0) {
+    // What is left of the budget, not the whole of it: outages this wait has
+    // already lived through were banked by `onLinkBack` and are spent. A budget
+    // that is gone fails now, which is also the grace-of-0 case.
+    const remaining = this.linkLostGraceMs - this.linkDownElapsedMs();
+    if (remaining <= 0) {
       this.failWaitersLinkLost();
       return;
     }
@@ -1383,17 +1477,35 @@ export class CoreSession {
     this.linkLostTimer = setTimeout(() => {
       this.linkLostTimer = null;
       if (this.disposed || !this.linkDown) return;
+      // The budget is the authority, not the timer. A `setTimeout` may arrive a
+      // millisecond ahead of the wall clock it was sized against, and a wait
+      // failed a millisecond early is a wait failed before its link was out of
+      // time — so a short arrival re-arms for the remainder rather than firing.
+      if (this.linkDownElapsedMs() < this.linkLostGraceMs) {
+        this.armLinkLostGrace();
+        return;
+      }
       this.failWaitersLinkLost();
-    }, this.linkLostGraceMs);
+    }, remaining);
   }
 
-  /** The grace is only ever about a wait; with none left there is nothing to time. */
+  /**
+   * The grace is only ever about a wait; with none left there is nothing to time
+   * — and nothing to have banked, either.
+   *
+   * The budget belongs to a wait rather than to the Session, so the accumulator
+   * is zeroed here and the clock restarted if the link happens to be down. A
+   * wait that starts later gets the whole budget; what it does not get is the
+   * previous wait's part-spent timer (#492 review, should fix 1).
+   */
   private releaseLinkLostGrace(): void {
     if (this.idleWaiters.size > 0) return;
     if (this.linkLostTimer) {
       clearTimeout(this.linkLostTimer);
       this.linkLostTimer = null;
     }
+    this.linkDownBankedMs = 0;
+    this.linkDownSince = this.linkDown ? Date.now() : null;
   }
 
   /**
@@ -1404,6 +1516,8 @@ export class CoreSession {
    * them would be a turn reported as ended on the strength of a network failure.
    */
   private failWaitersLinkLost(): void {
+    // Read once, before the first `fail` empties the waiter set and resets it.
+    const downMs = this.linkDownElapsedMs();
     for (const waiter of [...this.idleWaiters]) {
       waiter.fail(
         new CoreSessionLinkLostError({
@@ -1412,6 +1526,7 @@ export class CoreSession {
           lastStatus: this.lastStatus,
           reportedSinceDelivery: this.lastStatusEventId > waiter.afterEventId,
           graceMs: this.linkLostGraceMs,
+          downMs,
           reason: this.linkLostReason,
         }),
       );

--- a/packages/sdk/src/durable-core-client.ts
+++ b/packages/sdk/src/durable-core-client.ts
@@ -136,6 +136,19 @@ export class DurableCoreClient extends CoreClient {
   }
 
   /**
+   * Yes — surviving a drop is what this class is for (#396).
+   *
+   * Not the same question as {@link reconnectScheduled}, which is about the
+   * timer that happens to be armed right now. This is about the client: a caller
+   * deciding how long to keep waiting after a drop is asking whether a
+   * reconnect is coming at all, and the honest answer stops being yes only once
+   * this client has been hung up on.
+   */
+  override willReconnect(): boolean {
+    return !this.closed;
+  }
+
+  /**
    * What this client owes the Core on every connection, in the one order that
    * works.
    *

--- a/packages/shared/src/orchestration-skill-payload.ts
+++ b/packages/shared/src/orchestration-skill-payload.ts
@@ -197,7 +197,7 @@ object** \`start --wait --json\` prints — same keys, same \`screen\` — so on
 reads all three verbs. Two of those keys are \`null\` on a Session you attached to
 rather than started: \`command\` and \`reportsTurnStart\` are answers to a spawn.
 
-Four things to know before you build on it:
+Five things to know before you build on it:
 
 1. **Sending into a turn that is already running resolves on *that* turn's
    end.** A keystroke into a busy Harness is not a new turn. If the Session was
@@ -232,6 +232,17 @@ Four things to know before you build on it:
    exits zero** — which reads as a completed turn and is not one. To carry on
    waiting, follow the log from the delivery instead:
    \`actana events tail --since <event id>\`, the id the timeout message names.
+5. **A wait whose link to the Core drops ends as *unknown*.** Every wait listens
+   over that link, so a Core that restarts or a connection that is reaped takes
+   the report the wait was waiting for with it. Rather than hang — which is what
+   it used to do, with no deadline of any kind to end it — the command exits
+   non-zero saying **the turn's outcome is unknown**: it may have ended while
+   this side was deaf, and it may still be running. That is not a failed turn
+   and not a finished one, and it is the one case where the Session's status has
+   to be re-read from the Core rather than taken from the wait. Do that once the
+   Core is reachable again — \`actana session ls\` says whether it is still live,
+   \`actana events tail --since <event id>\` follows the log from your delivery —
+   and **do not** answer it with \`session wait\`, for the reason in 4.
 
 **Every turn of that loop gets its own report file**, and the turn number in the
 filename is what keeps them apart. See below.


### PR DESCRIPTION
`actana session start proj "prompt" --wait` with no `--wait-timeout` hung for ever if the Core blipped mid-wait. `waitForTurnEnd` had no disconnect handler, and every way a wait can end well — the settling status a harness's hooks produce, the process exit behind it — arrives down the core link. A link that drops takes all of them at once, so the wait does not end: it goes quiet, and with no deadline (or with the `--wait-timeout 0` #405 added) nothing left in the world can settle it.

## The decision

**A drop is an ending in its own right, and it rejects.** The cheap fix is the forbidden one: resolving the wait with the status the Session was last seen at reports a turn as ended on the evidence that *this side stopped listening*. That is a false completion arriving through the transport rather than through the harness — the exact failure this train exists to remove — so the wait fails and says the turn's outcome is **unknown**.

Three endings, three classes, so a caller branches without parsing prose:

| ending | means |
| --- | --- |
| resolves | the Core reported a turn ended |
| `CoreSessionTurnTimeoutError` (#405) | this side gave up on a clock it set |
| `CoreSessionLinkLostError` (new) | this side went deaf; the outcome is unknown |

## What changed

**1. `CoreSessionLinkLostError`**, exported from `packages/sdk/src/core-session.ts`, carrying `taskId`, `afterEventId`, `lastStatus`, `reportedSinceDelivery`, `graceMs` and `reason`. `lastStatus` is context and is documented as never the answer. Its message names both readings and settles neither — the turn may have ended in the silence, and it may still be running — for the same reason #405's does: choosing between them would mean reading the screen (#191, ADR 0026 D3) or consulting `reportsTurnStart` (ADR 0033 D2).

**2. `CoreSession` listens on the link**, on both the `start` and the `attach` path (`onDisconnected` / `onReady`), and a wait begun while the link is *already* down gets the same treatment as one that was running when it went.

**3. A grace, not a deadline.** On a client that reconnects a drop is usually not even an interruption: the link returns, the client re-subscribes from its cursor, and the Core streams the tail it missed — including the status this wait was waiting for. So the drop starts a clock that runs **only while the link is down** and is cancelled the moment a connection comes back. `CORE_LINK_LOST_GRACE_MS` is 30s, which is six or more of `DurableCoreClient`'s backoff attempts. It is not `timeoutMs` and does not become one: a caller that passed no deadline still has none while the Core is reachable.

**4. A client with no reconnect coming gets a grace of 0** and fails on the drop itself. A grace is time given to a reconnect, and the `actana` CLI's one-shot `CoreClient` has none — sitting out 30s there would be 30 more seconds of the hang. The new `CoreClient.willReconnect()` predicate decides (false here; `DurableCoreClient` overrides it to true until this client hangs up), and `linkLostGraceMs` on `start`/`attach` overrides that in turn.

**5. `subscribeEvents` records the subscribe only when the frame went out.** It set `eventsSubscribed = true` before `sendNow`, so `isSubscribedToEvents()` answered true for a subscribe no link ever carried. `CoreSession` reads that flag to decide whether it still owes the Core a subscribe: the lie is a Session wired to an event stream nobody asked for, hearing no status ever — another wait nothing can end. Named in the issue's own **Where** section.

**6. The CLI names the next step**, as it already does for the deadline: where the answer is (the Core, once reachable), and `events tail --since <delivery id>` where there is a cursor. **Not `session wait`** — uncursored, it answers from the status the Session was parked at before the drop and exits zero, which is #405's false completion one layer up.

**7. ADR 0033 gains D6**, extending D4. `docs/README.md`'s index row and the `actana-sessions` skill say so, and the skill payload was regenerated from its authored source.

## Acceptance criteria (issue #396)

1. **If the core-link drops during `--wait`, the command exits non-zero (or reconnects and still exits) rather than hanging for ever** — both halves. A client that reconnects inside the grace carries on waiting and ends on the Core's own report; one that does not exits non-zero with `CoreSessionLinkLostError`. Pinned at both layers: the SDK suite drops a live socket under a wait with **no deadline at all** and asserts the rejection, and the CLI suite asserts `EXIT_FAILURE` plus a `--json` document with no `status` key.

## Landmines, and how each is respected

- **No turn is settled from PTY bytes or output quietness** (#191, ADR 0026 D3) — the facts here are the link going down and two event ids.
- **No wait path consults `reportsTurnStart`** (ADR 0033 D2) — the new handlers live below `// ─── Internals`, outside the source-sweep's slice, and consult nothing.
- **An unknown outcome reads as unknown** — the wait rejects; it never resolves with a status the Core did not send.
- **#405 is extended, not undone** (ADR 0033 D5) — `CoreSessionTurnTimeoutError`, the `send`-only default deadline and `--wait-timeout 0` are untouched, and a regression test asserts a turn that really ends still resolves the wait.

## Files this touches, for the tickets landing beside it

- `packages/core/src/harness-prompt-delivery.ts`, `packages/core/src/pty-manager.ts`, `packages/cli/src/session-gateway.ts` — **not touched** (#483).
- the codex hooks code — **not touched** (#290). The codex `HARNESS_READINESS` table and `packages/core/src/__tests__/fixtures/` — **not touched** (#277).
- `packages/panel/**` — **not touched** (#484).
- `packages/cli/src/session-command.ts` — the `awaitTurn` catch only; `sessionSend`'s refusal and the timeout advice #405 added are unchanged.

## Verification

`pnpm -r typecheck`, `pnpm lint` (0 errors; 43 warnings, byte-identical to the base), `pnpm scan:secrets`, and the `sdk`, `cli`, `core` and `shared` unit suites all pass locally. Panel is untouched and left to CI.

Refs #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TbQDZV12xtjR55RsQqivh
